### PR TITLE
Improve keyboard selection scrolling

### DIFF
--- a/Tinycast/Core/EdgeDissolve.swift
+++ b/Tinycast/Core/EdgeDissolve.swift
@@ -50,16 +50,18 @@ struct EdgeDissolveMask: ViewModifier {
 
     private func stops(height: CGFloat) -> [Gradient.Stop] {
         guard canScroll, height > 0 else { return [.init(color: .black, location: 0)] }
-        // Midpoint alpha eases from 1 toward the floor as a full band of content scrolls past (Raycast: opacity = 1 − (1 − min) · clamp(scrollDistance / fadeHeight, 0, 1)).
-        let topAlpha = 1 - (1 - Self.topMinAlpha) * min(topDistance / topFade, 1)
-        let bottomAlpha = 1 - (1 - Self.bottomMinAlpha) * min(bottomDistance / bottomFade, 1)
+        // Each edge stays opaque at its resting boundary, then dissolves as content passes behind it.
+        let topProgress = min(topDistance / topFade, 1)
+        let bottomProgress = min(bottomDistance / bottomFade, 1)
+        let topAlpha = 1 - (1 - Self.topMinAlpha) * topProgress
+        let bottomAlpha = 1 - (1 - Self.bottomMinAlpha) * bottomProgress
         return [
-            .init(color: .black.opacity(0), location: 0),
+            .init(color: .black.opacity(1 - topProgress), location: 0),
             .init(color: .black.opacity(topAlpha), location: topFade / 2 / height),
             .init(color: .black, location: topFade / height),
             .init(color: .black, location: 1 - bottomFade / height),
             .init(color: .black.opacity(bottomAlpha), location: 1 - bottomFade / 2 / height),
-            .init(color: .black.opacity(0), location: 1),
+            .init(color: .black.opacity(1 - bottomProgress), location: 1),
         ]
     }
 }

--- a/Tinycast/Core/ThinScrollbar.swift
+++ b/Tinycast/Core/ThinScrollbar.swift
@@ -178,6 +178,73 @@ extension View {
     func hideNativeScrollers() -> some View {
         background(NativeScrollerHider().frame(width: 0, height: 0))
     }
+
+    /// Attach inside a `ScrollView` to restore its backing clip view to AppKit's exact inset-aware top edge when lazy filtering would otherwise preserve a stale offset.
+    func resetNativeScrollToTop(id: UUID?) -> some View {
+        background(NativeScrollTopResetter(resetID: id).frame(width: 0, height: 0))
+    }
+}
+
+/// Resets immediately to clear the old offset before drawing, then once next run loop to win over late lazy-stack layout restoration.
+private struct NativeScrollTopResetter: NSViewRepresentable {
+    let resetID: UUID?
+
+    func makeNSView(context: Context) -> NSView { ResetterView() }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        (nsView as? ResetterView)?.requestReset(id: resetID)
+    }
+
+    private final class ResetterView: NSView {
+        private var requestedID: UUID?
+        private var passesLeft = 0
+        private var hierarchyRetriesLeft = 0
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) { fatalError() }
+        override init(frame: NSRect) { super.init(frame: frame) }
+
+        func requestReset(id: UUID?) {
+            guard id != requestedID else { return }
+            requestedID = id
+            guard id != nil else {
+                passesLeft = 0
+                hierarchyRetriesLeft = 0
+                return
+            }
+            passesLeft = 2
+            hierarchyRetriesLeft = 10
+            resetIfCurrent(id)
+        }
+
+        private func resetIfCurrent(_ id: UUID?) {
+            guard id != nil, id == requestedID, passesLeft > 0 else { return }
+
+            if let scrollView = enclosingScrollView {
+                passesLeft -= 1
+                scrollView.layoutSubtreeIfNeeded()
+                scrollView.documentView?.layoutSubtreeIfNeeded()
+
+                let clip = scrollView.contentView
+                var probe = clip.bounds
+                probe.origin.y = -1_000_000_000
+                var origin = clip.bounds.origin
+                origin.y = clip.constrainBoundsRect(probe).origin.y
+                clip.scroll(to: origin)
+                scrollView.reflectScrolledClipView(clip)
+            } else {
+                // Preserve the second pass when SwiftUI updates the representable before splicing it into the scroll hierarchy.
+                guard hierarchyRetriesLeft > 0 else {
+                    passesLeft = 0
+                    return
+                }
+                hierarchyRetriesLeft -= 1
+            }
+
+            guard passesLeft > 0 else { return }
+            DispatchQueue.main.async { [weak self] in self?.resetIfCurrent(id) }
+        }
+    }
 }
 
 /// Forces the backing `NSScrollView` to a hidden `.overlay` scroller (removing the always-on legacy widget and its reserved gutter), re-asserting it on `preferredScrollerStyleDidChangeNotification` since macOS otherwise resets it.

