### PR TITLE
Add configurable application search scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Never break these without an explicit task to do so.
   `Core/ClipboardStore.swift` must keep to Foundation + SQLite3 with no other app source, so
   `Tools/clipboard-test.swift` can compile it standalone. `Core/LauncherRankingStore.swift` is the
   same deal for `Tools/ranking-test.swift` — Foundation only, with the clock injected via `now` and
-  the store path via `fileURL`.
+  the store path via `fileURL`, as is `Core/SearchScopes.swift` for `Tools/scopes-test.swift`.
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		05561CD36EF1A0775A282165 /* ShortcutsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5AE919A2699E6EB8BF7DC8 /* ShortcutsSettingsView.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
+		11C4CC0D767EFD44AB28D6DD /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0E1FD530C764A021E6053 /* SearchScopes.swift */; };
 		14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DC5A4706854493D23FD18A /* HyperKey.swift */; };
 		14A5A5ACD35A572EE906769F /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B976C84AFE60E357A346224 /* CalcEngine.swift */; };
 		1D0C2F452B3801503B70EA9E /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */; };
@@ -18,6 +19,7 @@
 		24842144273FF92228540DBE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */; };
 		32697AB3853D043A12888B96 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */; };
 		344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */; };
+		34CD5C2F15B1011434182CA7 /* SearchScopesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */; };
 		34E5FF0B3C9FD2FFE504D87A /* ClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ADC36002F1A5B04D61B4D3 /* ClipboardView.swift */; };
 		36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */ = {isa = PBXBuildFile; fileRef = 6621A88681E993D49EEF07A3 /* tinycast.icon */; };
 		374235D358A127741447551E /* SettingsBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043CD44B4B40C49BE79852A /* SettingsBackup.swift */; };
@@ -138,9 +140,11 @@
 		8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
 		919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKeyTap.swift; sourceTree = "<group>"; };
 		93E9ACD504E016DFF6FE6C1B /* RightClick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClick.swift; sourceTree = "<group>"; };
+		98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopesCard.swift; sourceTree = "<group>"; };
 		98B7211D27EDF764EC477A0F /* PopoverMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverMenu.swift; sourceTree = "<group>"; };
 		99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageThumbnail.swift; sourceTree = "<group>"; };
 		9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentEmojiStore.swift; sourceTree = "<group>"; };
+		9AA0E1FD530C764A021E6053 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
@@ -210,6 +214,7 @@
 				F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */,
 				93E9ACD504E016DFF6FE6C1B /* RightClick.swift */,
 				4B432D84D8F9C10521342199 /* RunningApps.swift */,
+				9AA0E1FD530C764A021E6053 /* SearchScopes.swift */,
 				C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */,
 				7BC2DEA0A052116A92F9A539 /* Theme.swift */,
 				A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */,
@@ -352,6 +357,7 @@
 				297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */,
 				0C36D92A5018B9A7B33775DE /* PermissionsSettingsView.swift */,
 				1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */,
+				98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */,
 				D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */,
 				68952539C0BD045BA175CBB6 /* SettingsRootView.swift */,
 				596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */,
@@ -520,6 +526,8 @@
 				6F08764D6CC09E9B3FD1E05A /* RootPaletteView.swift in Sources */,
 				C7DD1345A6BFB1D9EB22FCEE /* RunningApps.swift in Sources */,
 				9A254BEE278D7B78B76553A9 /* Scrypt.swift in Sources */,
