### PR TITLE
Order clipboard pins by pin time, and harden the pin paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ Never break these without an explicit task to do so.
   SwiftUI imports, no clock or network reads. `Tools/calc-test.swift` compiles the real engine
   sources. Both externally-sourced inputs are injected: the clock via `now`/`calendar`, the FX table
   via `rates` (`CurrencyRateStore` owns the fetch). Likewise `Core/Emoji/`
-  (`EmojiCatalog`, `EmojiGridGeometry`) stays AppKit/SwiftUI-free for `Tools/emoji-test.swift`.
+  (`EmojiCatalog`, `EmojiGridGeometry`) stays AppKit/SwiftUI-free for `Tools/emoji-test.swift`, and
+  `Core/ClipboardStore.swift` must keep to Foundation + SQLite3 with no other app source, so
+  `Tools/clipboard-test.swift` can compile it standalone.
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and

--- a/Tinycast/Core/ClipboardStore.swift
+++ b/Tinycast/Core/ClipboardStore.swift
@@ -14,7 +14,7 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
     let createdAt: Date
     /// Bundle ID of the app frontmost when the copy was captured (see `ClipboardManager.poll`).
     let sourceBundleID: String?
-    /// When the entry was pinned. Pinned entries lead the list in their own section, newest pin first, and are exempt from retention pruning.
+    /// When the entry was pinned. Pinned entries lead the list in their own section, in pin order, and are exempt from retention pruning.
     let pinnedAt: Date?
 
     var isPinned: Bool { pinnedAt != nil }
@@ -324,10 +324,10 @@ final class ClipboardStore: ObservableObject {
         return result
     }
 
-    /// The Pinned section's contents: newest pin first, so pinning a row never reshuffles the pins already there.
+    /// The Pinned section's contents in pin order, oldest pin first: a new pin joins the end of the section instead of displacing the ones already there.
     private var pinnedItems: [ClipboardItem] {
         items.filter(\.isPinned)
-            .sorted { ($0.pinnedAt ?? .distantPast) > ($1.pinnedAt ?? .distantPast) }
+            .sorted { ($0.pinnedAt ?? .distantFuture) < ($1.pinnedAt ?? .distantFuture) }
     }
 
     /// The row keeps its place in the history and gains a stamp, which puts it at the head of the Pinned section.

--- a/Tinycast/Core/ClipboardStore.swift
+++ b/Tinycast/Core/ClipboardStore.swift
@@ -1,4 +1,4 @@
-import AppKit
+import Foundation
 import SQLite3
 
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
@@ -14,8 +14,10 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
     let createdAt: Date
     /// Bundle ID of the app frontmost when the copy was captured (see `ClipboardManager.poll`).
     let sourceBundleID: String?
