### PR TITLE
Add adaptive launcher ranking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,9 @@ Never break these without an explicit task to do so.
   via `rates` (`CurrencyRateStore` owns the fetch). Likewise `Core/Emoji/`
   (`EmojiCatalog`, `EmojiGridGeometry`) stays AppKit/SwiftUI-free for `Tools/emoji-test.swift`, and
   `Core/ClipboardStore.swift` must keep to Foundation + SQLite3 with no other app source, so
-  `Tools/clipboard-test.swift` can compile it standalone.
+  `Tools/clipboard-test.swift` can compile it standalone. `Core/LauncherRankingStore.swift` is the
+  same deal for `Tools/ranking-test.swift` — Foundation only, with the clock injected via `now` and
+  the store path via `fileURL`.
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		9A3972BE11AE353EFBB839A0 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555E9C7EA62BDB40891A5751 /* PalettePanel.swift */; };
 		9EC89A6398BD075275FECC9E /* CalcUnits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */; };
 		A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D045D032498C2294A99890E /* LaunchAtLogin.swift */; };
+		B0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift */; };
 		A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */; };
 		A41C0DCB2DEBCCA46F6C4B10 /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB750D045194AE34D39D792 /* FavoritesStore.swift */; };
 		A9D8B54D88A60DE9FC1F43BF /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */; };
@@ -139,6 +140,7 @@
 		9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentEmojiStore.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
+		A0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
 		A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
 		A76E4099082D59FA686C3485 /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */,
 				99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */,
 				0D045D032498C2294A99890E /* LaunchAtLogin.swift */,
+				A0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift */,
 				7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */,
 				B8A9B4E6E477C30372C85F86 /* OnboardingState.swift */,
 				3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */,
@@ -495,6 +498,7 @@
 				F5F3381FF70997223F8888B0 /* KeyShortcut.swift in Sources */,
 				A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */,
 				DCC36924E538C11136CEC060 /* LauncherView.swift in Sources */,
+				B0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift in Sources */,
 				8F7431A1340D0A5783599087 /* MiscellaneousSettingsView.swift in Sources */,
 				6962B8A2850A45401275F677 /* NotificationToken.swift in Sources */,
 				DA5BCA13045FF91B3FC8EB35 /* OnboardingState.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		34E5FF0B3C9FD2FFE504D87A /* ClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ADC36002F1A5B04D61B4D3 /* ClipboardView.swift */; };
 		36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */ = {isa = PBXBuildFile; fileRef = 6621A88681E993D49EEF07A3 /* tinycast.icon */; };
 		374235D358A127741447551E /* SettingsBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043CD44B4B40C49BE79852A /* SettingsBackup.swift */; };
+		3FEBE1C993C5BD92F1C3D95B /* LauncherRankingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */; };
 		42828BD1C5E4E6E7AA1BF103 /* CalculatorHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */; };
 		441CF705AE1D03F6E236A61E /* ClipboardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */; };
 		4F3D96E59E117459153336F4 /* SettingsPaneScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */; };
@@ -52,7 +53,6 @@
 		9A3972BE11AE353EFBB839A0 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555E9C7EA62BDB40891A5751 /* PalettePanel.swift */; };
 		9EC89A6398BD075275FECC9E /* CalcUnits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */; };
 		A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D045D032498C2294A99890E /* LaunchAtLogin.swift */; };
-		B0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift */; };
 		A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */; };
 		A41C0DCB2DEBCCA46F6C4B10 /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB750D045194AE34D39D792 /* FavoritesStore.swift */; };
 		A9D8B54D88A60DE9FC1F43BF /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */; };
@@ -131,6 +131,7 @@
 		7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityStore.swift; sourceTree = "<group>"; };
 		849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardSettingsView.swift; sourceTree = "<group>"; };
+		87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		88A65B4EC5AE7E22594BFC5E /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
 		8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
 		919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKeyTap.swift; sourceTree = "<group>"; };
@@ -140,7 +141,6 @@
 		9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentEmojiStore.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
-		A0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
 		A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
 		A76E4099082D59FA686C3485 /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
@@ -198,7 +198,7 @@
 				D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */,
 				99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */,
 				0D045D032498C2294A99890E /* LaunchAtLogin.swift */,
-				A0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift */,
+				87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */,
 				7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */,
 				B8A9B4E6E477C30372C85F86 /* OnboardingState.swift */,
 				3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */,
@@ -497,8 +497,8 @@
 				E5072CA7D34BA877D97DF392 /* ImageThumbnail.swift in Sources */,
 				F5F3381FF70997223F8888B0 /* KeyShortcut.swift in Sources */,
 				A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */,
+				3FEBE1C993C5BD92F1C3D95B /* LauncherRankingStore.swift in Sources */,
 				DCC36924E538C11136CEC060 /* LauncherView.swift in Sources */,
