### PR TITLE
Resolve review findings from #35

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,9 @@ Never break these without an explicit task to do so.
   be withdrawn mid-flight. Consent flags live on the owning store, never in `AppSettings`
   (`SettingsBackup` mirrors that type, and an import must not grant network access). Model the gate
   so the *safe* state is the default: `CalcEngine.evaluate`'s `currency:` parameter defaults to
-  `.off`, so forgetting to pass one disables the feature rather than enabling it.
+  `.off`, so forgetting to pass one disables the feature rather than enabling it. Fetch on a private
+  **cacheless** `URLSession` (`.ephemeral`, `urlCache = nil`), never `URLSession.shared` — a cacheable
+  response would leave a second copy in the on-disk `URLCache` that opting out doesn't delete.
   `CurrencyRateStore` is the reference implementation — follow it rather than inventing a second shape.
 - **Swift 6 language mode: data-race violations are hard errors.** Almost everything is `@MainActor`;
   cross-actor model types are `Sendable`; heavy / IO work (app scan, image decode) is pushed off-main

--- a/Tinycast/Core/Calculator/CalcFormatter.swift
+++ b/Tinycast/Core/Calculator/CalcFormatter.swift
@@ -19,13 +19,12 @@ enum CalcFormatter {
 
     /// Money rounding for currency answers: two decimals, widening to four significant digits below a cent so a small cross-rate never collapses to "0.00". Deliberately not `%g` — a satoshi-scale rate must read "0.00001551", never "1.551e-05". Ungrouped; the display side wraps this in `grouped`.
     static func currency(_ value: Double) -> String {
-        let v = value == 0 ? 0 : value  // normalize -0
-        let magnitude = abs(v)
-        guard magnitude > 0, magnitude < 0.01 else { return String(format: "%.2f", v) }
-        // Below ~1e-9 even four significant digits are noise, so fall back to plain cents.
-        let decimals = 3 - Int(floor(log10(magnitude)))
-        guard decimals <= 12 else { return String(format: "%.2f", v) }
-        var text = String(format: "%.\(decimals)f", v)
+        let magnitude = abs(value)
+        // Below ~1e-9 even four significant digits are noise. Answering with a literal "0.00" also
+        // keeps a tiny negative from printing as "-0.00", which `%.2f` would happily do.
+        guard magnitude >= 1e-9 else { return "0.00" }
+        guard magnitude < 0.01 else { return String(format: "%.2f", value) }
+        var text = String(format: "%.\(3 - Int(floor(log10(magnitude))))f", value)
         while text.hasSuffix("0") { text.removeLast() }
         return text
     }

--- a/Tinycast/Core/Calculator/CurrencyData.generated.swift
+++ b/Tinycast/Core/Calculator/CurrencyData.generated.swift
@@ -306,7 +306,6 @@ enum CurrencyData {
         "reals": "BRL",
         "riel": "KHR",
         "riels": "KHR",
-        "rights": "XDR",
         "ringgit": "MYR",
         "ringgits": "MYR",
         "rufiyaa": "MVR",

--- a/Tinycast/Core/CurrencyRateStore.swift
+++ b/Tinycast/Core/CurrencyRateStore.swift
@@ -56,11 +56,15 @@ final class CurrencyRateStore: ObservableObject {
     /// otherwise sleep exactly until it expires. A failed fetch keeps the stale snapshot and retries
     /// sooner. Guard 3 — no consent, no loop, so `AppCore.start()` can call this unconditionally.
     func start() {
-        guard isEnabled, pump == nil else { return }
+        guard isEnabled else { return }
+        // Replace rather than bail on a live pump: a loop that has already exited still leaves a
+        // non-nil task behind, and a `pump == nil` guard would let that dead task block every restart.
+        pump?.cancel()
         pump = Task { [weak self] in
-            while !Task.isCancelled {
-                guard let self, self.isEnabled else { return }
-                let age = self.rates.map { Date().timeIntervalSince($0.fetchedAt) } ?? .infinity
+            while !Task.isCancelled, let self, self.isEnabled {
+                // Clamped: a snapshot stamped in the future (clock skew, an edited cache file) must
+                // not park the loop for longer than one interval.
+                let age = max(0, self.rates.map { Date().timeIntervalSince($0.fetchedAt) } ?? .infinity)
                 guard age >= Self.refreshInterval else {
                     try? await Task.sleep(for: .seconds(Self.refreshInterval - age))
                     continue
@@ -88,13 +92,13 @@ final class CurrencyRateStore: ObservableObject {
         }
     }
 
-    /// Manual "Update Now" from Settings; a no-op without consent.
-    func refreshNow() async {
-        guard isEnabled else { return }
-        await fetchAndStore()
+    /// Manual "Update Now" from Settings. Returns whether a fresh table landed, so the pane can say
+    /// the fetch failed instead of leaving the button to spring back with nothing changed.
+    func refreshNow() async -> Bool {
+        guard isEnabled else { return false }
+        return await fetchAndStore()
     }
 
-    @discardableResult
     private func fetchAndStore() async -> Bool {
         // Guard 4 — re-checked at the network boundary itself: the pump may have been sleeping when
         // the user revoked consent, and this is the last line before a request goes out.
@@ -109,11 +113,19 @@ final class CurrencyRateStore: ObservableObject {
         return true
     }
 
+    /// Deliberately not `URLSession.shared`: the provider serves the table `Cache-Control: public,
+    /// max-age=…`, so the shared session would write a second copy into the on-disk `URLCache` that
+    /// `setEnabled(false)` never deletes. Cacheless, so revoking consent really does leave nothing behind.
+    private nonisolated static let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.urlCache = nil
+        return URLSession(configuration: config)
+    }()
+
     /// Off-main by way of `URLSession`'s async API; the decoded table is a plain value, so nothing but `CurrencyRates` crosses back.
     private nonisolated static func fetch() async throws -> CurrencyRates {
-        var request = URLRequest(url: endpoint, timeoutInterval: 20)
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let request = URLRequest(url: endpoint, timeoutInterval: 20)
+        let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             throw URLError(.badServerResponse)
         }

--- a/Tinycast/Core/CurrencyRateStore.swift
+++ b/Tinycast/Core/CurrencyRateStore.swift
@@ -16,7 +16,10 @@ final class CurrencyRateStore: ObservableObject {
     static let providerURL = URL(string: "https://frankfurter.dev")!
     private nonisolated static let endpoint = URL(
         string: "https://api.frankfurter.dev/v2/rates?base=USD")!
-    static let refreshInterval: TimeInterval = 6 * 3600
+    /// Daily. The feed republishes about once a day, so asking more often just costs requests without
+    /// getting newer numbers — and the age is measured from the persisted snapshot, so relaunching
+    /// Tinycast repeatedly doesn't re-fetch.
+    static let refreshInterval: TimeInterval = 24 * 3600
     /// Shorter retry so a machine that was offline at launch picks rates up soon after it reconnects.
     private static let retryInterval: TimeInterval = 15 * 60
 

--- a/Tinycast/Features/Launcher/CalculatorCardView.swift
+++ b/Tinycast/Features/Launcher/CalculatorCardView.swift
@@ -94,7 +94,7 @@ private struct CalcColumn: View {
                 Text(badge)
                     .font(Theme.Typography.keyCap)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.75)
+                    .minimumScaleFactor(0.6)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, Theme.Spacing.sm)
                     .padding(.vertical, Theme.Spacing.xxs)

--- a/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
+++ b/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
@@ -6,6 +6,7 @@ struct MiscellaneousSettingsView: View {
     @ObservedObject private var currencyRates = AppCore.shared.currencyRates
     @State private var askingConsent = false
     @State private var refreshing = false
+    @State private var refreshFailed = false
 
     var body: some View {
         SettingsPane(
@@ -52,7 +53,8 @@ struct MiscellaneousSettingsView: View {
                         Button("Update Now") {
                             refreshing = true
                             Task {
-                                await currencyRates.refreshNow()
+                                let landed = await currencyRates.refreshNow()
+                                refreshFailed = !landed
                                 refreshing = false
                             }
                         }
@@ -94,6 +96,10 @@ struct MiscellaneousSettingsView: View {
     }
 
     private var ratesStatus: String {
+        if refreshing { return "Updating…" }
+        if refreshFailed {
+            return "Couldn't reach \(CurrencyRateStore.provider) — check your connection and try again."
+        }
         guard let fetched = currencyRates.rates?.fetchedAt else {
             return "Not downloaded yet — conversions will say so until the first update lands."
         }

--- a/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
+++ b/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
@@ -16,9 +16,7 @@ struct MiscellaneousSettingsView: View {
             SettingsCard(header: "Calculator") {
                 SettingsRow(
                     title: "Currency Conversion",
-                    subtitle:
-                        "Convert currencies inline — \"100 dollars to yen\", \"€20 to GBP\". "
-                        + "Needs exchange rates from an external service.",
+                    subtitle: conversionStatus,
                     systemImage: "dollarsign.arrow.circlepath",
                     tint: .green,
                     statusDot: currencyRates.isEnabled ? .green : nil
@@ -62,28 +60,6 @@ struct MiscellaneousSettingsView: View {
                     }
                 }
             }
-
-            if currencyRates.isEnabled {
-                SettingsCallout(
-                    title: "Rates come from \(CurrencyRateStore.provider).",
-                    message:
-                        "Tinycast requests the published rate table roughly every six hours and "
-                        + "caches it locally. The request carries nothing about you or what you type.",
-                    systemImage: "network",
-                    tint: .green
-                ) {
-                    Link("Learn More", destination: CurrencyRateStore.providerURL)
-                }
-            } else {
-                SettingsCallout(
-                    title: "Currency conversion is off.",
-                    message:
-                        "Tinycast won't contact the exchange-rate service until you turn this on, "
-                        + "and the calculator simply won't answer currency questions.",
-                    systemImage: "wifi.slash",
-                    tint: .secondary
-                )
-            }
         }
         .sheet(isPresented: $askingConsent) {
             CurrencyConsentSheet(
@@ -95,21 +71,26 @@ struct MiscellaneousSettingsView: View {
         }
     }
 
+    /// Carries the off-state promise that used to need its own callout: nothing is contacted until
+    /// the switch is on.
+    private var conversionStatus: String {
+        let examples = "Convert inline — \"100 dollars to yen\", \"€20 to GBP\"."
+        return currencyRates.isEnabled ? examples : "\(examples) Off — no service is contacted."
+    }
+
     private var ratesStatus: String {
         if refreshing { return "Updating…" }
-        if refreshFailed {
-            return "Couldn't reach \(CurrencyRateStore.provider) — check your connection and try again."
-        }
+        if refreshFailed { return "Couldn't reach \(CurrencyRateStore.provider). Try again." }
         guard let fetched = currencyRates.rates?.fetchedAt else {
-            return "Not downloaded yet — conversions will say so until the first update lands."
+            return "\(CurrencyRateStore.provider) · not downloaded yet."
         }
         let stamp = fetched.formatted(date: .abbreviated, time: .shortened)
-        return "Last updated \(stamp). Refreshes automatically every six hours."
+        return "\(CurrencyRateStore.provider) · updated \(stamp). Refreshes daily."
     }
 }
 
-/// The consent step. Spells out what enabling actually does — which service is contacted, how often,
-/// what leaves the machine — and links to the provider so the claim is checkable before agreeing.
+/// The consent step. Three facts are the ones that actually decide the answer — who is contacted, how
+/// often, and that nothing personal goes with it — plus the provider link so the claim is checkable.
 private struct CurrencyConsentSheet: View {
     let onCancel: () -> Void
     let onAccept: () -> Void
@@ -120,36 +101,18 @@ private struct CurrencyConsentSheet: View {
                 Image(systemName: "network")
                     .font(.system(size: 22, weight: .medium))
                     .foregroundStyle(.green)
-                VStack(alignment: .leading, spacing: Theme.Spacing.xs / 2) {
-                    Text("Turn on currency conversion?")
-                        .font(.headline)
-                    Text("It needs an internet connection to fetch exchange rates.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                Text("Turn on currency conversion?")
+                    .font(.headline)
             }
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
-                ConsentPoint(
-                    systemImage: "arrow.down.circle",
-                    text:
-                        "Tinycast will download exchange rates from \(CurrencyRateStore.provider), "
-                        + "an open-source service that publishes rates from central banks.")
-                ConsentPoint(
-                    systemImage: "clock",
-                    text:
-                        "It asks for the published rate table about every six hours while Tinycast "
-                        + "is running, and keeps a copy on your Mac so it still answers offline.")
-                ConsentPoint(
-                    systemImage: "eye.slash",
-                    text:
-                        "The request contains no account, no identifier, and nothing you type into "
-                        + "the calculator — the whole table is fetched and the maths happens locally.")
-                ConsentPoint(
-                    systemImage: "arrow.uturn.backward",
-                    text:
-                        "Turning this off later stops all requests and deletes the cached rates.")
-            }
+            Text(
+                "Tinycast downloads exchange rates from \(CurrencyRateStore.provider) once a day and "
+                + "keeps a copy on your Mac. No account, no identifiers, nothing you type. "
+                + "Turning it off deletes the cached rates."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
 
             HStack(spacing: Theme.Spacing.lg) {
                 Link(destination: CurrencyRateStore.providerURL) {
@@ -167,26 +130,6 @@ private struct CurrencyConsentSheet: View {
             }
         }
         .padding(Theme.Spacing.xxl)
-        .frame(width: 460)
-    }
-}
-
-/// One bullet in the consent sheet: symbol plus a line of plain-language explanation.
-private struct ConsentPoint: View {
-    let systemImage: String
-    let text: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: Theme.Spacing.lg) {
-            Image(systemName: systemImage)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.secondary)
-                .frame(width: Theme.Size.settingsRowIcon)
-            Text(text)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-        }
+        .frame(width: 420)
     }
 }

--- a/Tools/calc-test.swift
+++ b/Tools/calc-test.swift
@@ -281,6 +281,12 @@ struct CalcTests {
         // Slang is no longer carried: CLDR has no "quid", and we don't hand-maintain synonyms
         expectNil("50 quid to usd")
         expectNil("100 bucks to eur")
+        // The last word of a name isn't always its noun — "Special Drawing Rights" is not a "rights"
+        expectNil("1 rights to usd")
+        // A result too small to show at all reads as a clean zero, never "-0.00"
+        expectDisplay("-0.0000000000001 usd to eur", "0.00 EUR")
+        expectDisplay("0 usd to eur", "0.00 EUR")
+        expectDisplay("-5 usd to eur", "-4.60 EUR")
         // CUP (Cuban peso) is a generated code that collides with a unit; volume still wins
         expectDisplay("1 cup to ml", "236.5882365 mL")
         expectDisplay("1 cup to tbsp", "16 tbsp")

--- a/Tools/gen-currencies.js
+++ b/Tools/gen-currencies.js
@@ -44,6 +44,10 @@ const isSign = (s) => [...s].length === 1 && !/[\p{L}\p{N}]/u.test(s);
 // Capitalise each word without touching the rest, so "UAE dirham" survives as "UAE Dirham".
 const titleCase = (s) => s.replace(/(^|[\s(])(\p{Ll})/gu, (_, lead, c) => lead + c.toUpperCase());
 
+// The noun is taken as the last word of the name, which only fails where that word isn't a noun for
+// the money itself: nobody asks to convert "1 rights". Naming the exceptions beats parsing grammar.
+const NOT_NOUNS = new Set(["rights"]);
+
 /// The card's badge is a small pill, so prefer whichever CLDR form is shorter: `displayName` is the
 /// title-cased label ("US Dollar"), but for a few currencies the singular is far tighter
 /// ("United Arab Emirates Dirham" vs "UAE dirham").
@@ -110,7 +114,7 @@ async function main() {
     // both as written and folded, so "krónur" and "kronur" both resolve without a US keyboard.
     for (const field of ["displayName-count-one", "displayName-count-other"]) {
       const word = (cldrEntry[field] || "").toLowerCase().split(/\s+/).filter(Boolean).pop() || "";
-      if (word.length < 3 || !/^\p{L}+$/u.test(word)) continue;
+      if (word.length < 3 || !/^\p{L}+$/u.test(word) || NOT_NOUNS.has(word)) continue;
       for (const form of new Set([word, fold(word), fold(word).replace(/[^a-z]/g, "")]))
         if (form.length >= 3) claim(wordClaims, form, code);
     }

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -39,11 +39,13 @@ sources on the ISO code and emits `CurrencyData.generated.swift`:
   Read from the pinned `cldr-json` checkout, not the host's `Intl`, whose output shifts with the
   local ICU version.
 
-Only *unambiguous* CLDR data is emitted — 26 signs and 129 nouns. CLDR itself supplies the sign
+Only *unambiguous* CLDR data is emitted — 26 signs and 128 nouns. CLDR itself supplies the sign
 tie-break: it writes every dollar but USD as `CA$`/`A$`/`NT$`, so plain `$` is claimed by exactly one
 currency. Bare Latin letters CLDR lists as symbols (`P` for BWP, `L` for HNL) are dropped, since a
 letter is indistinguishable from a word to the tokenizer. Accented nouns are emitted both as written
-and folded, so `krónur` and `kronur` both resolve.
+and folded, so `krónur` and `kronur` both resolve. The noun itself is the name's last word, which is
+only wrong where that word isn't one — `NOT_NOUNS` in the generator drops those ("Special Drawing
+Rights" is not a "rights").
 
 What's left hand-written in `CalcCurrency.swift` is one table, `contested`: the nouns several
 currencies share, where CLDR correctly refuses to choose and the calculator must. `dollars` is
@@ -81,6 +83,11 @@ can be withdrawn while a response is in flight. Revoking cancels the loop, drops
 deletes the cached file. The flag lives on the store, deliberately *not* in `AppSettings`:
 `SettingsBackup` mirrors that type field-for-field, and importing a config must never be able to
 grant network access.
+
+For "revoking deletes the rates" to be true there has to be exactly one copy, so the fetch runs on a
+private **cacheless** `URLSession` (`.ephemeral`, `urlCache = nil`) rather than `URLSession.shared`.
+The provider serves the table `Cache-Control: public, max-age=…`, so the shared session would store a
+second copy in the on-disk `URLCache` that deleting `currency-rates.json` doesn't touch.
 
 Rates come from `CurrencyRateStore` (`Core/`, owned by `AppCore`), which reads
 [Frankfurter](https://frankfurter.dev) — open source, no key, no account, no quota, rates blended

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -95,8 +95,11 @@ from 84 central banks. One `GET api.frankfurter.dev/v2/rates?base=USD`, ~1.4 KB 
 with one flat `{date, base, quote, rate}` row per pair rather than a keyed table, and omits the
 base's own row — the store folds both into the `[code: rate]` shape `CurrencyRates` stores.
 
-The table is cached at `~/Library/Caches/<bundle-id>/currency-rates.json`, refreshed every 6h with a
-15-minute retry after a failure. Offline, the last snapshot keeps answering; with no snapshot at all
+The table is cached at `~/Library/Caches/<bundle-id>/currency-rates.json`, refreshed every 24h with a
+15-minute retry after a failure. The feed republishes about once a day, so a tighter interval would
+cost requests without returning newer numbers. Age is measured from the persisted `fetchedAt`, not
+from launch, so relaunching Tinycast never re-fetches a snapshot that is still fresh — a cold start
+with a same-day cache makes zero requests. Offline, the last snapshot keeps answering; with no snapshot at all
 the card says so rather than guessing, and a currency the feed doesn't quote reports
 `No exchange rate for <CODE>.` The store hands `CalcEngine.evaluate` a finished `CurrencyRates`
 value — the engine never fetches, which is what keeps it Foundation-only and testable. `CalcMemo`


### PR DESCRIPTION
Follow-up to #35. Seven findings from the review, all verified against the merged code.

## The one that matters

**The rate table survived being turned off.** `CurrencyRateStore` fetched on `URLSession.shared`, and the provider serves the table cacheably:

```
cache-control: public, max-age=25187, stale-if-error=86400
```

`request.cachePolicy = .reloadIgnoringLocalCacheData` governs cache *reads*, not *writes*, so the shared session stored a second copy in the disk-backed `URLCache` under `~/Library/Caches/<bundle-id>/`. `setEnabled(false)` only removed `currency-rates.json`, leaving that copy behind — while the consent sheet promises "Turning this off later stops all requests and deletes the cached rates."

Fixed with a private cacheless session, so there is exactly one copy to delete:

```swift
private nonisolated static let session: URLSession = {
    let config = URLSessionConfiguration.ephemeral
    config.urlCache = nil
    return URLSession(configuration: config)
}()
```

The request's `cachePolicy` line goes away with it — with no cache attached it was dead code. Recorded as an invariant in `CLAUDE.md` alongside the rest of the consent rules, since it generalises to any future networked feature.

## Store

- **"Update Now" swallowed every failure.** `refreshNow()` discarded `fetchAndStore()`'s `Bool`; clicking it offline just re-enabled the button with the status line unchanged. It now returns that `Bool` and the pane says `Couldn't reach Frankfurter — check your connection and try again.`, plus an `Updating…` state while in flight.
- **`start()` could be blocked by a dead pump.** The loop's `guard let self, self.isEnabled else { return }` exits without clearing `pump`, and the old `pump == nil` guard would then refuse every restart. Cancel-and-replace instead — one fewer guard clause and no reachable-only-by-accident invariant. The loop condition folds into `while !Task.isCancelled, let self, self.isEnabled`.
- **Negative snapshot age parked the loop.** A `fetchedAt` in the future (clock skew, an edited cache file) made the loop sleep `refreshInterval - age`, i.e. longer than one interval, unbounded. Clamped with `max(0, …)`.

## Engine, generator, card

- **`-0.00`.** `CalcFormatter.currency` fell back to `%.2f` below ~1e-9 without re-normalising the sign, so `-0.0000000000001 usd to eur` rendered `-0.00 EUR`. Returns a literal `"0.00"` there instead. The `decimals <= 12` guard collapses into the same threshold expressed directly (`magnitude >= 1e-9` — algebraically identical), which also retires the separate `-0` normalisation.
- **Junk alias `rights` → XDR**, from taking the last word of "Special Drawing Rights". Added `NOT_NOUNS` to `gen-currencies.js` and **re-ran the generator** rather than hand-editing the file — output is otherwise byte-identical (165 currencies, 26 signs, 128 aliases), confirming reproducibility.
- **Badge truncation.** The badge used `minimumScaleFactor(0.75)` under a value line using `0.6`; "Bosnia-Herzegovina Convertible Mark" ellipsized in a half-width column. Matched to `0.6`.

## Not addressed

The review also noted there's **no staleness cue on the answer card** — offline for a week, the palette answers from a week-old snapshot indistinguishably from a live one, and only Settings shows the age. That's a product/visual decision about the card's design rather than a defect, and #35 deliberately chose "keep answering offline", so I've left it for a separate call.

## Verification

- `swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift` → **248 passed, 0 failed** (4 new: `rights` no longer resolves; the `-0.00`, zero and ordinary-negative money paths).
- `xcodebuild -scheme Tinycast -configuration Debug` → clean, no new warnings.
- `node Tools/gen-currencies.js` re-run; `xcodegen generate` produces no diff.