### PR TITLE
Resolve review findings from #34

### DIFF
--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -263,10 +263,33 @@ final class AppCore: ObservableObject {
 
     /// Quits the app behind an entry; a no-op (palette stays put) when it isn't running.
     func quit(_ app: AppEntry) {
-        guard app.kind == .application, let bundleID = app.bundleID,
-            AppLauncher.quit(bundleID: bundleID)
-        else { return }
-        hidePalette(restoreFocus: false)
+        guard app.kind == .application, let bundleID = app.bundleID else { return }
+        // Unlike `launch`, nothing here takes focus on its own — hand it back to where the user was, unless that's the app now on its way out.
+        let quittingPreviousApp = windowController.previousApp?.bundleIdentifier == bundleID
+        guard AppLauncher.quit(bundleID: bundleID) else { return }
+        hidePalette(restoreFocus: !quittingPreviousApp)
+    }
+
+    /// Quit All: the one action whose blast radius reaches outside Tinycast, so it confirms first. The target list is resolved once and both counted and terminated, so the set the user approves is the set that quits.
+    private func quitAllApps() {
+        let targets = AppLauncher.quitAllTargets()
+        guard !targets.isEmpty, Self.confirmQuitAll(count: targets.count) else { return }
+        for app in targets { app.terminate() }
+    }
+
+    private static func confirmQuitAll(count: Int) -> Bool {
+        // An accessory app's alert opens behind the frontmost app unless it activates first (same as `BackupActions`).
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = count == 1 ? "Quit 1 application?" : "Quit \(count) applications?"
+        alert.informativeText = "Applications with unsaved changes will ask you to save."
+        alert.alertStyle = .warning
+        let quitButton = alert.addButton(withTitle: "Quit All")
+        quitButton.hasDestructiveAction = true
+        // `hasDestructiveAction` only tints the button — it stays the ↵ default. Hand ↵ to Cancel instead: this command is one ↵ away in the palette, and a second reflexive ↵ must not quit the desktop.
+        quitButton.keyEquivalent = ""
+        alert.addButton(withTitle: "Cancel").keyEquivalent = "\r"
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     private func runCommand(_ entry: AppEntry) {
@@ -293,8 +316,9 @@ final class AppCore: ObservableObject {
             hidePalette(restoreFocus: false)
             showAbout()
         case .quitAllApps:
+            // Hide before confirming: the palette is a floating panel and would sit above the alert.
             hidePalette(restoreFocus: false)
-            AppLauncher.quitAll()
+            quitAllApps()
         case .quit:
             NSApp.terminate(nil)
         case nil:

--- a/Tinycast/Core/AppLauncher.swift
+++ b/Tinycast/Core/AppLauncher.swift
@@ -53,19 +53,15 @@ enum AppLauncher {
     /// Finder is never a Quit All target: `terminate()` only makes it relaunch, and nobody means the desktop when they say "quit everything".
     private static let quitAllExclusions: Set<String> = ["com.apple.finder"]
 
-    /// What Quit All acts on: every app with a Dock presence, minus Finder and Tinycast itself. Accessories and background agents are left alone.
+    /// What Quit All acts on: every app with a Dock presence, minus Finder and Tinycast itself. Accessories and background agents are left alone. The caller resolves this once and terminates that same list, so the set it confirms is the set it quits.
     @MainActor
     static func quitAllTargets() -> [NSRunningApplication] {
+        // Excluded by PID, not by activation policy: About/Settings temporarily flips Tinycast to `.regular`, which a policy-only filter would read as a target.
         let ownPID = NSRunningApplication.current.processIdentifier
         return NSWorkspace.shared.runningApplications.filter { app in
             app.activationPolicy == .regular
                 && app.processIdentifier != ownPID
                 && !quitAllExclusions.contains(app.bundleIdentifier ?? "")
         }
-    }
-
-    @MainActor
-    static func quitAll() {
-        for app in quitAllTargets() { app.terminate() }
     }
 }

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -38,7 +38,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .importFromRaycast: return "arrow.down.doc"
         case .settings: return "gearshape"
         case .about: return "info.circle"
-        case .quitAllApps: return "xmark.app"
+        case .quitAllApps: return "xmark.circle"
         case .quit: return "power"
         }
     }

--- a/Tinycast/Core/RunningApps.swift
+++ b/Tinycast/Core/RunningApps.swift
@@ -27,8 +27,10 @@ final class RunningAppsMonitor: ObservableObject {
         return runningBundleIDs.contains(bundleID)
     }
 
+    /// Launch/terminate fire for helpers and agents the launcher never lists, so republish only on a real change — an unconditional assign would invalidate every observer for nothing.
     private func refresh() {
-        runningBundleIDs = Set(
-            NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+        let next = Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+        guard next != runningBundleIDs else { return }
+        runningBundleIDs = next
     }
 }

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -10,13 +10,13 @@ struct RootPaletteView: View {
     @EnvironmentObject private var calcHistory: CalculatorHistoryStore
     @EnvironmentObject private var emojiIndex: EmojiIndex
     @EnvironmentObject private var frequentEmoji: FrequentEmojiStore
-    /// Observed so an app launching / quitting re-renders the Quit action's availability.
-    @EnvironmentObject private var runningApps: RunningAppsMonitor
     /// Observed so a skin tone changed in Settings re-renders the grid glyphs immediately.
     @ObservedObject private var settings = AppCore.shared.settings
     @FocusState private var searchFocused: Bool
     @State private var showActions = false
     @State private var showAppMenu = false
+    /// The selection's running state, sampled once by `openActions` — an app launching or quitting elsewhere must not add or drop the Quit row while the menu is up. `RunningAppsMonitor` is deliberately not observed here: only `LauncherList` needs live running state, and observing it would re-render the whole palette on every workspace launch/terminate.
+    @State private var selectionIsRunning = false
     /// Highlighted row of whichever popover menu is open; reset to the first row on open, moved by ↑/↓ and hover, activated by ↵/click.
     @State private var menuSelection = 0
     /// Bumped only when the selection should pull the scroll view with it (keyboard nav, list resets); mouse selection targets a visible row, so it leaves this and the list put.
@@ -108,8 +108,7 @@ struct RootPaletteView: View {
             }
             if let app = selectedAppEntry {
                 return AppActionsMenu.content(
-                    app: app, core: core, favorites: favorites,
-                    running: runningApps.isRunning(app))
+                    app: app, core: core, favorites: favorites, running: selectionIsRunning)
             }
             return nil
         case .clipboard:
@@ -348,10 +347,10 @@ struct RootPaletteView: View {
                 guard command, histResults.indices.contains(index) else { return .ignored }
                 core.copyHistoryExpression(histResults[index])
             case .launcher:
-                // ⌘↵ quits the selected app when it's running (the Actions menu advertises it); nothing else in the launcher takes a modified ↵.
-                guard command, let app = selectedAppEntry, runningApps.isRunning(app) else {
-                    return .ignored
-                }
+                // ⌘↵ quits the selected app when it's running (the Actions menu advertises it); nothing else in the launcher takes a modified ↵. The condition mirrors the menu row's exactly, so the key never swallows a press it won't act on.
+                guard command, let app = selectedAppEntry, app.kind == .application,
+                    core.runningApps.isRunning(app)
+                else { return .ignored }
                 core.quit(app)
             }
             return .handled
@@ -382,7 +381,7 @@ struct RootPaletteView: View {
             guard resultCount > 0 else { return .handled }
             // An error calc card is the selection but has no actions — don't open an empty panel.
             if calcCount > 0, selection == 0, calcResult?.isActionable != true { return .handled }
-            withAnimation(Self.menuAnimation) { showActions.toggle() }
+            toggleActions()
             return .handled
         }
         // Bare backspace (back out of a sub-screen when the search is empty) is intercepted by PalettePanel.sendEvent — the field editor consumes it before onKeyPress could fire.
@@ -482,11 +481,11 @@ struct RootPaletteView: View {
                 onCalcActions: {
                     guard let calc, case .value = calc.payload else { return }
                     vm.selection = 0
-                    withAnimation(Self.menuAnimation) { showActions = true }
+                    openActions()
                 },
                 onActions: { app in
                     if let index = apps.firstIndex(of: app) { vm.selection = index + offset }
-                    withAnimation(Self.menuAnimation) { showActions = true }
+                    openActions()
                 }
             )
         case .clipboard:
@@ -504,7 +503,7 @@ struct RootPaletteView: View {
                         onActivate: activateSelection,
                         onActions: { item in
                             if let index = clips.firstIndex(of: item) { vm.selection = index }
-                            withAnimation(Self.menuAnimation) { showActions = true }
+                            openActions()
                         }
                     )
                     .frame(width: Theme.Size.clipboardListWidth)
@@ -536,7 +535,7 @@ struct RootPaletteView: View {
                     onCalcActions: {
                         guard let calc, case .value = calc.payload else { return }
                         vm.selection = 0
-                        withAnimation(Self.menuAnimation) { showActions = true }
+                        openActions()
                     },
                     onSelect: { entry in
                         if let index = hist.firstIndex(of: entry) { vm.selection = index + offset }
@@ -544,7 +543,7 @@ struct RootPaletteView: View {
                     onActivate: activateSelection,
                     onActions: { entry in
                         if let index = hist.firstIndex(of: entry) { vm.selection = index + offset }
-                        withAnimation(Self.menuAnimation) { showActions = true }
+                        openActions()
                     }
                 )
             }
@@ -563,7 +562,7 @@ struct RootPaletteView: View {
                     onActivate: activateSelection,
                     onActions: { flat in
                         vm.selection = flat
-                        withAnimation(Self.menuAnimation) { showActions = true }
+                        openActions()
                     }
                 )
             }
@@ -599,7 +598,7 @@ struct RootPaletteView: View {
                     KeyCapChip(text: "↵", style: .outline)
                 }
             }
-            BarButton(action: { withAnimation(Self.menuAnimation) { showActions.toggle() } }) {
+            BarButton(action: toggleActions) {
                 HStack(spacing: Theme.Spacing.sm) {
                     Text("Actions")
                         .font(Theme.Typography.bar)
@@ -629,6 +628,25 @@ struct RootPaletteView: View {
             case .command: return "Open Command"
             default: return "Open Application"
             }
+        }
+    }
+
+    /// The single path that opens the Actions menu: samples the state its rows depend on, then shows it. Callers set `vm.selection` first, so the sample matches the row the menu is for.
+    private func openActions() {
+        // Only the launcher's menu carries a Quit row, so the other modes skip the (unmemoized) `appResults` walk entirely.
+        if vm.mode == .launcher, let app = selectedAppEntry {
+            selectionIsRunning = core.runningApps.isRunning(app)
+        } else {
+            selectionIsRunning = false
+        }
+        withAnimation(Self.menuAnimation) { showActions = true }
+    }
+
+    private func toggleActions() {
+        if showActions {
+            withAnimation(Self.menuAnimation) { showActions = false }
+        } else {
+            openActions()
         }
     }
 

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -20,10 +20,17 @@ running dot and the availability of the quit actions:
 - **Quit Application** — the last row of an app's ⌘K Actions menu, shown only while that app is
   running, also bound to **⌘↵** on the selected row. `AppLauncher.quit(bundleID:)` terminates every
   instance of the bundle and reports whether anything was running; the palette only dismisses when
-  something was.
+  something was, and it restores focus unless the app it just quit *was* `previousApp`.
 - **Quit All Applications** — a `CommandRegistry` command. `AppLauncher.quitAllTargets()` is the
-  policy (every `.regular` app except Finder — `terminate()` only relaunches it — and Tinycast
-  itself); `quitAll()` terminates that list.
+  policy (every `.regular` app except Finder — `terminate()` only relaunches it — and Tinycast,
+  excluded by PID because About/Settings temporarily flips it to `.regular`). `AppCore.quitAllApps()`
+  resolves that list **once**, confirms it with an `NSAlert`, then terminates exactly what was
+  confirmed. The palette hides before the alert — it is a floating panel and would sit above it.
 
 Both quits are graceful `NSRunningApplication.terminate()`, so an app with unsaved work still puts up
 its own save sheet.
+
+The ⌘K menu samples `isRunning` **once, when it opens** (`RootPaletteView.openActions()`), so an app
+launching or quitting elsewhere can't add or drop the Quit row while the menu is up — the same freeze
+the rest of the menu already has ([palette.md](palette.md)). Only `LauncherList` observes
+`RunningAppsMonitor` live, for the running dot.


### PR DESCRIPTION
Follow-up to #34, resolving the findings from [that PR's review](https://github.com/abue-ammar/tinycast/pull/34#pullrequestreview-4789146976). Each change below links back to the thread it came from.

## Changes

**[Menu content no longer mutates while open](https://github.com/abue-ammar/tinycast/pull/34#discussion_r3658953474)** — `RootPaletteView` sampled `RunningAppsMonitor` live, so an app launching or quitting *elsewhere* could add or drop the Quit row while the ⌘K menu was up: the popover resized under the cursor and a highlight parked on that row silently became a no-op. It now samples once, on open, into `selectionIsRunning` — the same freeze the rest of the menu already has per `docs/palette.md`.

All eight menu-open sites funnel through a single `openActions()`, which is what makes "sample on open" a one-liner rather than eight. Selection can't change while a menu is up (input is frozen), so the sample stays coherent for as long as the menu lives. Non-launcher modes skip the sample entirely — theirs is the only menu with a Quit row, and `appResults` isn't memoized.

**Palette no longer re-renders on every workspace event** — dropping the `@EnvironmentObject RunningAppsMonitor` from `RootPaletteView` returns invalidation to `LauncherList` alone, which is the only thing that needs live running state (the running dot). Paired with an equality guard in `RunningAppsMonitor.refresh()`: launch/terminate fires for helpers and agents the launcher never lists, and the unconditional `Set` assign was republishing to every observer for nothing.

**⌘↵ mirrors the menu row's condition** — the key handler guarded only `isRunning`, the menu guarded `running, kind == .application`. `core.quit` re-guarded the kind, so nothing bad happened, but a running non-`.application` entry returned `.handled` and did nothing. Both now read identically, so they can't drift.

**Quit All confirms first** — an `NSAlert` in the existing `BackupActions` idiom (`NSApp.activate` first, or an accessory app's alert opens behind the frontmost app). The palette hides before the alert: it's a floating panel and would otherwise sit above it.

Two details worth the review:

- The target list is resolved **once** and both counted and terminated, so the set the user approves is exactly the set that quits. Resolving twice would race against anything launching in between.
- `hasDestructiveAction` tints the button but does **not** vacate the default slot — I checked, "Quit All" kept `keyEquivalent == "\r"`. Since this command is one ↵ away in the palette, leaving ↵ on the destructive button would have made the guard nearly worthless against a second reflexive press, so ↵ is explicitly moved to Cancel.

**Focus restoration after a quit** — `restoreFocus: false` was copied from the other commands, but the semantics differ: after `launch` the launched app takes focus, whereas after quitting a *background* app nothing does, and the user was dropped wherever macOS landed them. Now restores to `previousApp`, unless `previousApp` is the app being quit (re-fronting a dying app).

**`xmark.app` → `xmark.circle`** for the Quit All command glyph.

**`AppLauncher.quitAll()` deleted** — with `AppCore` resolving the list to count it, the loop lives there and `quitAll()` had no callers. This also settles the "extra entry point with no committed harness" note: `quitAllTargets()` is now the single, genuinely-used seam.

## Validation

- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug` — **BUILD SUCCEEDED**, no Swift warnings.
- Alert wiring verified in a standalone harness rather than by eye: `[0] Quit All | key: "" | destructive: true`, `[1] Cancel | key: "\r"`, and `.alertFirstButtonReturn` maps to Quit All. This is what caught the `hasDestructiveAction` assumption above.
- `xmark.circle` confirmed to resolve via `NSImage(systemSymbolName:)`.
- `quitAllTargets()` re-checked against this machine's live process list: 3 targets of 77 running apps, Finder and self excluded, no `.regular` app with a nil bundle ID.
- The Quit All alert path itself was not executed end-to-end — confirming it would have terminated the apps hosting the session. What's verified is the button wiring and the target list; the executor is a `terminate()` loop over exactly that list.

## Notes

No new observers, timers or escaping closures, so nothing to leak — `RunningAppsMonitor`'s existing `[weak self]` + `NotificationToken` teardown is untouched, and `selectionIsRunning` is plain `@State` on a value-type view.
