### PR TITLE
Open the palette on the display under the cursor

### DIFF
--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -138,7 +138,6 @@ final class AppSettings: ObservableObject {
             || defaults.bool(forKey: Key.showFavoritesInCompactMode)
         // An unset key means "never configured" and seeds the defaults; a stored empty array is a user who deliberately cleared the list.
         searchScopes = defaults.stringArray(forKey: Key.searchScopes) ?? SearchScopes.defaults
-        // Also defaults to true, so absence must be distinguished from a stored `false`.
         openOnCursorScreen =
             defaults.object(forKey: Key.openOnCursorScreen) == nil
             || defaults.bool(forKey: Key.openOnCursorScreen)

--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -39,6 +39,7 @@ final class AppSettings: ObservableObject {
         static let compactMode = "compactMode"
         static let showFavoritesInCompactMode = "showFavoritesInCompactMode"
         static let searchScopes = "launcherSearchScopes"
+        static let openOnCursorScreen = "openOnCursorScreen"
     }
 
     /// Folders (and individual `.app` bundles) `AppIndex` scans, in scan order. Editing this re-indexes — `AppIndex.start(settings:)` observes it.
@@ -98,6 +99,11 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(showFavoritesInCompactMode, forKey: Key.showFavoritesInCompactMode) }
     }
 
+    /// Summon the palette on the display under the pointer instead of the one holding the menu bar.
+    @Published var openOnCursorScreen: Bool {
+        didSet { defaults.set(openOnCursorScreen, forKey: Key.openOnCursorScreen) }
+    }
+
     init() {
         // integer(forKey:) returns 0 when unset, which no case matches — falls through to 3 Months.
         clipboardRetention =
@@ -132,5 +138,10 @@ final class AppSettings: ObservableObject {
             || defaults.bool(forKey: Key.showFavoritesInCompactMode)
         // An unset key means "never configured" and seeds the defaults; a stored empty array is a user who deliberately cleared the list.
         searchScopes = defaults.stringArray(forKey: Key.searchScopes) ?? SearchScopes.defaults
+        // Also defaults to true: following the pointer is what a multi-display user expects, and the
+        // alternative pins the palette to the menu-bar display no matter where they're working.
+        openOnCursorScreen =
+            defaults.object(forKey: Key.openOnCursorScreen) == nil
+            || defaults.bool(forKey: Key.openOnCursorScreen)
     }
 }

--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -138,8 +138,7 @@ final class AppSettings: ObservableObject {
             || defaults.bool(forKey: Key.showFavoritesInCompactMode)
         // An unset key means "never configured" and seeds the defaults; a stored empty array is a user who deliberately cleared the list.
         searchScopes = defaults.stringArray(forKey: Key.searchScopes) ?? SearchScopes.defaults
-        // Also defaults to true: following the pointer is what a multi-display user expects, and the
-        // alternative pins the palette to the menu-bar display no matter where they're working.
+        // Also defaults to true, so absence must be distinguished from a stored `false`.
         openOnCursorScreen =
             defaults.object(forKey: Key.openOnCursorScreen) == nil
             || defaults.bool(forKey: Key.openOnCursorScreen)

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -24,6 +24,7 @@ struct SettingsBackup: Codable {
         var compactMode: Bool?
         var showFavoritesInCompactMode: Bool?
         var searchScopes: [String]?
+        var openOnCursorScreen: Bool?
     }
 
     struct HotkeyBackup: Codable {
@@ -64,7 +65,8 @@ extension SettingsBackup {
             popToRootSeconds: s.popToRootTimeout.rawValue,
             compactMode: s.compactMode,
             showFavoritesInCompactMode: s.showFavoritesInCompactMode,
-            searchScopes: s.searchScopes)
+            searchScopes: s.searchScopes,
+            openOnCursorScreen: s.openOnCursorScreen)
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
@@ -160,6 +162,10 @@ extension SettingsBackup {
         }
         if let scopes = s.searchScopes {
             settings.searchScopes = SearchScopes.normalize(scopes)
+            count += 1
+        }
+        if let flag = s.openOnCursorScreen {
+            settings.openOnCursorScreen = flag
             count += 1
         }
         return count

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -151,11 +151,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.setFrame(frame, display: true)
     }
 
