### PR TITLE
feat: support side-specific hotkey modifiers

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		B1B3F5715BE7A092F0CEFA09 /* ClipboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76E4099082D59FA686C3485 /* ClipboardManager.swift */; };
 		B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */; };
 		BA76E53A12248B3A9C42B4F9 /* Bundle+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */; };
+		BE85B09CE8F35DBC976A66F9 /* SideHotKeyMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE99374FEBCF09B625A8DAF8 /* SideHotKeyMatcher.swift */; };
 		C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37CCD024267EB21876C7E9 /* AppDelegate.swift */; };
 		C7DD1345A6BFB1D9EB22FCEE /* RunningApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B432D84D8F9C10521342199 /* RunningApps.swift */; };
 		C8F4555ECA895F63A34A327C /* EmojiGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */; };
@@ -158,6 +159,7 @@
 		D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppName.swift"; sourceTree = "<group>"; };
 		D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
 		DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridGeometry.swift; sourceTree = "<group>"; };
+		DE99374FEBCF09B625A8DAF8 /* SideHotKeyMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideHotKeyMatcher.swift; sourceTree = "<group>"; };
 		E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateTime.swift; sourceTree = "<group>"; };
 		EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		EDE0C0DC05F958A4B4DCAA8C /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 				C6DC5A4706854493D23FD18A /* HyperKey.swift */,
 				919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */,
 				2C3EB07C07902C53BFD3B08B /* KeyShortcut.swift */,
+				DE99374FEBCF09B625A8DAF8 /* SideHotKeyMatcher.swift */,
 			);
 			path = HotKey;
 			sourceTree = "<group>";
@@ -518,6 +521,7 @@
 				CFB516312C4694DDFD99DBCA /* SettingsRootView.swift in Sources */,
 				57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */,
 				05561CD36EF1A0775A282165 /* ShortcutsSettingsView.swift in Sources */,
+				BE85B09CE8F35DBC976A66F9 /* SideHotKeyMatcher.swift in Sources */,
 				72ACD144841BF1117CD4E705 /* Theme.swift in Sources */,
 				85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */,
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,