--- a/Tinycast/Features/Calculator/CalculatorHistoryView.swift
+++ b/Tinycast/Features/Calculator/CalculatorHistoryView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 struct CalculatorHistoryList: View {
     let results: [CalcHistoryEntry]
     let selectedID: CalcHistoryEntry.ID?
-    /// Changes only when the list should scroll to follow the selection (keyboard nav / reset), so mouse selection never yanks the scroll position.
-    let scrollToken: UUID
+    /// Present only when the list should follow selection or return to its origin.
+    let scrollIntent: ListScrollIntent?
     /// Live answer for a calculation typed into the history search — same card and flat-index-0 contract as the launcher (`LauncherList.calc`).
     var calc: CalcResult?
     var calcSelected = false
@@ -50,43 +50,49 @@ struct CalculatorHistoryList: View {
         let rows = rows
         return ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(rows) { row in
-                        switch row {
-                        case .header(let title):
-                            SectionHeader(title: title, isFirst: row.id == rows.first?.id)
-                        case .calc(let result):
-                            CalculatorCard(result: result, selected: calcSelected)
-                                .contentShape(Rectangle())
-                                .onTapGesture(perform: onActivateCalc)
-                                .onRightClick(perform: onCalcActions)
-                                .padding(.bottom, Theme.Spacing.xs)
-                        case .entry(let entry):
-                            CalcHistoryRow(entry: entry, selected: entry.id == selectedID)
-                                .contentShape(Rectangle())
-                                .onTapGesture { onSelect(entry) }
-                                .simultaneousGesture(
-                                    TapGesture(count: 2).onEnded {
-                                        onSelect(entry)
-                                        onActivate()
-                                    }
-                                )
-                                .onRightClick { onActions(entry) }
+                VStack(spacing: 0) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(rows) { row in
+                            switch row {
+                            case .header(let title):
+                                SectionHeader(title: title, isFirst: row.id == rows.first?.id)
+                            case .calc(let result):
+                                CalculatorCard(result: result, selected: calcSelected)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture(perform: onActivateCalc)
+                                    .onRightClick(perform: onCalcActions)
+                                    .padding(.bottom, Theme.Spacing.xs)
+                            case .entry(let entry):
+                                CalcHistoryRow(entry: entry, selected: entry.id == selectedID)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture { onSelect(entry) }
+                                    .simultaneousGesture(
+                                        TapGesture(count: 2).onEnded {
+                                            onSelect(entry)
+                                            onActivate()
+                                        }
+                                    )
+                                    .onRightClick { onActions(entry) }
+                            }
                         }
                     }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.top, Theme.Spacing.xs)
+                    .padding(.bottom, Theme.Spacing.md)
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
                 .hideNativeScrollers()
+                .resetNativeScrollToTop(
+                    id: scrollIntent?.kind == .top ? scrollIntent?.id : nil
+                )
             }
             .edgeDissolve()
             .thinScrollbar()
-            .onChange(of: scrollToken) {
-                if calcSelected {
-                    proxy.scrollTo(Self.calcRowID, anchor: .center)
-                } else if let selectedID {
-                    proxy.scrollTo(selectedID.uuidString, anchor: .center)
+            .task(id: scrollIntent) {
+                guard let scrollIntent else { return }
+                if scrollIntent.kind == .follow, calcSelected {
+                    proxy.scrollTo(Self.calcRowID)
+                } else if scrollIntent.kind == .follow, let selectedID {
+                    proxy.scrollTo(selectedID.uuidString)
                 }
             }
         }

--- a/Tinycast/Features/Clipboard/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/ClipboardView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 struct ClipboardList: View {
     let results: [ClipboardItem]
     let selectedID: ClipboardItem.ID?
-    /// Changes only when the list should scroll to follow the selection (keyboard nav / reset), so mouse selection never yanks the scroll position.
-    let scrollToken: UUID
+    /// Present only when the list should follow selection or return to its origin.
+    let scrollIntent: ListScrollIntent?
     let onSelect: (ClipboardItem) -> Void
     let onActivate: () -> Void
     let onActions: (ClipboardItem) -> Void
@@ -41,38 +41,46 @@ struct ClipboardList: View {
         let rows = rows
         return ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(rows) { row in
-                        switch row {
-                        case .header(let title):
-                            SectionHeader(title: title, isFirst: row.id == rows.first?.id)
-                        case .item(let item):
-                            ClipboardRow(
-                                item: item, selected: item.id == selectedID,
-                                imageURL: store.imageURL(for: item)
-                            )
-                            .contentShape(Rectangle())
-                            // Single click selects instantly (double-click-to-paste is a `.simultaneousGesture`, so the tap never waits on the double-click timeout); right-click uses the lightweight catcher, since `.contextMenu` stalls clicks for seconds in a LazyVStack.
-                            .onTapGesture { onSelect(item) }
-                            .simultaneousGesture(
-                                TapGesture(count: 2).onEnded {
-                                    onSelect(item)
-                                    onActivate()
-                                }
-                            )
-                            .onRightClick { onActions(item) }
+                VStack(spacing: 0) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(rows) { row in
+                            switch row {
+                            case .header(let title):
+                                SectionHeader(title: title, isFirst: row.id == rows.first?.id)
+                            case .item(let item):
+                                ClipboardRow(
+                                    item: item, selected: item.id == selectedID,
+                                    imageURL: store.imageURL(for: item)
+                                )
+                                .contentShape(Rectangle())
+                                // Single click selects instantly (double-click-to-paste is a `.simultaneousGesture`, so the tap never waits on the double-click timeout); right-click uses the lightweight catcher, since `.contextMenu` stalls clicks for seconds in a LazyVStack.
+                                .onTapGesture { onSelect(item) }
+                                .simultaneousGesture(
+                                    TapGesture(count: 2).onEnded {
+                                        onSelect(item)
+                                        onActivate()
+                                    }
+                                )
+                                .onRightClick { onActions(item) }
+                            }
                         }
                     }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.top, Theme.Spacing.xs)
+                    .padding(.bottom, Theme.Spacing.md)
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
                 .hideNativeScrollers()
+                .resetNativeScrollToTop(
+                    id: scrollIntent?.kind == .top ? scrollIntent?.id : nil
+                )
             }
             .edgeDissolve()
             .thinScrollbar()
-            .onChange(of: scrollToken) {
-                if let selectedID { proxy.scrollTo(selectedID.uuidString, anchor: .center) }
+            .task(id: scrollIntent) {
+                guard let scrollIntent else { return }
+                if scrollIntent.kind == .follow, let selectedID {
+                    proxy.scrollTo(selectedID.uuidString)
+                }
             }
         }
     }

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -5,8 +5,8 @@ struct LauncherList: View {
     let selectedID: AppEntry.ID?
     let favoriteCount: Int
     let showSections: Bool
-    /// Changes only when the list should scroll to follow the selection (keyboard nav / reset), so mouse selection never yanks the scroll position.
-    let scrollToken: UUID
+    /// Present only when the list should follow selection or return to its origin.
+    let scrollIntent: ListScrollIntent?
     /// Inline calculator answer; occupies flat selection index 0 when present (requires a non-empty query, so it never coexists with the sectioned view).
     var calc: CalcResult?
     var calcSelected = false
@@ -64,41 +64,48 @@ struct LauncherList: View {
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(rows) { row in
-                                switch row {
-                                case .header(let title):
-                                    SectionHeader(title: title, isFirst: row.id == rows.first?.id)
-                                case .calc(let result):
-                                    CalculatorCard(result: result, selected: calcSelected)
+                        VStack(spacing: 0) {
+                            LazyVStack(spacing: 0) {
+                                ForEach(rows) { row in
+                                    switch row {
+                                    case .header(let title):
+                                        SectionHeader(
+                                            title: title, isFirst: row.id == rows.first?.id)
+                                    case .calc(let result):
+                                        CalculatorCard(result: result, selected: calcSelected)
+                                            .contentShape(Rectangle())
+                                            .onTapGesture(perform: onActivateCalc)
+                                            .onRightClick(perform: onCalcActions)
+                                            .padding(.bottom, Theme.Spacing.xs)
+                                    case .app(let app):
+                                        AppRow(
+                                            app: app,
+                                            selected: app.id == selectedID,
+                                            running: runningApps.isRunning(app)
+                                        )
                                         .contentShape(Rectangle())
-                                        .onTapGesture(perform: onActivateCalc)
-                                        .onRightClick(perform: onCalcActions)
-                                        .padding(.bottom, Theme.Spacing.xs)
-                                case .app(let app):
-                                    AppRow(
-                                        app: app,
-                                        selected: app.id == selectedID,
-                                        running: runningApps.isRunning(app)
-                                    )
-                                    .contentShape(Rectangle())
-                                    .onTapGesture { onActivate(app) }
-                                    .onRightClick { onActions(app) }
+                                        .onTapGesture { onActivate(app) }
+                                        .onRightClick { onActions(app) }
+                                    }
                                 }
                             }
+                            .padding(.horizontal, Theme.Spacing.md)
+                            .padding(.top, Theme.Spacing.xs)
+                            .padding(.bottom, Theme.Spacing.md)
                         }
-                        .padding(.horizontal, Theme.Spacing.md)
-                        .padding(.top, Theme.Spacing.xs)
-                        .padding(.bottom, Theme.Spacing.md)
                         .hideNativeScrollers()
+                        .resetNativeScrollToTop(
+                            id: scrollIntent?.kind == .top ? scrollIntent?.id : nil
+                        )
                     }
                     .edgeDissolve()
                     .thinScrollbar()
-                    .onChange(of: scrollToken) {
-                        if calcSelected {
-                            proxy.scrollTo(Self.calcRowID, anchor: .center)
-                        } else if let selectedID {
-                            proxy.scrollTo(selectedID, anchor: .center)
+                    .task(id: scrollIntent) {
+                        guard let scrollIntent else { return }
+                        if scrollIntent.kind == .follow, calcSelected {
+                            proxy.scrollTo(Self.calcRowID)
+                        } else if scrollIntent.kind == .follow, let selectedID {
+                            proxy.scrollTo(selectedID)
                         }
                     }
                 }

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+/// A cancellable list-scroll request that either minimally reveals the selection or restores the content origin.
+struct ListScrollIntent: Equatable {
+    enum Kind: Equatable {
+        case follow
+        case top
+    }
+
+    let id = UUID()
+    let kind: Kind
+}
+
 struct RootPaletteView: View {
     @EnvironmentObject private var core: AppCore
     @EnvironmentObject private var vm: PaletteViewModel
@@ -22,9 +33,9 @@ struct RootPaletteView: View {
     @State private var selectionIsRunning = false
     /// Highlighted row of whichever popover menu is open; reset to the first row on open, moved by ↑/↓ and hover, activated by ↵/click.
     @State private var menuSelection = 0
-    /// Bumped only when the selection should pull the scroll view with it (keyboard nav, list resets); mouse selection targets a visible row, so it leaves this and the list put.
-    @State private var scrollToken = UUID()
-    /// The emoji grid's scroll request — the lazy grid needs distinct reset/follow scroll ops, unlike the 1-D lists that recenter fine on `scrollToken`.
+    /// Changes only when a query/reset/navigation/reorder needs the list to move; mouse selection never changes it.
+    @State private var listScroll: ListScrollIntent?
+    /// The emoji grid's scroll request — the lazy grid needs distinct reset/follow scroll ops.
     @State private var emojiScroll = EmojiScrollIntent(kind: .top)
 
     private var isQueryEmpty: Bool { vm.query.trimmingCharacters(in: .whitespaces).isEmpty }
@@ -251,18 +262,18 @@ struct RootPaletteView: View {
         }
         .onChange(of: vm.query) {
             vm.selection = 0
-            scrollToken = UUID()
+            listScroll = ListScrollIntent(kind: .top)
             emojiScroll = EmojiScrollIntent(kind: .top)
         }
         .onChange(of: vm.mode) {
             vm.selection = 0
             showActions = false
-            scrollToken = UUID()
+            listScroll = ListScrollIntent(kind: .top)
             emojiScroll = EmojiScrollIntent(kind: .top)
         }
-        // Pop-to-root: `prepare` clears query/selection, but if both were already at their defaults the handlers above never fire — this token guarantees the scroll itself snaps back to the top.
+        // Pop-to-root can leave query and mode unchanged, so explicitly restore the content origin.
         .onChange(of: vm.resetToken) {
-            scrollToken = UUID()
+            listScroll = ListScrollIntent(kind: .top)
             emojiScroll = EmojiScrollIntent(kind: .top)
         }
         // Opening either menu highlights its first row and closes the other, so exactly one menu is ever open and always has a highlight.
@@ -289,11 +300,19 @@ struct RootPaletteView: View {
             {
                 vm.selection = index
             }
-            scrollToken = UUID()
+            listScroll = ListScrollIntent(kind: .top)
         }
         .onAppear { searchFocused = true }
-        // Typing/clearing/overflow/settings all flip `paletteIsCollapsed`; resize the window to match.
-        .onChange(of: core.paletteIsCollapsed) { core.syncPaletteSize() }
+        // Resize first, then reassert the top after a compact→expanded layout has adopted the full frame.
+        .onChange(of: core.paletteIsCollapsed) { oldCollapsed, collapsed in
+            core.syncPaletteSize()
+            guard oldCollapsed, !collapsed else { return }
+            Task { @MainActor in
+                await Task.yield()
+                guard !core.paletteIsCollapsed else { return }
+                listScroll = ListScrollIntent(kind: .top)
+            }
+        }
         // ⌘1–⌘5 launch the compact bar's favorite slots (or expand, for the "…" overflow slot).
         .onKeyPress(keys: ["1", "2", "3", "4", "5"], phases: .down) { press in
             guard isCollapsed, settings.showFavoritesInCompactMode,
@@ -511,7 +530,7 @@ struct RootPaletteView: View {
                 selectedID: calcSelected ? nil : selectedID,
                 favoriteCount: favoriteCount,
                 showSections: showSections,
-                scrollToken: scrollToken,
+                scrollIntent: listScroll,
                 calc: calc,
                 calcSelected: calcSelected,
                 onActivateCalc: {
@@ -539,7 +558,7 @@ struct RootPaletteView: View {
                     ClipboardList(
                         results: clips,
                         selectedID: selected?.id,
-                        scrollToken: scrollToken,
+                        scrollIntent: listScroll,
                         onSelect: { item in vm.selection = clips.firstIndex(of: item) ?? 0 },
                         onActivate: activateSelection,
                         onActions: { item in
@@ -566,7 +585,7 @@ struct RootPaletteView: View {
                 CalculatorHistoryList(
                     results: hist,
                     selectedID: calcSelected ? nil : selected?.id,
-                    scrollToken: scrollToken,
+                    scrollIntent: listScroll,
                     calc: calc,
                     calcSelected: calcSelected,
                     onActivateCalc: {
@@ -721,8 +740,10 @@ struct RootPaletteView: View {
 
     private func move(_ delta: Int) {
         guard resultCount > 0 else { return }
-        vm.selection = min(max(selection + delta, 0), resultCount - 1)
-        scrollToken = UUID()
+        let nextSelection = min(max(selection + delta, 0), resultCount - 1)
+        vm.selection = nextSelection
+        let kind: ListScrollIntent.Kind = delta < 0 && nextSelection == 0 ? .top : .follow
+        listScroll = ListScrollIntent(kind: kind)
         emojiScroll = EmojiScrollIntent(kind: .follow)
     }
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -120,7 +120,7 @@ the `ScrollView`, **before `.thinScrollbar()`** (so the scrollbar overlay stays 
 
 - Fade bands: top = `headerHeight + headerPadding + 32`, bottom = `bottomBarHeight + 28` — each overshoots its bar into the visible list, so the ramp finishes ~32/28px _past_ the bar rather than cliffing at its edge.
 - Alpha floors mid-scroll (not to 0): **top 0.15, bottom 0.25**, eased by how much content is hidden past the edge (`1 − (1 − floor)·clamp(dist/band, 0, 1)`).
-- Only masks when the list is scrollable; the edge stop stays transparent so rubber-band bounces still dissolve. A list that fits gets no mask.
+- The outer edge is opaque at its resting boundary and dissolves continuously as content passes behind it. A list that fits gets no mask.
 - The mask spans the scroll view's **full** frame (`.ignoresSafeArea()`) — otherwise the bars' safe-area insets shift the gradient onto at-rest rows.
 
 ---
@@ -132,7 +132,7 @@ All lists share one row grammar so launcher and clipboard look identical:
 - `HStack(spacing: lg)`: leading 24pt icon/thumbnail, title (`.body`, `lineLimit(1)`), optional trailing keycaps/kind label, `Spacer`. Insets: `.horizontal md`, `.vertical sm`.
 - Background is a `RoundedRectangle(row, .continuous)` filled by `fill`: **selection → hover → clear**, in that precedence. This `fill` computed property is copy-identical across `AppRow`, `ClipboardRow`, `CalculatorCard` — keep them in sync.
 - **Hover state lives on the row**, not the list, so a mouse sweep repaints only the rows entering/leaving (a list-level hover rebuilds every row per move — don't do that).
-- **Scroll follows selection only on keyboard nav/reset**, driven by a `scrollToken` UUID — mouse selection targets a visible row and never yanks scroll.
+- **Scroll follows explicit intent only**, driven by a cancellable `ListScrollIntent` — mouse selection never yanks scroll and arrows minimally reveal rows. Top intents reset the backing clip view to AppKit's exact inset-aware minimum, and the scroll view retains its identity across query changes so lazy filtering cannot restore a stale offset or briefly lose the header inset.
 - **Keycaps** use `KeyCapChip`: `.outline` (white-0.20 border) for hotkey hints on rows, `.filled` (white-0.10 fill) for footer shortcuts.
 
 ### Section headers


### PR DESCRIPTION
## Related issue

Closes #100

## What changed

- Keep launcher, clipboard, and calculator-history lists stationary while keyboard selection remains visible.
- Minimally reveal the next row when selection reaches a viewport edge.
- Restore the exact inset-aware top origin when navigating to the first row or changing/resetting a query.
- Keep filtered scroll containers mounted so lazy list updates cannot restore a stale offset for one frame.
- Reassert the top origin after compact mode expands.

The implementation uses an explicit `ListScrollIntent`: follow requests use unanchored `ScrollViewReader.scrollTo`, while top requests reset the backing `NSClipView` to its constrained native origin.

## Why the additional scroll handling is needed

- A simple `scrollTo` left the previous offset active when typing after keyboard navigation, causing filtered results to appear partially displaced.
- Recreating the filtered scroll view could briefly render the stale offset, producing a one-frame jump or flicker.
- Expanding from compact mode changes the layout after the initial reset, so the top position must be reasserted once the expanded layout is available.
- Scrolling only to the first result does not restore the search/header inset precisely, which is why the native clip-view origin is reset for top requests.
- The same behavior is shared by launcher, clipboard, and calculator history to keep keyboard navigation consistent.

## Memory footprint

Measured with `footprint` after 300 Down presses, 300 Up presses, and 10 repeated query-change cycles.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 21 MB  |
| Palette open            | 35 MB  |
| Feature in use (peak)   | 80.7 MB |
| Palette closed, settled | 80 MB  |

Leak-tested: yes. `leaks` reports 287 allocations / 14,320 bytes in the existing AppIntents `NSXPCConnection` cycle; the count and allocation tree are identical on current `main`. No new app-attributable leak or cumulative growth was observed. `xcodebuild analyze` succeeds.

## Demo

Side-by-side video uses the official v0.7.5 stable build on the left and this PR on the right. Both start in compact mode and use the same 750 × 475 expanded window and actions: type `a`, press Down eight times, then Up eight times. v0.7.5 recenters the selection and moves the search/header area while the selected row is still visible; the PR keeps the viewport stationary until an edge is reached.

https://github.com/user-attachments/assets/f8cf67fe-fcf4-4a27-a736-23e4328a94e3

## Drawbacks

After a full icon-list traversal, macOS image and Core Animation caches remain warm, so the process does not return to its cold-launch 21 MB footprint. Current `main` has the same behavior. A second stress cycle remains at the same warm baseline with no cumulative growth.

## Tests & validation

- Clean unsigned Debug build: `xcodebuild ... clean build`
- Static analysis: `xcodebuild ... analyze`
- `swift Tools/fuzz-test.swift`
- `Tools/ranking-test.swift`
- `Tools/calc-test.swift` — 426 passed
- `Tools/clipboard-test.swift` — 23/23 passed
- `Tools/scopes-test.swift`
- `Tools/emoji-test.swift` — 2,054 records
- `Tools/custom-command-test.swift`
- Manual launcher navigation in expanded and compact mode, including edge scrolling, returning to the first result, repeated `w`/`wh` query changes, and clearing the query after scrolling.
- Manual Clipboard History navigation/filter reset and Calculator History launch.

I have read and accept the Contributor License and Feedback Agreement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge dissolve behavior so scroll boundaries transition smoothly as content moves behind them.
  * Fixed stale scroll offsets and restored correct top positioning when switching queries, modes, or selections.
  * Reduced unwanted scrolling during mouse selection while preserving minimal row visibility during keyboard navigation.

* **Documentation**
  * Updated UI documentation to describe the revised edge masking and selection scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->