+				11C4CC0D767EFD44AB28D6DD /* SearchScopes.swift in Sources */,
+				34CD5C2F15B1011434182CA7 /* SearchScopesCard.swift in Sources */,
 				374235D358A127741447551E /* SettingsBackup.swift in Sources */,
 				86D400D72735A8D0829029DE /* SettingsComponents.swift in Sources */,
 				4F3D96E59E117459153336F4 /* SettingsPaneScanner.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -127,6 +127,7 @@ final class AppCore: ObservableObject {
         Task { clipboardStore.load() }
         clipboardManager.start()
 
+        appIndex.start(settings: settings)
         Task { await appIndex.refresh() }
         Task { await emojiIndex.load() }
         currencyRates.start()

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 
 struct AppEntry: Identifiable, Hashable, Sendable {
     enum Kind: String, Sendable {
@@ -156,56 +157,67 @@ final class AppIndex: ObservableObject {
     private var matchCache: (query: String, rankingRevision: Int, result: [AppEntry])?
 
     private var isRefreshing = false
+    /// Set when a refresh is requested mid-scan, so a scope edit landing during an in-flight scan isn't silently dropped.
+    private var refreshPending = false
     private let ranking: LauncherRankingStore
+    private var settings: AppSettings?
+    private var cancellables: Set<AnyCancellable> = []
 
     init(ranking: LauncherRankingStore) {
         self.ranking = ranking
     }
 
-    /// Re-scan (called on every launcher open); the in-flight guard drops overlapping reopens and `apps` is only re-published when the set changed, so an unchanged reopen does no UI work.
-    func refresh() async {
-        guard !isRefreshing else { return }
-        isRefreshing = true
-        defer { isRefreshing = false }
-        let found = await Task.detached(priority: .utility) { AppIndex.scan() }.value
-        guard found != apps else { return }
-        apps = found
-        matchCache = nil
+    /// Wires the search scopes, re-indexing when the user edits them so Settings changes land without waiting for the next launcher open.
+    func start(settings: AppSettings) {
+        self.settings = settings
+        settings.$searchScopes
+            .dropFirst()
+            // @Published emits synchronously on the main actor (hence assumeIsolated), before the property is written, so the scan is deferred to a task that reads the settled value.
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    Task { await self.refresh() }
+                }
+            }
+            .store(in: &cancellables)
     }
 
-    nonisolated private static func scan() -> [AppEntry] {
-        let fm = FileManager.default
-        var searchDirs = [
-            "/Applications",
-            "/Applications/Utilities",
-            "/System/Applications",
-            "/System/Applications/Utilities",
-        ].map { URL(fileURLWithPath: $0) }
-        searchDirs.append(fm.homeDirectoryForCurrentUser.appendingPathComponent("Applications"))
+    /// Re-scan (called on every launcher open); overlapping reopens collapse into one trailing scan and `apps` is only re-published when the set changed, so an unchanged reopen does no UI work.
+    func refresh() async {
+        guard !isRefreshing else {
+            refreshPending = true
+            return
+        }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        repeat {
+            refreshPending = false
+            let scopes = settings?.searchScopes ?? SearchScopes.defaults
+            let found = await Task.detached(priority: .utility) { AppIndex.scan(scopes: scopes) }
+                .value
+            guard found != apps else { continue }
+            apps = found
+            matchCache = nil
+        } while refreshPending
+    }
 
+    nonisolated private static func scan(scopes: [String]) -> [AppEntry] {
         var seenBundleIDs = Set<String>()
         var result: [AppEntry] = []
-        for dir in searchDirs {
-            guard
-                let items = try? fm.contentsOfDirectory(
-                    at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
-                )
-            else { continue }
-            for url in items where url.pathExtension == "app" {
-                let bundle = Bundle(url: url)
-                let bundleID = bundle?.bundleIdentifier
-                // Dedup by bundle id; first directory (/Applications) wins.
-                if let bundleID, !seenBundleIDs.insert(bundleID).inserted { continue }
+        for url in SearchScopes.appBundles(in: scopes) {
+            let bundle = Bundle(url: url)
+            let bundleID = bundle?.bundleIdentifier
+            // Dedup by bundle id; the earliest scope wins.
+            if let bundleID, !seenBundleIDs.insert(bundleID).inserted { continue }
 
-                let name =
-                    (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
-                    ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)
-                    ?? url.deletingPathExtension().lastPathComponent
-                result.append(
-                    AppEntry(
-                        id: url.path, name: name, url: url, bundleID: bundleID,
-                        kind: .application))
-            }
+            let name =
+                (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+                ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)
+                ?? url.deletingPathExtension().lastPathComponent
+            result.append(
+                AppEntry(
+                    id: url.path, name: name, url: url, bundleID: bundleID,
+                    kind: .application))
         }
         // Apps, then Settings panes, then Commands — the sectioned launcher relies on this order so its flat selection index maps 1:1 onto rows.
         let apps = result.sorted {

--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -38,6 +38,12 @@ final class AppSettings: ObservableObject {
         static let popToRootTimeout = "popToRootTimeout"
         static let compactMode = "compactMode"
         static let showFavoritesInCompactMode = "showFavoritesInCompactMode"
+        static let searchScopes = "launcherSearchScopes"
+    }
+
+    /// Folders (and individual `.app` bundles) `AppIndex` scans, in scan order. Editing this re-indexes — `AppIndex.start(settings:)` observes it.
+    @Published var searchScopes: [String] {
+        didSet { defaults.set(searchScopes, forKey: Key.searchScopes) }
     }
 
     @Published var clipboardRetention: ClipboardRetention {
@@ -124,5 +130,7 @@ final class AppSettings: ObservableObject {
         showFavoritesInCompactMode =
             defaults.object(forKey: Key.showFavoritesInCompactMode) == nil
             || defaults.bool(forKey: Key.showFavoritesInCompactMode)
+        // An unset key means "never configured" and seeds the defaults; a stored empty array is a user who deliberately cleared the list.
+        searchScopes = defaults.stringArray(forKey: Key.searchScopes) ?? SearchScopes.defaults
     }
 }

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -23,6 +23,7 @@ struct SettingsBackup: Codable {
         var popToRootSeconds: Int?
         var compactMode: Bool?
         var showFavoritesInCompactMode: Bool?
+        var searchScopes: [String]?
     }
 
     struct HotkeyBackup: Codable {
@@ -62,7 +63,8 @@ extension SettingsBackup {
                 ?? true,
             popToRootSeconds: s.popToRootTimeout.rawValue,
             compactMode: s.compactMode,
-            showFavoritesInCompactMode: s.showFavoritesInCompactMode)
+            showFavoritesInCompactMode: s.showFavoritesInCompactMode,
+            searchScopes: s.searchScopes)
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
@@ -154,6 +156,10 @@ extension SettingsBackup {
         }
         if let flag = s.showFavoritesInCompactMode {
             settings.showFavoritesInCompactMode = flag
+            count += 1
+        }
+        if let scopes = s.searchScopes {
+            settings.searchScopes = SearchScopes.normalize(scopes)
             count += 1
         }
         return count

--- a/Tinycast/Core/SearchScopes.swift
+++ b/Tinycast/Core/SearchScopes.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// The folders (and individual bundles) `AppIndex` scans for applications. Foundation-only and pure so `Tools/scopes-test.swift` can compile it standalone.
+enum SearchScopes {
+    /// Seeded into `AppSettings.searchScopes` on a fresh install. Order matters: `AppIndex.scan()` dedups by bundle ID and the first hit wins.
+    static let defaults: [String] = [
+        "/Applications",
+        "/Applications/Utilities",
+        "/System/Applications",
+        "/System/Applications/Utilities",
+        "/System/Library/CoreServices/Applications",
+        // Safari and the other cryptex-delivered system apps; `/Applications/Safari.app` is only a symlink, and a hidden one, so `.skipsHiddenFiles` never sees it.
+        "/System/Volumes/Preboot/Cryptexes/App/System/Applications",
+        // The one user-facing app in CoreServices — the other ~120 bundles there are background agents with no reliable way to tell them apart, so the directory itself is not a default.
+        "/System/Library/CoreServices/Finder.app",
+        "~/Applications",
+    ]
+
+    /// Storage form: tilde-abbreviated and without a trailing slash, so the Settings list reads cleanly and a settings backup stays portable across machines.
+    static func abbreviate(_ path: String) -> String {
+        let trimmed = trimTrailingSlash(path)
+        return (trimmed as NSString).abbreviatingWithTildeInPath
+    }
+
+    static func expand(_ path: String) -> String {
+        (trimTrailingSlash(path) as NSString).expandingTildeInPath
+    }
+
+    /// Abbreviates every path and drops duplicates, preserving order.
+    static func normalize(_ paths: [String]) -> [String] {
+        var seen = Set<String>()
+        return paths.map(abbreviate).filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    /// Every `.app` bundle the scopes point at. Flat: one directory listing per scope, no recursion — a nested folder is indexed by adding it as its own scope. Missing or unreadable scopes are skipped.
+    static func appBundles(in scopes: [String]) -> [URL] {
+        let fm = FileManager.default
+        var result: [URL] = []
+        for scope in scopes {
+            let url = URL(fileURLWithPath: expand(scope))
+            if url.pathExtension == "app" {
+                if fm.fileExists(atPath: url.path) { result.append(url) }
+                continue
+            }
+            guard
+                let items = try? fm.contentsOfDirectory(
+                    at: url, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+                )
+            else { continue }
+            result.append(contentsOf: items.filter { $0.pathExtension == "app" })
+        }
+        return result
+    }
+
+    private static func trimTrailingSlash(_ path: String) -> String {
+        var path = path.trimmingCharacters(in: .whitespaces)
+        while path.count > 1 && path.hasSuffix("/") { path.removeLast() }
+        return path
+    }
+}

--- a/Tinycast/Features/Settings/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/GeneralSettingsView.swift
@@ -67,6 +67,8 @@ struct GeneralSettingsView: View {
                 }
             }
 
+            SearchScopesCard()
+
             SettingsCard(header: "Hyper Key") {
                 SettingsRow(
                     title: "Hyper Key",
@@ -154,7 +156,8 @@ struct GeneralSettingsView: View {
                 SettingsDivider()
                 SettingsRow(
                     title: "Show favorites in compact mode",
-                    subtitle: "Pin favorite app icons to the right of the compact bar (⌘1–⌘5 to launch).",
+                    subtitle:
+                        "Pin favorite app icons to the right of the compact bar (⌘1–⌘5 to launch).",
                     systemImage: "star",
                     tint: .yellow
                 ) {
@@ -210,7 +213,8 @@ struct GeneralSettingsView: View {
                 SettingsDivider()
                 SettingsRow(
                     title: "Welcome Guide",
-                    subtitle: "Re-run the first-launch setup: shortcut, permissions, and Raycast import.",
+                    subtitle:
+                        "Re-run the first-launch setup: shortcut, permissions, and Raycast import.",
                     systemImage: "sparkles",
                     tint: .yellow
                 ) {

--- a/Tinycast/Features/Settings/SearchScopesCard.swift
+++ b/Tinycast/Features/Settings/SearchScopesCard.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// The editable list of folders (and individual `.app` bundles) the launcher indexes.
+struct SearchScopesCard: View {
+    @ObservedObject private var settings = AppCore.shared.settings
+    /// Recomputed only when the list changes — a `fileExists` per row is cheap, but not cheap enough to run on every body render.
+    @State private var missing: Set<String> = []
+
+    private var isDefault: Bool { settings.searchScopes == SearchScopes.defaults }
+
+    var body: some View {
+        SettingsCard(header: "Search Scopes") {
+            ForEach(settings.searchScopes, id: \.self) { scope in
+                ScopeRow(scope: scope, isMissing: missing.contains(scope)) {
+                    settings.searchScopes.removeAll { $0 == scope }
+                }
+                SettingsDivider()
+            }
+
+            HStack(spacing: Theme.Spacing.lg) {
+                Text("Folders searched when indexing applications.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: Theme.Spacing.xl)
+                if !isDefault {
+                    Button("Restore Defaults") { settings.searchScopes = SearchScopes.defaults }
+                        .controlSize(.small)
+                }
+                Button(action: addScopes) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .medium))
+                }
+                .buttonStyle(.borderless)
+                .help("Add a folder or application to search.")
+            }
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
+        }
+        .onAppear(perform: refreshMissing)
+        .onChange(of: settings.searchScopes) { _, _ in refreshMissing() }
+    }
+
+    private func refreshMissing() {
+        let fm = FileManager.default
+        missing = Set(
+            settings.searchScopes.filter { !fm.fileExists(atPath: SearchScopes.expand($0)) })
+    }
+
+    private func addScopes() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.applicationBundle]
+        // Otherwise an .app is navigated into rather than selected.
+        panel.treatsFilePackagesAsDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.prompt = "Add"
+        panel.message = "Choose folders or applications to include in the launcher."
+        // Tinycast is an accessory app, so the panel opens behind the frontmost app without this.
+        NSApp.activate(ignoringOtherApps: true)
+        guard panel.runModal() == .OK else { return }
+        settings.searchScopes = SearchScopes.normalize(
+            settings.searchScopes + panel.urls.map(\.path))
+    }
+}
+
+private struct ScopeRow: View {
+    let scope: String
+    let isMissing: Bool
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: (scope as NSString).pathExtension == "app" ? "app" : "folder")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: Theme.Size.settingsRowIcon)
+            Text(scope)
+                .font(Theme.Typography.rowTitle)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(isMissing ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.primary))
+            Spacer(minLength: Theme.Spacing.xl)
+            if isMissing {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .help("This location no longer exists.")
+            }
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+        .padding(.vertical, Theme.Spacing.lg)
+    }
+}

--- a/Tools/scopes-test.swift
+++ b/Tools/scopes-test.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+@main
+struct ScopesTest {
+    static func main() {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("tinycast-scopes-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: root) }
+
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        func makeDir(_ url: URL) {
+            try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+
+        // A scope directory with two apps, a non-app sibling, a hidden app, and a nested app.
+        let apps = root.appendingPathComponent("Apps")
+        makeDir(apps.appendingPathComponent("Alpha.app"))
+        makeDir(apps.appendingPathComponent("Beta.app"))
+        makeDir(apps.appendingPathComponent("Notes.txt"))
+        makeDir(apps.appendingPathComponent(".Hidden.app"))
+        let nested = apps.appendingPathComponent("Sub")
+        makeDir(nested.appendingPathComponent("Deep.app"))
+
+        let found = SearchScopes.appBundles(in: [apps.path]).map(\.lastPathComponent)
+        check("direct .app children are indexed", Set(found) == ["Alpha.app", "Beta.app"])
+        check("non-app children are skipped", !found.contains("Notes.txt"))
+        check("hidden bundles are skipped", !found.contains(".Hidden.app"))
+        // Flat by contract: a nested folder is indexed by adding it as its own scope.
+        check("nested bundles are not indexed", !found.contains("Deep.app"))
+        check(
+            "a nested folder works as its own scope",
+            SearchScopes.appBundles(in: [nested.path]).map(\.lastPathComponent) == ["Deep.app"])
+
+        // A scope may be a single bundle rather than a directory — that's how Finder ships as a default.
+        check(
+            "an .app scope is indexed directly",
+            SearchScopes.appBundles(in: [apps.appendingPathComponent("Alpha.app").path])
+                .map(\.lastPathComponent) == ["Alpha.app"])
+        check(
+            "a missing .app scope yields nothing",
+            SearchScopes.appBundles(in: [apps.appendingPathComponent("Gone.app").path]).isEmpty)
+        check(
+            "a missing directory scope is skipped without failing the rest",
+            SearchScopes.appBundles(in: [root.appendingPathComponent("Nope").path, nested.path])
+                .map(\.lastPathComponent) == ["Deep.app"])
+
+        check(
+            "scopes are scanned in order",
+            SearchScopes.appBundles(in: [nested.path, apps.path]).map(\.lastPathComponent).first
+                == "Deep.app")
+
+        let home = fm.homeDirectoryForCurrentUser.path
+        check(
+            "expand resolves a tilde",
+            SearchScopes.expand("~/Applications") == home + "/Applications")
+        check(
+            "abbreviate restores the tilde",
+            SearchScopes.abbreviate(home + "/Applications") == "~/Applications")
+        check(
+            "tilde survives a round trip",
+            SearchScopes.abbreviate(SearchScopes.expand("~/Applications")) == "~/Applications")
+        check(
+            "expand leaves an absolute path alone",
+            SearchScopes.expand("/Applications") == "/Applications")
+        check(
+            "a trailing slash is trimmed",
+            SearchScopes.abbreviate("/Applications/") == "/Applications")
+        check("root survives trimming", SearchScopes.abbreviate("/") == "/")
+
+        check(
+            "normalize dedups after abbreviating",
+            SearchScopes.normalize([
+                "/Applications", "/Applications/", home + "/Applications", "~/Applications",
+            ])
+                == ["/Applications", "~/Applications"])
+        check("normalize preserves order", SearchScopes.normalize(["/B", "/A"]) == ["/B", "/A"])
+        check("normalize drops blanks", SearchScopes.normalize(["  ", "/A"]) == ["/A"])
+        check(
+            "defaults are already normalized",
+            SearchScopes.normalize(SearchScopes.defaults) == SearchScopes.defaults)
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -82,6 +82,8 @@ swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift \
     -o /tmp/calc-test && /tmp/calc-test                           # calculator engine
 swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.swift \
     -o /tmp/clipboard-test && /tmp/clipboard-test                 # clipboard store
+swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift \
+    -o /tmp/scopes-test && /tmp/scopes-test                       # launcher search scopes
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -1,7 +1,33 @@
 # App launcher & fuzzy match
 
-`AppIndex.scan()` runs off-main, enumerates the standard `/Applications` dirs, and dedups by bundle ID
-(first dir wins).
+`AppIndex.scan()` runs off-main, enumerates the user's search scopes, and dedups by bundle ID (the
+earliest scope wins).
+
+## Search scopes
+
+`SearchScopes` (`Core/SearchScopes.swift`) owns the paths; the list is user-editable in General
+Settings and persisted as `AppSettings.searchScopes`. A scope is either a directory or a single `.app`
+bundle, stored tilde-abbreviated so the UI reads cleanly and a settings backup stays portable.
+
+Enumeration is **flat** — one `contentsOfDirectory` per scope, no recursion. A nested folder such as
+`/Applications/Adobe` is indexed by adding it as its own scope, which keeps the list honest: what it
+shows is exactly what is scanned. (A one-level nested walk was measured against the flat list over the
+real default set: same 96 apps, same ~0.5 ms once `Bundle()` metadata reads are counted.)
+
+The defaults cover `/Applications` and `/System/Applications` plus their `Utilities` folders,
+`/System/Library/CoreServices/Applications`, the cryptex apps under
+`/System/Volumes/Preboot/Cryptexes/App/System/Applications` (this is the only place Safari really
+lives — `/Applications/Safari.app` is a symlink flagged hidden, so `.skipsHiddenFiles` never sees it),
+`~/Applications`, and `/System/Library/CoreServices/Finder.app`.
+
+Finder ships as an individual bundle scope rather than by adding `/System/Library/CoreServices`, which
+holds ~120 background-agent bundles. There is no reliable way to filter those: `LSUIElement`,
+`LSBackgroundOnly` and "declares no icon" each also exclude legitimately launchable apps — Raycast,
+Stats, Tinycast itself, Mission Control, Siri, Time Machine, Screenshot, System Information, Font
+Book. Don't reintroduce such a heuristic.
+
+`AppIndex.start(settings:)` observes `$searchScopes`, so an edit re-indexes immediately; overlapping
+refreshes collapse into a single trailing scan.
 
 `FuzzyMatch.score` is a tiered scorer: exact → prefix → substring / word-start → subsequence with
 consecutive / word-boundary bonuses. `LauncherRankingStore` then adds a bounded, query-specific


### PR DESCRIPTION
> **Development disclosure**
>
> This PR was created with Claude Code using Opus 5. The scope model was developed test-first against a standalone harness, and the default scope list was chosen from measurements taken on a real macOS 26 machine rather than copied from Raycast — see *Why not `/System/Library/CoreServices`* below.

Closes #58. Closes #48.

## Summary

`AppIndex.scan()` walked five hardcoded directories. That had two consequences: users could not point the launcher at their own folders, and two stock apps were unreachable.

Search scopes are now a user-editable list in **Settings ▸ General**, seeded with defaults that fix both. A scope is a folder **or** a single `.app` bundle.

| | before | after |
| --- | --- | --- |
| Apps indexed | 83 | 96 |
| Apps lost | — | 0 |
| Finder | ❌ | ✅ |
| Safari | ❌ | ✅ |

The 13 additions are all real, user-facing apps: About This Mac, Archive Utility, Desk View, Directory Utility, DVD Player, Expansion Slot Utility, **Finder**, Folder Actions Setup, iOS App Installer, Keychain Access, **Safari**, Ticket Viewer, Wireless Diagnostics.

## Why Finder and Safari were missing (#48)

Two unrelated causes, neither an intentional filter:

- **Finder** lives at `/System/Library/CoreServices/Finder.app`, which was never in the search path.
- **Safari** was missed twice over. `/Applications/Safari.app` is a symlink carrying the BSD `hidden` flag, so `options: [.skipsHiddenFiles]` dropped it before the `.app` test ever ran; and its real bundle is in the cryptex at `/System/Volumes/Preboot/Cryptexes/App/System/Applications/`, which was also unscanned.

`.skipsHiddenFiles` is kept — it earns its keep on `.DS_Store` and hidden junk. Adding the cryptex directory is the correct fix rather than letting a hidden symlink through.

## Why not `/System/Library/CoreServices`

Raycast lists that directory in its own scope list, and adding it would surface Finder for free. It is not a default here, because it holds **123 `.app` bundles, ~120 of them background agents**.

Every plausible filter was measured against the current scan set, and each one also drops legitimately launchable apps:

| Filter | Also excludes |
| --- | --- |
| `LSUIElement` | Raycast, Stats, **Tinycast itself**, Mission Control, Siri, Time Machine, Screenshot, System Information |
| `LSBackgroundOnly` | user-installed URL-handler stubs |
| requires an icon key | Font Book |

So there is no safe heuristic. Instead a scope may be an individual bundle, and `/System/Library/CoreServices/Finder.app` ships as one of the defaults — visible and removable in the UI rather than buried in a constant. A user who wants the whole directory can still add it. This reasoning is recorded in `docs/launcher.md` so it does not get re-litigated.

## Why enumeration stays flat

A one-level nested walk was benchmarked against the flat list over the real default set:

| | directory listing | full scan incl. `Bundle()` metadata | apps found |
| --- | --- | --- | --- |
| Flat | 0.81 ms | 0.50 ms | 96 |
| Depth-2 | 0.74 ms | 0.50 ms | 96 |

Identical. On a real machine the nested walk descends into exactly the two `Utilities` directories the flat list already names. It bought nothing while adding a nested loop, an `isDirectoryKey` lookup and a "descend only into extension-less directories" rule — so `SearchScopes.appBundles(in:)` is one `contentsOfDirectory` per scope, no recursion.

That also makes the UI honest: the list shows precisely what is scanned. A nested folder such as `/Applications/Adobe` or an external `/Volumes/SSD/Apps` (#58) is indexed by adding it as its own row.

## Implementation

`Core/SearchScopes.swift` is Foundation-only and pure, so `Tools/scopes-test.swift` compiles it standalone — the same arrangement as `LauncherRankingStore`. It owns the defaults, tilde expand/abbreviate, `normalize`, and `appBundles(in:)`.

- **Storage** is `AppSettings.searchScopes`, mirroring the existing `clipboardDisabledApps` shape. Paths are stored tilde-abbreviated and without a trailing slash, so the Settings list reads cleanly and a settings backup stays portable across machines and user accounts. An unset key seeds the defaults; a stored empty array is honoured as a user who deliberately cleared the list, so no migration is needed for existing installs.
- **`AppIndex.scan(scopes:)`** loses its hardcoded array; everything downstream is untouched — `Bundle(url:)` metadata reads, bundle-ID dedup (earliest scope wins), the alphabetical sort, and the `apps + SettingsPaneScanner + CommandRegistry` ordering the flat selection index depends on.
- **`AppIndex.start(settings:)`** observes `$searchScopes` and re-indexes on edit, following `HyperKeyTap.start(settings:)`. Registered from `AppCore.start()`, the single wiring point.
- **`refresh()`** previously *dropped* an overlapping call via its `isRefreshing` guard, which would have silently swallowed a scope edit landing mid-scan. Overlapping refreshes now collapse into a single trailing re-scan.
- **`SettingsBackup`** gains an optional `searchScopes`, normalized on import. It is a plain `[String]`, so the JSON stays legible.

## UI

`Features/Settings/SearchScopesCard.swift`, rendered in **General** directly under the existing Search card. It follows the "Disabled Applications" card in `ClipboardSettingsView` — `SettingsCard`, rows split by `SettingsDivider`, footer strip — and uses `Theme` tokens throughout, with the established `xmark.circle.fill` remove affordance.

- `folder` / `app` glyph per row so a bundle scope is distinguishable at a glance.
- `+` opens an `NSOpenPanel` accepting folders *and* `.app` bundles, multi-select, with the `NSApp.activate(ignoringOtherApps:)` call accessory apps need before `runModal()`. Results go through `normalize`, so re-adding an existing scope is a no-op.
- **Restore Defaults** appears only once the list diverges from the built-ins.
- A scope whose path no longer exists dims and shows an orange warning; the scan skips it and still succeeds. Missing-path state is recomputed on change rather than per body render.

No security-scoped bookmarks: the app is unsandboxed, so plain stored paths keep working across launches, and the panel selection satisfies TCC for protected locations.

## Verification

- `swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift ...` → **19/19 passed** (new). Covers flat-by-contract, hidden and non-app children, bundle scopes, missing scopes, scan order, tilde round-trip, and `normalize` dedup.
- `swift Tools/fuzz-test.swift` → all passed.
- `swiftc ... Tools/ranking-test.swift` → all passed.
- `swiftc ... Tools/calc-test.swift` → **426 passed, 0 failed**.
- `swiftc ... Tools/clipboard-test.swift` → **23/23 passed**.
- Clean Xcode 26 Debug build on macOS 26 → **BUILD SUCCEEDED**, no new warnings.
- Index diffed old scopes vs new over the real filesystem: 83 → 96 apps, **0 removed**, Finder and Safari both present, no CoreServices daemons pulled in.
- Driven through `Tinycast Dev.app`: adding a folder re-indexes without reopening Settings, removing a default scope drops its apps, Restore Defaults re-seeds, and a deleted scope shows the warning without breaking the scan.

Docs updated: `docs/launcher.md` (scopes, defaults, the CoreServices rationale), `docs/development.md` (harness command), `AGENTS.md` (Foundation-only invariant).
