### PR TITLE
Quit apps from the launcher: per-app Quit Application and a Quit All Applications command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there
 
 ## Features
 
-- **App launcher** — fuzzy-search and launch anything, pin favorites, see what's running.
+- **App launcher** — fuzzy-search and launch anything, pin favorites, see what's running, quit an app
+  or every app at once.
 - **Calculator** — do math and unit conversions inline, right in the palette.
 - **Clipboard history** — text and images, searchable, pasted back into the app you were using.
 - **Global hotkey** — one shortcut summons the palette from anywhere.

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -261,6 +261,14 @@ final class AppCore: ObservableObject {
         }
     }
 
+    /// Quits the app behind an entry; a no-op (palette stays put) when it isn't running.
+    func quit(_ app: AppEntry) {
+        guard app.kind == .application, let bundleID = app.bundleID,
+            AppLauncher.quit(bundleID: bundleID)
+        else { return }
+        hidePalette(restoreFocus: false)
+    }
+
     private func runCommand(_ entry: AppEntry) {
         switch CommandRegistry.command(for: entry) {
         case .calculatorHistory:
@@ -284,6 +292,9 @@ final class AppCore: ObservableObject {
         case .about:
             hidePalette(restoreFocus: false)
             showAbout()
+        case .quitAllApps:
+            hidePalette(restoreFocus: false)
+            AppLauncher.quitAll()
         case .quit:
             NSApp.terminate(nil)
         case nil:

--- a/Tinycast/Core/AppLauncher.swift
+++ b/Tinycast/Core/AppLauncher.swift
@@ -40,4 +40,32 @@ enum AppLauncher {
             running.activate()
         }
     }
+
+    /// Asks every running instance of a bundle ID to quit — graceful, so an app with unsaved work still gets to put its own sheet up. False when nothing was running.
+    @MainActor
+    @discardableResult
+    static func quit(bundleID: String) -> Bool {
+        let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        for app in running { app.terminate() }
+        return !running.isEmpty
+    }
+
+    /// Finder is never a Quit All target: `terminate()` only makes it relaunch, and nobody means the desktop when they say "quit everything".
+    private static let quitAllExclusions: Set<String> = ["com.apple.finder"]
+
+    /// What Quit All acts on: every app with a Dock presence, minus Finder and Tinycast itself. Accessories and background agents are left alone.
+    @MainActor
+    static func quitAllTargets() -> [NSRunningApplication] {
+        let ownPID = NSRunningApplication.current.processIdentifier
+        return NSWorkspace.shared.runningApplications.filter { app in
+            app.activationPolicy == .regular
+                && app.processIdentifier != ownPID
+                && !quitAllExclusions.contains(app.bundleIdentifier ?? "")
+        }
+    }
+
+    @MainActor
+    static func quitAll() {
+        for app in quitAllTargets() { app.terminate() }
+    }
 }

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -10,6 +10,7 @@ enum CommandID: String, CaseIterable, Sendable {
     case importFromRaycast = "command:import-from-raycast"
     case settings = "command:settings"
     case about = "command:about"
+    case quitAllApps = "command:quit-all-apps"
     case quit = "command:quit"
 
     var name: String {
@@ -22,6 +23,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .importFromRaycast: return "Import from Raycast"
         case .settings: return "Settings"
         case .about: return "About Tinycast"
+        case .quitAllApps: return "Quit All Applications"
         case .quit: return "Quit Tinycast"
         }
     }
@@ -36,6 +38,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .importFromRaycast: return "arrow.down.doc"
         case .settings: return "gearshape"
         case .about: return "info.circle"
+        case .quitAllApps: return "xmark.app"
         case .quit: return "power"
         }
     }

--- a/Tinycast/Core/RunningApps.swift
+++ b/Tinycast/Core/RunningApps.swift
@@ -21,6 +21,12 @@ final class RunningAppsMonitor: ObservableObject {
         }
     }
 
