### PR TITLE
Expand compact launcher with Down arrow

### DIFF
--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -310,7 +310,13 @@ struct RootPaletteView: View {
             return .handled
         }
         .onKeyPress(.downArrow) {
-            if isCollapsed { return .ignored }
+            if isCollapsed {
+                // The compact bar has no visible selection; Down reveals the list at its first row
+                // while the shared search field stays mounted and focused.
+                vm.selection = 0
+                core.expandFromCompact()
+                return .handled
+            }
             if menuOpen {
                 moveMenu(1)
                 return .handled

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -107,6 +107,7 @@ the forced-dark environment). **Selection always beats hover** when a row is bot
 - **`PalettePanel`** is a borderless `NSPanel`: `isOpaque = false`, `backgroundColor = .clear`, `.floating` level, `hasShadow`, `animationBehavior = .none`. It hosts SwiftUI via `NSHostingView`. `PaletteWindowController` centers it slightly above screen center (`+8%`) and dismisses it on `windowDidResignKey`.
 - **The results layer fills the whole panel.** The header and bottom bar attach via `.safeAreaInset(edge: .top/.bottom)` as transparent overlays that float _over_ the list. The list underlaps them and dissolves at the edges.
 - **Header** (`headerHeight 44`): a back-chevron _or_ mode glyph, then the plain `TextField` (no border/background). Sub-screens (Clipboard, Calculator History) show the back chevron; the launcher shows a magnifying glass. The search icon aligns horizontally with row content.
+- **Compact keyboard entry:** pressing `↓` in the collapsed launcher expands the results and selects the first row without replacing or defocusing the shared search field.
 - **Bottom bar** (`bottomBarHeight 52`): a menu circle on the left, the action group on the right — both floating glass, no bar background. The action group is one glass `Capsule` holding the primary-action pill (label + `↵`) and the Actions toggle (`⌘K`).
 
 ---


### PR DESCRIPTION
## Summary

- make `↓` expand the launcher when compact mode is collapsed
- select the first result immediately after expansion
- keep the shared search field mounted and focused
- leave `↑` and expanded-list navigation unchanged

## Testing

- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`