-    /// Pinned entries lead the list under their own section and are exempt from retention pruning.
-    let isPinned: Bool
+    /// When the entry was pinned. Pinned entries lead the list in their own section, newest pin first, and are exempt from retention pruning.
+    let pinnedAt: Date?
+
+    var isPinned: Bool { pinnedAt != nil }
 
     init(text: String, sourceBundleID: String?) {
         self.init(
@@ -31,7 +33,7 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
 
     init(
         id: UUID, kind: Kind, text: String?, imagePath: String?, createdAt: Date,
-        sourceBundleID: String?, isPinned: Bool = false
+        sourceBundleID: String?, pinnedAt: Date? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -39,15 +41,15 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
         self.imagePath = imagePath
         self.createdAt = createdAt
         self.sourceBundleID = sourceBundleID
-        self.isPinned = isPinned
+        self.pinnedAt = pinnedAt
     }
 
-    /// Copy carrying one changed field — the store rewrites rows in place to re-recency (promote) or flip the pin.
-    func with(createdAt: Date? = nil, isPinned: Bool? = nil) -> ClipboardItem {
+    /// Copy with the two fields the store rewrites in place; the pin is stated outright because every rewrite either stamps it or drops the row back into the history.
+    func with(createdAt: Date? = nil, pinnedAt: Date?) -> ClipboardItem {
         ClipboardItem(
             id: id, kind: kind, text: text, imagePath: imagePath,
             createdAt: createdAt ?? self.createdAt, sourceBundleID: sourceBundleID,
-            isPinned: isPinned ?? self.isPinned)
+            pinnedAt: pinnedAt)
     }
 
     /// Case-insensitive substring match — how the store filters without FTS: short queries, the no-database path, and the pinned block.
@@ -88,8 +90,7 @@ enum ClipboardRetention: Int, CaseIterable, Identifiable, Sendable {
 /// SQLite-backed clipboard history (rows + trigram FTS5 index in `clipboard.sqlite3`, image blobs on disk), degrading to session-only in-memory history if the database can't be opened.
 @MainActor
 final class ClipboardStore: ObservableObject {
-    /// Newest-first, pins included in place — `search` is the one place that lifts pinned rows to the head for display.
-    /// Every pinned row is resident here however old it is (`load` fetches them all, neither `trimWindow` nor `prune` drops one), which is what lets `search` match the pinned block in memory.
+    /// Newest-first, pins included in place — `search` is the one place that lifts them to the head. Every pinned row is resident however old it is (`load` fetches them all; neither `trimWindow` nor `prune` drops one), which is what lets `search` match the pinned block in memory.
     @Published private(set) var items: [ClipboardItem] = [] {
         didSet {
             searchCache = nil
@@ -113,7 +114,7 @@ final class ClipboardStore: ObservableObject {
           image_path TEXT,
           created_at REAL NOT NULL,
           source_app TEXT,
-          pinned INTEGER NOT NULL DEFAULT 0
+          pinned_at REAL
         );
         CREATE INDEX IF NOT EXISTS items_created_at ON items(created_at);
         CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
@@ -135,16 +136,13 @@ final class ClipboardStore: ObservableObject {
     private var windowFloorStmt: OpaquePointer?
     private var searchStmt: OpaquePointer?
     private var deleteByIDStmt: OpaquePointer?
-    private var setPinnedStmt: OpaquePointer?
+    private var pinStmt: OpaquePointer?
     private var staleImagesStmt: OpaquePointer?
     private var deleteStaleStmt: OpaquePointer?
 
-    init() {
-        // Stored under ~/Library/Caches/<bundle-id> since clipboard history is regenerable; "Clear History" is the durable control.
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
-        let base = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent(bundleID, isDirectory: true)
+    /// `directory` defaults to the per-channel cache; `Tools/clipboard-test.swift` passes a throwaway one so a harness run can never reach a real history.
+    init(directory: URL? = nil) {
+        let base = directory ?? Self.defaultDirectory
         imagesDir = base.appendingPathComponent("images", isDirectory: true)
         dbURL = base.appendingPathComponent("clipboard.sqlite3")
         try? FileManager.default.createDirectory(at: imagesDir, withIntermediateDirectories: true)
@@ -156,6 +154,14 @@ final class ClipboardStore: ObservableObject {
             }
             if !openDatabase() { closeDatabase() }
         }
+    }
+
+    /// Under ~/Library/Caches/<bundle-id> since clipboard history is regenerable; "Clear History" is the durable control.
+    private static var defaultDirectory: URL {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
+        return FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(bundleID, isDirectory: true)
     }
 
     // Isolated so teardown may touch the main-actor statement/db pointers; AppCore only ever releases the store on the main actor, so no hop.
@@ -237,42 +243,15 @@ final class ClipboardStore: ObservableObject {
         return inserted
     }
 
-    /// Move an item to the top of history (pasting/copying it from the palette re-recencies it, Raycast-style). Stored order is rowid, so this is a delete + re-insert under the same id; the fresh `createdAt` keeps date buckets descending, the pin rides along, and the image blob is never touched.
+    /// Move an item to the top of history (pasting/copying it from the palette re-recencies it, Raycast-style).
     func promote(_ item: ClipboardItem) {
-        guard items.first?.id != item.id else { return }
-        let promoted = item.with(createdAt: Date())
-        if let deleteStmt = deleteByIDStmt, let insertStmt {
-            // One transaction: `id` is UNIQUE and a crash between the two statements must not lose the row.
-            sqlite3_exec(db, "BEGIN", nil, nil, nil)
-            sqlite3_bind_text(deleteStmt, 1, item.id.uuidString, -1, SQLITE_TRANSIENT)
-            sqlite3_step(deleteStmt)
-            sqlite3_reset(deleteStmt)
-            sqlite3_clear_bindings(deleteStmt)
-            bindAndInsert(insertStmt, promoted)
-            sqlite3_exec(db, "COMMIT", nil, nil, nil)
-        }
-        // Array ops also cover items surfaced by FTS from beyond the in-memory window.
-        items.removeAll { $0.id == item.id }
-        items.insert(promoted, at: 0)
-        trimWindow()
+        // A pinned row holds its place in the Pinned section, so re-recencying one would rewrite the row and its FTS entry for no visible change.
+        guard !item.isPinned, items.first?.id != item.id else { return }
+        reinsert(item.with(createdAt: Date(), pinnedAt: nil))
     }
 
-    /// Flip an entry's pin. Pinned rows render in their own section above the history and survive retention pruning; a row pinned from an FTS hit older than the in-memory window is spliced into it so the section can show it.
     func togglePinned(_ item: ClipboardItem) {
-        let updated = item.with(isPinned: !item.isPinned)
-        if let stmt = setPinnedStmt {
-            sqlite3_bind_int(stmt, 1, updated.isPinned ? 1 : 0)
-            sqlite3_bind_text(stmt, 2, item.id.uuidString, -1, SQLITE_TRANSIENT)
-            sqlite3_step(stmt)
-            sqlite3_reset(stmt)
-            sqlite3_clear_bindings(stmt)
-        }
-        if let index = items.firstIndex(where: { $0.id == item.id }) {
-            items[index] = updated
-        } else if updated.isPinned {
-            let index = items.firstIndex { $0.createdAt < updated.createdAt } ?? items.count
-            items.insert(updated, at: index)
-        }
+        if item.isPinned { unpin(item) } else { pin(item) }
     }
 
     func remove(_ item: ClipboardItem) {
@@ -345,8 +324,54 @@ final class ClipboardStore: ObservableObject {
         return result
     }
 
-    /// The Pinned section's contents, in display order.
-    private var pinnedItems: [ClipboardItem] { items.filter(\.isPinned) }
+    /// The Pinned section's contents: newest pin first, so pinning a row never reshuffles the pins already there.
+    private var pinnedItems: [ClipboardItem] {
+        items.filter(\.isPinned)
+            .sorted { ($0.pinnedAt ?? .distantPast) > ($1.pinnedAt ?? .distantPast) }
+    }
+
+    /// The row keeps its place in the history and gains a stamp, which puts it at the head of the Pinned section.
+    private func pin(_ item: ClipboardItem) {
+        let stamp = Date()
+        let pinned = item.with(pinnedAt: stamp)
+        if let stmt = pinStmt {
+            sqlite3_bind_double(stmt, 1, stamp.timeIntervalSince1970)
+            sqlite3_bind_text(stmt, 2, item.id.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(stmt)
+            sqlite3_reset(stmt)
+            sqlite3_clear_bindings(stmt)
+        }
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index] = pinned
+        } else {
+            // Pinned from an FTS hit older than the in-memory window: splice it in at its recency position, since the Pinned section can only show resident rows.
+            let index = items.firstIndex { $0.createdAt < pinned.createdAt } ?? items.count
+            items.insert(pinned, at: index)
+        }
+    }
+
+    /// Unpinning rejoins the history as its newest entry rather than dropping the row back into the date bucket it came from, which would scroll the list out from under the selection. Raycast does the same.
+    private func unpin(_ item: ClipboardItem) {
+        reinsert(item.with(createdAt: Date(), pinnedAt: nil))
+    }
+
+    /// Rewrite a row under the same id so it leads the history: stored order is rowid, so this is a delete + re-insert, and the fresh `createdAt` keeps the date buckets descending. The image blob is never touched.
+    private func reinsert(_ updated: ClipboardItem) {
+        if let deleteStmt = deleteByIDStmt, let insertStmt {
+            // One transaction: `id` is UNIQUE and a crash between the two statements must not lose the row.
+            sqlite3_exec(db, "BEGIN", nil, nil, nil)
+            sqlite3_bind_text(deleteStmt, 1, updated.id.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(deleteStmt)
+            sqlite3_reset(deleteStmt)
+            sqlite3_clear_bindings(deleteStmt)
+            bindAndInsert(insertStmt, updated)
+            sqlite3_exec(db, "COMMIT", nil, nil, nil)
+        }
+        // Array ops also cover items surfaced by FTS from beyond the in-memory window.
+        items.removeAll { $0.id == updated.id }
+        items.insert(updated, at: 0)
+        trimWindow()
+    }
 
     /// Cap the in-memory window, but never drop a pinned row: those render however old they are.
     private func trimWindow() {
@@ -381,7 +406,11 @@ final class ClipboardStore: ObservableObject {
         } else {
             sqlite3_bind_null(stmt, 6)
         }
-        sqlite3_bind_int(stmt, 7, item.isPinned ? 1 : 0)
+        if let pinnedAt = item.pinnedAt {
+            sqlite3_bind_double(stmt, 7, pinnedAt.timeIntervalSince1970)
+        } else {
+            sqlite3_bind_null(stmt, 7)
+        }
         sqlite3_step(stmt)
         sqlite3_reset(stmt)
         sqlite3_clear_bindings(stmt)
@@ -455,47 +484,48 @@ final class ClipboardStore: ObservableObject {
         if !columnExists("source_app", in: "items") {
             sqlite3_exec(db, "ALTER TABLE items ADD COLUMN source_app TEXT", nil, nil, nil)
         }
-        if !columnExists("pinned", in: "items") {
-            sqlite3_exec(
-                db, "ALTER TABLE items ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0", nil, nil, nil)
+        if !columnExists("pinned_at", in: "items") {
+            sqlite3_exec(db, "ALTER TABLE items ADD COLUMN pinned_at REAL", nil, nil, nil)
         }
-        // Partial index so `load`'s pinned branch is a lookup instead of a table scan. Created after the migration rather than in `schema`, since the column may not exist yet on an older database.
+        // Created after the migration rather than in `schema`, since the column may not exist yet on an older database.
         sqlite3_exec(
-            db, "CREATE INDEX IF NOT EXISTS items_pinned ON items(pinned) WHERE pinned = 1", nil,
-            nil, nil)
+            db,
+            "CREATE INDEX IF NOT EXISTS items_pinned_at ON items(pinned_at) WHERE pinned_at IS NOT NULL",
+            nil, nil, nil)
         insertStmt = prepare(
             """
-            INSERT INTO items(id, kind, text, image_path, created_at, source_app, pinned)
+            INSERT INTO items(id, kind, text, image_path, created_at, source_app, pinned_at)
             VALUES(?,?,?,?,?,?,?)
             """
         )
-        // Every pinned row plus the newest `memoryWindow` unpinned ones, keyed off the floor rowid `windowFloor` looks up. Two indexed branches rather than one `pinned = 1 OR rowid >= ?` scan: the planner can't drive an OR from an index while holding the row order, so that form reads the whole table (~12ms at 200k rows against ~1ms here).
+        // Every pinned row plus the newest `memoryWindow` unpinned ones, keyed off the floor rowid `windowFloor` looks up. Two indexed branches rather than one `pinned_at IS NOT NULL OR rowid >= ?`: the planner can't drive an OR from an index while holding the row order, so that form reads the whole table.
         loadStmt = prepare(
             """
-            SELECT id, kind, text, image_path, created_at, source_app, pinned FROM (
+            SELECT id, kind, text, image_path, created_at, source_app, pinned_at FROM (
               SELECT rowid AS rid, * FROM items WHERE rowid >= ?1
               UNION ALL
-              SELECT rowid AS rid, * FROM items WHERE pinned = 1 AND rowid < ?1
+              SELECT rowid AS rid, * FROM items WHERE pinned_at IS NOT NULL AND rowid < ?1
             ) ORDER BY rid DESC
             """)
         windowFloorStmt = prepare(
-            "SELECT rowid FROM items WHERE pinned = 0 ORDER BY rowid DESC LIMIT 1 OFFSET ?")
+            "SELECT rowid FROM items WHERE pinned_at IS NULL ORDER BY rowid DESC LIMIT 1 OFFSET ?")
         searchStmt = prepare(
             """
-            SELECT i.id, i.kind, i.text, i.image_path, i.created_at, i.source_app, i.pinned
+            SELECT i.id, i.kind, i.text, i.image_path, i.created_at, i.source_app, i.pinned_at
             FROM items_fts f JOIN items i ON i.rowid = f.rowid
             WHERE items_fts MATCH ? ORDER BY f.rowid DESC LIMIT 200
             """)
         deleteByIDStmt = prepare("DELETE FROM items WHERE id = ?")
-        setPinnedStmt = prepare("UPDATE items SET pinned = ? WHERE id = ?")
+        // Only ever sets a stamp: unpinning rewrites the whole row so it leads the history again.
+        pinStmt = prepare("UPDATE items SET pinned_at = ? WHERE id = ?")
         staleImagesStmt = prepare(
             """
             SELECT image_path FROM items
-            WHERE created_at < ? AND pinned = 0 AND image_path IS NOT NULL
+            WHERE created_at < ? AND pinned_at IS NULL AND image_path IS NOT NULL
             """)
-        deleteStaleStmt = prepare("DELETE FROM items WHERE created_at < ? AND pinned = 0")
+        deleteStaleStmt = prepare("DELETE FROM items WHERE created_at < ? AND pinned_at IS NULL")
         return insertStmt != nil && loadStmt != nil && windowFloorStmt != nil && searchStmt != nil
-            && deleteByIDStmt != nil && setPinnedStmt != nil && staleImagesStmt != nil
+            && deleteByIDStmt != nil && pinStmt != nil && staleImagesStmt != nil
             && deleteStaleStmt != nil
     }
 
@@ -516,7 +546,7 @@ final class ClipboardStore: ObservableObject {
 
     private func closeDatabase() {
         [
-            insertStmt, loadStmt, windowFloorStmt, searchStmt, deleteByIDStmt, setPinnedStmt,
+            insertStmt, loadStmt, windowFloorStmt, searchStmt, deleteByIDStmt, pinStmt,
             staleImagesStmt, deleteStaleStmt,
         ].forEach { sqlite3_finalize($0) }
         insertStmt = nil
@@ -524,7 +554,7 @@ final class ClipboardStore: ObservableObject {
         windowFloorStmt = nil
         searchStmt = nil
         deleteByIDStmt = nil
-        setPinnedStmt = nil
+        pinStmt = nil
         staleImagesStmt = nil
         deleteStaleStmt = nil
         sqlite3_close_v2(db)
@@ -539,7 +569,12 @@ final class ClipboardStore: ObservableObject {
         return ClipboardItem(
             id: id, kind: kind, text: columnString(stmt, 2), imagePath: columnString(stmt, 3),
             createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 4)),
-            sourceBundleID: columnString(stmt, 5), isPinned: sqlite3_column_int(stmt, 6) != 0)
+            sourceBundleID: columnString(stmt, 5), pinnedAt: columnDate(stmt, 6))
+    }
+
+    private static func columnDate(_ stmt: OpaquePointer?, _ index: Int32) -> Date? {
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL else { return nil }
+        return Date(timeIntervalSince1970: sqlite3_column_double(stmt, index))
     }
 
     private static func columnString(_ stmt: OpaquePointer?, _ index: Int32) -> String? {

--- a/Tinycast/Core/ClipboardStore.swift
+++ b/Tinycast/Core/ClipboardStore.swift
@@ -49,6 +49,11 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
             createdAt: createdAt ?? self.createdAt, sourceBundleID: sourceBundleID,
             isPinned: isPinned ?? self.isPinned)
     }
+
+    /// Case-insensitive substring match — how the store filters without FTS: short queries, the no-database path, and the pinned block.
+    func matches(_ query: String) -> Bool {
+        text?.localizedCaseInsensitiveContains(query) ?? false
+    }
 }
 
 /// How long clipboard history is kept before pruning; raw value is the age in days persisted to UserDefaults, and `forever` is -1 so an unset key (0) falls through to the default.
@@ -84,6 +89,7 @@ enum ClipboardRetention: Int, CaseIterable, Identifiable, Sendable {
 @MainActor
 final class ClipboardStore: ObservableObject {
     /// Newest-first, pins included in place — `search` is the one place that lifts pinned rows to the head for display.
+    /// Every pinned row is resident here however old it is (`load` fetches them all, neither `trimWindow` nor `prune` drops one), which is what lets `search` match the pinned block in memory.
     @Published private(set) var items: [ClipboardItem] = [] {
         didSet {
             searchCache = nil
@@ -126,6 +132,7 @@ final class ClipboardStore: ObservableObject {
     private var db: OpaquePointer?
     private var insertStmt: OpaquePointer?
     private var loadStmt: OpaquePointer?
+    private var windowFloorStmt: OpaquePointer?
     private var searchStmt: OpaquePointer?
     private var deleteByIDStmt: OpaquePointer?
     private var setPinnedStmt: OpaquePointer?
@@ -158,8 +165,7 @@ final class ClipboardStore: ObservableObject {
 
     func load() {
         guard let stmt = loadStmt else { return }
-        // The window counts unpinned rows only; `loadStmt` adds every pinned row on top, however old.
-        sqlite3_bind_int(stmt, 1, Int32(Self.memoryWindow - 1))
+        sqlite3_bind_int64(stmt, 1, windowFloor())
         var loaded: [ClipboardItem] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
             if let item = Self.row(stmt) { loaded.append(item) }
@@ -174,6 +180,17 @@ final class ClipboardStore: ObservableObject {
     /// Called on load and when the retention setting changes.
     func enforceLimits() {
         prune()
+    }
+
+    /// Rowid of the oldest unpinned row the in-memory window keeps — the floor `loadStmt` reads from. 0 (no floor, load everything) when the history is shorter than the window.
+    private func windowFloor() -> sqlite3_int64 {
+        guard let stmt = windowFloorStmt else { return 0 }
+        defer {
+            sqlite3_reset(stmt)
+            sqlite3_clear_bindings(stmt)
+        }
+        sqlite3_bind_int(stmt, 1, Int32(Self.memoryWindow - 1))
+        return sqlite3_step(stmt) == SQLITE_ROW ? sqlite3_column_int64(stmt, 0) : 0
     }
 
     func addText(_ text: String, sourceBundleID: String?) {
@@ -286,7 +303,8 @@ final class ClipboardStore: ObservableObject {
         let q = query.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return orderedItems }
         if let searchCache, searchCache.query == q { return searchCache.result }
-        let result = Self.pinnedFirst(runSearch(q))
+        // Pins are matched in memory rather than taken from the FTS result: they are all resident (see `items`), and the statement's LIMIT would otherwise drop one out of a busy query's matches.
+        let result = pinnedItems.filter { $0.matches(q) } + runSearch(q).filter { !$0.isPinned }
         searchCache = (q, result)
         return result
     }
@@ -315,22 +333,20 @@ final class ClipboardStore: ObservableObject {
     // MARK: - Private
 
     private func fallbackSearch(_ q: String) -> [ClipboardItem] {
-        items.filter { ($0.text?.localizedCaseInsensitiveContains(q)) ?? false }
+        items.filter { $0.matches(q) }
     }
 
     private var orderedItems: [ClipboardItem] {
         if let orderedCache { return orderedCache }
-        let result = Self.pinnedFirst(items)
+        let pinned = pinnedItems
+        // An unpinned history renders `items` as-is, so it never pays for the split.
+        let result = pinned.isEmpty ? items : pinned + items.filter { !$0.isPinned }
         orderedCache = result
         return result
     }
 
-    /// Lift pinned rows to the head, preserving the newest-first order within each block.
-    private static func pinnedFirst(_ list: [ClipboardItem]) -> [ClipboardItem] {
-        let pinned = list.filter(\.isPinned)
-        guard !pinned.isEmpty else { return list }
-        return pinned + list.filter { !$0.isPinned }
-    }
+    /// The Pinned section's contents, in display order.
+    private var pinnedItems: [ClipboardItem] { items.filter(\.isPinned) }
 
     /// Cap the in-memory window, but never drop a pinned row: those render however old they are.
     private func trimWindow() {
@@ -416,7 +432,8 @@ final class ClipboardStore: ObservableObject {
                 }
             }
         }
-        if items.last.map({ $0.createdAt < cutoff }) == true {
+        // Checked against the oldest *unpinned* row: an exempt pin sitting at the tail would otherwise make this guard permanently true and re-scan the window on every capture.
+        if items.last(where: { !$0.isPinned }).map({ $0.createdAt < cutoff }) == true {
             items.removeAll { $0.createdAt < cutoff && !$0.isPinned }
         }
     }
@@ -442,20 +459,27 @@ final class ClipboardStore: ObservableObject {
             sqlite3_exec(
                 db, "ALTER TABLE items ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0", nil, nil, nil)
         }
+        // Partial index so `load`'s pinned branch is a lookup instead of a table scan. Created after the migration rather than in `schema`, since the column may not exist yet on an older database.
+        sqlite3_exec(
+            db, "CREATE INDEX IF NOT EXISTS items_pinned ON items(pinned) WHERE pinned = 1", nil,
+            nil, nil)
         insertStmt = prepare(
             """
             INSERT INTO items(id, kind, text, image_path, created_at, source_app, pinned)
             VALUES(?,?,?,?,?,?,?)
             """
         )
-        // Every pinned row plus the newest `memoryWindow` unpinned ones (rowid of the oldest kept unpinned row is the floor; NULL when there are fewer than that, so everything loads).
+        // Every pinned row plus the newest `memoryWindow` unpinned ones, keyed off the floor rowid `windowFloor` looks up. Two indexed branches rather than one `pinned = 1 OR rowid >= ?` scan: the planner can't drive an OR from an index while holding the row order, so that form reads the whole table (~12ms at 200k rows against ~1ms here).
         loadStmt = prepare(
             """
-            SELECT id, kind, text, image_path, created_at, source_app, pinned FROM items
-            WHERE pinned = 1 OR rowid >= COALESCE(
-              (SELECT rowid FROM items WHERE pinned = 0 ORDER BY rowid DESC LIMIT 1 OFFSET ?), 0)
-            ORDER BY rowid DESC
+            SELECT id, kind, text, image_path, created_at, source_app, pinned FROM (
+              SELECT rowid AS rid, * FROM items WHERE rowid >= ?1
+              UNION ALL
+              SELECT rowid AS rid, * FROM items WHERE pinned = 1 AND rowid < ?1
+            ) ORDER BY rid DESC
             """)
+        windowFloorStmt = prepare(
+            "SELECT rowid FROM items WHERE pinned = 0 ORDER BY rowid DESC LIMIT 1 OFFSET ?")
         searchStmt = prepare(
             """
             SELECT i.id, i.kind, i.text, i.image_path, i.created_at, i.source_app, i.pinned
@@ -470,7 +494,7 @@ final class ClipboardStore: ObservableObject {
             WHERE created_at < ? AND pinned = 0 AND image_path IS NOT NULL
             """)
         deleteStaleStmt = prepare("DELETE FROM items WHERE created_at < ? AND pinned = 0")
-        return insertStmt != nil && loadStmt != nil && searchStmt != nil
+        return insertStmt != nil && loadStmt != nil && windowFloorStmt != nil && searchStmt != nil
             && deleteByIDStmt != nil && setPinnedStmt != nil && staleImagesStmt != nil
             && deleteStaleStmt != nil
     }
@@ -492,11 +516,12 @@ final class ClipboardStore: ObservableObject {
 
     private func closeDatabase() {
         [
-            insertStmt, loadStmt, searchStmt, deleteByIDStmt, setPinnedStmt, staleImagesStmt,
-            deleteStaleStmt,
+            insertStmt, loadStmt, windowFloorStmt, searchStmt, deleteByIDStmt, setPinnedStmt,
+            staleImagesStmt, deleteStaleStmt,
         ].forEach { sqlite3_finalize($0) }
         insertStmt = nil
         loadStmt = nil
+        windowFloorStmt = nil
         searchStmt = nil
         deleteByIDStmt = nil
         setPinnedStmt = nil

--- a/Tools/clipboard-test.swift
+++ b/Tools/clipboard-test.swift
@@ -1,0 +1,291 @@
+// Standalone test for the clipboard store — compiles the *real* source (no copy to sync):
+// swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.swift -o /tmp/clipboard-test && /tmp/clipboard-test
+//
+// Every store here is built on a throwaway directory under the system temp dir, so a run can never
+// see or touch a real clipboard history.
+
+import Foundation
+
+@main
+@MainActor
+struct ClipboardTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func main() {
+        pinOrder()
+        unpinRejoinsAsNewest()
+        pasteLeavesPinsAlone()
+        pinsSurvivePruningAndTheWindow()
+        pinsLeadFilteredSearches()
+        persistence()
+        migrationFromShippedDatabase()
+
+        print("\(passes)/\(passes + failures) passed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Cases
+
+    /// Pins stack in pin order, newest pin first, regardless of how old the entries are.
+    static func pinOrder() {
+        withStore { store, _ in
+            store.addText("oldest", sourceBundleID: nil)
+            store.addText("middle", sourceBundleID: nil)
+            store.addText("newest", sourceBundleID: nil)
+
+            store.togglePinned(item(store, "oldest"))
+            expect(texts(store) == ["oldest", "newest", "middle"], "first pin leads the list")
+
+            store.togglePinned(item(store, "middle"))
+            expect(
+                texts(store) == ["middle", "oldest", "newest"],
+                "second pin goes above the first, and does not sort by recency")
+
+            store.togglePinned(item(store, "newest"))
+            expect(
+                texts(store) == ["newest", "middle", "oldest"],
+                "pins hold pin order, not the recency order they had in the history")
+        }
+    }
+
+    /// Unpinning drops the row in as today's newest entry rather than back where it came from.
+    static func unpinRejoinsAsNewest() {
+        withStore { store, _ in
+            store.addText("a", sourceBundleID: nil)
+            store.addText("b", sourceBundleID: nil)
+            store.addText("c", sourceBundleID: nil)
+            let before = item(store, "a").createdAt
+
+            store.togglePinned(item(store, "a"))
+            store.togglePinned(item(store, "a"))
+
+            expect(texts(store) == ["a", "c", "b"], "unpinned row leads the history")
+            expect(!item(store, "a").isPinned, "pin stamp cleared")
+            expect(item(store, "a").createdAt > before, "unpin re-recencies the row")
+        }
+    }
+
+    /// Pasting a pinned entry must not reshuffle the Pinned section.
+    static func pasteLeavesPinsAlone() {
+        withStore { store, _ in
+            store.addText("one", sourceBundleID: nil)
+            store.addText("two", sourceBundleID: nil)
+            store.togglePinned(item(store, "one"))
+            store.togglePinned(item(store, "two"))
+            let stamp = item(store, "one").createdAt
+
+            store.promote(item(store, "one"))
+
+            expect(texts(store) == ["two", "one"], "promote leaves a pinned row in place")
+            expect(item(store, "one").createdAt == stamp, "promote does not rewrite a pinned row")
+
+            store.addText("three", sourceBundleID: nil)
+            store.addText("four", sourceBundleID: nil)
+            store.promote(item(store, "three"))
+            expect(
+                texts(store) == ["two", "one", "three", "four"],
+                "an unpinned row still promotes to the head of the history")
+        }
+    }
+
+    /// Retention sweeps everything around a pin but never the pin itself.
+    static func pinsSurvivePruningAndTheWindow() {
+        withStore { store, dir in
+            // Older than the 1-day retention the case sets below, but inside the default the import prunes against.
+            let old = Date().addingTimeInterval(-2 * 86_400)
+            _ = store.importEntries([
+                entry("ancient-pinned", at: old),
+                entry("ancient-loose", at: old.addingTimeInterval(1)),
+                entry("fresh", at: Date()),
+            ])
+            store.togglePinned(item(store, "ancient-pinned"))
+
+            store.maxAge = 86_400
+            store.enforceLimits()
+            expect(
+                Set(texts(store)) == ["ancient-pinned", "fresh"],
+                "pruning skips pinned rows and takes the rest")
+
+            // Reopen: the pin must come back even though it is far outside the retention window.
+            let reopened = ClipboardStore(directory: dir)
+            reopened.maxAge = 86_400
+            reopened.load()
+            expect(
+                Set(texts(reopened)) == ["ancient-pinned", "fresh"],
+                "a pin outlives retention across a relaunch")
+        }
+    }
+
+    /// A pin must lead a filtered search even when the FTS statement's LIMIT cannot reach it.
+    static func pinsLeadFilteredSearches() {
+        withStore { store, _ in
+            var seed: [ClipboardItem] = []
+            let base = Date().addingTimeInterval(-10_000)
+            // The pinned hit is the oldest of 260 matches; the FTS statement stops at 200.
+            seed.append(entry("needle in the haystack", at: base))
+            for i in 1...259 {
+                seed.append(entry("haystack filler \(i)", at: base.addingTimeInterval(Double(i))))
+            }
+            _ = store.importEntries(seed)
+            store.togglePinned(item(store, "needle in the haystack"))
+
+            let results = store.search("haystack")
+            expect(results.count > 200, "FTS results plus the pinned block")
+            expect(
+                results.first?.text == "needle in the haystack",
+                "the pinned match leads the filtered results")
+            expect(
+                results.filter(\.isPinned).count == 1, "the pinned row is not duplicated")
+
+            let short = store.search("ne")  // below the trigram threshold: the fallback path
+            expect(
+                short.first?.text == "needle in the haystack",
+                "the pinned match leads the fallback search too")
+        }
+    }
+
+    /// Pin stamps and their order survive a reopen.
+    static func persistence() {
+        withStore { store, dir in
+            store.addText("first", sourceBundleID: nil)
+            store.addText("second", sourceBundleID: nil)
+            store.addText("third", sourceBundleID: nil)
+            store.togglePinned(item(store, "third"))
+            store.togglePinned(item(store, "first"))
+
+            let reopened = ClipboardStore(directory: dir)
+            reopened.load()
+            expect(
+                texts(reopened) == ["first", "third", "second"],
+                "pin order is restored from disk, not recomputed from recency")
+
+            reopened.togglePinned(item(reopened, "first"))
+            expect(texts(reopened) == ["third", "first", "second"], "unpin after a reload")
+
+            reopened.clearAll()
+            expect(reopened.items.isEmpty, "Clear History takes pins too")
+        }
+    }
+
+    /// A shipped pre-pin database migrates in place. Failing to open one is not a soft failure: the store deletes and recreates a database it can't open, taking the history with it.
+    static func migrationFromShippedDatabase() {
+        let dir = scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let db = dir.appendingPathComponent("clipboard.sqlite3")
+        seedPrePinDatabase(at: db)
+
+        let store = ClipboardStore(directory: dir)
+        store.load()
+        expect(texts(store) == ["newer", "older"], "existing history survives the migration")
+
+        store.addText("after", sourceBundleID: nil)
+        store.togglePinned(item(store, "older"))
+        expect(texts(store) == ["older", "after", "newer"], "the migrated database takes pins")
+
+        let reopened = ClipboardStore(directory: dir)
+        reopened.load()
+        expect(texts(reopened) == ["older", "after", "newer"], "and keeps them across a reopen")
+
+        expect(
+            sqlite(db, "SELECT name FROM pragma_table_info('items')").contains("pinned_at"),
+            "the pin stamp column was added")
+        expect(
+            sqlite(db, "SELECT name FROM sqlite_master WHERE type = 'index'")
+                .contains("items_pinned_at"),
+            "and indexed")
+    }
+
+    // MARK: - Harness
+
+    /// Runs `body` against a store rooted in a fresh temp directory, torn down afterwards.
+    static func withStore(_ body: (ClipboardStore, URL) -> Void) {
+        let dir = scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        body(ClipboardStore(directory: dir), dir)
+    }
+
+    static func scratchDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "tinycast-clipboard-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Writes the schema as shipped before pinning existed: no `pinned_at`, and two rows to migrate.
+    static func seedPrePinDatabase(at url: URL) {
+        let now = Date().timeIntervalSince1970
+        sqlite(
+            url,
+            """
+            CREATE TABLE items(
+              id TEXT NOT NULL UNIQUE, kind TEXT NOT NULL, text TEXT, image_path TEXT,
+              created_at REAL NOT NULL, source_app TEXT
+            );
+            CREATE INDEX items_created_at ON items(created_at);
+            CREATE VIRTUAL TABLE items_fts USING fts5(
+              text, content='items', content_rowid='rowid', tokenize='trigram'
+            );
+            CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+              INSERT INTO items_fts(rowid, text) VALUES(new.rowid, new.text);
+            END;
+            CREATE TRIGGER items_ad AFTER DELETE ON items BEGIN
+              INSERT INTO items_fts(items_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+            END;
+            INSERT INTO items(id, kind, text, created_at)
+              VALUES('\(UUID().uuidString)', 'text', 'older', \(now - 60));
+            INSERT INTO items(id, kind, text, created_at)
+              VALUES('\(UUID().uuidString)', 'text', 'newer', \(now));
+            """)
+    }
+
+    /// Rows returned by the `sqlite3` CLI — used to write a legacy database and to read the schema back, neither of which the store exposes.
+    @discardableResult
+    static func sqlite(_ database: URL, _ sql: String) -> Set<String> {
+        let task = Process()
+        let pipe = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        task.arguments = [database.path, sql]
+        task.standardOutput = pipe
+        guard (try? task.run()) != nil else {
+            fail("could not run sqlite3")
+            return []
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        if task.terminationStatus != 0 { fail("sqlite3 failed: \(sql.prefix(60))") }
+        return Set(String(decoding: data, as: UTF8.self).split(separator: "\n").map(String.init))
+    }
+
+    static func entry(_ text: String, at date: Date) -> ClipboardItem {
+        ClipboardItem(
+            id: UUID(), kind: .text, text: text, imagePath: nil, createdAt: date,
+            sourceBundleID: nil)
+    }
+
+    static func texts(_ store: ClipboardStore) -> [String] {
+        store.search("").compactMap(\.text)
+    }
+
+    static func item(_ store: ClipboardStore, _ text: String) -> ClipboardItem {
+        guard let match = store.items.first(where: { $0.text == text }) else {
+            fail("no entry named \(text)")
+            exit(1)
+        }
+        return match
+    }
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition {
+            passes += 1
+        } else {
+            fail(label)
+        }
+    }
+
+    static func fail(_ label: String) {
+        print("FAIL: \(label)")
+        failures += 1
+    }
+}

--- a/Tools/clipboard-test.swift
+++ b/Tools/clipboard-test.swift
@@ -27,7 +27,7 @@ struct ClipboardTests {
 
     // MARK: - Cases
 
-    /// Pins stack in pin order, newest pin first, regardless of how old the entries are.
+    /// Pins stack in pin order, oldest pin first, regardless of how old the entries are.
     static func pinOrder() {
         withStore { store, _ in
             store.addText("oldest", sourceBundleID: nil)
@@ -39,12 +39,12 @@ struct ClipboardTests {
 
             store.togglePinned(item(store, "middle"))
             expect(
-                texts(store) == ["middle", "oldest", "newest"],
-                "second pin goes above the first, and does not sort by recency")
+                texts(store) == ["oldest", "middle", "newest"],
+                "second pin joins below the first, and does not sort by recency")
 
             store.togglePinned(item(store, "newest"))
             expect(
-                texts(store) == ["newest", "middle", "oldest"],
+                texts(store) == ["oldest", "middle", "newest"],
                 "pins hold pin order, not the recency order they had in the history")
         }
     }
@@ -77,14 +77,14 @@ struct ClipboardTests {
 
             store.promote(item(store, "one"))
 
-            expect(texts(store) == ["two", "one"], "promote leaves a pinned row in place")
+            expect(texts(store) == ["one", "two"], "promote leaves a pinned row in place")
             expect(item(store, "one").createdAt == stamp, "promote does not rewrite a pinned row")
 
             store.addText("three", sourceBundleID: nil)
             store.addText("four", sourceBundleID: nil)
             store.promote(item(store, "three"))
             expect(
-                texts(store) == ["two", "one", "three", "four"],
+                texts(store) == ["one", "two", "three", "four"],
                 "an unpinned row still promotes to the head of the history")
         }
     }
@@ -157,11 +157,11 @@ struct ClipboardTests {
             let reopened = ClipboardStore(directory: dir)
             reopened.load()
             expect(
-                texts(reopened) == ["first", "third", "second"],
+                texts(reopened) == ["third", "first", "second"],
                 "pin order is restored from disk, not recomputed from recency")
 
-            reopened.togglePinned(item(reopened, "first"))
-            expect(texts(reopened) == ["third", "first", "second"], "unpin after a reload")
+            reopened.togglePinned(item(reopened, "third"))
+            expect(texts(reopened) == ["first", "third", "second"], "unpin after a reload")
 
             reopened.clearAll()
             expect(reopened.items.isEmpty, "Clear History takes pins too")

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -28,9 +28,10 @@ recency.
 Pins change four things:
 
 - **Order.** `search` returns pinned rows first — for the empty query and for FTS hits alike — under
-  one "Pinned" section above the date buckets, newest pin at the top, so pinning a row never
-  reshuffles the pins already there. `items` itself stays in pure recency order; the display split is
-  memoized next to the search memo and invalidated with it. Pinned rows are matched **in memory**
+  one "Pinned" section above the date buckets, in pin order with the oldest pin at the top, so a new
+  pin joins the end of the section instead of displacing the ones already there. `items` itself stays
+  in pure recency order; the display split is memoized next to the search memo and invalidated with
+  it. Pinned rows are matched **in memory**
   rather than taken from the FTS result, since the statement's `LIMIT` could otherwise drop one out
   of a busy query's matches — which holds because every pinned row is resident in `items`, however
   old (`load` fetches them all, and neither the window trim nor pruning drops one).

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -20,18 +20,35 @@ inserts, search, and pruning stay on the main actor.
 
 ## Pinned entries
 
-A row's ⌘K Actions menu carries **Pin Entry / Unpin Entry** (⌘P), persisted as a `pinned` column on
-`items` (added to existing databases by an `ALTER TABLE` migration, alongside `source_app`'s).
+A row's ⌘K Actions menu carries **Pin Entry / Unpin Entry** (⌘P), persisted as a `pinned_at` column
+on `items` (added to existing databases by an `ALTER TABLE` migration, alongside `source_app`'s) —
+a stamp rather than a flag, because the Pinned section is ordered by *when you pinned*, not by
+recency.
 
-Pins change three things:
+Pins change four things:
 
-- **Order.** `search` returns pinned rows first — for the empty query and for FTS hits alike — each
-  block still newest-first, so the list renders them under one "Pinned" section above the date
-  buckets. `items` itself stays in pure recency order; the display split is memoized next to the
-  search memo and invalidated with it.
-- **Retention.** Pruning skips pinned rows (`AND pinned = 0`), so a pin outlives the retention
-  window; the in-memory window keeps every pinned row too (`load` fetches all of them plus the
-  newest 1000 unpinned, and the trim never drops a pin). "Clear History" still deletes everything.
+- **Order.** `search` returns pinned rows first — for the empty query and for FTS hits alike — under
+  one "Pinned" section above the date buckets, newest pin at the top, so pinning a row never
+  reshuffles the pins already there. `items` itself stays in pure recency order; the display split is
+  memoized next to the search memo and invalidated with it. Pinned rows are matched **in memory**
+  rather than taken from the FTS result, since the statement's `LIMIT` could otherwise drop one out
+  of a busy query's matches — which holds because every pinned row is resident in `items`, however
+  old (`load` fetches them all, and neither the window trim nor pruning drops one).
+- **Unpinning re-recencies.** An unpinned row rejoins the history as its *newest* entry (Raycast does
+  the same) rather than dropping back into the date bucket it came from, which would scroll the list
+  out from under the selection. It's the same delete + re-insert `promote` uses.
+- **Retention.** Pruning skips pinned rows (`AND pinned_at IS NULL`), so a pin outlives the retention
+  window. "Clear History" still deletes everything.
 - **Selection.** Pinning lifts a row out of its date bucket, so `AppCore.togglePinnedClip` moves the
   palette selection to the row's new index in the *current* results and bumps `palette.followToken`,
   which is what makes the list scroll the highlight back into view.
+
+Pasting a pinned entry deliberately does **not** promote it: it holds its place in the Pinned
+section, so `promote` skips pinned rows instead of rewriting the row and its FTS entry for no
+visible change.
+
+`load` reads every pinned row plus the newest 1000 unpinned ones as two indexed branches over a
+partial index on `pinned_at` (`Tools/clipboard-test.swift` covers the shape). The single
+`pinned_at IS NOT NULL OR rowid >= ?` form reads better but cannot be driven from an index while
+holding row order, so it scans the whole table — ~12ms against ~1ms at 200k rows, on the main actor
+at launch.

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,17 +72,23 @@ app; changes always apply (fixed build path — no need to delete `build/`).
 
 ## Tests
 
-There's no XCTest target. Two standalone harnesses:
+There's no XCTest target. Standalone harnesses:
 
 ```sh
 swift Tools/fuzz-test.swift                                        # launcher fuzzy matcher
 swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift \
     -o /tmp/calc-test && /tmp/calc-test                           # calculator engine
+swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.swift \
+    -o /tmp/clipboard-test && /tmp/clipboard-test                 # clipboard store
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —
 change the scoring in one and mirror it in the other. The calc harness compiles the real engine
 sources, which is why `Tinycast/Core/Calculator/` must stay Foundation-only.
+
+The clipboard harness likewise compiles the real `ClipboardStore.swift`, so that file must keep to
+Foundation + SQLite3 and depend on no other app source. Each case drives a store rooted in a
+throwaway temp directory (`ClipboardStore(directory:)`), so a run can never reach a real history.
 
 ## Generated data
 


### PR DESCRIPTION
Follow-up to #63: pinned entries now behave like Raycast's, plus three fixes from that PR's review.

## Pin ordering

`pinned` was a boolean, so the Pinned section stayed in **recency** order. Pinning two entries
interleaved them by when they were *copied* rather than keeping them in the order they were
*pinned*, and unpinning dropped a row back into whatever date bucket it came from — jumping the list
under the selection.

`pinned` becomes `pinned_at`, a stamp:

- **Pin order.** The section is ordered by pin time, oldest pin at the top, so a new pin joins the
  end of the section instead of displacing the ones already there.
- **Unpinning re-recencies.** The row rejoins the history as its newest entry — the same delete +
  re-insert `promote` uses — so it lands right under the Pinned section instead of scrolling the
  list out from under you.
- **Pasting a pin leaves it alone.** `promote` skips pinned rows: a pasted pin holds its place
  rather than rewriting the row and its FTS entry for no visible change.

The boolean column never shipped (it existed only between #63 and here), so nothing migrates it —
no legacy path is carried.

## Review fixes

- **A pin could vanish from a filtered search.** A pinned entry outside the FTS statement's
  `LIMIT 200` never reached the Pinned section. Adding `pinned DESC` to the `ORDER BY` would force
  SQLite to enumerate every match instead of streaming the top 200, so pins are matched **in
  memory** instead: every pinned row is resident in `items` by construction, making that exact and
  free.
- **`load` scanned the whole table on every launch.** The partial index alone changes nothing — the
  planner can't drive an `OR` from an index while holding row order, so `pinned = 1 OR rowid >= ?`
  reads every row. Split into two indexed branches over a partial index, with the floor rowid looked
  up separately: **~12.3ms → ~0.9ms at 200k rows**, on the main actor at launch.
- **`prune`'s cheap guard was defeated by pins.** It tested the oldest row, which a retention-exempt
  pin at the tail made permanently true, re-scanning the window on every capture. It now tests the
  oldest *unpinned* row.

## Validation

- **`Tools/clipboard-test.swift`** — new, 23/23. Compiles the real `ClipboardStore.swift`: pin
  order, unpin recency, paste-leaves-pins-alone, retention exemption across a relaunch, the FTS
  limit case, persistence, and migrating a shipped pre-pin database (including the resulting
  schema). Each case drives a store rooted in a throwaway temp directory, which is why the store
  gained an injectable `directory` — `HOME` overrides don't redirect Foundation's caches dir, so
  without that seam a harness run would write to a real history. The store also dropped its unused
  AppKit import, so it now compiles standalone from Foundation + SQLite3.
- Existing harnesses: `fuzz-test` all passed, `calc-test` 248/248, `emoji-test` 2054 records.
- Build clean, no new warnings. Pin/unpin behavior signed off in the running app.
- Docs: `docs/clipboard.md`, `docs/development.md`, `AGENTS.md`.

## Not included

Two lower-severity findings from the #63 review are deliberately left out — say the word and
they're easy follow-ups:

- With a query typed, a new capture shifts the highlight by a row (the follow handler keeps the
  index rather than the item).
- `trimWindow` caps *total* rows while `load` budgets 1000 *unpinned* ones, so the in-memory list
  can be slightly longer after a relaunch than while running.

