### PR TITLE
Add pin and unpin to clipboard history

### DIFF
--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -59,6 +59,8 @@ final class PaletteViewModel: ObservableObject {
     @Published var focusToken = UUID()
     /// Changes only when `prepare` resets the palette, so the lists snap their scroll to the top even when query/mode were already at their defaults (`focusToken` can't serve: it bumps on every reopen, which must preserve a within-timeout scroll).
     @Published var resetToken = UUID()
+    /// Changes when an action reorders the list under the selection (pinning a clip lifts it into the Pinned section), so the list scrolls the highlight back into view.
+    @Published var followToken = UUID()
     /// Set by the compact bar's "…" overflow to expand into the full launcher without a query; cleared on every `prepare`.
     @Published var forceExpanded = false
     /// The app a paste would land in, mirrored from `PaletteWindowController.previousApp` on every show. Deliberately *not* cleared by `prepare` — pop-to-root resets the screen, not the paste target.
@@ -355,22 +357,22 @@ final class AppCore: ObservableObject {
     func paste(_ item: ClipboardItem) {
         let previous = windowController.previousApp
         hidePalette(restoreFocus: false)
-        // A successful write promotes the item to index 0; follow it so any preserved (pop-to-root) or open clipboard state highlights the row that moved.
+        // A successful write promotes the item to the head of its section; follow it so any preserved (pop-to-root) or open clipboard state highlights the row that moved.
         if Paster.paste(item, store: clipboardStore, previousApp: previous) {
-            palette.selection = 0
+            selectClip(item)
         }
     }
 
     func pasteKeepingWindowOpen(_ item: ClipboardItem) {
         if windowController.pasteKeepingWindowOpen(item, store: clipboardStore) {
-            palette.selection = 0
+            selectClip(item)
         }
     }
 
     func copyToClipboard(_ item: ClipboardItem) {
         hidePalette(restoreFocus: false)
         if Paster.copy(item, store: clipboardStore) {
-            palette.selection = 0
+            selectClip(item)
         }
     }
 
@@ -378,6 +380,18 @@ final class AppCore: ObservableObject {
         guard let url = clipboardStore.imageURL(for: item) else { return }
         hidePalette(restoreFocus: false)
         AppLauncher.showInFinder(url)
+    }
+
+    /// Pin or unpin a clipboard entry: the row jumps into (or out of) the Pinned section at the top, so the selection and the scroll follow it.
+    func togglePinnedClip(_ item: ClipboardItem) {
+        clipboardStore.togglePinned(item)
+        selectClip(item)
+        palette.followToken = UUID()
+    }
+
+    /// Put the selection on `item`'s row in the list as currently filtered — pinned rows hold the top, so a row that moved isn't always index 0.
+    private func selectClip(_ item: ClipboardItem) {
+        palette.selection = clipboardStore.rowIndex(of: item, in: palette.query) ?? 0
     }
 
     // MARK: - Emoji actions (frequency is tallied on the base glyph; the configured tone is applied at copy time)

--- a/Tinycast/Core/ClipboardStore.swift
+++ b/Tinycast/Core/ClipboardStore.swift
@@ -14,6 +14,8 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
     let createdAt: Date
     /// Bundle ID of the app frontmost when the copy was captured (see `ClipboardManager.poll`).
     let sourceBundleID: String?
+    /// Pinned entries lead the list under their own section and are exempt from retention pruning.
+    let isPinned: Bool
 
     init(text: String, sourceBundleID: String?) {
         self.init(
@@ -29,7 +31,7 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
 
     init(
         id: UUID, kind: Kind, text: String?, imagePath: String?, createdAt: Date,
-        sourceBundleID: String?
+        sourceBundleID: String?, isPinned: Bool = false
     ) {
         self.id = id
         self.kind = kind
@@ -37,6 +39,15 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
         self.imagePath = imagePath
         self.createdAt = createdAt
         self.sourceBundleID = sourceBundleID
+        self.isPinned = isPinned
+    }
+
+    /// Copy carrying one changed field — the store rewrites rows in place to re-recency (promote) or flip the pin.
+    func with(createdAt: Date? = nil, isPinned: Bool? = nil) -> ClipboardItem {
+        ClipboardItem(
+            id: id, kind: kind, text: text, imagePath: imagePath,
+            createdAt: createdAt ?? self.createdAt, sourceBundleID: sourceBundleID,
+            isPinned: isPinned ?? self.isPinned)
     }
 }
 
@@ -72,13 +83,19 @@ enum ClipboardRetention: Int, CaseIterable, Identifiable, Sendable {
 /// SQLite-backed clipboard history (rows + trigram FTS5 index in `clipboard.sqlite3`, image blobs on disk), degrading to session-only in-memory history if the database can't be opened.
 @MainActor
 final class ClipboardStore: ObservableObject {
+    /// Newest-first, pins included in place — `search` is the one place that lifts pinned rows to the head for display.
     @Published private(set) var items: [ClipboardItem] = [] {
-        didSet { searchCache = nil }
+        didSet {
+            searchCache = nil
+            orderedCache = nil
+        }
     }
     var maxAge: TimeInterval = ClipboardRetention.threeMonths.maxAge
 
     /// One-entry memo so repeated renders (e.g. arrow-key nav) for the same query reuse the FTS result instead of re-querying SQLite every frame; invalidated whenever `items` changes.
     private var searchCache: (query: String, result: [ClipboardItem])?
+    /// Same memo for the empty query — every render reads the full display order, so the pinned/unpinned split runs once per mutation.
+    private var orderedCache: [ClipboardItem]?
 
     private static let memoryWindow = 1000
 
@@ -89,7 +106,8 @@ final class ClipboardStore: ObservableObject {
           text TEXT,
           image_path TEXT,
           created_at REAL NOT NULL,
-          source_app TEXT
+          source_app TEXT,
+          pinned INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS items_created_at ON items(created_at);
         CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
@@ -110,6 +128,7 @@ final class ClipboardStore: ObservableObject {
     private var loadStmt: OpaquePointer?
     private var searchStmt: OpaquePointer?
     private var deleteByIDStmt: OpaquePointer?
+    private var setPinnedStmt: OpaquePointer?
     private var staleImagesStmt: OpaquePointer?
     private var deleteStaleStmt: OpaquePointer?
 
@@ -139,7 +158,8 @@ final class ClipboardStore: ObservableObject {
 
     func load() {
         guard let stmt = loadStmt else { return }
-        sqlite3_bind_int(stmt, 1, Int32(Self.memoryWindow))
+        // The window counts unpinned rows only; `loadStmt` adds every pinned row on top, however old.
+        sqlite3_bind_int(stmt, 1, Int32(Self.memoryWindow - 1))
         var loaded: [ClipboardItem] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
             if let item = Self.row(stmt) { loaded.append(item) }
@@ -200,12 +220,10 @@ final class ClipboardStore: ObservableObject {
         return inserted
     }
 
-    /// Move an item to the top of history (pasting/copying it from the palette re-recencies it, Raycast-style). Display order is rowid, so this is a delete + re-insert under the same id; the fresh `createdAt` keeps date buckets descending and the image blob is never touched.
+    /// Move an item to the top of history (pasting/copying it from the palette re-recencies it, Raycast-style). Stored order is rowid, so this is a delete + re-insert under the same id; the fresh `createdAt` keeps date buckets descending, the pin rides along, and the image blob is never touched.
     func promote(_ item: ClipboardItem) {
         guard items.first?.id != item.id else { return }
-        let promoted = ClipboardItem(
-            id: item.id, kind: item.kind, text: item.text, imagePath: item.imagePath,
-            createdAt: Date(), sourceBundleID: item.sourceBundleID)
+        let promoted = item.with(createdAt: Date())
         if let deleteStmt = deleteByIDStmt, let insertStmt {
             // One transaction: `id` is UNIQUE and a crash between the two statements must not lose the row.
             sqlite3_exec(db, "BEGIN", nil, nil, nil)
@@ -219,7 +237,25 @@ final class ClipboardStore: ObservableObject {
         // Array ops also cover items surfaced by FTS from beyond the in-memory window.
         items.removeAll { $0.id == item.id }
         items.insert(promoted, at: 0)
-        if items.count > Self.memoryWindow { items.removeLast() }
+        trimWindow()
+    }
+
+    /// Flip an entry's pin. Pinned rows render in their own section above the history and survive retention pruning; a row pinned from an FTS hit older than the in-memory window is spliced into it so the section can show it.
+    func togglePinned(_ item: ClipboardItem) {
+        let updated = item.with(isPinned: !item.isPinned)
+        if let stmt = setPinnedStmt {
+            sqlite3_bind_int(stmt, 1, updated.isPinned ? 1 : 0)
+            sqlite3_bind_text(stmt, 2, item.id.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(stmt)
+            sqlite3_reset(stmt)
+            sqlite3_clear_bindings(stmt)
+        }
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index] = updated
+        } else if updated.isPinned {
+            let index = items.firstIndex { $0.createdAt < updated.createdAt } ?? items.count
+            items.insert(updated, at: index)
+        }
     }
 
     func remove(_ item: ClipboardItem) {
@@ -245,13 +281,19 @@ final class ClipboardStore: ObservableObject {
         return URL(fileURLWithPath: path)
     }
 
+    /// Display order for `query`: pinned entries first, each block newest-first.
     func search(_ query: String) -> [ClipboardItem] {
         let q = query.trimmingCharacters(in: .whitespaces)
-        guard !q.isEmpty else { return items }
+        guard !q.isEmpty else { return orderedItems }
         if let searchCache, searchCache.query == q { return searchCache.result }
-        let result = runSearch(q)
+        let result = Self.pinnedFirst(runSearch(q))
         searchCache = (q, result)
         return result
+    }
+
+    /// Row index of `item` among the results for `query` — lets the palette keep its selection on a row that moved (pin toggle, promote) whether or not the search is filtered. Reads the same memoized result the list renders.
+    func rowIndex(of item: ClipboardItem, in query: String) -> Int? {
+        search(query).firstIndex { $0.id == item.id }
     }
 
     private func runSearch(_ q: String) -> [ClipboardItem] {
@@ -276,10 +318,31 @@ final class ClipboardStore: ObservableObject {
         items.filter { ($0.text?.localizedCaseInsensitiveContains(q)) ?? false }
     }
 
+    private var orderedItems: [ClipboardItem] {
+        if let orderedCache { return orderedCache }
+        let result = Self.pinnedFirst(items)
+        orderedCache = result
+        return result
+    }
+
+    /// Lift pinned rows to the head, preserving the newest-first order within each block.
+    private static func pinnedFirst(_ list: [ClipboardItem]) -> [ClipboardItem] {
+        let pinned = list.filter(\.isPinned)
+        guard !pinned.isEmpty else { return list }
+        return pinned + list.filter { !$0.isPinned }
+    }
+
+    /// Cap the in-memory window, but never drop a pinned row: those render however old they are.
+    private func trimWindow() {
+        guard items.count > Self.memoryWindow, let index = items.lastIndex(where: { !$0.isPinned })
+        else { return }
+        items.remove(at: index)
+    }
+
     private func insert(_ item: ClipboardItem) {
         if let stmt = insertStmt { bindAndInsert(stmt, item) }
         items.insert(item, at: 0)
-        if items.count > Self.memoryWindow { items.removeLast() }
+        trimWindow()
         prune()
     }
 
@@ -302,6 +365,7 @@ final class ClipboardStore: ObservableObject {
         } else {
             sqlite3_bind_null(stmt, 6)
         }
+        sqlite3_bind_int(stmt, 7, item.isPinned ? 1 : 0)
         sqlite3_step(stmt)
         sqlite3_reset(stmt)
         sqlite3_clear_bindings(stmt)
@@ -353,7 +417,7 @@ final class ClipboardStore: ObservableObject {
             }
         }
         if items.last.map({ $0.createdAt < cutoff }) == true {
-            items.removeAll { $0.createdAt < cutoff }
+            items.removeAll { $0.createdAt < cutoff && !$0.isPinned }
         }
     }
 
@@ -374,25 +438,41 @@ final class ClipboardStore: ObservableObject {
         if !columnExists("source_app", in: "items") {
             sqlite3_exec(db, "ALTER TABLE items ADD COLUMN source_app TEXT", nil, nil, nil)
         }
+        if !columnExists("pinned", in: "items") {
+            sqlite3_exec(
+                db, "ALTER TABLE items ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0", nil, nil, nil)
+        }
         insertStmt = prepare(
-            "INSERT INTO items(id, kind, text, image_path, created_at, source_app) VALUES(?,?,?,?,?,?)"
+            """
+            INSERT INTO items(id, kind, text, image_path, created_at, source_app, pinned)
+            VALUES(?,?,?,?,?,?,?)
+            """
         )
+        // Every pinned row plus the newest `memoryWindow` unpinned ones (rowid of the oldest kept unpinned row is the floor; NULL when there are fewer than that, so everything loads).
         loadStmt = prepare(
             """
-            SELECT id, kind, text, image_path, created_at, source_app FROM items
-            ORDER BY rowid DESC LIMIT ?
+            SELECT id, kind, text, image_path, created_at, source_app, pinned FROM items
+            WHERE pinned = 1 OR rowid >= COALESCE(
+              (SELECT rowid FROM items WHERE pinned = 0 ORDER BY rowid DESC LIMIT 1 OFFSET ?), 0)
+            ORDER BY rowid DESC
             """)
         searchStmt = prepare(
             """
-            SELECT i.id, i.kind, i.text, i.image_path, i.created_at, i.source_app FROM items_fts f
-            JOIN items i ON i.rowid = f.rowid WHERE items_fts MATCH ? ORDER BY f.rowid DESC LIMIT 200
+            SELECT i.id, i.kind, i.text, i.image_path, i.created_at, i.source_app, i.pinned
+            FROM items_fts f JOIN items i ON i.rowid = f.rowid
+            WHERE items_fts MATCH ? ORDER BY f.rowid DESC LIMIT 200
             """)
         deleteByIDStmt = prepare("DELETE FROM items WHERE id = ?")
+        setPinnedStmt = prepare("UPDATE items SET pinned = ? WHERE id = ?")
         staleImagesStmt = prepare(
-            "SELECT image_path FROM items WHERE created_at < ? AND image_path IS NOT NULL")
-        deleteStaleStmt = prepare("DELETE FROM items WHERE created_at < ?")
+            """
+            SELECT image_path FROM items
+            WHERE created_at < ? AND pinned = 0 AND image_path IS NOT NULL
+            """)
+        deleteStaleStmt = prepare("DELETE FROM items WHERE created_at < ? AND pinned = 0")
         return insertStmt != nil && loadStmt != nil && searchStmt != nil
-            && deleteByIDStmt != nil && staleImagesStmt != nil && deleteStaleStmt != nil
+            && deleteByIDStmt != nil && setPinnedStmt != nil && staleImagesStmt != nil
+            && deleteStaleStmt != nil
     }
 
     private func prepare(_ sql: String) -> OpaquePointer? {
@@ -411,12 +491,15 @@ final class ClipboardStore: ObservableObject {
     }
 
     private func closeDatabase() {
-        [insertStmt, loadStmt, searchStmt, deleteByIDStmt, staleImagesStmt, deleteStaleStmt]
-            .forEach { sqlite3_finalize($0) }
+        [
+            insertStmt, loadStmt, searchStmt, deleteByIDStmt, setPinnedStmt, staleImagesStmt,
+            deleteStaleStmt,
+        ].forEach { sqlite3_finalize($0) }
         insertStmt = nil
         loadStmt = nil
         searchStmt = nil
         deleteByIDStmt = nil
+        setPinnedStmt = nil
         staleImagesStmt = nil
         deleteStaleStmt = nil
         sqlite3_close_v2(db)
@@ -431,7 +514,7 @@ final class ClipboardStore: ObservableObject {
         return ClipboardItem(
             id: id, kind: kind, text: columnString(stmt, 2), imagePath: columnString(stmt, 3),
             createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 4)),
-            sourceBundleID: columnString(stmt, 5))
+            sourceBundleID: columnString(stmt, 5), isPinned: sqlite3_column_int(stmt, 6) != 0)
     }
 
     private static func columnString(_ stmt: OpaquePointer?, _ index: Int32) -> String? {

--- a/Tinycast/Features/Clipboard/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/ClipboardView.swift
@@ -22,15 +22,15 @@ struct ClipboardList: View {
         }
     }
 
-    /// Items are newest-first, so grouping walks and emits a date header whenever the bucket changes — mirrors the launcher's sectioning.
+    /// Pinned entries come first from the store and share one "Pinned" header; the rest are newest-first, so grouping walks and emits a date header whenever the bucket changes — mirrors the launcher's sectioning.
     private var rows: [Row] {
         var rows: [Row] = []
-        var currentBucket: DateBucket?
+        var currentTitle: String?
         for item in results {
-            let bucket = DateBucket(for: item.createdAt)
-            if bucket != currentBucket {
-                rows.append(.header(bucket.title))
-                currentBucket = bucket
+            let title = item.isPinned ? "Pinned" : DateBucket(for: item.createdAt).title
+            if title != currentTitle {
+                rows.append(.header(title))
+                currentTitle = title
             }
             rows.append(.item(item))
         }
@@ -124,11 +124,22 @@ enum ClipboardActionsMenu {
                 core.copyToClipboard(item)
             },
             PopoverMenuItem(
-                title: "Paste & Keep Window Open", icon: .paste(target, fallback: "pin")
+                title: "Paste & Keep Window Open", icon: .paste(target, fallback: "macwindow")
             ) {
                 core.pasteKeepingWindowOpen(item)
             },
         ]
+        if item.isPinned {
+            items.append(
+                PopoverMenuItem(title: "Unpin Entry", systemImage: "pin.slash", shortcut: "⌘P") {
+                    core.togglePinnedClip(item)
+                })
+        } else {
+            items.append(
+                PopoverMenuItem(title: "Pin Entry", systemImage: "pin", shortcut: "⌘P") {
+                    core.togglePinnedClip(item)
+                })
+        }
         if item.kind == .image {
             items.append(
                 PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {

--- a/Tinycast/Features/Emoji/EmojiGridView.swift
+++ b/Tinycast/Features/Emoji/EmojiGridView.swift
@@ -271,7 +271,7 @@ enum EmojiActionsMenu {
                     core.copyEmoji(entry)
                 },
                 PopoverMenuItem(
-                    title: "Paste & Keep Window Open", icon: .paste(target, fallback: "pin")
+                    title: "Paste & Keep Window Open", icon: .paste(target, fallback: "macwindow")
                 ) {
                     core.pasteEmojiKeepingWindowOpen(entry)
                 },

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -165,6 +165,8 @@ struct RootPaletteView: View {
         let hist = vm.mode == .calculatorHistory ? histResults : []
         let emojiSections = vm.mode == .emoji ? emojiSections : []
         let emojis = emojiSections.flatMap(\.entries)
+        // Newest stored clip + the reorder token: the pair changes only when the store mutates, never when a query filters the list.
+        let clipFollow = ClipFollowKey(id: store.items.first?.id, token: vm.followToken)
         // Every count/selection below derives from this one calc/offset pair — the flat selection index must always match the visible row order, calc card included.
         let calc = calcResult
         let offset = calc == nil ? 0 : 1
@@ -270,10 +272,15 @@ struct RootPaletteView: View {
             }
             vm.menuOpen = menuOpen
         }
-        // A new top clip while the list is showing (promote-on-paste, live capture) pulls the highlight and scroll back to the row that just moved up.
-        .onChange(of: clips.first?.id) { _, newTop in
-            guard vm.mode == .clipboard, newTop != nil else { return }
-            vm.selection = 0
+        // Follow a row the store moved: a fresh capture (or promote-on-paste) lands at the head of its section, and pinning lifts a row into the Pinned section. With a query typed the highlight stays put; `AppCore` has already placed it for pin/paste.
+        .onChange(of: clipFollow) { old, new in
+            // A nil `old.id` is the first load landing, not a row that moved.
+            guard vm.mode == .clipboard, old.id != nil else { return }
+            if isQueryEmpty, old.id != new.id, let id = new.id,
+                let index = clips.firstIndex(where: { $0.id == id })
+            {
+                vm.selection = index
+            }
             scrollToken = UUID()
         }
         .onAppear { searchFocused = true }
@@ -400,6 +407,14 @@ struct RootPaletteView: View {
             case .launcher, .emoji:
                 return .ignored
             }
+            return .handled
+        }
+        // ⌘P pins/unpins the selected clip — mirrors the Actions menu row, and works while that menu is open like the other advertised chords.
+        .onKeyPress(keys: ["p"], phases: .down) { press in
+            guard press.modifiers.contains(.command), vm.mode == .clipboard,
+                clipResults.indices.contains(selection)
+            else { return .ignored }
+            core.togglePinnedClip(clipResults[selection])
             return .handled
         }
     }
@@ -751,6 +766,12 @@ struct RootPaletteView: View {
             core.pasteEmoji(emojiResults[selection])
         }
     }
+}
+
+/// Change key for the clipboard list's follow-the-moved-row handler: the newest stored clip (a capture or promote puts a different row there) plus the token an action bumps when it reorders the list (pin/unpin). Deliberately read from the store, not the filtered results, so typing a query never reads as a row that moved.
+private struct ClipFollowKey: Equatable {
+    let id: ClipboardItem.ID?
+    let token: UUID
 }
 
 /// The footer's glass menu circle; hover lives here so a mouse sweep never re-renders the palette body.

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -17,3 +17,21 @@ in-memory history).
 
 Image capture (TIFF→PNG re-encode + blob write) runs off the main actor via detached tasks; row
 inserts, search, and pruning stay on the main actor.
+
+## Pinned entries
+
+A row's ⌘K Actions menu carries **Pin Entry / Unpin Entry** (⌘P), persisted as a `pinned` column on
+`items` (added to existing databases by an `ALTER TABLE` migration, alongside `source_app`'s).
+
+Pins change three things:
+
+- **Order.** `search` returns pinned rows first — for the empty query and for FTS hits alike — each
+  block still newest-first, so the list renders them under one "Pinned" section above the date
+  buckets. `items` itself stays in pure recency order; the display split is memoized next to the
+  search memo and invalidated with it.
+- **Retention.** Pruning skips pinned rows (`AND pinned = 0`), so a pin outlives the retention
+  window; the in-memory window keeps every pinned row too (`load` fetches all of them plus the
+  newest 1000 unpinned, and the trim never drops a pin). "Clear History" still deletes everything.
+- **Selection.** Pinning lifts a row out of its date bucket, so `AppCore.togglePinnedClip` moves the
+  palette selection to the row's new index in the *current* results and bumps `palette.followToken`,
+  which is what makes the list scroll the highlight back into view.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -140,7 +140,8 @@ All four palette lists (App Launcher, Clipboard, Emoji, Calculator History) rend
 through one shared **`SectionHeader`** (`.subheadline.medium`, secondary — `Features/Launcher/LauncherView.swift`).
 The launcher shows a single "Results" header over search matches, and per-kind sections
 (Favorites / Applications / System Settings / Commands) for the empty query; clipboard/history use
-date buckets (Today / Yesterday / …).
+date buckets (Today / Yesterday / …), and the clipboard adds a "Pinned" section above them holding
+every pinned entry (filtered searches included).
 
 Spacing lives in `Theme.Spacing`: `sectionHeaderBottom` (header → first row) and `sectionSpacing`
 (gap above every header **except the list's first**, which reads as the previous section's closing


### PR DESCRIPTION
Closes #49.

A clipboard row's ⌘K menu gains **Pin Entry / Unpin Entry** (⌘P). Pinned rows lead the list under
their own **Pinned** section — for the empty query and for filtered searches alike — so the handful of
entries you keep reaching for stop sinking under the day's noise.

## Demo

https://github.com/user-attachments/assets/cd6a19b1-7d9a-4473-b552-ca32a0f7c4aa

## How it works

- **Order.** `pinned` is a new column on `items`, added to existing databases by an `ALTER TABLE`
  guarded exactly like `source_app`'s. `items` itself stays in pure recency order; `search` lifts
  pinned rows to the head (each block still newest-first) and memoizes the split next to the existing
  search memo, invalidated with it — an unpinned history pays nothing and renders exactly as before.
- **Retention.** Pruning skips pinned rows, and so does the in-memory window: `load` fetches every
  pinned row plus the newest 1000 unpinned ones, and the window trim never drops a pin. A pin you set
  in March is still there after the 1-month retention has swept everything around it. *Clear History*
  still deletes everything, pins included.
- **Selection.** Pinning lifts a row out of its date bucket, so the selection follows it: `AppCore`
  resolves the row's index in the *current* results and bumps a token the list watches to scroll the
  highlight back into view. Paste and copy now use the same lookup instead of assuming index 0, which
  pins would otherwise break. The list's follow-the-moved-row handler keys off the store's newest row
  rather than the filtered results, so typing a query no longer reads as a row that moved.
- `Paste & Keep Window Open` gives up its `pin` fallback glyph for `macwindow` (clipboard + emoji
  menus) so it can't be confused with the real pin row.

No new files, so no `xcodegen` run; `docs/clipboard.md` and `docs/ui.md` are updated.

## Validation

- **UI, driven end to end** on the shipping `RootPaletteView`: pin from ⌘K and from ⌘P; the row moves
  into *Pinned* and the selection follows; the menu flips to *Unpin Entry*; an FTS query (`com`) groups
  the pinned hit above a newer match; typing a query leaves the selection on row 0; two pins order
  newest-first and survive a relaunch. Confirmed in the real app too (the palette renders the Pinned
  section from the stored flag).
- **Store harness** against the real `ClipboardStore` (throwaway, isolated cache): pinned-first order
  for empty/fallback/FTS queries, `createdAt` preserved across a pin, promote within a block, prune
  exemption, persistence across a reopen, unpin, `clearAll`. 18/18.
- **Migration**: a pre-`pinned` database opens, migrates, loads, pins and persists.
- `Tools/` harnesses: `fuzz-test` all passed, `calc-test` 248/248, `emoji-test` 2054 records OK.
- **Build**: clean, no new warnings.

### Memory

Debug builds of `main` and this branch, own channel, identical seeded history, `footprint` + `leaks`:

| | idle (menu bar only) | palette open (clipboard) | leaks |
| --- | --- | --- | --- |
| `main` | 18 MB | 29 MB (peak 29) | 0 |
| this PR | 18 MB | 30 MB (peak 30) | 0 |

Six open cycles land back at 29 MB — no growth. I could not script the palette *closing* (it hides on
resign-key, and no automation here can take key focus away from the panel), so the post-close figure is
the one thing I did not measure; both builds behave identically up to that point.

## Notes

- The pin is a boolean, not a pin timestamp: the pinned block stays sorted by recency, which is what
  keeps promote-on-paste coherent (a pasted pin returns to the top of its own block instead of
  reshuffling the section).
- Pins live in the SQLite cache like the rest of the history, so they are not part of the settings
  backup — `SettingsBackup` deliberately mirrors settings only.