-    /// The screen to place the palette on. `NSScreen.main` is the key window's screen, and an accessory app driving a non-activating panel has none, so it resolves to the menu-bar display rather than the one the user is working on.
+    /// The display to anchor to. `NSScreen.main` is the *key window's* screen, which an accessory app driving a non-activating panel never has — it resolves to the menu-bar display, not the one the user is working on.
     private func targetScreen() -> NSScreen? {
         guard core.settings.openOnCursorScreen else { return NSScreen.main }
         let mouse = NSEvent.mouseLocation
-        return NSScreen.screens.first { $0.frame.containsMouseLocation(mouse) } ?? NSScreen.main
+        // NSMouseInRect, not `contains`: a mouse location falls in the half-open interval `(minY, maxY]`, so `contains` hands a pointer on a display's topmost row to the display stacked above it.
+        return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
     }
 
     /// The current session's anchor, resolved from the target screen on first use and cached until hide — so compact and expanded placements can never read a different `visibleFrame`.
@@ -169,12 +170,5 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         )
         anchor = resolved
         return resolved
-    }
-}
-
-extension CGRect {
-    /// `contains` is wrong for a mouse location: the y axis is flipped about the primary display's height, so a screen's pixel rows land in `(minY, maxY]` — the topmost row is exactly `maxY`, which `contains` excludes, and `minY` belongs to the display stacked below.
-    fileprivate func containsMouseLocation(_ point: CGPoint) -> Bool {
-        point.x >= minX && point.x < maxX && point.y > minY && point.y <= maxY
     }
 }

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -151,11 +151,11 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.setFrame(frame, display: true)
     }
 
-    /// The screen to place the palette on. `NSScreen.main` alone can't serve when following the pointer: this is an accessory app with no key window on the display the user is looking at, so `main` resolves to the menu-bar display and the palette always opened there. Falls back to `main` when the pointer sits in a gap between display frames.
+    /// The screen to place the palette on. `NSScreen.main` is the key window's screen, and an accessory app driving a non-activating panel has none, so it resolves to the menu-bar display rather than the one the user is working on.
     private func targetScreen() -> NSScreen? {
         guard core.settings.openOnCursorScreen else { return NSScreen.main }
         let mouse = NSEvent.mouseLocation
-        return NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
+        return NSScreen.screens.first { $0.frame.containsMouseLocation(mouse) } ?? NSScreen.main
     }
 
     /// The current session's anchor, resolved from the target screen on first use and cached until hide — so compact and expanded placements can never read a different `visibleFrame`.
@@ -169,5 +169,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         )
         anchor = resolved
         return resolved
+    }
+}
+
+extension CGRect {
+    /// `contains` is wrong for a mouse location: the y axis is flipped about the primary display's height, so a screen's pixel rows land in `(minY, maxY]` — the topmost row is exactly `maxY`, which `contains` excludes, and `minY` belongs to the display stacked below.
+    fileprivate func containsMouseLocation(_ point: CGPoint) -> Bool {
+        point.x >= minX && point.x < maxX && point.y > minY && point.y <= maxY
     }
 }

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -151,10 +151,17 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.setFrame(frame, display: true)
     }
 