--- a/Tinycast/Core/HotKey/KeyShortcut.swift
+++ b/Tinycast/Core/HotKey/KeyShortcut.swift
@@ -5,24 +5,39 @@ import Carbon.HIToolbox
 struct KeyShortcut: Hashable, Sendable {
     let carbonKeyCode: Int
     let carbonModifiers: Int
+    let sideModifiers: SideModifierRequirement?
 
-    init(carbonKeyCode: Int, carbonModifiers: Int) {
+    init(
+        carbonKeyCode: Int, carbonModifiers: Int,
+        sideModifiers: SideModifierRequirement? = nil
+    ) {
         self.carbonKeyCode = carbonKeyCode
         // Mask to the four real modifiers so equality (and conflict detection) isn't thrown off by device-dependent bits older builds may have stored.
         self.carbonModifiers = carbonModifiers & Self.allModifiers
+        self.sideModifiers = sideModifiers
     }
 
     /// Captures a shortcut from a key-down event, or `nil` if unbindable: a global hotkey needs one of ⌘⌥⌃ (⇧ alone shadows typing), except function keys which are fine standalone.
-    init?(keyCode: Int, modifierFlags: NSEvent.ModifierFlags) {
+    init?(
+        keyCode: Int, modifierFlags: NSEvent.ModifierFlags,
+        sideModifiers: SideModifierRequirement? = nil
+    ) {
         let flags = modifierFlags.intersection([.command, .option, .control, .shift])
         let hasCommandingModifier = !flags.isDisjoint(with: [.command, .option, .control])
         guard hasCommandingModifier || Self.isFunctionKey(keyCode) else { return nil }
-        self.init(carbonKeyCode: keyCode, carbonModifiers: Self.carbonModifiers(from: flags))
+        guard sideModifiers?.modifierFlags.isSubset(of: flags) ?? true else { return nil }
+        self.init(
+            carbonKeyCode: keyCode,
+            carbonModifiers: Self.carbonModifiers(from: flags),
+            sideModifiers: sideModifiers
+        )
     }
 
     /// One string per keycap in canonical macOS order (⌃⌥⇧⌘) with the key glyph last, feeding the launcher rows and settings recorder.
     @MainActor var keycaps: [String] {
-        Self.collapsedModifierSymbols(from: modifierFlags) + [keyGlyph]
+        (sideModifiers == nil
+            ? Self.collapsedModifierSymbols(from: modifierFlags)
+            : Self.modifierSymbols(from: modifierFlags, sideModifiers: sideModifiers)) + [keyGlyph]
     }
 
     var modifierFlags: NSEvent.ModifierFlags {
@@ -60,12 +75,32 @@ struct KeyShortcut: Hashable, Sendable {
 
     /// Modifier symbols in the fixed ⌃⌥⇧⌘ order every macOS surface uses.
     static func modifierSymbols(from flags: NSEvent.ModifierFlags) -> [String] {
+        modifierSymbols(from: flags, sideModifiers: nil)
+    }
+
+    static func modifierSymbols(
+        from flags: NSEvent.ModifierFlags, sideModifiers: SideModifierRequirement?
+    ) -> [String] {
         var symbols: [String] = []
-        if flags.contains(.control) { symbols.append("⌃") }
-        if flags.contains(.option) { symbols.append("⌥") }
-        if flags.contains(.shift) { symbols.append("⇧") }
-        if flags.contains(.command) { symbols.append("⌘") }
+        for (flag, symbol) in [
+            (NSEvent.ModifierFlags.control, "⌃"),
+            (.option, "⌥"),
+            (.shift, "⇧"),
+            (.command, "⌘"),
+        ] where flags.contains(flag) {
+            let sideSymbols = sideModifiers?.symbols(for: flag) ?? []
+            symbols += sideSymbols.isEmpty ? [symbol] : sideSymbols
+        }
         return symbols
+    }
+
+    func conflicts(with other: KeyShortcut) -> Bool {
+        guard
+            carbonKeyCode == other.carbonKeyCode,
+            carbonModifiers == other.carbonModifiers
+        else { return false }
+        guard let sideModifiers, let otherSideModifiers = other.sideModifiers else { return true }
+        return sideModifiers == otherSideModifiers
     }
 
     static func isFunctionKey(_ keyCode: Int) -> Bool {
@@ -133,15 +168,24 @@ struct KeyShortcut: Hashable, Sendable {
 // Decoding routes through the masking initializer; the encoded shape stays byte-compatible with the legacy `{"carbonKeyCode":N,"carbonModifiers":N}` records.
 extension KeyShortcut: Codable {
     private enum CodingKeys: String, CodingKey {
-        case carbonKeyCode, carbonModifiers
+        case carbonKeyCode, carbonModifiers, sideModifiers
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
             carbonKeyCode: try container.decode(Int.self, forKey: .carbonKeyCode),
-            carbonModifiers: try container.decode(Int.self, forKey: .carbonModifiers)
+            carbonModifiers: try container.decode(Int.self, forKey: .carbonModifiers),
+            sideModifiers: try container.decodeIfPresent(
+                SideModifierRequirement.self, forKey: .sideModifiers)
         )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(carbonKeyCode, forKey: .carbonKeyCode)
+        try container.encode(carbonModifiers, forKey: .carbonModifiers)
+        try container.encodeIfPresent(sideModifiers, forKey: .sideModifiers)
     }
 }
 

--- a/Tinycast/Core/HotKey/SideHotKeyMatcher.swift
+++ b/Tinycast/Core/HotKey/SideHotKeyMatcher.swift
@@ -1,0 +1,258 @@
+import AppKit
+import Carbon.HIToolbox
+
+enum SideModifier: String, CaseIterable, Codable, Hashable, Sendable {
+    case leftControl, rightControl
+    case leftOption, rightOption
+    case leftShift, rightShift
+    case leftCommand, rightCommand
+
+    init?(keyCode: Int) {
+        switch keyCode {
+        case kVK_Control: self = .leftControl
+        case kVK_RightControl: self = .rightControl
+        case kVK_Option: self = .leftOption
+        case kVK_RightOption: self = .rightOption
+        case kVK_Shift: self = .leftShift
+        case kVK_RightShift: self = .rightShift
+        case kVK_Command: self = .leftCommand
+        case kVK_RightCommand: self = .rightCommand
+        default: return nil
+        }
+    }
+
+    var modifierFlag: NSEvent.ModifierFlags {
+        switch self {
+        case .leftControl, .rightControl: .control
+        case .leftOption, .rightOption: .option
+        case .leftShift, .rightShift: .shift
+        case .leftCommand, .rightCommand: .command
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .leftControl: "L⌃"
+        case .rightControl: "R⌃"
+        case .leftOption: "L⌥"
+        case .rightOption: "R⌥"
+        case .leftShift: "L⇧"
+        case .rightShift: "R⇧"
+        case .leftCommand: "L⌘"
+        case .rightCommand: "R⌘"
+        }
+    }
+}
+
+struct SideModifierRequirement: Hashable, Codable, Sendable {
+    let modifiers: Set<SideModifier>
+
+    init(_ modifiers: Set<SideModifier>) {
+        self.modifiers = modifiers
+    }
+
+    var modifierFlags: NSEvent.ModifierFlags {
+        modifiers.reduce(into: []) { $0.insert($1.modifierFlag) }
+    }
+
+    func symbols(for flag: NSEvent.ModifierFlags) -> [String] {
+        SideModifier.allCases
+            .filter { modifiers.contains($0) && $0.modifierFlag == flag }
+            .map(\.symbol)
+    }
+}
+
+struct SideModifierState: Sendable {
+    private(set) var pressedModifiers: Set<SideModifier> = []
+
+    mutating func handleFlagsChanged(keyCode: Int) {
+        guard let modifier = SideModifier(keyCode: keyCode) else { return }
+        if pressedModifiers.contains(modifier) {
+            pressedModifiers.remove(modifier)
+        } else {
+            pressedModifiers.insert(modifier)
+        }
+    }
+
+    mutating func reset() {
+        pressedModifiers = []
+    }
+}
+
+private func sideHotKeyEventTapCallback(
+    _: CGEventTapProxy, type: CGEventType, event: CGEvent, userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard let userInfo else { return Unmanaged.passUnretained(event) }
+    let matcher = Unmanaged<SideHotKeyMatcher>.fromOpaque(userInfo).takeUnretainedValue()
+    let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+    let flagsRaw = event.flags.rawValue
+    MainActor.assumeIsolated { matcher.handle(type: type, keyCode: keyCode, flagsRaw: flagsRaw) }
+    return Unmanaged.passUnretained(event)
+}
+
+@MainActor
+final class SideHotKeyMatcher {
+    private struct Entry {
+        let shortcut: KeyShortcut
+        let onKeyDown: () -> Void
+    }
+
+    private var entries: [String: Entry] = [:]
+    private var state = SideModifierState()
+    private var tapPort: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var healthTimer: Timer?
+    private var started = false
+    private var sessionTokens: [NotificationToken] = []
+
+    var isPaused = false {
+        didSet {
+            if isPaused { state.reset() }
+        }
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+        let center = NSWorkspace.shared.notificationCenter
+        sessionTokens = [
+            NotificationToken(
+                center.addObserver(
+                    forName: NSWorkspace.sessionDidResignActiveNotification, object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.sessionDidResign() }
+                }, center: center),
+            NotificationToken(
+                center.addObserver(
+                    forName: NSWorkspace.sessionDidBecomeActiveNotification, object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.sessionDidBecomeActive() }
+                }, center: center),
+        ]
+        syncTapPresence()
+    }
+
+    func register(id: String, shortcut: KeyShortcut, onKeyDown: @escaping () -> Void) {
+        entries[id] = Entry(shortcut: shortcut, onKeyDown: onKeyDown)
+        syncTapPresence()
+    }
+
+    func unregister(id: String) {
+        entries.removeValue(forKey: id)
+        syncTapPresence()
+    }
+
+    fileprivate func handle(type: CGEventType, keyCode: Int, flagsRaw: UInt64) {
+        switch type {
+        case .tapDisabledByTimeout, .tapDisabledByUserInput:
+            state.reset()
+            if let tapPort { CGEvent.tapEnable(tap: tapPort, enable: true) }
+        case .flagsChanged:
+            state.handleFlagsChanged(keyCode: keyCode)
+        case .keyDown:
+            guard !isPaused else { return }
+            for entry in entries.values
+            where Self.matches(
+                entry.shortcut,
+                keyCode: keyCode,
+                modifierFlags: Self.modifierFlags(from: CGEventFlags(rawValue: flagsRaw)),
+                pressedModifiers: state.pressedModifiers
+            ) {
+                entry.onKeyDown()
+            }
+        default:
+            break
+        }
+    }
+
+    static func matches(
+        _ shortcut: KeyShortcut, keyCode: Int, modifierFlags: NSEvent.ModifierFlags,
+        pressedModifiers: Set<SideModifier>
+    ) -> Bool {
+        guard
+            shortcut.carbonKeyCode == keyCode,
+            shortcut.carbonModifiers == KeyShortcut.carbonModifiers(from: modifierFlags),
+            let requirements = shortcut.sideModifiers
+        else { return false }
+        return pressedModifiers == requirements.modifiers
+    }
+
+    private static func modifierFlags(from flags: CGEventFlags) -> NSEvent.ModifierFlags {
+        var result: NSEvent.ModifierFlags = []
+        if flags.contains(.maskControl) { result.insert(.control) }
+        if flags.contains(.maskAlternate) { result.insert(.option) }
+        if flags.contains(.maskShift) { result.insert(.shift) }
+        if flags.contains(.maskCommand) { result.insert(.command) }
+        return result
+    }
+
+    private func installTapIfNeeded() {
+        guard started, !entries.isEmpty, tapPort == nil else { return }
+        let mask: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.flagsChanged.rawValue)
+        guard let port = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: mask,
+            callback: sideHotKeyEventTapCallback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else { return }
+        tapPort = port
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0)
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+    }
+
+    private func startHealthTimer() {
+        guard healthTimer == nil else { return }
+        healthTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.installTapIfNeeded() }
+        }
+    }
+
+    private func syncTapPresence() {
+        guard started, !entries.isEmpty else {
+            stopHealthTimer()
+            tearDownTap()
+            return
+        }
+        startHealthTimer()
+        installTapIfNeeded()
+    }
+
+    private func stopHealthTimer() {
+        healthTimer?.invalidate()
+        healthTimer = nil
+    }
+
+    private func tearDownTap() {
+        state.reset()
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+            self.runLoopSource = nil
+        }
+        if let tapPort {
+            CGEvent.tapEnable(tap: tapPort, enable: false)
+            CFMachPortInvalidate(tapPort)
+            self.tapPort = nil
+        }
+    }
+
+    private func sessionDidResign() {
+        state.reset()
+        if let tapPort { CGEvent.tapEnable(tap: tapPort, enable: false) }
+    }
+
+    private func sessionDidBecomeActive() {
+        state.reset()
+        if let tapPort {
+            CGEvent.tapEnable(tap: tapPort, enable: true)
+        } else {
+            installTapIfNeeded()
+        }
+    }
+}

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -9,14 +9,19 @@ final class HotKeyManager: ObservableObject {
 
     /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses Carbon so the typed combo can't fire a hotkey.
     @Published var recordingAction: HotKeyAction? {
-        didSet { center.isPaused = recordingAction != nil }
+        didSet {
+            center.isPaused = recordingAction != nil
+            sideMatcher.isPaused = recordingAction != nil
+        }
     }
 
     private let center = HotKeyCenter()
+    private let sideMatcher = SideHotKeyMatcher()
     private let boundKey = "boundAppBundleIDs"
     private let boundPaneKey = "boundPaneBundleIDs"
 
     func start() {
+        sideMatcher.start()
         register(.togglePalette)
         register(.toggleClipboard)
         register(.toggleEmoji)
@@ -46,6 +51,7 @@ final class HotKeyManager: ObservableObject {
     /// Persists (or clears, when `nil`) the binding, swaps the live Carbon registration, and publishes so the launcher and recorders re-render.
     func setShortcut(_ shortcut: KeyShortcut?, for action: HotKeyAction) {
         objectWillChange.send()
+        if shortcut?.sideModifiers != nil { Permissions.ensureAccessibility() }
         if let shortcut,
             let data = try? JSONEncoder().encode(shortcut),
             let json = String(data: data, encoding: .utf8)
@@ -55,6 +61,7 @@ final class HotKeyManager: ObservableObject {
         } else {
             UserDefaults.standard.removeObject(forKey: action.defaultsKey)
             center.unregister(id: action.defaultsKey)
+            sideMatcher.unregister(id: action.defaultsKey)
         }
         switch action {
         case .app(let bundleID):
@@ -76,7 +83,7 @@ final class HotKeyManager: ObservableObject {
         candidates += boundBundleIDs.map { .app(bundleID: $0) }
         candidates += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
         for candidate in candidates
-        where candidate != action && self.shortcut(for: candidate) == shortcut {
+        where candidate != action && self.shortcut(for: candidate)?.conflicts(with: shortcut) == true {
             return displayName(of: candidate)
         }
         return nil
@@ -103,8 +110,15 @@ final class HotKeyManager: ObservableObject {
 
     private func register(_ action: HotKeyAction) {
         guard let shortcut = shortcut(for: action) else { return }
-        center.register(id: action.defaultsKey, shortcut: shortcut) { [weak self] in
+        center.unregister(id: action.defaultsKey)
+        sideMatcher.unregister(id: action.defaultsKey)
+        let handler: () -> Void = { [weak self] in
             self?.perform(action)
+        }
+        if shortcut.sideModifiers == nil {
+            center.register(id: action.defaultsKey, shortcut: shortcut, onKeyDown: handler)
+        } else {
+            sideMatcher.register(id: action.defaultsKey, shortcut: shortcut, onKeyDown: handler)
         }
     }
 

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -66,7 +66,14 @@ struct ShortcutRecorder: View {
                     .foregroundStyle(.orange)
             } else if !session.heldModifiers.isEmpty {
                 // Collapsed so holding the Hyper key previews as "✦" while recording.
-                Text(KeyShortcut.collapsedModifierSymbols(from: session.heldModifiers).joined())
+                Text(
+                    KeyShortcut.modifierSymbols(
+                        from: session.heldModifiers,
+                        sideModifiers: session.heldSideModifiers.isEmpty
+                            ? nil
+                            : SideModifierRequirement(session.heldSideModifiers)
+                    ).joined()
+                )
                     .foregroundStyle(.primary)
             } else {
                 Text("Type shortcut…")
@@ -113,6 +120,7 @@ struct ShortcutRecorder: View {
 private final class CaptureSession: ObservableObject {
     /// Modifiers currently held, for the live "⌃⌥…" preview while recording.
     @Published var heldModifiers: NSEvent.ModifierFlags = []
+    @Published var heldSideModifiers: Set<SideModifier> = []
     /// Owner of a just-typed conflicting combo; shown for a moment, then recording resumes.
     @Published var conflictOwner: String?
 
@@ -123,6 +131,7 @@ private final class CaptureSession: ObservableObject {
     func start(action: HotKeyAction, hotKeys: HotKeyManager) {
         stop()
         heldModifiers = NSEvent.modifierFlags.intersection([.command, .option, .control, .shift])
+        heldSideModifiers = []
 
         // The handlers run on the main thread but AppKit predates actor annotations, hence assumeIsolated; only Sendable event pieces (key code, flags) cross in.
         if let monitor = NSEvent.addLocalMonitorForEvents(
@@ -147,7 +156,18 @@ private final class CaptureSession: ObservableObject {
             handler: {
                 [weak self] event in
                 let flags = event.modifierFlags.intersection([.command, .option, .control, .shift])
-                MainActor.assumeIsolated { self?.heldModifiers = flags }
+                let keyCode = Int(event.keyCode)
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.heldModifiers = flags
+                    if let modifier = SideModifier(keyCode: keyCode) {
+                        if self.heldSideModifiers.contains(modifier) {
+                            self.heldSideModifiers.remove(modifier)
+                        } else {
+                            self.heldSideModifiers.insert(modifier)
+                        }
+                    }
+                }
                 return event
             })
         {
@@ -184,6 +204,7 @@ private final class CaptureSession: ObservableObject {
         conflictReset = nil
         conflictOwner = nil
         heldModifiers = []
+        heldSideModifiers = []
     }
 
     private func handleKeyDown(
@@ -202,7 +223,12 @@ private final class CaptureSession: ObservableObject {
             return
         }
         // Not a bindable combo (e.g. a bare letter): swallow it and keep recording.
-        guard let shortcut = KeyShortcut(keyCode: keyCode, modifierFlags: flags) else { return }
+        let sideModifiers = heldSideModifiers.isEmpty
+            ? nil
+            : SideModifierRequirement(heldSideModifiers)
+        guard let shortcut = KeyShortcut(
+            keyCode: keyCode, modifierFlags: flags, sideModifiers: sideModifiers
+        ) else { return }
 
         if let owner = hotKeys.conflictOwner(of: shortcut, excluding: action) {
             flashConflict(owner)

--- a/Tools/hotkey-test.swift
+++ b/Tools/hotkey-test.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Carbon.HIToolbox
+
+@MainActor
+final class AppCore {
+    static let shared = AppCore()
+    let settings = AppSettings()
+}
+
+@MainActor
+final class AppSettings {
+    var hyperKey: HyperKeyPhysicalKey = .none
+    var hyperKeyReplacesGlyph = false
+    var hyperKeyIncludesShift = false
+}
+
+enum HyperKeyPhysicalKey {
+    case none
+
+    static let hyperGlyph = "✦"
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else { fatalError(message) }
+}
+
+@main
+struct HotKeyTest {
+    static func main() throws {
+        let legacyJSON = #"{"carbonKeyCode":12,"carbonModifiers":256}"#
+        let legacy = try JSONDecoder().decode(KeyShortcut.self, from: Data(legacyJSON.utf8))
+        expect(legacy == KeyShortcut(carbonKeyCode: 12, carbonModifiers: cmdKey), "legacy equality")
+        let reencoded = try JSONEncoder().encode(legacy)
+        let legacyObject = try JSONSerialization.jsonObject(with: reencoded) as? [String: Int]
+        expect(
+            legacyObject == ["carbonKeyCode": 12, "carbonModifiers": cmdKey],
+            "legacy encoding"
+        )
+
+        let leftCommand = KeyShortcut(
+            carbonKeyCode: 12,
+            carbonModifiers: cmdKey,
+            sideModifiers: .init([.leftCommand])
+        )
+        let rightCommand = KeyShortcut(
+            carbonKeyCode: 12,
+            carbonModifiers: cmdKey,
+            sideModifiers: .init([.rightCommand])
+        )
+        expect(legacy.conflicts(with: leftCommand), "legacy conflicts with side-aware")
+        expect(leftCommand.conflicts(with: leftCommand), "same side conflicts")
+        expect(!leftCommand.conflicts(with: rightCommand), "opposite sides are distinct")
+
+        var state = SideModifierState()
+        state.handleFlagsChanged(keyCode: kVK_Command)
+        expect(
+            SideHotKeyMatcher.matches(
+                leftCommand,
+                keyCode: 12,
+                modifierFlags: [.command],
+                pressedModifiers: state.pressedModifiers),
+            "left modifier matches"
+        )
+        state.handleFlagsChanged(keyCode: kVK_Command)
+        expect(state.pressedModifiers.isEmpty, "modifier release clears state")
+        expect(
+            !SideHotKeyMatcher.matches(
+                leftCommand,
+                keyCode: 12,
+                modifierFlags: [.command],
+                pressedModifiers: state.pressedModifiers),
+            "released modifier does not match"
+        )
+        state.handleFlagsChanged(keyCode: kVK_RightCommand)
+        state.reset()
+        expect(state.pressedModifiers.isEmpty, "reset clears stale modifier state")
+    }
+}


### PR DESCRIPTION
## Summary

Adds side-specific global hotkey modifiers while preserving existing aggregate Carbon bindings:

- persist left/right Command, Option, Control, and Shift requirements alongside legacy shortcut data
- record physical modifier side using public `flagsChanged` events and virtual key codes
- use a dedicated listen-only `CGEventTap` matcher only for side-specific shortcuts; legacy shortcuts remain Carbon-registered
- render modifier side explicitly in Settings
- cover legacy decoding, conflicts, matching, release, and reset behavior in `Tools/hotkey-test.swift`

## Contributor-guide checklist

- [x] Rebased on current `main` (`ec136f1`)
- [x] Read `AGENTS.md`, `docs/development.md`, and `CONTRIBUTING.md`
- [x] Read the diff top to bottom
- [x] No generated files were hand-edited
- [x] No networked behavior or new long-lived singleton was added
- [x] Existing Carbon persistence keys remain compatible

## Validation

- `swift Tools/fuzz-test.swift` — passed
- calculator + hotkey harnesses — `248 passed, 0 failed`
- normal signed Xcode 27 Debug build — `BUILD SUCCEEDED`
- `codesign --verify --deep --strict` — valid; authority: `Tinycast Self-Signed`
- signing-disabled Debug compilation — `BUILD SUCCEEDED` on Xcode 27.0
- launched `Tinycast Dev.app`; idle physical footprint: **33.7 MB** (<100 MB); process exited cleanly after quit

## Remaining environment evidence gaps

- macOS `leaks` cannot fully inspect this launchd-owned process and reported framework-startup allocations (417 allocations / 20,016 bytes, including AppIntents). I am not representing that as a zero-leak certification.
- Screenshots are not applicable: this PR changes input/persistence behavior rather than visual output. The feature's automated hotkey behavior is covered by the focused harness, but it still needs an Accessibility/Input Monitoring-enabled physical hotkey pass before merge.

## Tradeoff

Side-specific shortcuts cannot use Carbon because Carbon does not encode modifier side. The additional event tap is limited to side-specific bindings; unchanged shortcuts retain the existing Carbon path and do not double-register.