-				B0F1E2D3C4B5A69788776655 /* LauncherRankingStore.swift in Sources */,
 				8F7431A1340D0A5783599087 /* MiscellaneousSettingsView.swift in Sources */,
 				6962B8A2850A45401275F677 /* NotificationToken.swift in Sources */,
 				DA5BCA13045FF91B3FC8EB35 /* OnboardingState.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -89,7 +89,8 @@ final class PaletteViewModel: ObservableObject {
 final class AppCore: ObservableObject {
     static let shared = AppCore()
 
-    let appIndex = AppIndex()
+    let launcherRanking: LauncherRankingStore
+    let appIndex: AppIndex
     let clipboardStore = ClipboardStore()
     let clipboardManager: ClipboardManager
     let hotKeys = HotKeyManager()
@@ -108,6 +109,9 @@ final class AppCore: ObservableObject {
     private let auxWindows = AuxWindowController()
 
     private init() {
+        let launcherRanking = LauncherRankingStore()
+        self.launcherRanking = launcherRanking
+        appIndex = AppIndex(ranking: launcherRanking)
         clipboardManager = ClipboardManager(store: clipboardStore, settings: settings)
     }
 
@@ -247,7 +251,10 @@ final class AppCore: ObservableObject {
 
     // MARK: - Actions invoked from the palette UI
 
-    func launch(_ app: AppEntry) {
+    func launch(_ app: AppEntry, searchQuery: String? = nil) {
+        if let searchQuery {
+            launcherRanking.record(itemKey: app.preferenceKey, query: searchQuery)
+        }
         // Commands dispatch before the palette hides: mode-switching commands keep it open.
         if app.kind == .command {
             runCommand(app)
@@ -263,6 +270,10 @@ final class AppCore: ObservableObject {
         case .command:
             break  // handled above
         }
+    }
+
+    func resetRanking(for app: AppEntry) {
+        launcherRanking.reset(itemKey: app.preferenceKey)
     }
 
     /// Quits the app behind an entry; a no-op (palette stays put) when it isn't running.

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -229,9 +229,10 @@ final class AppIndex: ObservableObject {
     }
 
     private func rank(_ q: String, limit: Int) -> [AppEntry] {
+        let learned = ranking.boosts(query: q)
         let scored = apps.compactMap { app -> (AppEntry, Int)? in
             guard let score = FuzzyMatch.score(query: q, candidate: app.name) else { return nil }
-            return (app, score + ranking.boost(itemKey: app.preferenceKey, query: q))
+            return (app, score + (learned[app.preferenceKey] ?? 0))
         }
         return
             scored
@@ -264,8 +265,7 @@ enum FuzzyMatch {
         return sub
     }
 
-    /// App metadata can contain invisible bidirectional/zero-width format scalars (WhatsApp's
-    /// display name starts with U+200E). They must not demote an otherwise-visible prefix match.
+    /// App metadata can contain invisible bidirectional/zero-width format scalars (WhatsApp's display name starts with U+200E); they must not demote an otherwise-visible prefix match.
     private static func normalized(_ value: String) -> String {
         let scalars = value.unicodeScalars.filter {
             $0.properties.generalCategory != .format

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -13,6 +13,9 @@ struct AppEntry: Identifiable, Hashable, Sendable {
     let bundleID: String?
     let kind: Kind
 
+    /// Stable identity for learned ranking, favorites, and other per-entry preferences.
+    var preferenceKey: String { bundleID ?? id }
+
     var kindLabel: String {
         switch kind {
         case .application: return "Application"
@@ -150,9 +153,14 @@ final class AppIndex: ObservableObject {
     @Published private(set) var apps: [AppEntry] = []
 
     /// One-entry memo so repeated renders for the same query reuse the ranking instead of re-matching every frame.
-    private var matchCache: (query: String, result: [AppEntry])?
+    private var matchCache: (query: String, rankingRevision: Int, result: [AppEntry])?
 
     private var isRefreshing = false
+    private let ranking: LauncherRankingStore
+
+    init(ranking: LauncherRankingStore) {
+        self.ranking = ranking
+    }
 
     /// Re-scan (called on every launcher open); the in-flight guard drops overlapping reopens and `apps` is only re-published when the set changed, so an unchanged reopen does no UI work.
     func refresh() async {
@@ -210,16 +218,20 @@ final class AppIndex: ObservableObject {
     func matches(_ query: String, limit: Int = 200) -> [AppEntry] {
         let q = query.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return apps }
-        if let matchCache, matchCache.query == q { return matchCache.result }
+        if let matchCache, matchCache.query == q,
+            matchCache.rankingRevision == ranking.revision
+        {
+            return matchCache.result
+        }
         let result = rank(q, limit: limit)
-        matchCache = (q, result)
+        matchCache = (q, ranking.revision, result)
         return result
     }
 
     private func rank(_ q: String, limit: Int) -> [AppEntry] {
         let scored = apps.compactMap { app -> (AppEntry, Int)? in
             guard let score = FuzzyMatch.score(query: q, candidate: app.name) else { return nil }
-            return (app, score)
+            return (app, score + ranking.boost(itemKey: app.preferenceKey, query: q))
         }
         return
             scored
@@ -236,8 +248,8 @@ final class AppIndex: ObservableObject {
 enum FuzzyMatch {
     /// Tiered relevance score (higher is better), or nil when the query doesn't match; tiers are spaced so a better kind always wins.
     static func score(query: String, candidate: String) -> Int? {
-        let q = query.lowercased()
-        let c = candidate.lowercased()
+        let q = normalized(query)
+        let c = normalized(candidate)
         guard !q.isEmpty else { return 0 }
 
         if c == q { return 100_000 }
@@ -250,6 +262,15 @@ enum FuzzyMatch {
 
         guard let sub = subsequenceScore(Array(q), Array(c)) else { return nil }
         return sub
+    }
+
+    /// App metadata can contain invisible bidirectional/zero-width format scalars (WhatsApp's
+    /// display name starts with U+200E). They must not demote an otherwise-visible prefix match.
+    private static func normalized(_ value: String) -> String {
+        let scalars = value.unicodeScalars.filter {
+            $0.properties.generalCategory != .format
+        }
+        return String(String.UnicodeScalarView(scalars)).lowercased()
     }
 
     private static func isWordStart(_ s: String, _ index: String.Index) -> Bool {

--- a/Tinycast/Core/FavoritesStore.swift
+++ b/Tinycast/Core/FavoritesStore.swift
@@ -12,7 +12,7 @@ final class FavoritesStore: ObservableObject {
         keys = defaults.stringArray(forKey: key) ?? []
     }
 
-    func key(for app: AppEntry) -> String { app.bundleID ?? app.id }
+    func key(for app: AppEntry) -> String { app.preferenceKey }
 
     func isFavorite(_ app: AppEntry) -> Bool { keys.contains(key(for: app)) }
 

--- a/Tinycast/Core/LauncherRankingStore.swift
+++ b/Tinycast/Core/LauncherRankingStore.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// One learned launcher choice for a normalized query prefix.
+struct LauncherRankingRecord: Codable, Hashable, Sendable {
+    let itemKey: String
+    let query: String
+    var count: Int
+    var lastUsed: Date
+}
+
+/// Learns which launcher results the user chooses for each query and persists the bounded,
+/// on-device-only frecency data under `~/Library/Caches/<bundle-id>/`.
+@MainActor
+final class LauncherRankingStore: ObservableObject {
+    private static let cap = 1_000
+    /// The adaptive boost stays below half the 10k gaps between FuzzyMatch's relevance tiers, so
+    /// learned usage can reorder similarly-matching results without beating a stronger match kind.
+    private static let maximumBoost = 4_500
+
+    private let fileURL: URL
+    private let now: () -> Date
+
+    @Published private(set) var records: [LauncherRankingRecord]
+    /// AppIndex includes this in its one-entry cache key, invalidating a result after a visit/reset.
+    private(set) var revision = 0
+
+    private var lookup: [String: [String: LauncherRankingRecord]]?
+
+    init(fileURL: URL? = nil, now: @escaping () -> Date = Date.init) {
+        self.fileURL = fileURL ?? Self.defaultFileURL()
+        self.now = now
+
+        if let data = try? Data(contentsOf: self.fileURL),
+            let decoded = try? JSONDecoder().decode([LauncherRankingRecord].self, from: data)
+        {
+            records = decoded.filter {
+                !$0.itemKey.isEmpty && !$0.query.isEmpty && $0.count > 0
+            }
+        } else {
+            records = []
+        }
+    }
+
+    var isEmpty: Bool { records.isEmpty }
+
+    /// Record every prefix of the submitted query: choosing WhatsApp for "wha" teaches "w",
+    /// "wh", and "wha", letting the preferred result surface for progressively shorter input.
+    func record(itemKey: String, query: String) {
+        let query = Self.normalize(query)
+        guard !itemKey.isEmpty, !query.isEmpty else { return }
+
+        let timestamp = now()
+        for prefix in Self.prefixes(of: query) {
+            if let index = records.firstIndex(where: {
+                $0.itemKey == itemKey && $0.query == prefix
+            }) {
+                records[index].count += 1
+                records[index].lastUsed = timestamp
+            } else {
+                records.append(
+                    LauncherRankingRecord(
+                        itemKey: itemKey, query: prefix, count: 1, lastUsed: timestamp))
+            }
+        }
+
+        if records.count > Self.cap {
+            records.sort {
+                $0.count != $1.count ? $0.count > $1.count : $0.lastUsed > $1.lastUsed
+            }
+            records.removeLast(records.count - Self.cap)
+        }
+        didMutate()
+    }
+
+    /// A bounded blend of frequency and exponentially-decaying recency for this exact query.
+    func boost(itemKey: String, query: String) -> Int {
+        let query = Self.normalize(query)
+        guard !query.isEmpty, let record = rankingLookup()[query]?[itemKey] else { return 0 }
+
+        let age = max(0, now().timeIntervalSince(record.lastUsed))
+        let ageInDays = age / 86_400
+        // Cap frequency separately so an old, once-dominant habit cannot stay permanently pinned;
+        // enough recent visits to a different result can eventually overtake it.
+        let frequency = min(3_000, log2(Double(record.count) + 1) * 600)
+        let recency = 1_500 * exp(-ageInDays / 14)
+        return min(Self.maximumBoost, Int((frequency + recency).rounded()))
+    }
+
+    func hasRanking(for itemKey: String) -> Bool {
+        records.contains { $0.itemKey == itemKey }
+    }
+
+    func reset(itemKey: String) {
+        let oldCount = records.count
+        records.removeAll { $0.itemKey == itemKey }
+        guard records.count != oldCount else { return }
+        didMutate()
+    }
+
+    func resetAll() {
+        guard !records.isEmpty else { return }
+        records = []
+        didMutate()
+    }
+
+    static func normalize(_ query: String) -> String {
+        query
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+    }
+
+    private static func prefixes(of query: String) -> [String] {
+        // Launcher names and useful queries are short; cap pathological pasted input so one visit
+        // cannot evict the whole bounded ranking table.
+        let limit = min(query.count, 64)
+        var result: [String] = []
+        result.reserveCapacity(limit)
+        var end = query.startIndex
+        for _ in 0..<limit {
+            end = query.index(after: end)
+            result.append(String(query[..<end]))
+        }
+        return result
+    }
+
+    private func rankingLookup() -> [String: [String: LauncherRankingRecord]] {
+        if let lookup { return lookup }
+        var built: [String: [String: LauncherRankingRecord]] = [:]
+        for record in records {
+            built[record.query, default: [:]][record.itemKey] = record
+        }
+        lookup = built
+        return built
+    }
+
+    private func didMutate() {
+        lookup = nil
+        revision &+= 1
+        if let data = try? JSONEncoder().encode(records) {
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    private static func defaultFileURL() -> URL {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
+        let base = FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(bundleID, isDirectory: true)
+        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        return base.appendingPathComponent("launcher-ranking.json")
+    }
+}

--- a/Tinycast/Core/LauncherRankingStore.swift
+++ b/Tinycast/Core/LauncherRankingStore.swift
@@ -103,10 +103,13 @@ final class LauncherRankingStore: ObservableObject {
         didMutate()
     }
 
+    /// `locale: nil` asks for the locale-independent canonical form. These strings are persisted
+    /// lookup keys, so folding must not depend on ambient state — a locale-sensitive fold maps "I"
+    /// to "ı" under Turkish, which would orphan every record keyed on the dotted form.
     static func normalize(_ query: String) -> String {
         query
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
     }
 
     private static func prefixes(of query: String) -> [String] {

--- a/Tinycast/Core/LauncherRankingStore.swift
+++ b/Tinycast/Core/LauncherRankingStore.swift
@@ -8,13 +8,11 @@ struct LauncherRankingRecord: Codable, Hashable, Sendable {
     var lastUsed: Date
 }
 
-/// Learns which launcher results the user chooses for each query and persists the bounded,
-/// on-device-only frecency data under `~/Library/Caches/<bundle-id>/`.
+/// Learns which launcher results the user chooses for each query and persists the bounded, on-device-only frecency data under `~/Library/Caches/<bundle-id>/`.
 @MainActor
 final class LauncherRankingStore: ObservableObject {
     private static let cap = 1_000
-    /// The adaptive boost stays below half the 10k gaps between FuzzyMatch's relevance tiers, so
-    /// learned usage can reorder similarly-matching results without beating a stronger match kind.
+    /// Stays below half the 10k gaps between FuzzyMatch's relevance tiers, so learned usage can reorder similarly-matching results without ever beating a stronger match kind.
     private static let maximumBoost = 4_500
 
     private let fileURL: URL
@@ -43,8 +41,7 @@ final class LauncherRankingStore: ObservableObject {
 
     var isEmpty: Bool { records.isEmpty }
 
-    /// Record every prefix of the submitted query: choosing WhatsApp for "wha" teaches "w",
-    /// "wh", and "wha", letting the preferred result surface for progressively shorter input.
+    /// Records every prefix of the submitted query: choosing WhatsApp for "wha" teaches "w", "wh" and "wha", so the preferred result surfaces for progressively shorter input.
     func record(itemKey: String, query: String) {
         let query = Self.normalize(query)
         guard !itemKey.isEmpty, !query.isEmpty else { return }
@@ -72,15 +69,17 @@ final class LauncherRankingStore: ObservableObject {
         didMutate()
     }
 
-    /// A bounded blend of frequency and exponentially-decaying recency for this exact query.
-    func boost(itemKey: String, query: String) -> Int {
+    /// Learned boosts for one query, keyed by item — a ranking pass folds the query and reads the clock once here rather than per candidate.
+    func boosts(query: String) -> [String: Int] {
         let query = Self.normalize(query)
-        guard !query.isEmpty, let record = rankingLookup()[query]?[itemKey] else { return 0 }
+        guard !query.isEmpty, let learned = rankingLookup()[query] else { return [:] }
+        let timestamp = now()
+        return learned.mapValues { boost($0, at: timestamp) }
+    }
 
-        let age = max(0, now().timeIntervalSince(record.lastUsed))
-        let ageInDays = age / 86_400
-        // Cap frequency separately so an old, once-dominant habit cannot stay permanently pinned;
-        // enough recent visits to a different result can eventually overtake it.
+    private func boost(_ record: LauncherRankingRecord, at timestamp: Date) -> Int {
+        let ageInDays = max(0, timestamp.timeIntervalSince(record.lastUsed)) / 86_400
+        // Cap frequency separately so an old, once-dominant habit cannot stay permanently pinned; enough recent visits to a different result can eventually overtake it.
         let frequency = min(3_000, log2(Double(record.count) + 1) * 600)
         let recency = 1_500 * exp(-ageInDays / 14)
         return min(Self.maximumBoost, Int((frequency + recency).rounded()))
@@ -103,9 +102,7 @@ final class LauncherRankingStore: ObservableObject {
         didMutate()
     }
 
-    /// `locale: nil` asks for the locale-independent canonical form. These strings are persisted
-    /// lookup keys, so folding must not depend on ambient state — a locale-sensitive fold maps "I"
-    /// to "ı" under Turkish, which would orphan every record keyed on the dotted form.
+    /// `locale: nil` is the locale-independent canonical form: these are persisted lookup keys, and a locale-sensitive fold maps "I" to "ı" under Turkish, orphaning every record keyed on the dotted form.
     static func normalize(_ query: String) -> String {
         query
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -113,8 +110,7 @@ final class LauncherRankingStore: ObservableObject {
     }
 
     private static func prefixes(of query: String) -> [String] {
-        // Launcher names and useful queries are short; cap pathological pasted input so one visit
-        // cannot evict the whole bounded ranking table.
+        // Launcher names and useful queries are short; cap pathological pasted input so one visit cannot evict the whole bounded ranking table.
         let limit = min(query.count, 64)
         var result: [String] = []
         result.reserveCapacity(limit)

--- a/Tinycast/Core/VisibilityStore.swift
+++ b/Tinycast/Core/VisibilityStore.swift
@@ -23,7 +23,7 @@ final class VisibilityStore: ObservableObject {
         defaults.set(Array(hiddenKinds), forKey: kindsKey)
     }
 
-    func key(for entry: AppEntry) -> String { entry.bundleID ?? entry.id }
+    func key(for entry: AppEntry) -> String { entry.preferenceKey }
 
     /// Whether the entry appears in the launcher: its category and the item itself must be on.
     func isVisible(_ entry: AppEntry) -> Bool {

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -240,10 +240,12 @@ enum AppActionsMenu {
                     favorites.toggle(app)
                 })
         }
-        items.append(
-            PopoverMenuItem(title: "Reset Ranking", systemImage: "arrow.counterclockwise") {
-                onResetRanking()
-            })
+        if core.launcherRanking.hasRanking(for: app.preferenceKey) {
+            items.append(
+                PopoverMenuItem(title: "Reset Ranking", systemImage: "arrow.counterclockwise") {
+                    onResetRanking()
+                })
+        }
         if app.kind != .command {
             items.append(
                 PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -12,8 +12,8 @@ struct LauncherList: View {
     var calcSelected = false
     var onActivateCalc: () -> Void = {}
     var onCalcActions: () -> Void = {}
+    let onActivate: (AppEntry) -> Void
     let onActions: (AppEntry) -> Void
-    @EnvironmentObject private var core: AppCore
     @EnvironmentObject private var runningApps: RunningAppsMonitor
 
     private nonisolated static let calcRowID = "calc-card"
@@ -82,7 +82,7 @@ struct LauncherList: View {
                                         running: runningApps.isRunning(app)
                                     )
                                     .contentShape(Rectangle())
-                                    .onTapGesture { core.launch(app) }
+                                    .onTapGesture { onActivate(app) }
                                     .onRightClick { onActions(app) }
                                 }
                             }
@@ -220,13 +220,14 @@ struct AppIconView: View {
 /// Actions menu content for a launcher app, shown bottom-right on right-click or from the Actions pill.
 @MainActor
 enum AppActionsMenu {
-    static func content(app: AppEntry, core: AppCore, favorites: FavoritesStore, running: Bool)
-        -> PopoverMenuContent
-    {
+    static func content(
+        app: AppEntry, searchQuery: String, core: AppCore, favorites: FavoritesStore,
+        running: Bool, onResetRanking: @escaping () -> Void
+    ) -> PopoverMenuContent {
         var items: [PopoverMenuItem] = [
             PopoverMenuItem(
                 title: openTitle(app), systemImage: "list.bullet.rectangle", shortcut: "↵"
-            ) { core.launch(app) }
+            ) { core.launch(app, searchQuery: searchQuery) }
         ]
         if favorites.isFavorite(app) {
             items.append(
@@ -239,6 +240,10 @@ enum AppActionsMenu {
                     favorites.toggle(app)
                 })
         }
+        items.append(
+            PopoverMenuItem(title: "Reset Ranking", systemImage: "arrow.counterclockwise") {
+                onResetRanking()
+            })
         if app.kind != .command {
             items.append(
                 PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -112,7 +112,15 @@ struct RootPaletteView: View {
             }
             if let app = selectedAppEntry {
                 return AppActionsMenu.content(
-                    app: app, core: core, favorites: favorites, running: selectionIsRunning)
+                    app: app, searchQuery: vm.query, core: core, favorites: favorites,
+                    running: selectionIsRunning,
+                    onResetRanking: {
+                        core.resetRanking(for: app)
+                        // Reset can move the item; keep the highlight on the item whose action ran.
+                        if let index = appResults.firstIndex(of: app) {
+                            vm.selection = index + calcCount
+                        }
+                    })
             }
             return nil
         case .clipboard:
@@ -502,6 +510,7 @@ struct RootPaletteView: View {
                     vm.selection = 0
                     openActions()
                 },
+                onActivate: { core.launch($0, searchQuery: vm.query) },
                 onActions: { app in
                     if let index = apps.firstIndex(of: app) { vm.selection = index + offset }
                     openActions()
@@ -748,7 +757,7 @@ struct RootPaletteView: View {
             }
             let index = selection - calcCount
             guard appResults.indices.contains(index) else { return }
-            core.launch(appResults[index])
+            core.launch(appResults[index], searchQuery: vm.query)
         case .clipboard:
             guard clipResults.indices.contains(selection) else { return }
             core.paste(clipResults[selection])

--- a/Tinycast/Features/Settings/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/GeneralSettingsView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 struct GeneralSettingsView: View {
     @ObservedObject private var settings = AppCore.shared.settings
     @ObservedObject private var hyperTap = AppCore.shared.hyperKeyTap
+    @ObservedObject private var launcherRanking = AppCore.shared.launcherRanking
     // Same UserDefaults key the `App` binds its `MenuBarExtra(isInserted:)` to — toggling here updates the menu-bar icon live, with no shared observable between them.
     @AppStorage(SettingsKey.showInMenuBar) private var showInMenuBar = true
+    @State private var confirmingRankingReset = false
 
     /// The Hyper modifier chord as prose glyphs, tracking the Include Shift toggle.
     private var hyperGlyphs: String { settings.hyperKeyIncludesShift ? "⌃⌥⇧⌘" : "⌃⌥⌘" }
@@ -46,6 +48,22 @@ struct GeneralSettingsView: View {
                     tint: .blue
                 ) {
                     ShortcutRecorder(action: .togglePalette)
+                }
+            }
+
+            SettingsCard(header: "Search") {
+                SettingsRow(
+                    title: "Learned ranking",
+                    subtitle:
+                        "Tinycast privately learns which results you choose for each query. Reset all learned choices to restore the default order.",
+                    systemImage: "chart.line.uptrend.xyaxis",
+                    tint: .blue
+                ) {
+                    Button("Reset…", role: .destructive) {
+                        confirmingRankingReset = true
+                    }
+                    .controlSize(.small)
+                    .disabled(launcherRanking.isEmpty)
                 }
             }
 
@@ -200,6 +218,18 @@ struct GeneralSettingsView: View {
                         .controlSize(.small)
                 }
             }
+        }
+        .confirmationDialog(
+            "Reset learned launcher ranking?",
+            isPresented: $confirmingRankingReset,
+            titleVisibility: .visible
+        ) {
+            Button("Reset Ranking", role: .destructive) {
+                launcherRanking.resetAll()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Tinycast will relearn your preferred results as you use the launcher.")
         }
     }
 }

--- a/Tools/fuzz-test.swift
+++ b/Tools/fuzz-test.swift
@@ -4,8 +4,8 @@ import Foundation
 
 enum FuzzyMatch {
     static func score(query: String, candidate: String) -> Int? {
-        let q = query.lowercased()
-        let c = candidate.lowercased()
+        let q = normalized(query)
+        let c = normalized(candidate)
         guard !q.isEmpty else { return 0 }
 
         if c == q { return 100_000 }
@@ -17,6 +17,13 @@ enum FuzzyMatch {
         }
 
         return subsequenceScore(Array(q), Array(c))
+    }
+
+    private static func normalized(_ value: String) -> String {
+        let scalars = value.unicodeScalars.filter {
+            $0.properties.generalCategory != .format
+        }
+        return String(String.UnicodeScalarView(scalars)).lowercased()
     }
 
     private static func isWordStart(_ s: String, _ index: String.Index) -> Bool {
@@ -56,13 +63,13 @@ enum FuzzyMatch {
 let apps = [
     "Google Chrome", "Chess", "Time Machine", "Safari", "Bluetooth File Exchange",
     "Screenshot", "Screen Sharing", "Visual Studio Code", "Photos", "App Store",
-    "System Settings", "Calendar", "Terminal",
+    "System Settings", "Calendar", "Terminal", "WhatsApp", "Wick",
 ]
 
-func rank(_ query: String) -> [String] {
+func rank(_ query: String, boosts: [String: Int] = [:]) -> [String] {
     apps.compactMap { name -> (String, Int)? in
         guard let s = FuzzyMatch.score(query: query, candidate: name) else { return nil }
-        return (name, s)
+        return (name, s + boosts[name, default: 0])
     }
     .sorted { $0.1 != $1.1 ? $0.1 > $1.1 : $0.0.count < $1.0.count }
     .map(\.0)
@@ -96,6 +103,26 @@ check(
     "got \(rank("code"))")
 check("'terminal' exact top", rank("terminal").first == "Terminal")
 check("'xyz' matches nothing", rank("xyz").isEmpty, "got \(rank("xyz"))")
+
+let defaultW = rank("w")
+check(
+    "shorter Wick wins the default prefix tie",
+    defaultW.firstIndex(of: "Wick")! < defaultW.firstIndex(of: "WhatsApp")!,
+    "got \(defaultW)")
+let learnedW = rank("w", boosts: ["WhatsApp": 2_100])
+check(
+    "learned boost promotes WhatsApp within the prefix tier",
+    learnedW.firstIndex(of: "WhatsApp")! < learnedW.firstIndex(of: "Wick")!,
+    "got \(learnedW)")
+let markedWhatsApp = "\u{200E}WhatsApp"
+check(
+    "invisible format mark does not demote WhatsApp's prefix match",
+    FuzzyMatch.score(query: "w", candidate: markedWhatsApp)
+        == FuzzyMatch.score(query: "w", candidate: "WhatsApp"))
+check(
+    "learned marked WhatsApp can outrank Wick",
+    FuzzyMatch.score(query: "w", candidate: markedWhatsApp)! + 2_100
+        > FuzzyMatch.score(query: "w", candidate: "Wick")!)
 
 print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
 exit(failures == 0 ? 0 : 1)

--- a/Tools/ranking-test.swift
+++ b/Tools/ranking-test.swift
@@ -21,6 +21,11 @@ struct RankingTest {
             }
         }
 
+        // Mirrors how AppIndex.rank reads the table: one boosts(query:) pass, then a per-item lookup.
+        func boost(_ store: LauncherRankingStore, _ itemKey: String, _ query: String) -> Int {
+            store.boosts(query: query)[itemKey] ?? 0
+        }
+
         let whatsApp = "net.whatsapp.WhatsApp"
         let wick = "com.example.wick"
         let cafe = "com.example.cafe"
@@ -30,9 +35,7 @@ struct RankingTest {
             LauncherRankingStore.normalize(" wha \n") == "wha")
         check("query key folds case", LauncherRankingStore.normalize("WhA") == "wha")
         check("query key folds diacritics", LauncherRankingStore.normalize("Café") == "cafe")
-        // Records are keyed on the folded query, so the fold must resolve to one canonical form no
-        // matter the ambient locale. A Turkish fold maps "I" to "ı"; asserting the difference keeps
-        // this check from going vacuous if that ever stops being true.
+        // A Turkish fold maps "I" to "ı"; asserting the difference keeps this from going vacuous if that ever stops being true.
         check(
             "query key is locale-independent",
             LauncherRankingStore.normalize("I") == "i"
@@ -41,42 +44,58 @@ struct RankingTest {
                         options: [.caseInsensitive, .diacriticInsensitive],
                         locale: Locale(identifier: "tr_TR")))
 
-        check("unvisited result has no boost", store.boost(itemKey: whatsApp, query: "w") == 0)
+        check("unvisited result has no boost", boost(store, whatsApp, "w") == 0)
+        check("an unlearned query yields an empty table", store.boosts(query: "w").isEmpty)
 
         store.record(itemKey: cafe, query: " Café ")
         check(
             "a learned query is recalled through its normalized key",
-            store.boost(itemKey: cafe, query: "cafe") > 0)
+            boost(store, cafe, "cafe") > 0)
 
         store.record(itemKey: whatsApp, query: "Wha")
-        let firstBoost = store.boost(itemKey: whatsApp, query: "w")
+        let firstBoost = boost(store, whatsApp, "w")
         check("visit teaches first query prefix", firstBoost > 0)
-        check("visit teaches full normalized query", store.boost(itemKey: whatsApp, query: "WHA") > 0)
-        check("visit does not teach a different query", store.boost(itemKey: whatsApp, query: "wa") == 0)
+        check("visit teaches full normalized query", boost(store, whatsApp, "WHA") > 0)
+        check("visit does not teach a different query", boost(store, whatsApp, "wa") == 0)
 
-        store.record(itemKey: whatsApp, query: "w")
-        check(
-            "frequency increases the boost",
-            store.boost(itemKey: whatsApp, query: "w") > firstBoost)
+        // Golden values: these pin the frecency curve, so a change to the scoring has to be deliberate rather than incidental.
+        check("one visit, same day, scores 2100", firstBoost == 2_100)
+        for _ in 0..<9 { store.record(itemKey: whatsApp, query: "Wha") }
+        check("ten visits, same day, score 3576", boost(store, whatsApp, "w") == 3_576)
+        clock.addTimeInterval(14 * 86_400)
+        check("ten visits, one half-life later, score 2627", boost(store, whatsApp, "w") == 2_627)
+        clock.addTimeInterval(351 * 86_400)
+        check("ten visits, a year later, score 2076", boost(store, whatsApp, "w") == 2_076)
+        for _ in 0..<200 { store.record(itemKey: wick, query: "w") }
+        check("the blend is capped at 4500", boost(store, wick, "w") == 4_500)
+
+        store.resetAll()
+        store.record(itemKey: whatsApp, query: "Wha")
+        let sameDay = boost(store, whatsApp, "w")
+        store.record(itemKey: whatsApp, query: "Wha")
+        check("frequency increases the boost", boost(store, whatsApp, "w") > sameDay)
 
         clock.addTimeInterval(60 * 86_400)
-        check(
-            "recency decays over time",
-            store.boost(itemKey: whatsApp, query: "w") < firstBoost)
+        check("recency decays over time", boost(store, whatsApp, "w") < sameDay)
 
         for _ in 0..<100 { store.record(itemKey: whatsApp, query: "w") }
         clock.addTimeInterval(60 * 86_400)
-        let oldFrequentBoost = store.boost(itemKey: whatsApp, query: "w")
+        let oldFrequentBoost = boost(store, whatsApp, "w")
         for _ in 0..<8 { store.record(itemKey: wick, query: "w") }
         check(
             "a newer habit can overtake an old frequent result",
-            store.boost(itemKey: wick, query: "w") > oldFrequentBoost)
+            boost(store, wick, "w") > oldFrequentBoost)
 
-        let persistedWickBoost = store.boost(itemKey: wick, query: "w")
+        let table = store.boosts(query: "w")
+        check(
+            "one pass returns every item learned for the query",
+            Set(table.keys) == [whatsApp, wick])
+
+        let persistedWickBoost = boost(store, wick, "w")
         let reloaded = LauncherRankingStore(fileURL: fileURL) { clock }
         check(
             "records persist across store instances",
-            reloaded.boost(itemKey: wick, query: "w") == persistedWickBoost)
+            boost(reloaded, wick, "w") == persistedWickBoost)
 
         reloaded.reset(itemKey: whatsApp)
         check("per-item reset clears every learned query", !reloaded.hasRanking(for: whatsApp))

--- a/Tools/ranking-test.swift
+++ b/Tools/ranking-test.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+@main
+struct RankingTest {
+    @MainActor
+    static func main() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-ranking-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        var clock = Date(timeIntervalSince1970: 2_000_000_000)
+        let store = LauncherRankingStore(fileURL: fileURL) { clock }
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        let whatsApp = "net.whatsapp.WhatsApp"
+        let wick = "com.example.wick"
+
+        check("unvisited result has no boost", store.boost(itemKey: whatsApp, query: "w") == 0)
+
+        store.record(itemKey: whatsApp, query: "Wha")
+        let firstBoost = store.boost(itemKey: whatsApp, query: "w")
+        check("visit teaches first query prefix", firstBoost > 0)
+        check("visit teaches full normalized query", store.boost(itemKey: whatsApp, query: "WHA") > 0)
+        check("visit does not teach a different query", store.boost(itemKey: whatsApp, query: "wa") == 0)
+
+        store.record(itemKey: whatsApp, query: "w")
+        check(
+            "frequency increases the boost",
+            store.boost(itemKey: whatsApp, query: "w") > firstBoost)
+
+        clock.addTimeInterval(60 * 86_400)
+        check(
+            "recency decays over time",
+            store.boost(itemKey: whatsApp, query: "w") < firstBoost)
+
+        for _ in 0..<100 { store.record(itemKey: whatsApp, query: "w") }
+        clock.addTimeInterval(60 * 86_400)
+        let oldFrequentBoost = store.boost(itemKey: whatsApp, query: "w")
+        for _ in 0..<8 { store.record(itemKey: wick, query: "w") }
+        check(
+            "a newer habit can overtake an old frequent result",
+            store.boost(itemKey: wick, query: "w") > oldFrequentBoost)
+
+        let persistedWickBoost = store.boost(itemKey: wick, query: "w")
+        let reloaded = LauncherRankingStore(fileURL: fileURL) { clock }
+        check(
+            "records persist across store instances",
+            reloaded.boost(itemKey: wick, query: "w") == persistedWickBoost)
+
+        reloaded.reset(itemKey: whatsApp)
+        check("per-item reset clears every learned query", !reloaded.hasRanking(for: whatsApp))
+        check("per-item reset preserves other items", reloaded.hasRanking(for: wick))
+
+        reloaded.resetAll()
+        check("global reset clears all learned ranking", reloaded.isEmpty)
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tools/ranking-test.swift
+++ b/Tools/ranking-test.swift
@@ -23,8 +23,30 @@ struct RankingTest {
 
         let whatsApp = "net.whatsapp.WhatsApp"
         let wick = "com.example.wick"
+        let cafe = "com.example.cafe"
+
+        check(
+            "query key trims surrounding whitespace",
+            LauncherRankingStore.normalize(" wha \n") == "wha")
+        check("query key folds case", LauncherRankingStore.normalize("WhA") == "wha")
+        check("query key folds diacritics", LauncherRankingStore.normalize("Café") == "cafe")
+        // Records are keyed on the folded query, so the fold must resolve to one canonical form no
+        // matter the ambient locale. A Turkish fold maps "I" to "ı"; asserting the difference keeps
+        // this check from going vacuous if that ever stops being true.
+        check(
+            "query key is locale-independent",
+            LauncherRankingStore.normalize("I") == "i"
+                && LauncherRankingStore.normalize("I")
+                    != "I".folding(
+                        options: [.caseInsensitive, .diacriticInsensitive],
+                        locale: Locale(identifier: "tr_TR")))
 
         check("unvisited result has no boost", store.boost(itemKey: whatsApp, query: "w") == 0)
+
+        store.record(itemKey: cafe, query: " Café ")
+        check(
+            "a learned query is recalled through its normalized key",
+            store.boost(itemKey: cafe, query: "cafe") > 0)
 
         store.record(itemKey: whatsApp, query: "Wha")
         let firstBoost = store.boost(itemKey: whatsApp, query: "w")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,9 @@ How Tinycast is wired together. See the per-subsystem docs for internals:
 
 `AppCore.shared` (`Core/AppCore.swift`) is a `@MainActor` singleton that owns every long-lived
 manager — `AppIndex`, `ClipboardStore`, `ClipboardManager`, `HotKeyManager`, `AppSettings`,
-`FavoritesStore`, `VisibilityStore`, `CalculatorHistoryStore`, `CurrencyRateStore`, `RunningAppsMonitor`,
-`PaletteViewModel` — plus the window controllers. `AppDelegate.applicationDidFinishLaunching` calls
+`FavoritesStore`, `VisibilityStore`, `LauncherRankingStore`, `CalculatorHistoryStore`,
+`CurrencyRateStore`, `RunningAppsMonitor`, `PaletteViewModel` — plus the window controllers.
+`AppDelegate.applicationDidFinishLaunching` calls
 `AppCore.shared.start()` and nothing else; that is the single wiring point. All palette / paste /
 launch actions are methods on `AppCore` that the SwiftUI views call.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,7 +76,7 @@ There's no XCTest target. Standalone harnesses:
 
 ```sh
 swift Tools/fuzz-test.swift                                        # launcher fuzzy matcher
-swiftc Tinycast/Core/LauncherRankingStore.swift Tools/ranking-test.swift \
+swiftc -swift-version 6 Tinycast/Core/LauncherRankingStore.swift Tools/ranking-test.swift \
     -o /tmp/ranking-test && /tmp/ranking-test                      # learned launcher ranking
 swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift \
     -o /tmp/calc-test && /tmp/calc-test                           # calculator engine

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,6 +76,8 @@ There's no XCTest target. Standalone harnesses:
 
 ```sh
 swift Tools/fuzz-test.swift                                        # launcher fuzzy matcher
+swiftc Tinycast/Core/LauncherRankingStore.swift Tools/ranking-test.swift \
+    -o /tmp/ranking-test && /tmp/ranking-test                      # learned launcher ranking
 swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift \
     -o /tmp/calc-test && /tmp/calc-test                           # calculator engine
 swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.swift \

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -11,11 +11,13 @@ format scalars first, since app metadata can contain bidi/zero-width markers bef
 
 Selecting a launcher result records every prefix of the submitted query, so choosing WhatsApp for
 `wha` also teaches `w` and `wh`. Direct hotkeys and empty-query favorites do not affect learned
-ranking. Learned data stays on device in `launcher-ranking.json`; every launcher result exposes the
-same per-item reset in its Actions menu, and users can clear all learned ranking in General Settings.
+ranking. Learned data stays on device in `launcher-ranking.json`; a result that has learned ranking
+offers a per-item reset in its Actions menu, and users can clear all learned ranking in General
+Settings.
 
 Rankings are memoized one query deep and keyed by the ranking store's revision, so a launch or reset
-invalidates the cached order.
+invalidates the cached order. `rank` resolves the whole learned table for a query up front via
+`boosts(query:)` — one fold and one clock read per pass, not per candidate.
 
 > **Invariant:** `Tools/fuzz-test.swift` contains a **copy** of `FuzzyMatch` from
 > `Tinycast/Core/AppIndex.swift`. If you change the scoring in one, mirror it in the other or the test

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -4,11 +4,25 @@
 (first dir wins).
 
 `FuzzyMatch.score` is a tiered scorer: exact → prefix → substring / word-start → subsequence with
-consecutive / word-boundary bonuses. Rankings are memoized one query deep.
+consecutive / word-boundary bonuses. `LauncherRankingStore` then adds a bounded, query-specific
+frecency boost (frequency plus decaying recency). The boost can reorder results within a relevance
+tier but cannot make a weaker match kind beat a stronger one. Matching strips invisible Unicode
+format scalars first, since app metadata can contain bidi/zero-width markers before the visible name.
+
+Selecting a launcher result records every prefix of the submitted query, so choosing WhatsApp for
+`wha` also teaches `w` and `wh`. Direct hotkeys and empty-query favorites do not affect learned
+ranking. Learned data stays on device in `launcher-ranking.json`; every launcher result exposes the
+same per-item reset in its Actions menu, and users can clear all learned ranking in General Settings.
+
+Rankings are memoized one query deep and keyed by the ranking store's revision, so a launch or reset
+invalidates the cached order.
 
 > **Invariant:** `Tools/fuzz-test.swift` contains a **copy** of `FuzzyMatch` from
 > `Tinycast/Core/AppIndex.swift`. If you change the scoring in one, mirror it in the other or the test
 > is meaningless.
+
+The ranking harness covers prefix learning, frequency/recency scoring, persistence, and both reset
+paths; see the command in `development.md`.
 
 Icons go through a count-capped `NSCache` (`IconCache`).
 


### PR DESCRIPTION
## Summary

- learn a query-specific frecency boost from results launched through search
- teach every prefix of the submitted query while keeping the boost bounded within fuzzy-match relevance tiers
- normalize invisible Unicode format markers in app metadata before matching
- persist learned data locally with per-result and global reset actions
- keep favorites, empty-query launches, and direct hotkeys outside learned ranking

## Testing

- `swift Tools/fuzz-test.swift` (14 checks)
- `swiftc Tinycast/Core/LauncherRankingStore.swift Tools/ranking-test.swift -o /tmp/ranking-test && /tmp/ranking-test` (11 checks)
- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`