+    /// True when the entry's bundle is currently running — drives the row's running dot and the Quit action.
+    func isRunning(_ app: AppEntry) -> Bool {
+        guard let bundleID = app.bundleID else { return false }
+        return runningBundleIDs.contains(bundleID)
+    }
+
     private func refresh() {
         runningBundleIDs = Set(
             NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -79,8 +79,7 @@ struct LauncherList: View {
                                     AppRow(
                                         app: app,
                                         selected: app.id == selectedID,
-                                        running: app.bundleID.map(
-                                            runningApps.runningBundleIDs.contains) ?? false
+                                        running: runningApps.isRunning(app)
                                     )
                                     .contentShape(Rectangle())
                                     .onTapGesture { core.launch(app) }
@@ -221,7 +220,7 @@ struct AppIconView: View {
 /// Actions menu content for a launcher app, shown bottom-right on right-click or from the Actions pill.
 @MainActor
 enum AppActionsMenu {
-    static func content(app: AppEntry, core: AppCore, favorites: FavoritesStore)
+    static func content(app: AppEntry, core: AppCore, favorites: FavoritesStore, running: Bool)
         -> PopoverMenuContent
     {
         var items: [PopoverMenuItem] = [
@@ -244,6 +243,15 @@ enum AppActionsMenu {
             items.append(
                 PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {
                     core.showInFinder(app)
+                })
+        }
+        if running, app.kind == .application {
+            items.append(
+                PopoverMenuItem(
+                    title: "Quit Application", systemImage: "power", shortcut: "⌘↵",
+                    isDestructive: true
+                ) {
+                    core.quit(app)
                 })
         }
         return PopoverMenuContent(header: app.name, items: items)

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -10,6 +10,8 @@ struct RootPaletteView: View {
     @EnvironmentObject private var calcHistory: CalculatorHistoryStore
     @EnvironmentObject private var emojiIndex: EmojiIndex
     @EnvironmentObject private var frequentEmoji: FrequentEmojiStore
+    /// Observed so an app launching / quitting re-renders the Quit action's availability.
+    @EnvironmentObject private var runningApps: RunningAppsMonitor
     /// Observed so a skin tone changed in Settings re-renders the grid glyphs immediately.
     @ObservedObject private var settings = AppCore.shared.settings
     @FocusState private var searchFocused: Bool
@@ -105,7 +107,9 @@ struct RootPaletteView: View {
                 return CalcActionsMenu.content(result: calc, core: core)
             }
             if let app = selectedAppEntry {
-                return AppActionsMenu.content(app: app, core: core, favorites: favorites)
+                return AppActionsMenu.content(
+                    app: app, core: core, favorites: favorites,
+                    running: runningApps.isRunning(app))
             }
             return nil
         case .clipboard:
@@ -344,7 +348,11 @@ struct RootPaletteView: View {
                 guard command, histResults.indices.contains(index) else { return .ignored }
                 core.copyHistoryExpression(histResults[index])
             case .launcher:
-                return .ignored
+                // ⌘↵ quits the selected app when it's running (the Actions menu advertises it); nothing else in the launcher takes a modified ↵.
+                guard command, let app = selectedAppEntry, runningApps.isRunning(app) else {
+                    return .ignored
+                }
+                core.quit(app)
             }
             return .handled
         }

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -11,3 +11,19 @@ consecutive / word-boundary bonuses. Rankings are memoized one query deep.
 > is meaningless.
 
 Icons go through a count-capped `NSCache` (`IconCache`).
+
+## Quitting apps
+
+`RunningAppsMonitor` (live from `NSWorkspace` launch/terminate notifications) drives both the row's
+running dot and the availability of the quit actions:
+
+- **Quit Application** — the last row of an app's ⌘K Actions menu, shown only while that app is
+  running, also bound to **⌘↵** on the selected row. `AppLauncher.quit(bundleID:)` terminates every
+  instance of the bundle and reports whether anything was running; the palette only dismisses when
+  something was.
+- **Quit All Applications** — a `CommandRegistry` command. `AppLauncher.quitAllTargets()` is the
+  policy (every `.regular` app except Finder — `terminate()` only relaunches it — and Tinycast
+  itself); `quitAll()` terminates that list.
+
+Both quits are graceful `NSRunningApplication.terminate()`, so an app with unsaved work still puts up
+its own save sheet.


### PR DESCRIPTION
## Summary

A running app can now be quit straight from the launcher instead of switching to it and pressing ⌘Q, and the whole desktop can be cleared with one command — the two things the issue asks for.

- **Quit Application** — the last row of an app's ⌘K Actions menu, and **⌘↵** on the selected row. It only appears while that app is actually running (same `RunningAppsMonitor` that drives the row's running dot), so it is never a dead action, and the palette dismisses only when something really was running.
- **Quit All Applications** — a new palette command. It targets every Dock-level (`.regular`) app except Finder and Tinycast itself; background agents, accessories and helpers are left alone.

Both are graceful `NSRunningApplication.terminate()`, so an app with unsaved work still puts up its own save sheet — nothing is force-killed.

Three decisions worth a look:

- Finder is excluded from Quit All because `terminate()` only makes it relaunch.
- Tinycast excludes itself by PID rather than by activation policy — About/Settings temporarily flips the app to `.regular`, so a policy-only filter could make it quit itself.
- ⌘↵ was unused in launcher mode and is the "secondary action" slot the other modes already use (clipboard copy, history copy-expression); the menu row advertises it.

Fixes #32

## Validation

- Compiled the real `AppLauncher` into a standalone harness (the repo's test idiom): `quit(bundleID:)` terminated a live TextEdit and returned `true`, and returned `false` both before the launch and after the termination. `quitAllTargets()` on a working desktop selected 10 of 162 running processes — Finder excluded, self excluded, only Dock-level apps.
- Drove the built Debug app: with TextEdit running, ⌘K on its row showed **Quit Application** (destructive red, `⌘↵` keycaps); activating it quit TextEdit and dismissed the palette. The row is absent for apps that are not running.
- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug` builds clean.
- `quitAll()` itself was deliberately not executed — it would have terminated the apps hosting the session. What was verified is the target list it iterates; the executor is a `terminate()` loop over exactly that list.

## Notes

Claude Code generated it.