-    /// The current session's anchor, resolved from the active screen on first use and cached until hide — so compact and expanded placements can never read a different `visibleFrame`.
+    /// The screen to place the palette on. `NSScreen.main` alone can't serve when following the pointer: this is an accessory app with no key window on the display the user is looking at, so `main` resolves to the menu-bar display and the palette always opened there. Falls back to `main` when the pointer sits in a gap between display frames.
+    private func targetScreen() -> NSScreen? {
+        guard core.settings.openOnCursorScreen else { return NSScreen.main }
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
+    }
+
+    /// The current session's anchor, resolved from the target screen on first use and cached until hide — so compact and expanded placements can never read a different `visibleFrame`.
     private func resolveAnchor() -> (x: CGFloat, topEdgeY: CGFloat)? {
         if let anchor { return anchor }
-        guard let screen = NSScreen.main else { return nil }
+        guard let screen = targetScreen() else { return nil }
         let visible = screen.visibleFrame
         let resolved = (
             x: visible.midX - Theme.Size.panelWidth / 2,

--- a/Tinycast/Features/Settings/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/GeneralSettingsView.swift
@@ -168,6 +168,19 @@ struct GeneralSettingsView: View {
                         .disabled(!settings.compactMode)
                 }
                 .opacity(settings.compactMode ? 1 : 0.5)
+                SettingsDivider()
+                SettingsRow(
+                    title: "Follow the cursor across displays",
+                    subtitle:
+                        "Open the launcher on whichever display the pointer is on, rather than the one with the menu bar.",
+                    systemImage: "display.2",
+                    tint: .teal
+                ) {
+                    Toggle("", isOn: $settings.openOnCursorScreen)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
             }
 
             SettingsCard(header: "General") {

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -32,15 +32,15 @@ Which display it anchors to depends on the **Follow the cursor across displays**
 - **On** — the screen holding `NSEvent.mouseLocation`, i.e. the display under the pointer.
 - **Off** — `NSScreen.main`.
 
-`NSScreen.main` alone can't implement the follow-the-cursor case: Tinycast is an accessory app with no
-key window on the display the user is looking at, so `main` resolves to the menu-bar display and the
-palette would always open there regardless of which screen the pointer is on.
+`NSScreen.main` alone can't implement the follow-the-cursor case: it is documented as the *key window's*
+screen, and an accessory app driving a non-activating panel has no key window on the display the user is
+looking at, so `main` resolves to the menu-bar display regardless of where the pointer is.
 
-The hit test is `CGRect.containsMouseLocation`, **not** `CGRect.contains`. A mouse location is the
-CoreGraphics cursor position flipped about the primary display's height, so a screen's pixel rows land
-in `(minY, maxY]`: the topmost row is exactly `maxY`, which `contains` excludes (a pointer parked at the
-top of a display would fall through to `NSScreen.main`), while `minY` is the topmost row of the display
-stacked below, which `contains` would wrongly claim.
+The hit test is `NSMouseInRect(mouse, screen.frame, false)`, **not** `CGRect.contains`. A mouse location
+is the CoreGraphics cursor position flipped about the primary display's height, so a screen's rows land
+in the half-open interval `(minY, maxY]`: the topmost row is exactly `maxY`, which `contains` excludes,
+while that same value is the `minY` of the display stacked above. `contains` would therefore hand a
+pointer parked at the top of one display to its neighbour. `NSMouseInRect` exists for precisely this.
 
 ## Menu-open input freeze
 

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -20,6 +20,24 @@ The flat `selection` index is the single source of truth for highlight / activat
 match the visible row order**, including the inline calculator card at index 0 when present (see
 [calculator.md](calculator.md)).
 
+## Window placement
+
+`PaletteWindowController` resolves an anchor (left edge + top edge) **once per summon** and reuses it
+for every compact↔expanded resize, so only the height changes and the top edge never drifts. The
+anchor is dropped on hide, so the next summon re-resolves for wherever the user is then.
+
+Which display it anchors to depends on the **Follow the cursor across displays** setting
+(`AppSettings.openOnCursorScreen`, on by default):
+
+- **On** — the screen whose `frame` contains `NSEvent.mouseLocation`, i.e. the display under the
+  pointer.
+- **Off** — `NSScreen.main`.
+
+`NSScreen.main` alone can't implement the follow-the-cursor case: Tinycast is an accessory app with no
+key window on the display the user is looking at, so `main` resolves to the menu-bar display and the
+palette would always open there regardless of which screen the pointer is on. The pointer lookup falls
+back to `NSScreen.main` when the pointer lands in a gap between display frames.
+
 ## Menu-open input freeze
 
 While a footer popover menu (⌘K Actions / app menu) is open the search field reads as inert but

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -29,14 +29,18 @@ anchor is dropped on hide, so the next summon re-resolves for wherever the user 
 Which display it anchors to depends on the **Follow the cursor across displays** setting
 (`AppSettings.openOnCursorScreen`, on by default):
 
-- **On** — the screen whose `frame` contains `NSEvent.mouseLocation`, i.e. the display under the
-  pointer.
+- **On** — the screen holding `NSEvent.mouseLocation`, i.e. the display under the pointer.
 - **Off** — `NSScreen.main`.
 
 `NSScreen.main` alone can't implement the follow-the-cursor case: Tinycast is an accessory app with no
 key window on the display the user is looking at, so `main` resolves to the menu-bar display and the
-palette would always open there regardless of which screen the pointer is on. The pointer lookup falls
-back to `NSScreen.main` when the pointer lands in a gap between display frames.
+palette would always open there regardless of which screen the pointer is on.
+
+The hit test is `CGRect.containsMouseLocation`, **not** `CGRect.contains`. A mouse location is the
+CoreGraphics cursor position flipped about the primary display's height, so a screen's pixel rows land
+in `(minY, maxY]`: the topmost row is exactly `maxY`, which `contains` excludes (a pointer parked at the
+top of a display would fall through to `NSScreen.main`), while `minY` is the topmost row of the display
+stacked below, which `contains` would wrongly claim.
 
 ## Menu-open input freeze
 


### PR DESCRIPTION
## Problem

On a multi-display setup the palette always opens on the display that holds the menu bar, regardless of
where the pointer is. With an external monitor set as the main display, summoning the launcher from the
built-in screen still puts the window on the external one — you have to look away from where you were
working to use it.

## Cause

`PaletteWindowController.resolveAnchor()` resolved its screen from `NSScreen.main`:

```swift
guard let screen = NSScreen.main else { return nil }
let visible = screen.visibleFrame
```

`NSScreen.main` is documented as the screen containing the window with keyboard focus. Tinycast is an
accessory app (`.accessory` activation policy) and the palette is a `.nonactivatingPanel`, so at the
moment the anchor is resolved there is no key window on the display the user is looking at — `main`
falls back to the display with the menu bar. The anchor is correct for a single-display machine, which
is why this only shows up with more than one screen attached.

## Fix

A new `targetScreen()` picks the display before the anchor is computed:

```swift
private func targetScreen() -> NSScreen? {
    guard core.settings.openOnCursorScreen else { return NSScreen.main }
    let mouse = NSEvent.mouseLocation
    return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
}
```

`NSEvent.mouseLocation` and `NSScreen.frame` share the same bottom-left screen coordinate space, so the
containment test needs no conversion — but it does need the right interval, which is why this is
`NSMouseInRect` and not `CGRect.contains`. A mouse location is the CoreGraphics cursor position flipped
about the primary display's height, so a screen's rows land in the half-open interval `(minY, maxY]`:
the topmost row is exactly `maxY`, which `contains` excludes, while that same value is the `minY` of the
display stacked above. `contains` would hand a pointer parked at the top of one display to its
neighbour. `NSMouseInRect(_:_:false)` is exactly this predicate and already ships in AppKit for this
purpose. The `?? NSScreen.main` is a defensive fallback for a location that matches no frame at all.

Everything else about placement is unchanged — the anchor is still resolved **once per summon** and held
for the session, so a compact↔expanded resize still only changes the height and can never move the
window, and dragging the pointer to another display while the palette is open does not teleport it.

## The setting

Exposed as `AppSettings.openOnCursorScreen`, with a toggle in **Settings → General → Appearance**:

> **Follow the cursor across displays** — Open the launcher on whichever display the pointer is on,
> rather than the one with the menu bar.

It is mirrored in `SettingsBackup` (`SettingsData.openOnCursorScreen`, gather + apply) since that type
mirrors `AppSettings` field-for-field. It is an ordinary UI preference — no network, no consent gate —
so it belongs in `AppSettings` rather than on a store of its own. The backup field is `Bool?`, so
importing a pre-#53 backup leaves the current value alone rather than forcing `false`.

### Defaulting it to `true` (resolved: keeping it on)

Absence is treated as `true`, following the same idiom as `showFavoritesInCompactMode` and
`hyperKeyIncludesShift`:

```swift
openOnCursorScreen =
    defaults.object(forKey: Key.openOnCursorScreen) == nil
    || defaults.bool(forKey: Key.openOnCursorScreen)
```

The reasoning: the current behavior reads as a bug rather than a preference, and defaulting on fixes it
for existing multi-display users without them having to find the switch. The trade-off, accepted
knowingly, is that a multi-display user who had adapted to the menu-bar placement gets moved once on
upgrade, with a discoverable switch to undo it.

## Known trade-off

The cursor is not always where attention is: summon by hotkey with the pointer parked on the external
display while typing on the built-in, and the palette follows the pointer, not your eyes. Reading the
focused window of the recorded `previousApp` would be more accurate but needs AX geometry on the summon
path for a marginal gain. The setting name says "follow the cursor", which is honest about what it does.

## Testing

Verified on a two-display setup (3440x1440 external set as main + built-in Retina), Debug channel:

- pointer on the external main display, toggle on — palette opens on the external display
- pointer on the built-in display, toggle on — palette opens on the built-in display (the reported bug)
- pointer on the built-in display, toggle off — palette opens on the external display (old behavior)
- palette open, pointer dragged to the other display, then typing to trigger compact→expanded — window
  stays put, top edge does not drift

`xcodebuild -scheme Tinycast -configuration Debug` succeeds with no new warnings.

## Files

| File | Change |
|---|---|
| `Tinycast/Core/PaletteWindowController.swift` | `targetScreen()`; `resolveAnchor()` calls it instead of reading `NSScreen.main` |
| `Tinycast/Core/AppSettings.swift` | `openOnCursorScreen` + its defaults key, defaulting to `true` |
| `Tinycast/Features/Settings/GeneralSettingsView.swift` | Toggle row in the Appearance card |
| `Tinycast/Core/Backup/SettingsBackup.swift` | Mirrored field in `SettingsData`, gather + apply |
| `docs/palette.md` | New **Window placement** section covering the anchor and the `NSScreen.main` gotcha |

No generated files touched, and no changes to `project.yml` (so no `xcodegen generate` needed).
