### PR TITLE
Add native localization foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,32 @@ Check existing [issues](https://github.com/abue-ammar/tinycast/issues) and
 - Details: [`docs/development.md`](docs/development.md). Architecture:
   [`docs/architecture.md`](docs/architecture.md).
 
+## Localization
+
+Tinycast uses Apple's native localization stack: an English-source
+`Tinycast/Localizable.xcstrings` String Catalog, SwiftUI's localization-aware text initializers, and
+Foundation's `String(localized:)` for strings resolved outside a view. `DisplayText` distinguishes
+catalog keys from runtime/user content in generic UI components; there is no generated API or
+third-party dependency.
+
+- Pass literal user-facing text directly to SwiftUI controls such as `Text`, `Button`, and `Label`.
+- Use `String(localized:)` when AppKit, a model, an error, or an interpolated status needs a `String`.
+- Keep interpolation inside the localized value so translators can reorder placeholders. Do not
+  assemble a sentence from translated fragments.
+- Generic settings and popover components resolve their string values through the catalog. Add their
+  English key and every supported translation to `Localizable.xcstrings` when introducing text there.
+- Wrap file names, app names, already-localized status messages, and other runtime values in
+  `DisplayText.verbatim` when passing them to a generic component.
+- Keep app names, file names, typed calculator expressions, keyboard glyphs, URLs, and user content
+  verbatim.
+
+To add a language, add it to `Localizable.xcstrings`, translate every entry, and run
+`swift Tools/localization-test.swift`. The app follows the language selected by macOS; it does not
+maintain a second in-app language setting. See Apple's documentation for
+[String Catalogs](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog),
+[preparing SwiftUI views](https://developer.apple.com/documentation/swiftui/preparing-views-for-localization),
+and [`LocalizedStringResource`](https://developer.apple.com/documentation/foundation/localizedstringresource).
+
 ## Before submitting
 
 - Builds clean — no new warnings.

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		05561CD36EF1A0775A282165 /* ShortcutsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5AE919A2699E6EB8BF7DC8 /* ShortcutsSettingsView.swift */; };
+		0AB7D86E77713851080DFF59 /* DisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F944B1936FD93BFD28C86C5 /* DisplayText.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
 		11C4CC0D767EFD44AB28D6DD /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0E1FD530C764A021E6053 /* SearchScopes.swift */; };
 		14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DC5A4706854493D23FD18A /* HyperKey.swift */; };
@@ -81,6 +82,7 @@
 		E952B659AEB905A3B233F78B /* EmojiGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94F0767AE0A5855FB22BF6 /* EmojiGridView.swift */; };
 		F25D58ED6EF3308D38D01732 /* PaletteWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */; };
 		F2B68DBA258D85DD5C6DC1CC /* Paster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6185011A02366B30B48B5B6C /* Paster.swift */; };
+		F5EEA88C9F6BBC94539173D3 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 1EE2F7E7C7F2A97594835F82 /* Localizable.xcstrings */; };
 		F5F3381FF70997223F8888B0 /* KeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3EB07C07902C53BFD3B08B /* KeyShortcut.swift */; };
 		F6B79728FF2D37A60FED72AF /* HyperKeyTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */; };
 		FC934E5AE6A933F5BC7AC4DD /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D93A4CEA9FE857034D63EF7 /* CalcQuantity.swift */; };
@@ -96,6 +98,7 @@
 		0F50886DC766B9923C3875A5 /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
 		1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportSelection.swift; sourceTree = "<group>"; };
 		1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
+		1EE2F7E7C7F2A97594835F82 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
 		297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscellaneousSettingsView.swift; sourceTree = "<group>"; };
@@ -138,6 +141,7 @@
 		88A65B4EC5AE7E22594BFC5E /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
 		8D93A4CEA9FE857034D63EF7 /* CalcQuantity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcQuantity.swift; sourceTree = "<group>"; };
 		8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
+		8F944B1936FD93BFD28C86C5 /* DisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayText.swift; sourceTree = "<group>"; };
 		919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKeyTap.swift; sourceTree = "<group>"; };
 		93E9ACD504E016DFF6FE6C1B /* RightClick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClick.swift; sourceTree = "<group>"; };
 		98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopesCard.swift; sourceTree = "<group>"; };
@@ -199,6 +203,7 @@
 				BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */,
 				5D57B0AE44D21035163BD422 /* CommandRegistry.swift */,
 				8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */,
+				8F944B1936FD93BFD28C86C5 /* DisplayText.swift */,
 				33A13DB27EE627AC08051165 /* EdgeDissolve.swift */,
 				9FB750D045194AE34D39D792 /* FavoritesStore.swift */,
 				D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */,
@@ -297,6 +302,7 @@
 				95CA98985928A88B33F82556 /* Features */,
 				C45190564C9D9F1722E83943 /* Assets.xcassets */,
 				4DA7B926405DAC632C056418 /* Info.plist */,
+				1EE2F7E7C7F2A97594835F82 /* Localizable.xcstrings */,
 				45D4BA6E1BD8EB1F96A8927F /* Tinycast.entitlements */,
 				6621A88681E993D49EEF07A3 /* tinycast.icon */,
 			);
@@ -432,6 +438,7 @@
 			knownRegions = (
 				Base,
 				en,
+				"zh-Hans",
 			);
 			mainGroup = FB9897CCA50570B3E7630145;
 			minimizedProjectReferenceProxies = 1;
@@ -451,6 +458,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9969E6858C4FDC5CCCDEB5D8 /* Assets.xcassets in Resources */,
+				F5EEA88C9F6BBC94539173D3 /* Localizable.xcstrings in Resources */,
 				36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -489,6 +497,7 @@
 				6D3DBE00FCB757C67669CFBA /* CommandRegistry.swift in Sources */,
 				AA8050D9A547CDDD37C581C4 /* CurrencyData.generated.swift in Sources */,
 				6CDCE462405648998CDF1E77 /* CurrencyRateStore.swift in Sources */,
+				0AB7D86E77713851080DFF59 /* DisplayText.swift in Sources */,
 				715F8A70F7A533D2EEEF6135 /* EdgeDissolve.swift in Sources */,
 				344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */,
 				B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */,
@@ -642,6 +651,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
@@ -709,6 +719,7 @@
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_SWIFT_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -10,10 +10,10 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     var id: String { rawValue }
     var title: String {
         switch self {
-        case .launcher: return "Apps"
-        case .clipboard: return "Clipboard"
-        case .calculatorHistory: return "Calculator History"
-        case .emoji: return "Emoji & Symbols"
+        case .launcher: return String(localized: "Apps")
+        case .clipboard: return String(localized: "Clipboard")
+        case .calculatorHistory: return String(localized: "Calculator History")
+        case .emoji: return String(localized: "Emoji & Symbols")
         }
     }
     var systemImage: String {
@@ -26,10 +26,11 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     }
     var placeholder: String {
         switch self {
-        case .launcher: return "Search for apps and commands…"
-        case .clipboard: return "Type to filter entries…"
-        case .calculatorHistory: return "Do math, convert units, or search your past calculations…"
-        case .emoji: return "Search emoji and symbols…"
+        case .launcher: return String(localized: "Search for apps and commands…")
+        case .clipboard: return String(localized: "Type to filter entries…")
+        case .calculatorHistory:
+            return String(localized: "Do math, convert units, or search your past calculations…")
+        case .emoji: return String(localized: "Search emoji and symbols…")
         }
     }
 }
@@ -46,7 +47,7 @@ struct PasteTarget: Equatable {
         iconPath = app.bundleURL?.path
     }
 
-    var pasteTitle: String { "Paste to \(name)" }
+    var pasteTitle: String { String(localized: "Paste to \(name)") }
 }
 
 /// View-model shared between the panel's SwiftUI tree and the coordinator.
@@ -214,7 +215,8 @@ final class AppCore: ObservableObject {
     /// Settings runs in its own window (the SwiftUI `Settings` scene is unreliable for accessory apps). A fresh window mounts directly on `tab` (no first-frame flicker); an already-open one is switched in place.
     func showSettings(tab: SettingsTab = .general) {
         let isNew = auxWindows.show(
-            id: "settings", title: "Settings", size: CGSize(width: 720, height: 550),
+            id: "settings", title: String(localized: "Settings"),
+            size: CGSize(width: 720, height: 550),
             seamlessTitleBar: true
         ) {
             SettingsRootView(initialTab: tab)
@@ -237,7 +239,7 @@ final class AppCore: ObservableObject {
     /// The first-run wizard: palette shortcut, Accessibility, Raycast import. Also re-runnable from Settings.
     func showOnboarding() {
         auxWindows.show(
-            id: "onboarding", title: "Welcome to Tinycast",
+            id: "onboarding", title: String(localized: "Welcome to Tinycast"),
             size: OnboardingView.windowSize, seamlessTitleBar: true
         ) {
             OnboardingView()
@@ -297,14 +299,18 @@ final class AppCore: ObservableObject {
         // An accessory app's alert opens behind the frontmost app unless it activates first (same as `BackupActions`).
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
-        alert.messageText = count == 1 ? "Quit 1 application?" : "Quit \(count) applications?"
-        alert.informativeText = "Applications with unsaved changes will ask you to save."
+        alert.messageText =
+            count == 1
+            ? String(localized: "Quit 1 application?")
+            : String(localized: "Quit \(count) applications?")
+        alert.informativeText = String(
+            localized: "Applications with unsaved changes will ask you to save.")
         alert.alertStyle = .warning
-        let quitButton = alert.addButton(withTitle: "Quit All")
+        let quitButton = alert.addButton(withTitle: String(localized: "Quit All"))
         quitButton.hasDestructiveAction = true
         // `hasDestructiveAction` only tints the button — it stays the ↵ default. Hand ↵ to Cancel instead: this command is one ↵ away in the palette, and a second reflexive ↵ must not quit the desktop.
         quitButton.keyEquivalent = ""
-        alert.addButton(withTitle: "Cancel").keyEquivalent = "\r"
+        alert.addButton(withTitle: String(localized: "Cancel")).keyEquivalent = "\r"
         return alert.runModal() == .alertFirstButtonReturn
     }
 

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -19,9 +19,9 @@ struct AppEntry: Identifiable, Hashable, Sendable {
 
     var kindLabel: String {
         switch kind {
-        case .application: return "Application"
-        case .systemSettings: return "System Setting"
-        case .command: return "Command"
+        case .application: return String(localized: "Application")
+        case .systemSettings: return String(localized: "System Setting")
+        case .command: return String(localized: "Command")
         }
     }
 

--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -18,7 +18,9 @@ enum PopToRootTimeout: Int, CaseIterable, Identifiable, Sendable {
     var id: Int { rawValue }
 
     var title: String {
-        self == .immediately ? "Immediately" : "After \(rawValue) seconds"
+        self == .immediately
+            ? String(localized: "Immediately")
+            : String(localized: "After \(rawValue) seconds")
     }
 
     var interval: TimeInterval { TimeInterval(rawValue) }

--- a/Tinycast/Core/Backup/BackupActions.swift
+++ b/Tinycast/Core/Backup/BackupActions.swift
@@ -22,7 +22,9 @@ enum BackupActions {
         do {
             try SettingsBackup.gather().encoded().write(to: url, options: .atomic)
         } catch {
-            present(title: "Export Failed", message: error.localizedDescription, style: .warning)
+            present(
+                title: String(localized: "Export Failed"), message: error.localizedDescription,
+                style: .warning)
         }
     }
 
@@ -35,11 +37,13 @@ enum BackupActions {
         do {
             let backup = try SettingsBackup(json: try Data(contentsOf: url))
             present(
-                title: "Settings Imported", message: summaryText(backup.apply()),
+                title: String(localized: "Settings Imported"), message: summaryText(backup.apply()),
                 style: .informational
             )
         } catch {
-            present(title: "Import Failed", message: error.localizedDescription, style: .warning)
+            present(
+                title: String(localized: "Import Failed"), message: error.localizedDescription,
+                style: .warning)
         }
     }
 
@@ -91,12 +95,33 @@ enum BackupActions {
 
     static func summaryText(_ s: SettingsBackup.ApplySummary) -> String {
         var parts: [String] = []
-        if s.settingsFields > 0 { parts.append("\(s.settingsFields) settings") }
-        if s.hotkeys > 0 { parts.append("\(s.hotkeys) shortcuts") }
-        if s.favorites > 0 { parts.append("\(s.favorites) favorites") }
-        if s.hiddenItems > 0 { parts.append("\(s.hiddenItems) hidden items") }
-        return parts.isEmpty
-            ? "Nothing to import from this file." : "Applied " + parts.joined(separator: ", ") + "."
+        if s.settingsFields > 0 {
+            parts.append(
+                s.settingsFields == 1
+                    ? String(localized: "1 setting")
+                    : String(localized: "\(s.settingsFields) settings"))
+        }
+        if s.hotkeys > 0 {
+            parts.append(
+                s.hotkeys == 1
+                    ? String(localized: "1 shortcut")
+                    : String(localized: "\(s.hotkeys) shortcuts"))
+        }
+        if s.favorites > 0 {
+            parts.append(
+                s.favorites == 1
+                    ? String(localized: "1 favorite")
+                    : String(localized: "\(s.favorites) favorites"))
+        }
+        if s.hiddenItems > 0 {
+            parts.append(
+                s.hiddenItems == 1
+                    ? String(localized: "1 hidden item")
+                    : String(localized: "\(s.hiddenItems) hidden items"))
+        }
+        guard !parts.isEmpty else { return String(localized: "Nothing to import from this file.") }
+        let summary = ListFormatter.localizedString(byJoining: parts)
+        return String(localized: "Applied \(summary).")
     }
 
     private static func dateStamp() -> String {

--- a/Tinycast/Core/Backup/RaycastImport.swift
+++ b/Tinycast/Core/Backup/RaycastImport.swift
@@ -9,9 +9,11 @@ enum RaycastImportError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .notRaycastFile: return "This doesn't look like a Raycast export (.rayconfig)."
-        case .incorrectPassphrase: return "Incorrect passphrase, or the file is corrupted."
-        case .corrupt: return "The Raycast export could not be read."
+        case .notRaycastFile:
+            return String(localized: "This doesn't look like a Raycast export (.rayconfig).")
+        case .incorrectPassphrase:
+            return String(localized: "Incorrect passphrase, or the file is corrupted.")
+        case .corrupt: return String(localized: "The Raycast export could not be read.")
         }
     }
 }

--- a/Tinycast/Core/Calculator/CalcCurrency.swift
+++ b/Tinycast/Core/Calculator/CalcCurrency.swift
@@ -4,6 +4,12 @@ import Foundation
 struct CurrencyDef: Equatable, Sendable {
     let code: String  // "EUR"
     let name: String  // "Euro"
+
+    var localizedName: String {
+        let identifier = Bundle.main.preferredLocalizations.first ?? Locale.current.identifier
+        guard !identifier.hasPrefix("en") else { return name }
+        return Locale(identifier: identifier).localizedString(forCurrencyCode: code) ?? name
+    }
 }
 
 /// An exchange-rate snapshot: every rate quoted as units of that currency per 1 `base`. Downloaded and persisted by `CurrencyRateStore` and handed to `CalcEngine.evaluate` — the engine never fetches, which is what keeps `Core/Calculator/` Foundation-only and pure.
@@ -49,7 +55,7 @@ enum CalcCurrency {
     }
 
     /// The category label used in the mismatch message, mirroring `UnitCategory.displayName`.
-    static let categoryName = "Currency"
+    static var categoryName: String { String(localized: "Currency") }
 
     /// Detects `expr currency (to|in|->) currency`, mirroring `CalcUnits.parseConversion`'s shape so both read the same. Runs *after* the unit path, so a query both sides of which are compatible units (`10 pounds to kg`) never reaches here. A missing amount defaults to 1, so `eur to usd` reads as `1 eur to usd`.
     static func parseConversion(_ tokens: [CalcToken], source: CurrencySource) -> ConversionParse? {

--- a/Tinycast/Core/Calculator/CalcDateTime.swift
+++ b/Tinycast/Core/Calculator/CalcDateTime.swift
@@ -63,7 +63,8 @@ enum CalcDateTime {
             value = target.timeIntervalSince(reference) / unit.seconds
         }
 
-        let word = value == 1 ? unit.singular : unit.plural
+        let display = localizedDuration(CalcFormatter.display(value), unit: unit)
+        let copy = localizedDuration(CalcFormatter.copyText(value), unit: unit)
         let source =
             unit.subDay
             ? timeString(now, calendar: calendar)
@@ -77,9 +78,7 @@ enum CalcDateTime {
             expression: echo,
             sourceBadge: source,
             targetBadge: targetBadge,
-            payload: .value(
-                display: "\(CalcFormatter.display(value)) \(word)",
-                copyText: "\(CalcFormatter.copyText(value)) \(word)"))
+            payload: .value(display: display, copyText: copy))
     }
 
     // MARK: - Grammar B: duration since a past moment
@@ -107,7 +106,8 @@ enum CalcDateTime {
             value = reference.timeIntervalSince(past) / unit.seconds
         }
 
-        let word = value == 1 ? unit.singular : unit.plural
+        let display = localizedDuration(CalcFormatter.display(value), unit: unit)
+        let copy = localizedDuration(CalcFormatter.copyText(value), unit: unit)
         let source =
             unit.subDay
             ? timeString(past, calendar: calendar)
@@ -121,9 +121,7 @@ enum CalcDateTime {
             expression: echo,
             sourceBadge: source,
             targetBadge: targetBadge,
-            payload: .value(
-                display: "\(CalcFormatter.display(value)) \(word)",
-                copyText: "\(CalcFormatter.copyText(value)) \(word)"))
+            payload: .value(display: display, copyText: copy))
     }
 
     // MARK: - Grammars C & D: moment ± duration / moment − moment
@@ -160,7 +158,8 @@ enum CalcDateTime {
             let sourceBadge = momentString(
                 base.date, hasTime: base.hasTime, now: now, calendar: calendar)
             return CalcResult(
-                expression: echo, sourceBadge: sourceBadge, targetBadge: "Result",
+                expression: echo, sourceBadge: sourceBadge,
+                targetBadge: String(localized: "Result"),
                 payload: .value(display: display, copyText: display))
         }
 
@@ -176,12 +175,12 @@ enum CalcDateTime {
                 [.day], from: calendar.startOfDay(for: other.date),
                 to: calendar.startOfDay(for: base.date)
             ).day ?? 0
-        let word = abs(days) == 1 ? "day" : "days"
+        let duration = localizedDays(String(days), singular: abs(days) == 1)
         return CalcResult(
             expression: echo,
             sourceBadge: dateString(base.date, now: now, calendar: calendar),
             targetBadge: dateString(other.date, now: now, calendar: calendar),
-            payload: .value(display: "\(days) \(word)", copyText: "\(days) \(word)"))
+            payload: .value(display: duration, copyText: duration))
     }
 
     // MARK: - Moment parsing
@@ -354,10 +353,11 @@ enum CalcDateTime {
 
     private enum DurKind { case subSecond, day, week }
 
+    private enum DurationDisplayUnit { case second, minute, hour, day, week }
+
     private struct DurUnit {
         let seconds: Double
-        let singular: String
-        let plural: String
+        let displayUnit: DurationDisplayUnit
         let kind: DurKind
         var subDay: Bool { kind == .subSecond }
     }
@@ -366,15 +366,15 @@ enum CalcDateTime {
         guard let last = phrase.split(separator: " ").last.map(String.init) else { return nil }
         switch last {
         case "s", "sec", "secs", "second", "seconds":
-            return DurUnit(seconds: 1, singular: "second", plural: "seconds", kind: .subSecond)
+            return DurUnit(seconds: 1, displayUnit: .second, kind: .subSecond)
         case "min", "mins", "minute", "minutes":
-            return DurUnit(seconds: 60, singular: "minute", plural: "minutes", kind: .subSecond)
+            return DurUnit(seconds: 60, displayUnit: .minute, kind: .subSecond)
         case "h", "hr", "hrs", "hour", "hours":
-            return DurUnit(seconds: 3600, singular: "hour", plural: "hours", kind: .subSecond)
+            return DurUnit(seconds: 3600, displayUnit: .hour, kind: .subSecond)
         case "d", "day", "days":
-            return DurUnit(seconds: 86400, singular: "day", plural: "days", kind: .day)
+            return DurUnit(seconds: 86400, displayUnit: .day, kind: .day)
         case "wk", "week", "weeks":
-            return DurUnit(seconds: 604800, singular: "week", plural: "weeks", kind: .week)
+            return DurUnit(seconds: 604800, displayUnit: .week, kind: .week)
         default:
             return nil
         }
@@ -405,28 +405,59 @@ enum CalcDateTime {
         -> String
     {
         let day = dateString(date, now: now, calendar: calendar)
-        return hasTime ? "\(day) at \(timeString(date, calendar: calendar))" : day
+        return hasTime
+            ? String(localized: "\(day) at \(timeString(date, calendar: calendar))") : day
     }
 
     private static func dateString(_ date: Date, now: Date, calendar: Calendar) -> String {
         let sameYear =
             calendar.component(.year, from: date) == calendar.component(.year, from: now)
         return format(
-            date, calendar: calendar, pattern: sameYear ? "EEEE, d MMMM" : "EEEE, d MMMM, yyyy")
+            date, calendar: calendar, template: sameYear ? "EEEEdMMMM" : "EEEEdMMMMy",
+            englishPattern: sameYear ? "EEEE, d MMMM" : "EEEE, d MMMM, yyyy")
     }
 
     private static func timeString(_ date: Date, calendar: Calendar) -> String {
-        format(date, calendar: calendar, pattern: "h:mm a")
+        format(date, calendar: calendar, template: "jm", englishPattern: "h:mm a")
     }
 
-    private static func format(_ date: Date, calendar: Calendar, pattern: String) -> String {
+    private static func format(
+        _ date: Date, calendar: Calendar, template: String, englishPattern: String
+    ) -> String {
         let formatter = DateFormatter()
         formatter.calendar = calendar
         formatter.timeZone = calendar.timeZone
         // Follow the injected calendar's locale so weekday/month names match the user's language; the test clock pins en_US for deterministic assertions.
         formatter.locale = calendar.locale ?? Locale(identifier: "en_US")
-        formatter.dateFormat = pattern
+        if formatter.locale.language.languageCode?.identifier == "en" {
+            formatter.dateFormat = englishPattern
+        } else {
+            formatter.setLocalizedDateFormatFromTemplate(template)
+        }
         return formatter.string(from: date)
+    }
+
+    private static func localizedDuration(_ number: String, unit: DurUnit) -> String {
+        let singular = number == "1"
+        switch unit.displayUnit {
+        case .second:
+            return singular
+                ? String(localized: "\(number) second") : String(localized: "\(number) seconds")
+        case .minute:
+            return singular
+                ? String(localized: "\(number) minute") : String(localized: "\(number) minutes")
+        case .hour:
+            return singular
+                ? String(localized: "\(number) hour") : String(localized: "\(number) hours")
+        case .day: return localizedDays(number, singular: singular)
+        case .week:
+            return singular
+                ? String(localized: "\(number) week") : String(localized: "\(number) weeks")
+        }
+    }
+
+    private static func localizedDays(_ number: String, singular: Bool) -> String {
+        singular ? String(localized: "\(number) day") : String(localized: "\(number) days")
     }
 
     // MARK: - Low-level helpers

--- a/Tinycast/Core/Calculator/CalcEngine.swift
+++ b/Tinycast/Core/Calculator/CalcEngine.swift
@@ -62,13 +62,15 @@ enum CalcEngine {
                 let display = CalcFormatter.grouped(String(value))
                 return CalcResult(
                     expression: query,
-                    sourceBadge: "Hexadecimal", targetBadge: "Decimal",
+                    sourceBadge: String(localized: "Hexadecimal"),
+                    targetBadge: String(localized: "Decimal"),
                     payload: .value(display: display, copyText: String(value)))
             }
             if case .compactNumber(let value) = tokens[0] {
                 return CalcResult(
                     expression: query,
-                    sourceBadge: "Expression", targetBadge: "Result",
+                    sourceBadge: String(localized: "Expression"),
+                    targetBadge: String(localized: "Result"),
                     payload: .value(
                         display: CalcFormatter.display(value),
                         copyText: CalcFormatter.copyText(value)))
@@ -84,8 +86,8 @@ enum CalcEngine {
             case .value(let input, let from, let to, let output):
                 return CalcResult(
                     expression: "\(CalcFormatter.display(input)) \(from.symbol)",
-                    sourceBadge: from.name,
-                    targetBadge: to.name,
+                    sourceBadge: from.localizedName,
+                    targetBadge: to.localizedName,
                     payload: .value(
                         display: "\(CalcFormatter.display(output)) \(to.symbol)",
                         copyText: "\(CalcFormatter.copyText(output)) \(to.symbol)"))
@@ -93,8 +95,10 @@ enum CalcEngine {
                 return CalcResult(
                     expression: query,
                     payload: .error(
-                        message:
-                            "Cannot convert \(from.category.displayName) to \(to.category.displayName)."
+                        message: String(
+                            localized:
+                                "Cannot convert \(from.category.displayName) to \(to.category.displayName)."
+                        )
                     ))
             }
         }
@@ -112,23 +116,25 @@ enum CalcEngine {
                 let amount = CalcFormatter.currency(output)
                 return CalcResult(
                     expression: "\(CalcFormatter.display(input)) \(from.code)",
-                    sourceBadge: from.name,
-                    targetBadge: to.name,
+                    sourceBadge: from.localizedName,
+                    targetBadge: to.localizedName,
                     payload: .value(
                         display: "\(CalcFormatter.grouped(amount)) \(to.code)",
                         copyText: "\(amount) \(to.code)"))
             case .mismatch(let from, let to):
                 return CalcResult(
                     expression: query,
-                    payload: .error(message: "Cannot convert \(from) to \(to)."))
+                    payload: .error(message: String(localized: "Cannot convert \(from) to \(to).")))
             case .noRate(let code):
                 return CalcResult(
                     expression: query,
-                    payload: .error(message: "No exchange rate for \(code)."))
+                    payload: .error(message: String(localized: "No exchange rate for \(code).")))
             case .unavailable:
                 return CalcResult(
                     expression: query,
-                    payload: .error(message: "Exchange rates unavailable — check your connection."))
+                    payload: .error(
+                        message: String(
+                            localized: "Exchange rates unavailable — check your connection.")))
             }
         }
 
@@ -143,8 +149,8 @@ enum CalcEngine {
                 ? display : "\(CalcFormatter.copyText(bare.output)) \(bare.to.symbol)"
             return CalcResult(
                 expression: "\(CalcFormatter.display(bare.input)) \(bare.from.symbol)",
-                sourceBadge: bare.from.name,
-                targetBadge: bare.to.name,
+                sourceBadge: bare.from.localizedName,
+                targetBadge: bare.to.localizedName,
                 payload: .value(display: display, copyText: copyText))
         }
 
@@ -160,8 +166,8 @@ enum CalcEngine {
         guard let value = CalcParser.evaluate(tokens) else { return nil }
         return CalcResult(
             expression: prettyExpression(query),
-            sourceBadge: "Expression",
-            targetBadge: "Result",
+            sourceBadge: String(localized: "Expression"),
+            targetBadge: String(localized: "Result"),
             payload: .value(
                 display: CalcFormatter.display(value),
                 copyText: CalcFormatter.copyText(value)))
@@ -198,7 +204,8 @@ enum CalcEngine {
         guard let value = CalcParser.evaluate(prefixTokens) else { return nil }
         return CalcResult(
             expression: prettyExpression(query),
-            sourceBadge: "Expression", targetBadge: "Result",
+            sourceBadge: String(localized: "Expression"),
+            targetBadge: String(localized: "Result"),
             payload: .value(
                 display: CalcFormatter.display(value),
                 copyText: CalcFormatter.copyText(value)))
@@ -259,11 +266,11 @@ enum CalcEngine {
         case .number(let value)
         where value >= 0 && value.rounded() == value && value <= 9_007_199_254_740_992:
             source = UInt64(value)
-            sourceBadge = "Decimal"
+            sourceBadge = String(localized: "Decimal")
         case .compactNumber(let value)
         where value >= 0 && value.rounded() == value && value <= 9_007_199_254_740_992:
             source = UInt64(value)
-            sourceBadge = "Decimal"
+            sourceBadge = String(localized: "Decimal")
         default:
             return nil
         }
@@ -273,16 +280,16 @@ enum CalcEngine {
         switch target {
         case "hex", "hexadecimal":
             output = "0x" + String(source, radix: 16, uppercase: true)
-            targetBadge = "Hexadecimal"
+            targetBadge = String(localized: "Hexadecimal")
         case "binary", "bin":
             output = "0b" + String(source, radix: 2)
-            targetBadge = "Binary"
+            targetBadge = String(localized: "Binary")
         case "octal", "oct":
             output = "0o" + String(source, radix: 8)
-            targetBadge = "Octal"
+            targetBadge = String(localized: "Octal")
         case "decimal", "dec":
             output = CalcFormatter.grouped(String(source))
-            targetBadge = "Decimal"
+            targetBadge = String(localized: "Decimal")
         default:
             return nil
         }
@@ -297,10 +304,10 @@ enum CalcEngine {
 
     private static func baseName(forRadix radix: Int) -> String {
         switch radix {
-        case 16: return "Hexadecimal"
-        case 2: return "Binary"
-        case 8: return "Octal"
-        default: return "Decimal"
+        case 16: return String(localized: "Hexadecimal")
+        case 2: return String(localized: "Binary")
+        case 8: return String(localized: "Octal")
+        default: return String(localized: "Decimal")
         }
     }
 

--- a/Tinycast/Core/Calculator/CalcFormatter.swift
+++ b/Tinycast/Core/Calculator/CalcFormatter.swift
@@ -35,9 +35,18 @@ enum CalcFormatter {
         let magnitude = abs(feet)
         let wholeFeet = magnitude.rounded(.towardZero)
         let inches = (magnitude - wholeFeet) * 12
-        let feetPart = wholeFeet == 0 ? "" : "\(sign)\(display(wholeFeet)) \(wholeFeet == 1 ? "foot" : "feet")"
+        let feetText = "\(sign)\(display(wholeFeet))"
+        let feetPart =
+            wholeFeet == 0
+            ? ""
+            : wholeFeet == 1
+                ? String(localized: "\(feetText) foot")
+                : String(localized: "\(feetText) feet")
         let inchText = display(inches)
-        let inchPart = "\(inchText) \(inchText == "1" ? "inch" : "inches")"
+        let inchPart =
+            inchText == "1"
+            ? String(localized: "\(inchText) inch")
+            : String(localized: "\(inchText) inches")
         if feetPart.isEmpty { return "\(sign)\(inchPart)" }
         return "\(feetPart) \(inchPart)"
     }

--- a/Tinycast/Core/Calculator/CalcPercent.swift
+++ b/Tinycast/Core/Calculator/CalcPercent.swift
@@ -33,8 +33,8 @@ enum CalcPercent {
     private static func card(_ query: String, _ display: String, _ copy: String) -> CalcResult {
         CalcResult(
             expression: query.split(whereSeparator: \.isWhitespace).joined(separator: " "),
-            sourceBadge: "Expression",
-            targetBadge: "Result",
+            sourceBadge: String(localized: "Expression"),
+            targetBadge: String(localized: "Result"),
             payload: .value(display: display, copyText: copy))
     }
 }

--- a/Tinycast/Core/Calculator/CalcQuantity.swift
+++ b/Tinycast/Core/Calculator/CalcQuantity.swift
@@ -26,12 +26,14 @@ enum CalcQuantity {
                 return CalcResult(
                     expression: query,
                     payload: .error(
-                        message: "Exchange rates unavailable — check your connection."))
+                        message: String(
+                            localized: "Exchange rates unavailable — check your connection.")))
             case .on(let rates?):
                 if let code = parser.currencyCodes.first(where: { rates.rate(for: $0) == nil }) {
                     return CalcResult(
                         expression: query,
-                        payload: .error(message: "No exchange rate for \(code)."))
+                        payload: .error(
+                            message: String(localized: "No exchange rate for \(code).")))
                 }
             }
         }
@@ -47,7 +49,8 @@ enum CalcQuantity {
             guard parser.operationCount > 0 else { return nil }
             return CalcResult(
                 expression: expressionText(split.expressionTokens),
-                sourceBadge: "Expression", targetBadge: "Result",
+                sourceBadge: String(localized: "Expression"),
+                targetBadge: String(localized: "Result"),
                 payload: .value(
                     display: CalcFormatter.display(value.effective),
                     copyText: CalcFormatter.copyText(value.effective)))
@@ -102,17 +105,20 @@ enum CalcQuantity {
                     return CalcResult(
                         expression: query,
                         payload: .error(
-                            message: "Exchange rates unavailable — check your connection."))
+                            message: String(
+                                localized: "Exchange rates unavailable — check your connection.")))
                 }
                 guard rates.rate(for: from.code) != nil else {
                     return CalcResult(
                         expression: query,
-                        payload: .error(message: "No exchange rate for \(from.code)."))
+                        payload: .error(
+                            message: String(localized: "No exchange rate for \(from.code).")))
                 }
                 guard rates.rate(for: to.code) != nil else {
                     return CalcResult(
                         expression: query,
-                        payload: .error(message: "No exchange rate for \(to.code)."))
+                        payload: .error(
+                            message: String(localized: "No exchange rate for \(to.code).")))
                 }
                 guard let output = rates.convert(value.amount, from: from.code, to: to.code)
                 else { return nil }
@@ -131,7 +137,7 @@ enum CalcQuantity {
     ) -> CalcResult {
         CalcResult(
             expression: expression,
-            sourceBadge: "Expression", targetBadge: unit.name,
+            sourceBadge: String(localized: "Expression"), targetBadge: unit.localizedName,
             payload: .value(
                 display: "\(CalcFormatter.display(amount)) \(unit.symbol)",
                 copyText: "\(CalcFormatter.copyText(amount)) \(unit.symbol)"))
@@ -143,7 +149,7 @@ enum CalcQuantity {
         let formatted = CalcFormatter.currency(amount)
         return CalcResult(
             expression: expression,
-            sourceBadge: "Expression", targetBadge: definition.name,
+            sourceBadge: String(localized: "Expression"), targetBadge: definition.localizedName,
             payload: .value(
                 display: "\(CalcFormatter.grouped(formatted)) \(definition.code)",
                 copyText: "\(formatted) \(definition.code)"))
@@ -152,7 +158,7 @@ enum CalcQuantity {
     private static func conversionError(_ query: String, from: String, to: String) -> CalcResult {
         CalcResult(
             expression: query,
-            payload: .error(message: "Cannot convert \(from) to \(to)."))
+            payload: .error(message: String(localized: "Cannot convert \(from) to \(to).")))
     }
 
     fileprivate static func convertUnit(_ amount: Double, from: UnitDef, to: UnitDef) -> Double {
@@ -384,12 +390,10 @@ private struct QuantityParser {
                 amount: left.effective + direction * right.effective, kind: .scalar)
         case (.unit(let lhs), .unit(let rhs)):
             guard lhs.category == rhs.category else {
-                return fail(
-                    "Cannot \(op == "+" ? "add" : "subtract") \(lhs.category.displayName) and \(rhs.category.displayName)."
-                )
+                return fail(operationError(op, lhs.category.displayName, rhs.category.displayName))
             }
             if lhs.category == .temperature, lhs.symbol != rhs.symbol {
-                return fail("Cannot combine temperatures with different units.")
+                return fail(String(localized: "Cannot combine temperatures with different units."))
             }
             // Composite notation ("5 feet 3 inches") reads as one quantity in its leading unit; an explicit `+`/`-` answers in the last unit typed.
             if implicit {
@@ -412,13 +416,9 @@ private struct QuantityParser {
             return QuantityValue(
                 amount: converted + direction * right.amount, kind: .currency(rhs))
         case (.unit(let lhs), .currency):
-            return fail(
-                "Cannot \(op == "+" ? "add" : "subtract") \(lhs.category.displayName) and Currency."
-            )
+            return fail(operationError(op, lhs.category.displayName, CalcCurrency.categoryName))
         case (.currency, .unit(let rhs)):
-            return fail(
-                "Cannot \(op == "+" ? "add" : "subtract") Currency and \(rhs.category.displayName)."
-            )
+            return fail(operationError(op, CalcCurrency.categoryName, rhs.category.displayName))
         // A bare number takes the unit it is written against ("10kg + 5" is 15 kg). Adjacency stays
         // silent instead, because there the bare number is a half-typed unit ("1hr 30" → "1hr 30min").
         case (.unit, .scalar), (.currency, .scalar):
@@ -445,7 +445,7 @@ private struct QuantityParser {
             return QuantityValue(
                 amount: left.effective * right.effective, kind: left.kind)
         default:
-            return fail("Multiplication of two unit values is not supported.")
+            return fail(String(localized: "Multiplication of two unit values is not supported."))
         }
     }
 
@@ -458,14 +458,17 @@ private struct QuantityParser {
         case (.unit, .scalar), (.currency, .scalar):
             return finiteDivision(left.effective, right.effective, kind: left.kind)
         case (.scalar, .unit), (.scalar, .currency):
-            return fail("Division by a unit value is not supported.")
+            return fail(String(localized: "Division by a unit value is not supported."))
         case (.unit(let lhs), .unit(let rhs)):
             guard lhs.category == rhs.category else {
                 return fail(
-                    "Cannot divide \(lhs.category.displayName) by \(rhs.category.displayName).")
+                    String(
+                        localized:
+                            "Cannot divide \(lhs.category.displayName) by \(rhs.category.displayName)."
+                    ))
             }
             guard lhs.category != .temperature else {
-                return fail("Division of temperature values is not supported.")
+                return fail(String(localized: "Division of temperature values is not supported."))
             }
             let numerator = left.amount * lhs.factor
             let denominator = right.amount * rhs.factor
@@ -475,10 +478,24 @@ private struct QuantityParser {
             else { return nil }
             return finiteDivision(left.amount, denominator, kind: .scalar)
         case (.unit(let lhs), .currency):
-            return fail("Cannot divide \(lhs.category.displayName) by Currency.")
+            return fail(
+                String(
+                    localized:
+                        "Cannot divide \(lhs.category.displayName) by \(CalcCurrency.categoryName)."
+                ))
         case (.currency, .unit(let rhs)):
-            return fail("Cannot divide Currency by \(rhs.category.displayName).")
+            return fail(
+                String(
+                    localized:
+                        "Cannot divide \(CalcCurrency.categoryName) by \(rhs.category.displayName)."
+                ))
         }
+    }
+
+    private func operationError(_ op: Character, _ left: String, _ right: String) -> String {
+        op == "+"
+            ? String(localized: "Cannot add \(left) and \(right).")
+            : String(localized: "Cannot subtract \(right) from \(left).")
     }
 
     private func finiteDivision(
@@ -568,15 +585,15 @@ private struct QuantityParser {
         recordCurrency(to.code)
         guard case .on(let rates) = currency else { return nil }
         guard let rates else {
-            issue = "Exchange rates unavailable — check your connection."
+            issue = String(localized: "Exchange rates unavailable — check your connection.")
             return nil
         }
         guard rates.rate(for: from.code) != nil else {
-            issue = "No exchange rate for \(from.code)."
+            issue = String(localized: "No exchange rate for \(from.code).")
             return nil
         }
         guard rates.rate(for: to.code) != nil else {
-            issue = "No exchange rate for \(to.code)."
+            issue = String(localized: "No exchange rate for \(to.code).")
             return nil
         }
         return rates.convert(amount, from: from.code, to: to.code)

--- a/Tinycast/Core/Calculator/CalcUnits.swift
+++ b/Tinycast/Core/Calculator/CalcUnits.swift
@@ -6,17 +6,17 @@ enum UnitCategory: String, CaseIterable, Sendable {
 
     var displayName: String {
         switch self {
-        case .length: return "Length"
-        case .weight: return "Weight"
-        case .temperature: return "Temperature"
-        case .time: return "Time"
-        case .area: return "Area"
-        case .volume: return "Volume"
-        case .digitalStorage: return "Digital Storage"
-        case .angle: return "Angle"
-        case .speed: return "Speed"
-        case .pressure: return "Pressure"
-        case .dataRate: return "Data Transfer Rate"
+        case .length: return String(localized: "Length")
+        case .weight: return String(localized: "Weight")
+        case .temperature: return String(localized: "Temperature")
+        case .time: return String(localized: "Time")
+        case .area: return String(localized: "Area")
+        case .volume: return String(localized: "Volume")
+        case .digitalStorage: return String(localized: "Digital Storage")
+        case .angle: return String(localized: "Angle")
+        case .speed: return String(localized: "Speed")
+        case .pressure: return String(localized: "Pressure")
+        case .dataRate: return String(localized: "Data Transfer Rate")
         }
     }
 }
@@ -28,6 +28,10 @@ struct UnitDef: Equatable, Sendable {
     let category: UnitCategory
     let factor: Double
     let offset: Double
+
+    var localizedName: String {
+        Bundle.main.localizedString(forKey: name, value: name, table: nil)
+    }
 
     init(_ symbol: String, _ name: String, _ category: UnitCategory, _ factor: Double, offset: Double = 0) {
         self.symbol = symbol

--- a/Tinycast/Core/ClipboardStore.swift
+++ b/Tinycast/Core/ClipboardStore.swift
@@ -72,13 +72,13 @@ enum ClipboardRetention: Int, CaseIterable, Identifiable, Sendable {
 
     var title: String {
         switch self {
-        case .day: return "1 Day"
-        case .week: return "1 Week"
-        case .month: return "1 Month"
-        case .threeMonths: return "3 Months"
-        case .sixMonths: return "6 Months"
-        case .year: return "1 Year"
-        case .forever: return "Forever"
+        case .day: return String(localized: "1 Day")
+        case .week: return String(localized: "1 Week")
+        case .month: return String(localized: "1 Month")
+        case .threeMonths: return String(localized: "3 Months")
+        case .sixMonths: return String(localized: "6 Months")
+        case .year: return String(localized: "1 Year")
+        case .forever: return String(localized: "Forever")
         }
     }
 

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -15,16 +15,16 @@ enum CommandID: String, CaseIterable, Sendable {
 
     var name: String {
         switch self {
-        case .calculatorHistory: return "Calculator History"
-        case .clipboardHistory: return "Clipboard History"
-        case .searchEmoji: return "Search Emoji & Symbols"
-        case .exportSettings: return "Export Settings"
-        case .importSettings: return "Import Settings"
-        case .importFromRaycast: return "Import from Raycast"
-        case .settings: return "Settings"
-        case .about: return "About Tinycast"
-        case .quitAllApps: return "Quit All Applications"
-        case .quit: return "Quit Tinycast"
+        case .calculatorHistory: return String(localized: "Calculator History")
+        case .clipboardHistory: return String(localized: "Clipboard History")
+        case .searchEmoji: return String(localized: "Search Emoji & Symbols")
+        case .exportSettings: return String(localized: "Export Settings")
+        case .importSettings: return String(localized: "Import Settings")
+        case .importFromRaycast: return String(localized: "Import from Raycast")
+        case .settings: return String(localized: "Settings")
+        case .about: return String(localized: "About Tinycast")
+        case .quitAllApps: return String(localized: "Quit All Applications")
+        case .quit: return String(localized: "Quit Tinycast")
         }
     }
 

--- a/Tinycast/Core/DisplayText.swift
+++ b/Tinycast/Core/DisplayText.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// User-facing text with an explicit boundary between catalog keys and runtime/user content.
+enum DisplayText: ExpressibleByStringLiteral {
+    case localized(String)
+    case verbatim(String)
+
+    init(stringLiteral value: String) {
+        self = .localized(value)
+    }
+
+    var rawValue: String {
+        switch self {
+        case .localized(let value), .verbatim(let value): return value
+        }
+    }
+}
+
+extension Text {
+    init(_ value: DisplayText) {
+        switch value {
+        case .localized(let key): self.init(LocalizedStringKey(key))
+        case .verbatim(let value): self.init(verbatim: value)
+        }
+    }
+}

--- a/Tinycast/Core/Emoji/EmojiCatalog.swift
+++ b/Tinycast/Core/Emoji/EmojiCatalog.swift
@@ -17,18 +17,18 @@ enum EmojiCategory: String, CaseIterable, Sendable {
 
     var title: String {
         switch self {
-        case .smileysAndPeople: return "Smileys & People"
-        case .animalsAndNature: return "Animals & Nature"
-        case .foodAndDrink: return "Food & Drink"
-        case .activity: return "Activity"
-        case .travelAndPlaces: return "Travel & Places"
-        case .objects: return "Objects"
-        case .symbols: return "Symbols"
-        case .flags: return "Flags"
-        case .arrows: return "Arrows"
-        case .currency: return "Currency"
-        case .math: return "Math"
-        case .shapesAndPunctuation: return "Shapes & Punctuation"
+        case .smileysAndPeople: return String(localized: "Smileys & People")
+        case .animalsAndNature: return String(localized: "Animals & Nature")
+        case .foodAndDrink: return String(localized: "Food & Drink")
+        case .activity: return String(localized: "Activity")
+        case .travelAndPlaces: return String(localized: "Travel & Places")
+        case .objects: return String(localized: "Objects")
+        case .symbols: return String(localized: "Symbols")
+        case .flags: return String(localized: "Flags")
+        case .arrows: return String(localized: "Arrows")
+        case .currency: return String(localized: "Currency")
+        case .math: return String(localized: "Math")
+        case .shapesAndPunctuation: return String(localized: "Shapes & Punctuation")
         }
     }
 }
@@ -52,12 +52,12 @@ enum EmojiSkinTone: String, CaseIterable, Identifiable, Sendable {
 
     var title: String {
         switch self {
-        case .none: return "Default"
-        case .light: return "Light"
-        case .mediumLight: return "Medium Light"
-        case .medium: return "Medium"
-        case .mediumDark: return "Medium Dark"
-        case .dark: return "Dark"
+        case .none: return String(localized: "Default")
+        case .light: return String(localized: "Light")
+        case .mediumLight: return String(localized: "Medium Light")
+        case .medium: return String(localized: "Medium")
+        case .mediumDark: return String(localized: "Medium Dark")
+        case .dark: return String(localized: "Dark")
         }
     }
 

--- a/Tinycast/Core/HotKey/HyperKey.swift
+++ b/Tinycast/Core/HotKey/HyperKey.swift
@@ -14,12 +14,12 @@ enum HyperKeyPhysicalKey: String, CaseIterable, Identifiable, Sendable {
 
     var title: String {
         switch self {
-        case .none: return "None"
-        case .capsLock: return "Caps Lock (⇪)"
-        case .rightControl: return "Right Control (⌃)"
-        case .rightShift: return "Right Shift (⇧)"
-        case .rightOption: return "Right Option (⌥)"
-        case .rightCommand: return "Right Command (⌘)"
+        case .none: return String(localized: "None")
+        case .capsLock: return String(localized: "Caps Lock (⇪)")
+        case .rightControl: return String(localized: "Right Control (⌃)")
+        case .rightShift: return String(localized: "Right Shift (⇧)")
+        case .rightOption: return String(localized: "Right Option (⌥)")
+        case .rightCommand: return String(localized: "Right Command (⌘)")
         }
     }
 
@@ -60,7 +60,7 @@ enum HyperKeyPhysicalKey: String, CaseIterable, Identifiable, Sendable {
 
     /// Quick Press label for triggering the key's original function.
     var quickPressOriginalTitle: String? {
-        self == .capsLock ? "Trigger Caps Lock (⇪)" : nil
+        self == .capsLock ? String(localized: "Trigger Caps Lock (⇪)") : nil
     }
 }
 

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -85,11 +85,11 @@ final class HotKeyManager: ObservableObject {
     private func displayName(of action: HotKeyAction) -> String {
         switch action {
         case .togglePalette:
-            return "App Launcher"
+            return String(localized: "App Launcher")
         case .toggleClipboard:
-            return "Clipboard History"
+            return String(localized: "Clipboard History")
         case .toggleEmoji:
-            return "Emoji & Symbols"
+            return String(localized: "Emoji & Symbols")
         case .app(let bundleID):
             let apps = AppCore.shared.appIndex.apps
             return apps.first { $0.kind == .application && $0.bundleID == bundleID }?.name

--- a/Tinycast/Features/About/AboutView.swift
+++ b/Tinycast/Features/About/AboutView.swift
@@ -5,7 +5,7 @@ struct AboutView: View {
     private static var version: String {
         let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
-        return "Version \(short) (\(build))"
+        return String(localized: "Version \(short) (\(build))")
     }
 
     // Loaded once and cached: reading the .icns is disk I/O, and body can re-run often. Read the
@@ -115,29 +115,31 @@ private struct AboutLink: Identifiable {
 
     let id: String
     let glyph: Glyph
-    let title: String
-    let detail: String
+    let title: DisplayText
+    let detail: DisplayText
     let url: URL
 
     static let all: [AboutLink] = [
         AboutLink(
             id: "website", glyph: .symbol("globe"), title: "Website",
-            detail: "abue-ammar.github.io/tinycast",
+            detail: .verbatim("abue-ammar.github.io/tinycast"),
             url: URL(string: "https://abue-ammar.github.io/tinycast/")!),
         AboutLink(
-            id: "github", glyph: .brand("BrandGitHub"), title: "GitHub",
-            detail: "github.com/abue-ammar/tinycast",
+            id: "github", glyph: .brand("BrandGitHub"), title: .verbatim("GitHub"),
+            detail: .verbatim("github.com/abue-ammar/tinycast"),
             url: URL(string: "https://github.com/abue-ammar/tinycast")!),
         AboutLink(
-            id: "discord", glyph: .brand("BrandDiscord"), title: "Discord",
+            id: "discord", glyph: .brand("BrandDiscord"), title: .verbatim("Discord"),
             detail: "Join the Tinycast community",
             url: URL(string: "https://discord.gg/v2Eeb4QQy3")!),
         AboutLink(
-            id: "x", glyph: .brand("BrandX"), title: "X", detail: "@abue_ammar",
+            id: "x", glyph: .brand("BrandX"), title: .verbatim("X"),
+            detail: .verbatim("@abue_ammar"),
             url: URL(string: "https://x.com/abue_ammar")!),
         AboutLink(
             id: "email", glyph: .symbol("envelope"), title: "Email",
-            detail: "iabueammar@gmail.com", url: URL(string: "mailto:iabueammar@gmail.com")!),
+            detail: .verbatim("iabueammar@gmail.com"),
+            url: URL(string: "mailto:iabueammar@gmail.com")!),
     ]
 }
 

--- a/Tinycast/Features/Calculator/CalculatorHistoryView.swift
+++ b/Tinycast/Features/Calculator/CalculatorHistoryView.swift
@@ -33,7 +33,7 @@ struct CalculatorHistoryList: View {
     /// Entries are newest-first, so grouping walks and emits a date header whenever the bucket changes (same as the clipboard list); a live calculation pins above them.
     private var rows: [Row] {
         var rows: [Row] = []
-        if let calc { rows = [.header("Calculator"), .calc(calc)] }
+        if let calc { rows = [.header(String(localized: "Calculator")), .calc(calc)] }
         var currentBucket: DateBucket?
         for entry in results {
             let bucket = DateBucket(for: entry.createdAt)

--- a/Tinycast/Features/Clipboard/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/ClipboardView.swift
@@ -27,7 +27,8 @@ struct ClipboardList: View {
         var rows: [Row] = []
         var currentTitle: String?
         for item in results {
-            let title = item.isPinned ? "Pinned" : DateBucket(for: item.createdAt).title
+            let title =
+                item.isPinned ? String(localized: "Pinned") : DateBucket(for: item.createdAt).title
             if title != currentTitle {
                 rows.append(.header(title))
                 currentTitle = title
@@ -84,11 +85,11 @@ enum DateBucket: Int {
 
     var title: String {
         switch self {
-        case .today: return "Today"
-        case .yesterday: return "Yesterday"
-        case .thisWeek: return "This Week"
-        case .thisMonth: return "This Month"
-        case .earlier: return "Earlier"
+        case .today: return String(localized: "Today")
+        case .yesterday: return String(localized: "Yesterday")
+        case .thisWeek: return String(localized: "This Week")
+        case .thisMonth: return String(localized: "This Month")
+        case .earlier: return String(localized: "Earlier")
         }
     }
 
@@ -115,7 +116,7 @@ enum ClipboardActionsMenu {
     ) -> PopoverMenuContent {
         var items: [PopoverMenuItem] = [
             PopoverMenuItem(
-                title: target?.pasteTitle ?? "Paste",
+                title: target.map { DisplayText.verbatim($0.pasteTitle) } ?? "Paste",
                 icon: .paste(target, fallback: "doc.on.clipboard"), shortcut: "↵"
             ) {
                 core.paste(item)
@@ -166,7 +167,7 @@ enum ClipboardActionsMenu {
             let oneLine = (item.text ?? "").split(whereSeparator: \.isWhitespace).joined(
                 separator: " ")
             return String(oneLine.prefix(40))
-        case .image: return "Image"
+        case .image: return String(localized: "Image")
         }
     }
 }
@@ -208,7 +209,7 @@ private struct ClipboardRow: View {
         case .text:
             return String((item.text ?? "").prefix(200)).trimmingCharacters(
                 in: .whitespacesAndNewlines)
-        case .image: return "Image"
+        case .image: return String(localized: "Image")
         }
     }
 
@@ -344,10 +345,10 @@ private struct ClipboardInfoSection: View {
     }
 
     private struct InfoRow: Identifiable {
-        let label: String
+        let label: DisplayText
         let value: String
         var icon: NSImage?
-        var id: String { label }
+        var id: String { label.rawValue }
     }
 
     /// Relative day name plus exact time ("Today at 1:22:57 AM"); shared because `DateFormatter` is expensive to build.
@@ -394,7 +395,7 @@ private struct ClipboardInfoSection: View {
         }
         switch item.kind {
         case .text:
-            rows.append(InfoRow(label: "Type", value: "Text"))
+            rows.append(InfoRow(label: "Type", value: String(localized: "Text")))
             if let characters = details.characters {
                 rows.append(InfoRow(label: "Characters", value: characters.formatted()))
             }
@@ -402,7 +403,7 @@ private struct ClipboardInfoSection: View {
                 rows.append(InfoRow(label: "Words", value: words.formatted()))
             }
         case .image:
-            rows.append(InfoRow(label: "Type", value: "Image"))
+            rows.append(InfoRow(label: "Type", value: String(localized: "Image")))
             if let size = details.pixelSize {
                 rows.append(
                     InfoRow(label: "Dimensions", value: "\(Int(size.width))×\(Int(size.height))"))

--- a/Tinycast/Features/Emoji/EmojiGridView.swift
+++ b/Tinycast/Features/Emoji/EmojiGridView.swift
@@ -25,12 +25,13 @@ enum EmojiGrid {
             start += entries.count
         }
         if query.trimmingCharacters(in: .whitespaces).isEmpty {
-            append("Frequently Used", frequent.top().compactMap(index.entry(for:)))
+            append(
+                String(localized: "Frequently Used"), frequent.top().compactMap(index.entry(for:)))
             for section in index.categorySections {
                 append(section.category.title, section.entries)
             }
         } else {
-            append("Results", index.search(query))
+            append(String(localized: "Results"), index.search(query))
         }
         return sections
     }
@@ -260,7 +261,7 @@ enum EmojiActionsMenu {
             header: entry.displayName,
             items: [
                 PopoverMenuItem(
-                    title: target?.pasteTitle ?? "Paste",
+                    title: target.map { DisplayText.verbatim($0.pasteTitle) } ?? "Paste",
                     icon: .paste(target, fallback: "doc.on.clipboard"), shortcut: "↵"
                 ) {
                     core.pasteEmoji(entry)

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -33,10 +33,10 @@ struct LauncherList: View {
 
     private var rows: [Row] {
         var calcRows: [Row] = []
-        if let calc { calcRows = [.header("Calculator"), .calc(calc)] }
+        if let calc { calcRows = [.header(String(localized: "Calculator")), .calc(calc)] }
         guard showSections else {
             guard !results.isEmpty else { return calcRows }
-            return calcRows + [.header("Results")] + results.map(Row.app)
+            return calcRows + [.header(String(localized: "Results"))] + results.map(Row.app)
         }
         var rows: [Row] = calcRows
         let favorites = results.prefix(favoriteCount)
@@ -46,8 +46,10 @@ struct LauncherList: View {
         let panes = rest.filter { $0.kind == .systemSettings }
         let commands = rest.filter { $0.kind == .command }
         for (title, group) in [
-            ("Favorites", Array(favorites)), ("Applications", apps),
-            ("System Settings", panes), ("Commands", commands),
+            (String(localized: "Favorites"), Array(favorites)),
+            (String(localized: "Applications"), apps),
+            (String(localized: "System Settings"), panes),
+            (String(localized: "Commands"), commands),
         ]
         where !group.isEmpty {
             rows.append(.header(title))
@@ -113,7 +115,7 @@ struct SectionHeader: View {
     /// The list's first header hugs the top; every later header gets `sectionSpacing` above it, which reads as bottom padding on the section that just ended.
     var isFirst = false
     var body: some View {
-        Text(title)
+        Text(verbatim: title)
             .font(Theme.Typography.sectionHeader)
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -226,7 +228,7 @@ enum AppActionsMenu {
     ) -> PopoverMenuContent {
         var items: [PopoverMenuItem] = [
             PopoverMenuItem(
-                title: openTitle(app), systemImage: "list.bullet.rectangle", shortcut: "↵"
+                title: .verbatim(openTitle(app)), systemImage: "list.bullet.rectangle", shortcut: "↵"
             ) { core.launch(app, searchQuery: searchQuery) }
         ]
         if favorites.isFavorite(app) {
@@ -266,9 +268,9 @@ enum AppActionsMenu {
 
     private static func openTitle(_ app: AppEntry) -> String {
         switch app.kind {
-        case .application: return "Open Application"
-        case .systemSettings: return "Open System Setting"
-        case .command: return "Open Command"
+        case .application: return String(localized: "Open Application")
+        case .systemSettings: return String(localized: "Open System Setting")
+        case .command: return String(localized: "Open Command")
         }
     }
 }

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -47,9 +47,9 @@ struct OnboardingView: View {
         VStack(spacing: Theme.Spacing.md) {
             heroMark
             VStack(spacing: Theme.Spacing.xs) {
-                Text(title)
+                Text(verbatim: title)
                     .font(.title2.weight(.bold))
-                Text(subtitle)
+                Text(verbatim: subtitle)
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -75,18 +75,18 @@ struct OnboardingView: View {
 
     private var title: String {
         switch step {
-        case 0: "Welcome to Tinycast"
-        case 1: "Enable Pasting"
-        case 2: "Import from Raycast"
-        default: "You're all set"
+        case 0: String(localized: "Welcome to Tinycast")
+        case 1: String(localized: "Enable Pasting")
+        case 2: String(localized: "Import from Raycast")
+        default: String(localized: "You're all set")
         }
     }
 
     private var subtitle: String {
         switch step {
-        case 0: "Set a shortcut to summon the launcher from anywhere."
-        case 1: "Let Tinycast paste items back into the app you were using."
-        case 2: "Bring your shortcuts, favorites, and clipboard history along."
+        case 0: String(localized: "Set a shortcut to summon the launcher from anywhere.")
+        case 1: String(localized: "Let Tinycast paste items back into the app you were using.")
+        case 2: String(localized: "Bring your shortcuts, favorites, and clipboard history along.")
         default: readyMessage
         }
     }
@@ -109,9 +109,9 @@ struct OnboardingView: View {
 
     private var readyMessage: String {
         if let caps = hotKeys.shortcut(for: .togglePalette)?.keycaps {
-            return "Press \(caps.joined()) anytime to start using Tinycast."
+            return String(localized: "Press \(caps.joined()) anytime to start using Tinycast.")
         }
-        return "Tinycast is ready. Set a shortcut in Settings to summon it."
+        return String(localized: "Tinycast is ready. Set a shortcut in Settings to summon it.")
     }
 
     // MARK: - Step content
@@ -142,7 +142,7 @@ struct OnboardingView: View {
                     subtitle: "Start Tinycast automatically when you log in.",
                     systemImage: "power", tint: .green
                 ) {
-                    Toggle("", isOn: $settings.launchAtLogin)
+                    Toggle("Launch at login", isOn: $settings.launchAtLogin)
                         .labelsHidden().toggleStyle(.switch).controlSize(.small)
                 }
             }
@@ -171,7 +171,7 @@ struct OnboardingView: View {
             SettingsCard {
                 SettingsRow(
                     title: "Raycast Export",
-                    subtitle: model.file?.lastPathComponent
+                    subtitle: model.file.map { DisplayText.verbatim($0.lastPathComponent) }
                         ?? "Choose a .rayconfig file exported from Raycast.",
                     systemImage: "doc.badge.gearshape", tint: .orange
                 ) {
@@ -242,7 +242,7 @@ struct OnboardingView: View {
                     .controlSize(.large)
                     .disabled(true)
                 } else {
-                    Button(primaryTitle, action: primaryAction)
+                    Button(action: primaryAction) { Text(verbatim: primaryTitle) }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.large)
                         .disabled(primaryDisabled)
@@ -258,17 +258,19 @@ struct OnboardingView: View {
 
     private var primaryTitle: String {
         switch step {
-        case 0: "Continue"
-        case 1: accessibilityTrusted ? "Continue" : "Grant Access"
+        case 0: String(localized: "Continue")
+        case 1:
+            accessibilityTrusted
+                ? String(localized: "Continue") : String(localized: "Grant Access")
         case 2:
             if model.didImport {
-                "Continue"
+                String(localized: "Continue")
             } else if model.importing {
-                "Importing…"
+                String(localized: "Importing…")
             } else {
-                "Import"
+                String(localized: "Import")
             }
-        default: "Get Started"
+        default: String(localized: "Get Started")
         }
     }
 
@@ -295,7 +297,7 @@ struct OnboardingView: View {
 
     // MARK: - Shared bits
 
-    private func caption(_ text: String) -> some View {
+    private func caption(_ text: DisplayText) -> some View {
         Text(text)
             .font(.caption)
             .foregroundStyle(.tertiary)
@@ -326,7 +328,9 @@ struct OnboardingView: View {
             Image(
                 systemName: accessibilityTrusted
                     ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-            Text(accessibilityTrusted ? "Granted" : "Not granted")
+            Text(
+                verbatim: accessibilityTrusted
+                    ? String(localized: "Granted") : String(localized: "Not granted"))
         }
         .font(.caption.weight(.semibold))
         .foregroundStyle(accessibilityTrusted ? Color.green : Color.orange)
@@ -385,10 +389,16 @@ final class OnboardingModel: ObservableObject {
                     file: file, passphrase: passphrase, options: selection)
                 var message = BackupActions.summaryText(outcome.summary)
                 if outcome.clipboardImported > 0 {
-                    message += " Imported \(outcome.clipboardImported) clipboard entries."
+                    message += " " + (outcome.clipboardImported == 1
+                        ? String(localized: "Imported 1 clipboard entry.")
+                        : String(
+                            localized: "Imported \(outcome.clipboardImported) clipboard entries."))
                 }
                 if outcome.missingImages > 0 {
-                    message += " \(outcome.missingImages) images were unavailable and skipped."
+                    message += " " + (outcome.missingImages == 1
+                        ? String(localized: "1 image was unavailable and skipped.")
+                        : String(
+                            localized: "\(outcome.missingImages) images were unavailable and skipped."))
                 }
                 status = .success(message)
                 passphrase = ""

--- a/Tinycast/Features/PopoverMenu.swift
+++ b/Tinycast/Features/PopoverMenu.swift
@@ -14,7 +14,7 @@ enum PopoverMenuIcon: Equatable {
 
 /// One popover-menu row's data: the render path and the keyboard handlers both address rows through these, so a selection index can drive highlight and activation. Actions are pure — closing the menu is the caller's job (one central `onActivate`).
 struct PopoverMenuItem {
-    let title: String
+    let title: DisplayText
     let icon: PopoverMenuIcon
     var shortcut: String? = nil
     /// Destructive rows (delete) tint their icon + label red, matching the native menu convention.
@@ -22,7 +22,8 @@ struct PopoverMenuItem {
     let action: () -> Void
 
     init(
-        title: String, icon: PopoverMenuIcon, shortcut: String? = nil, isDestructive: Bool = false,
+        title: DisplayText, icon: PopoverMenuIcon, shortcut: String? = nil,
+        isDestructive: Bool = false,
         action: @escaping () -> Void
     ) {
         self.title = title
@@ -33,7 +34,8 @@ struct PopoverMenuItem {
     }
 
     init(
-        title: String, systemImage: String, shortcut: String? = nil, isDestructive: Bool = false,
+        title: DisplayText, systemImage: String, shortcut: String? = nil,
+        isDestructive: Bool = false,
         action: @escaping () -> Void
     ) {
         self.init(
@@ -58,7 +60,7 @@ struct PopoverMenu: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
             if let header {
-                Text(header)
+                Text(verbatim: header)
                     .font(Theme.Typography.sectionHeader)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -477,7 +477,7 @@ struct RootPaletteView: View {
     /// The one search field, kept in a single tree position (the `header`) so its focus survives the compact↔expanded swap.
     private var searchField: some View {
         TextField(
-            "", text: $vm.query,
+            "Search", text: $vm.query,
             prompt: Text(vm.mode.placeholder).foregroundStyle(Theme.Colors.textTertiary)
         )
         .textFieldStyle(.plain)
@@ -626,7 +626,7 @@ struct RootPaletteView: View {
         HStack(spacing: 2) {
             BarButton(action: activateSelection) {
                 HStack(spacing: Theme.Spacing.sm) {
-                    Text(pillLabel)
+                    Text(verbatim: pillLabel)
                         .font(Theme.Typography.bar)
                         .foregroundStyle(.primary)
                     KeyCapChip(text: "↵", style: .outline)
@@ -652,15 +652,15 @@ struct RootPaletteView: View {
     private func actionPillLabel(selectedApp: AppEntry?, calcActionable: Bool) -> String {
         switch vm.mode {
         case .clipboard, .emoji:
-            return vm.pasteTarget?.pasteTitle ?? "Paste"
+            return vm.pasteTarget?.pasteTitle ?? String(localized: "Paste")
         case .calculatorHistory:
-            return "Copy Answer"
+            return String(localized: "Copy Answer")
         case .launcher:
-            if calcActionable { return "Copy Answer" }
+            if calcActionable { return String(localized: "Copy Answer") }
             switch selectedApp?.kind {
-            case .systemSettings: return "Open System Setting"
-            case .command: return "Open Command"
-            default: return "Open Application"
+            case .systemSettings: return String(localized: "Open System Setting")
+            case .command: return String(localized: "Open Command")
+            default: return String(localized: "Open Application")
             }
         }
     }
@@ -843,7 +843,7 @@ extension View {
 }
 
 struct EmptyResults: View {
-    let text: String
+    let text: DisplayText
     var body: some View {
         VStack(spacing: 8) {
             Image(systemName: "magnifyingglass").font(.largeTitle)
@@ -886,7 +886,10 @@ private struct CompactFavoritesRow: View {
                             .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
                     }
                 case .more:
-                    CompactFavoriteButton(help: "Show all  ⌘\(index + 1)", action: onOverflow) {
+                    CompactFavoriteButton(
+                        help: String(localized: "Show all  ⌘\(index + 1)"),
+                        action: onOverflow
+                    ) {
                         Image(systemName: "ellipsis")
                             .font(.system(size: 10))
                             .foregroundStyle(Theme.Colors.textSecondary)

--- a/Tinycast/Features/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Settings/BackupSettingsView.swift
@@ -23,7 +23,7 @@ struct BackupSettingsView: View {
             title: "Backup",
             subtitle: "Export your settings, restore a backup, or import from Raycast."
         ) {
-            SettingsCard(header: "Tinycast") {
+            SettingsCard(header: .verbatim("Tinycast")) {
                 SettingsRow(
                     title: "Export Settings",
                     subtitle: "Save your shortcuts, favorites, and preferences to a JSON file.",
@@ -49,7 +49,7 @@ struct BackupSettingsView: View {
             SettingsCard(header: "Import from Raycast") {
                 SettingsRow(
                     title: "Raycast Export",
-                    subtitle: raycastFile?.lastPathComponent
+                    subtitle: raycastFile.map { DisplayText.verbatim($0.lastPathComponent) }
                         ?? "Choose a .rayconfig file exported from Raycast.",
                     systemImage: "doc.badge.gearshape",
                     tint: .orange
@@ -124,12 +124,16 @@ struct BackupSettingsView: View {
     private func statusRow(_ status: Status) -> some View {
         switch status {
         case .success(let message):
-            SettingsRow(title: message, systemImage: "checkmark.circle.fill", tint: .green) {
+            SettingsRow(
+                title: .verbatim(message), systemImage: "checkmark.circle.fill", tint: .green
+            ) {
                 EmptyView()
             }
         case .failure(let message):
-            SettingsRow(title: message, systemImage: "exclamationmark.triangle.fill", tint: .orange)
-            {
+            SettingsRow(
+                title: .verbatim(message), systemImage: "exclamationmark.triangle.fill",
+                tint: .orange
+            ) {
                 EmptyView()
             }
         }
@@ -154,10 +158,16 @@ struct BackupSettingsView: View {
                     file: file, passphrase: passphrase, options: selection)
                 var message = BackupActions.summaryText(outcome.summary)
                 if outcome.clipboardImported > 0 {
-                    message += " Imported \(outcome.clipboardImported) clipboard entries."
+                    message += " " + (outcome.clipboardImported == 1
+                        ? String(localized: "Imported 1 clipboard entry.")
+                        : String(
+                            localized: "Imported \(outcome.clipboardImported) clipboard entries."))
                 }
                 if outcome.missingImages > 0 {
-                    message += " \(outcome.missingImages) images were unavailable and skipped."
+                    message += " " + (outcome.missingImages == 1
+                        ? String(localized: "1 image was unavailable and skipped.")
+                        : String(
+                            localized: "\(outcome.missingImages) images were unavailable and skipped."))
                 }
                 status = .success(message)
                 passphrase = ""

--- a/Tinycast/Features/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Settings/ClipboardSettingsView.swift
@@ -29,7 +29,7 @@ struct ClipboardSettingsView: View {
                     systemImage: "clock.arrow.circlepath",
                     tint: .orange
                 ) {
-                    Picker("", selection: $settings.clipboardRetention) {
+                    Picker("Keep history for", selection: $settings.clipboardRetention) {
                         ForEach(ClipboardRetention.allCases) { retention in
                             Text(retention.title).tag(retention)
                         }

--- a/Tinycast/Features/Settings/EmojiSettingsView.swift
+++ b/Tinycast/Features/Settings/EmojiSettingsView.swift
@@ -27,7 +27,7 @@ struct EmojiSettingsView: View {
                     tint: .orange
                 ) {
                     // A hand per tone, Raycast style — quicker to scan than a dropdown of tone names.
-                    Picker("", selection: $settings.emojiSkinTone) {
+                    Picker("Emoji Skin Tone", selection: $settings.emojiSkinTone) {
                         ForEach(EmojiSkinTone.allCases) { tone in
                             Text(tone.sample).tag(tone)
                         }

--- a/Tinycast/Features/Settings/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/GeneralSettingsView.swift
@@ -21,16 +21,22 @@ struct GeneralSettingsView: View {
 
     private var hyperSubtitle: String {
         guard settings.hyperKey != .none else {
-            return
-                "Select a physical key to remap to the \(hyperGlyphs) modifier keys simultaneously."
+            return String(
+                localized:
+                    "Select a physical key to remap to the \(hyperGlyphs) modifier keys simultaneously."
+            )
         }
-        var text =
-            "Pressing \(settings.hyperKey.title) will trigger the left \(hyperGlyphs) modifier keys."
+        var text = String(
+            localized:
+                "Pressing \(settings.hyperKey.title) will trigger the left \(hyperGlyphs) modifier keys."
+        )
         if settings.hyperKeyReplacesGlyph {
-            text += " Hyper Key shortcuts will be shown in Tinycast with ✦."
+            text += " " + String(
+                localized: "Hyper Key shortcuts will be shown in Tinycast with ✦.")
         }
         if hyperTap.status == .needsAccessibility {
-            text += " Tinycast needs Accessibility access to remap keys."
+            text += " " + String(
+                localized: "Tinycast needs Accessibility access to remap keys.")
         }
         return text
     }
@@ -72,7 +78,7 @@ struct GeneralSettingsView: View {
             SettingsCard(header: "Hyper Key") {
                 SettingsRow(
                     title: "Hyper Key",
-                    subtitle: hyperSubtitle,
+                    subtitle: .verbatim(hyperSubtitle),
                     systemImage: "sparkle",
                     tint: .purple,
                     statusDot: hyperStatusDot
@@ -81,7 +87,7 @@ struct GeneralSettingsView: View {
                         Button("Grant Access…") { Permissions.openAccessibilitySettings() }
                             .controlSize(.small)
                     }
-                    Picker("", selection: $settings.hyperKey) {
+                    Picker("Hyper Key", selection: $settings.hyperKey) {
                         ForEach(HyperKeyPhysicalKey.allCases) { key in
                             Text(key.title).tag(key)
                         }
@@ -98,12 +104,15 @@ struct GeneralSettingsView: View {
                     SettingsDivider()
                     SettingsRow(
                         title: "Quick Press",
-                        subtitle:
-                            "Select an action to perform when \(settings.hyperKey.title) is pressed without any other keys.",
+                        subtitle: .verbatim(
+                            String(
+                                localized:
+                                    "Select an action to perform when \(settings.hyperKey.title) is pressed without any other keys."
+                            )),
                         systemImage: "hand.tap",
                         tint: .teal
                     ) {
-                        Picker("", selection: $settings.hyperKeyQuickPress) {
+                        Picker("Quick Press", selection: $settings.hyperKeyQuickPress) {
                             Text("Does Nothing").tag(HyperKeyQuickPress.none)
                             if let original = settings.hyperKey.quickPressOriginalTitle {
                                 Text(original).tag(HyperKeyQuickPress.originalKey)
@@ -117,23 +126,26 @@ struct GeneralSettingsView: View {
                 SettingsDivider()
                 SettingsRow(
                     title: "Include Shift (⇧)",
-                    subtitle: "Hyper Key will remap to the \(hyperGlyphs) modifier keys.",
+                    subtitle: .verbatim(
+                        String(
+                            localized: "Hyper Key will remap to the \(hyperGlyphs) modifier keys.")),
                     systemImage: "shift",
                     tint: .indigo
                 ) {
-                    Toggle("", isOn: $settings.hyperKeyIncludesShift)
+                    Toggle("Include Shift (⇧)", isOn: $settings.hyperKeyIncludesShift)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }
                 SettingsDivider()
                 SettingsRow(
-                    title: "Replace occurrences of \(hyperGlyphs) with ✦",
+                    title: .verbatim(
+                        String(localized: "Replace occurrences of \(hyperGlyphs) with ✦")),
                     subtitle: "Shortcuts containing the Hyper Key modifiers are shown with ✦.",
                     systemImage: "keyboard",
                     tint: .gray
                 ) {
-                    Toggle("", isOn: $settings.hyperKeyReplacesGlyph)
+                    Toggle("Show Hyper Key as ✦", isOn: $settings.hyperKeyReplacesGlyph)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
@@ -148,7 +160,7 @@ struct GeneralSettingsView: View {
                     systemImage: "macwindow",
                     tint: .blue
                 ) {
-                    Toggle("", isOn: $settings.compactMode)
+                    Toggle("Compact mode", isOn: $settings.compactMode)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
@@ -161,7 +173,9 @@ struct GeneralSettingsView: View {
                     systemImage: "star",
                     tint: .yellow
                 ) {
-                    Toggle("", isOn: $settings.showFavoritesInCompactMode)
+                    Toggle(
+                        "Show favorites in compact mode",
+                        isOn: $settings.showFavoritesInCompactMode)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
@@ -177,7 +191,7 @@ struct GeneralSettingsView: View {
                     systemImage: "power",
                     tint: .green
                 ) {
-                    Toggle("", isOn: $settings.launchAtLogin)
+                    Toggle("Launch at login", isOn: $settings.launchAtLogin)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
@@ -190,7 +204,7 @@ struct GeneralSettingsView: View {
                     systemImage: "menubar.arrow.up.rectangle",
                     tint: .gray
                 ) {
-                    Toggle("", isOn: $showInMenuBar)
+                    Toggle("Show in menu bar", isOn: $showInMenuBar)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
@@ -202,7 +216,7 @@ struct GeneralSettingsView: View {
                     systemImage: "arrow.uturn.backward",
                     tint: .indigo
                 ) {
-                    Picker("", selection: $settings.popToRootTimeout) {
+                    Picker("Pop to Root Search", selection: $settings.popToRootTimeout) {
                         ForEach(PopToRootTimeout.allCases) { timeout in
                             Text(timeout.title).tag(timeout)
                         }

--- a/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
+++ b/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
@@ -16,7 +16,7 @@ struct MiscellaneousSettingsView: View {
             SettingsCard(header: "Calculator") {
                 SettingsRow(
                     title: "Currency Conversion",
-                    subtitle: conversionStatus,
+                    subtitle: .verbatim(conversionStatus),
                     systemImage: "dollarsign.arrow.circlepath",
                     tint: .green,
                     statusDot: currencyRates.isEnabled ? .green : nil
@@ -44,7 +44,7 @@ struct MiscellaneousSettingsView: View {
                     SettingsDivider()
                     SettingsRow(
                         title: "Exchange Rates",
-                        subtitle: ratesStatus,
+                        subtitle: .verbatim(ratesStatus),
                         systemImage: "clock.arrow.circlepath",
                         tint: .gray
                     ) {
@@ -74,18 +74,24 @@ struct MiscellaneousSettingsView: View {
     /// Carries the off-state promise that used to need its own callout: nothing is contacted until
     /// the switch is on.
     private var conversionStatus: String {
-        let examples = "Convert inline — \"100 dollars to yen\", \"€20 to GBP\"."
-        return currencyRates.isEnabled ? examples : "\(examples) Off — no service is contacted."
+        let examples = String(
+            localized: "Convert inline — \"100 dollars to yen\", \"€20 to GBP\".")
+        return currencyRates.isEnabled
+            ? examples
+            : String(localized: "\(examples) Off — no service is contacted.")
     }
 
     private var ratesStatus: String {
-        if refreshing { return "Updating…" }
-        if refreshFailed { return "Couldn't reach \(CurrencyRateStore.provider). Try again." }
+        if refreshing { return String(localized: "Updating…") }
+        if refreshFailed {
+            return String(localized: "Couldn't reach \(CurrencyRateStore.provider). Try again.")
+        }
         guard let fetched = currencyRates.rates?.fetchedAt else {
-            return "\(CurrencyRateStore.provider) · not downloaded yet."
+            return String(localized: "\(CurrencyRateStore.provider) · not downloaded yet.")
         }
         let stamp = fetched.formatted(date: .abbreviated, time: .shortened)
-        return "\(CurrencyRateStore.provider) · updated \(stamp). Refreshes daily."
+        return String(
+            localized: "\(CurrencyRateStore.provider) · updated \(stamp). Refreshes daily.")
     }
 }
 
@@ -106,9 +112,10 @@ private struct CurrencyConsentSheet: View {
             }
 
             Text(
-                "Tinycast downloads exchange rates from \(CurrencyRateStore.provider) once a day and "
-                + "keeps a copy on your Mac. No account, no identifiers, nothing you type. "
-                + "Turning it off deletes the cached rates."
+                String(
+                    localized:
+                        "Tinycast downloads exchange rates from \(CurrencyRateStore.provider) once a day and keeps a copy on your Mac. No account, no identifiers, nothing you type. Turning it off deletes the cached rates."
+                )
             )
             .font(.callout)
             .foregroundStyle(.secondary)

--- a/Tinycast/Features/Settings/PermissionsSettingsView.swift
+++ b/Tinycast/Features/Settings/PermissionsSettingsView.swift
@@ -45,7 +45,9 @@ struct PermissionsSettingsView: View {
                 systemName: accessibilityTrusted
                     ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
             )
-            Text(accessibilityTrusted ? "Granted" : "Not granted")
+            Text(
+                accessibilityTrusted
+                    ? LocalizedStringKey("Granted") : LocalizedStringKey("Not granted"))
         }
         .font(.caption.weight(.semibold))
         .foregroundStyle(accessibilityTrusted ? Color.green : Color.orange)

--- a/Tinycast/Features/Settings/RaycastImportSelection.swift
+++ b/Tinycast/Features/Settings/RaycastImportSelection.swift
@@ -7,7 +7,7 @@ struct RaycastImportSelection: View {
     private struct Category: Identifiable {
         let option: RaycastImportOptions
         let symbol: String
-        let label: String
+        let label: DisplayText
         var id: Int { option.rawValue }
     }
 
@@ -46,8 +46,10 @@ struct RaycastImportSelection: View {
                     .toggleStyle(.checkbox)
                 }
             }
-            Button(selection == .all ? "Deselect All" : "Select All") {
+            Button {
                 selection = selection == .all ? [] : .all
+            } label: {
+                Text(selection == .all ? "Deselect All" : "Select All")
             }
             .buttonStyle(.link)
             .font(.caption)

--- a/Tinycast/Features/Settings/SearchScopesCard.swift
+++ b/Tinycast/Features/Settings/SearchScopesCard.swift
@@ -55,8 +55,9 @@ struct SearchScopesCard: View {
         // Otherwise an .app is navigated into rather than selected.
         panel.treatsFilePackagesAsDirectories = false
         panel.allowsMultipleSelection = true
-        panel.prompt = "Add"
-        panel.message = "Choose folders or applications to include in the launcher."
+        panel.prompt = String(localized: "Add")
+        panel.message = String(
+            localized: "Choose folders or applications to include in the launcher.")
         // Tinycast is an accessory app, so the panel opens behind the frontmost app without this.
         NSApp.activate(ignoringOtherApps: true)
         guard panel.runModal() == .OK else { return }

--- a/Tinycast/Features/Settings/SettingsComponents.swift
+++ b/Tinycast/Features/Settings/SettingsComponents.swift
@@ -6,8 +6,8 @@ import SwiftUI
 
 /// Standard layout for a settings pane (title + subtitle header, then scrollable content) so headers, insets and scroll behaviour stay identical across the app.
 struct SettingsPane<Content: View>: View {
-    let title: String
-    let subtitle: String
+    let title: DisplayText
+    let subtitle: DisplayText
     @ViewBuilder var content: Content
 
     var body: some View {
@@ -28,8 +28,8 @@ struct SettingsPane<Content: View>: View {
 
 /// The title + subtitle block at the top of every pane.
 struct SettingsHeader: View {
-    let title: String
-    let subtitle: String
+    let title: DisplayText
+    let subtitle: DisplayText
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
@@ -46,7 +46,7 @@ struct SettingsHeader: View {
 
 /// A rounded, hairline-bordered container grouping related rows — the macOS System Settings "card" (rows split by inset dividers via `SettingsRow`/`SettingsDivider`).
 struct SettingsCard<Content: View>: View {
-    var header: String? = nil
+    var header: DisplayText? = nil
     @ViewBuilder var content: Content
 
     var body: some View {
@@ -84,8 +84,8 @@ struct SettingsDivider: View {
 
 /// A single settings line (optional SF Symbol, title with optional subtitle, trailing control); fixed vertical rhythm keeps every card aligned regardless of the control.
 struct SettingsRow<Trailing: View>: View {
-    let title: String
-    var subtitle: String? = nil
+    let title: DisplayText
+    var subtitle: DisplayText? = nil
     var systemImage: String? = nil
     var tint: Color = .secondary
     /// Optional state indicator rendered after the title (green = active, orange = attention).
@@ -129,8 +129,8 @@ struct SettingsRow<Trailing: View>: View {
 
 /// A tinted inset box for a notice or warning inside a `SettingsCard` — SF Symbol + title + optional message, with an optional trailing control (e.g. a fix-it button).
 struct SettingsCallout<Trailing: View>: View {
-    let title: String
-    var message: String? = nil
+    let title: DisplayText
+    var message: DisplayText? = nil
     var systemImage: String = "info.circle"
     var tint: Color = .secondary
     @ViewBuilder var trailing: Trailing
@@ -167,7 +167,10 @@ struct SettingsCallout<Trailing: View>: View {
 }
 
 extension SettingsCallout where Trailing == EmptyView {
-    init(title: String, message: String? = nil, systemImage: String = "info.circle", tint: Color = .secondary) {
+    init(
+        title: DisplayText, message: DisplayText? = nil, systemImage: String = "info.circle",
+        tint: Color = .secondary
+    ) {
         self.init(title: title, message: message, systemImage: systemImage, tint: tint) { EmptyView() }
     }
 }

--- a/Tinycast/Features/Settings/SettingsRootView.swift
+++ b/Tinycast/Features/Settings/SettingsRootView.swift
@@ -11,14 +11,14 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .general: return "General"
-        case .clipboard: return "Clipboard"
-        case .emoji: return "Emoji & Symbols"
-        case .permissions: return "Permissions"
-        case .shortcuts: return "Shortcuts"
-        case .backup: return "Backup"
-        case .miscellaneous: return "Miscellaneous"
-        case .about: return "About"
+        case .general: return String(localized: "General")
+        case .clipboard: return String(localized: "Clipboard")
+        case .emoji: return String(localized: "Emoji & Symbols")
+        case .permissions: return String(localized: "Permissions")
+        case .shortcuts: return String(localized: "Shortcuts")
+        case .backup: return String(localized: "Backup")
+        case .miscellaneous: return String(localized: "Miscellaneous")
+        case .about: return String(localized: "About")
         }
     }
 
@@ -143,7 +143,7 @@ private struct SidebarRow: View {
                             .foregroundStyle(.white)
                     )
                     .shadow(color: .black.opacity(0.2), radius: 0.5, y: 0.5)
-                Text(title)
+                Text(verbatim: title)
                     .font(Theme.Typography.rowTitle)
                 Spacer(minLength: 0)
             }

--- a/Tinycast/Features/Settings/ShortcutsSettingsView.swift
+++ b/Tinycast/Features/Settings/ShortcutsSettingsView.swift
@@ -39,9 +39,9 @@ struct ShortcutsSettingsView: View {
 
     private var searchPrompt: String {
         switch tab {
-        case .application: return "Search applications…"
-        case .systemSettings: return "Search System Settings…"
-        case .command: return "Search commands…"
+        case .application: return String(localized: "Search applications…")
+        case .systemSettings: return String(localized: "Search System Settings…")
+        case .command: return String(localized: "Search commands…")
         }
     }
 
@@ -89,7 +89,7 @@ private struct CategoryCard: View {
                     .font(Theme.Typography.sectionHeader)
                     .foregroundStyle(.secondary)
                 Spacer()
-                Toggle("", isOn: kindBinding)
+                Toggle("Show in launcher", isOn: kindBinding)
                     .labelsHidden()
                     .toggleStyle(.switch)
                     .controlSize(.small)
@@ -117,7 +117,10 @@ private struct CategoryCard: View {
             )
             .overlay {
                 if entries.isEmpty {
-                    Text(query.isEmpty ? "Nothing here yet." : "No matches for “\(query)”.")
+                    Text(
+                        verbatim: query.isEmpty
+                            ? String(localized: "Nothing here yet.")
+                            : String(localized: "No matches for “\(query)”."))
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
@@ -150,7 +153,7 @@ private struct ShortcutRow: View {
             if let action = entry.hotKeyAction {
                 ShortcutRecorder(action: action)
             }
-            Toggle("", isOn: itemBinding)
+            Toggle(entry.name, isOn: itemBinding)
                 .labelsHidden()
                 .toggleStyle(.checkbox)
         }

--- a/Tinycast/Localizable.xcstrings
+++ b/Tinycast/Localizable.xcstrings
@@ -1,0 +1,4278 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+      "shouldTranslate" : false
+    },
+    "%@ · not downloaded yet." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · 尚未下载。"
+          }
+        }
+      }
+    },
+    "%@ · updated %@. Refreshes daily." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · 更新于 %2$@。每天刷新。"
+          }
+        }
+      }
+    },
+    "%@ at %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
+    "%@ day" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 天"
+          }
+        }
+      }
+    },
+    "%@ days" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 天"
+          }
+        }
+      }
+    },
+    "%@ feet" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 英尺"
+          }
+        }
+      }
+    },
+    "%@ foot" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 英尺"
+          }
+        }
+      }
+    },
+    "%@ hour" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 小时"
+          }
+        }
+      }
+    },
+    "%@ hours" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 小时"
+          }
+        }
+      }
+    },
+    "%@ inch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 英寸"
+          }
+        }
+      }
+    },
+    "%@ inches" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 英寸"
+          }
+        }
+      }
+    },
+    "%@ minute" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 分钟"
+          }
+        }
+      }
+    },
+    "%@ minutes" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 分钟"
+          }
+        }
+      }
+    },
+    "%@ Off — no service is contacted." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@已关闭，不会连接任何服务。"
+          }
+        }
+      }
+    },
+    "%@ second" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 秒"
+          }
+        }
+      }
+    },
+    "%@ seconds" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 秒"
+          }
+        }
+      }
+    },
+    "%@ week" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 周"
+          }
+        }
+      }
+    },
+    "%@ weeks" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 周"
+          }
+        }
+      }
+    },
+    "%lld favorites" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个收藏项"
+          }
+        }
+      }
+    },
+    "%lld hidden items" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个隐藏项"
+          }
+        }
+      }
+    },
+    "%lld images were unavailable and skipped." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有 %lld 张图片不可用，已跳过。"
+          }
+        }
+      }
+    },
+    "%lld settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 项设置"
+          }
+        }
+      }
+    },
+    "%lld shortcuts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个快捷键"
+          }
+        }
+      }
+    },
+    "© 2026 Abue Ammar · Released under AGPL-3.0" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "© 2026 Abue Ammar · 依据 AGPL-3.0 许可发布"
+          }
+        }
+      }
+    },
+    "1 Day" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 天"
+          }
+        }
+      }
+    },
+    "1 favorite" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 个收藏项"
+          }
+        }
+      }
+    },
+    "1 hidden item" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 个隐藏项"
+          }
+        }
+      }
+    },
+    "1 image was unavailable and skipped." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有 1 张图片不可用，已跳过。"
+          }
+        }
+      }
+    },
+    "1 Month" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 个月"
+          }
+        }
+      }
+    },
+    "1 setting" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 项设置"
+          }
+        }
+      }
+    },
+    "1 shortcut" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 个快捷键"
+          }
+        }
+      }
+    },
+    "1 Week" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 周"
+          }
+        }
+      }
+    },
+    "1 Year" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 年"
+          }
+        }
+      }
+    },
+    "3 Months" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3 个月"
+          }
+        }
+      }
+    },
+    "6 Months" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 个月"
+          }
+        }
+      }
+    },
+    "A tiny, native macOS launcher." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小巧的原生 macOS 启动器。"
+          }
+        }
+      }
+    },
+    "About" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于"
+          }
+        }
+      }
+    },
+    "About Tinycast" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于 Tinycast"
+          }
+        }
+      }
+    },
+    "Access Tinycast needs to work with other apps." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 与其他应用协作所需的访问权限。"
+          }
+        }
+      }
+    },
+    "Accessibility" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "辅助功能"
+          }
+        }
+      }
+    },
+    "Acres" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英亩"
+          }
+        }
+      }
+    },
+    "Actions" : {
+      "comment" : "Label for the menu that lists actions available for the selected result.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        }
+      }
+    },
+    "Activity" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活动"
+          }
+        }
+      }
+    },
+    "Add" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        }
+      }
+    },
+    "Add a folder or application to search." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加要搜索的文件夹或应用。"
+          }
+        }
+      }
+    },
+    "Add to Favorites" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加到收藏"
+          }
+        }
+      }
+    },
+    "After %lld seconds" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒后"
+          }
+        }
+      }
+    },
+    "Angle" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角度"
+          }
+        }
+      }
+    },
+    "Animals & Nature" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "动物与自然"
+          }
+        }
+      }
+    },
+    "App Launcher" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用启动器"
+          }
+        }
+      }
+    },
+    "Appearance" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外观"
+          }
+        }
+      }
+    },
+    "Application" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用"
+          }
+        }
+      }
+    },
+    "Applications" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用"
+          }
+        }
+      }
+    },
+    "Applications with unsaved changes will ask you to save." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有未保存更改的应用会提示你保存。"
+          }
+        }
+      }
+    },
+    "Applied %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已应用%@。"
+          }
+        }
+      }
+    },
+    "Applied when an emoji supports skin tones; pastes use it too." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用于支持肤色的表情；粘贴时同样生效。"
+          }
+        }
+      }
+    },
+    "Apps" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用"
+          }
+        }
+      }
+    },
+    "Arcminutes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角分"
+          }
+        }
+      }
+    },
+    "Arcseconds" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角秒"
+          }
+        }
+      }
+    },
+    "Area" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面积"
+          }
+        }
+      }
+    },
+    "Arrows" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "箭头"
+          }
+        }
+      }
+    },
+    "Atmospheres" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标准大气压"
+          }
+        }
+      }
+    },
+    "Back" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回"
+          }
+        }
+      }
+    },
+    "Backup" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "备份"
+          }
+        }
+      }
+    },
+    "Bar" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "巴"
+          }
+        }
+      }
+    },
+    "Binary" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二进制"
+          }
+        }
+      }
+    },
+    "Bits" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比特"
+          }
+        }
+      }
+    },
+    "Bits per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比特/秒"
+          }
+        }
+      }
+    },
+    "Bring your shortcuts, favorites, and clipboard history along." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入你的快捷键、收藏和剪贴板历史记录。"
+          }
+        }
+      }
+    },
+    "Buy Me Brave Origin" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请我喝杯 Brave Origin"
+          }
+        }
+      }
+    },
+    "Bytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字节"
+          }
+        }
+      }
+    },
+    "Calculator" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "计算器"
+          }
+        }
+      }
+    },
+    "Calculator History" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "计算器历史记录"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "Cannot add %@ and %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法将%1$@与%2$@相加。"
+          }
+        }
+      }
+    },
+    "Cannot combine temperatures with different units." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法合并采用不同单位的温度。"
+          }
+        }
+      }
+    },
+    "Cannot convert %@ to %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法将%1$@转换为%2$@。"
+          }
+        }
+      }
+    },
+    "Cannot divide %@ by %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法用%2$@除%1$@。"
+          }
+        }
+      }
+    },
+    "Cannot subtract %@ from %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法从%2$@中减去%1$@。"
+          }
+        }
+      }
+    },
+    "Caps Lock (⇪)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大写锁定键（⇪）"
+          }
+        }
+      }
+    },
+    "Category" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "类别"
+          }
+        }
+      }
+    },
+    "Celsius" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摄氏度"
+          }
+        }
+      }
+    },
+    "Centimeters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "厘米"
+          }
+        }
+      }
+    },
+    "Characters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字符数"
+          }
+        }
+      }
+    },
+    "Choose a .rayconfig file exported from Raycast." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择从 Raycast 导出的 .rayconfig 文件。"
+          }
+        }
+      }
+    },
+    "Choose folders or applications to include in the launcher." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要纳入启动器的文件夹或应用。"
+          }
+        }
+      }
+    },
+    "Choose what appears in the launcher and assign global shortcuts." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择启动器中显示的内容并分配全局快捷键。"
+          }
+        }
+      }
+    },
+    "Choose what to bring over, then import." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要导入的内容，然后开始导入。"
+          }
+        }
+      }
+    },
+    "Choose…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择…"
+          }
+        }
+      }
+    },
+    "Clear clipboard history?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除剪贴板历史记录？"
+          }
+        }
+      }
+    },
+    "Clear history" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除历史记录"
+          }
+        }
+      }
+    },
+    "Clear History" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除历史记录"
+          }
+        }
+      }
+    },
+    "Clear…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除…"
+          }
+        }
+      }
+    },
+    "Clipboard" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板"
+          }
+        }
+      }
+    },
+    "Clipboard changes from these apps won't be recorded." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不会记录这些应用中的剪贴板变化。"
+          }
+        }
+      }
+    },
+    "Clipboard history" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板历史"
+          }
+        }
+      }
+    },
+    "Clipboard History" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板历史"
+          }
+        }
+      }
+    },
+    "Clipboard history is empty" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板历史为空"
+          }
+        }
+      }
+    },
+    "Command" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令"
+          }
+        }
+      }
+    },
+    "Commands" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令"
+          }
+        }
+      }
+    },
+    "Compact mode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紧凑模式"
+          }
+        }
+      }
+    },
+    "Continue" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
+          }
+        }
+      }
+    },
+    "Control how much history Tinycast keeps and which apps are recorded." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制 Tinycast 保留历史记录的时长以及记录哪些应用。"
+          }
+        }
+      }
+    },
+    "Convert inline — \"100 dollars to yen\", \"€20 to GBP\"." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直接输入即可换算，例如“100 dollars to yen”或“€20 to GBP”。"
+          }
+        }
+      }
+    },
+    "Copied" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制时间"
+          }
+        }
+      }
+    },
+    "Copy Answer" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制答案"
+          }
+        }
+      }
+    },
+    "Copy Expression" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制表达式"
+          }
+        }
+      }
+    },
+    "Copy to Clipboard" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制到剪贴板"
+          }
+        }
+      }
+    },
+    "Couldn't reach %@. Try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法连接 %@。请重试。"
+          }
+        }
+      }
+    },
+    "Cups" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "杯"
+          }
+        }
+      }
+    },
+    "Currency" : {
+      "comment" : "Calculator category name for monetary values, not a currency code.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "货币"
+          }
+        }
+      }
+    },
+    "Currency Conversion" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "货币换算"
+          }
+        }
+      }
+    },
+    "Danger Zone" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "危险操作"
+          }
+        }
+      }
+    },
+    "Dark" : {
+      "comment" : "Dark emoji skin tone, not interface appearance.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        }
+      }
+    },
+    "Data Transfer Rate" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据传输速率"
+          }
+        }
+      }
+    },
+    "Days" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天"
+          }
+        }
+      }
+    },
+    "Decimal" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "十进制"
+          }
+        }
+      }
+    },
+    "Default" : {
+      "comment" : "Default emoji skin-tone option.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认"
+          }
+        }
+      }
+    },
+    "Degrees" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "度"
+          }
+        }
+      }
+    },
+    "Delete All Entries" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除所有条目"
+          }
+        }
+      }
+    },
+    "Delete Entry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除条目"
+          }
+        }
+      }
+    },
+    "Deselect All" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消全选"
+          }
+        }
+      }
+    },
+    "Digital Storage" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数字存储"
+          }
+        }
+      }
+    },
+    "Dimensions" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尺寸"
+          }
+        }
+      }
+    },
+    "Disabled Applications" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已禁用的应用"
+          }
+        }
+      }
+    },
+    "Division by a unit value is not supported." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支持除以带单位的值。"
+          }
+        }
+      }
+    },
+    "Division of temperature values is not supported." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支持温度值之间的除法。"
+          }
+        }
+      }
+    },
+    "Do math, convert units, or search your past calculations…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进行计算、单位换算或搜索历史计算…"
+          }
+        }
+      }
+    },
+    "Does Nothing" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不执行任何操作"
+          }
+        }
+      }
+    },
+    "Earlier" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更早"
+          }
+        }
+      }
+    },
+    "Email" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电子邮件"
+          }
+        }
+      }
+    },
+    "Emoji & Symbols" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表情与符号"
+          }
+        }
+      }
+    },
+    "Emoji skin tone" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表情肤色"
+          }
+        }
+      }
+    },
+    "Emoji Skin Tone" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表情肤色"
+          }
+        }
+      }
+    },
+    "Enable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用"
+          }
+        }
+      }
+    },
+    "Enable Pasting" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用粘贴"
+          }
+        }
+      }
+    },
+    "Entries older than this are deleted automatically." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超过此时限的条目会自动删除。"
+          }
+        }
+      }
+    },
+    "Everything's ready. Hit Get Started to open the launcher." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一切准备就绪。点按“开始使用”打开启动器。"
+          }
+        }
+      }
+    },
+    "Exchange Rates" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "汇率"
+          }
+        }
+      }
+    },
+    "Exchange rates unavailable — check your connection." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "汇率不可用，请检查网络连接。"
+          }
+        }
+      }
+    },
+    "Export Failed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出失败"
+          }
+        }
+      }
+    },
+    "Export Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出设置"
+          }
+        }
+      }
+    },
+    "Export your settings, restore a backup, or import from Raycast." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出设置、恢复备份或从 Raycast 导入。"
+          }
+        }
+      }
+    },
+    "Export…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出…"
+          }
+        }
+      }
+    },
+    "Expression" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表达式"
+          }
+        }
+      }
+    },
+    "Fahrenheit" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "华氏度"
+          }
+        }
+      }
+    },
+    "Favorites" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收藏"
+          }
+        }
+      }
+    },
+    "Feet" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英尺"
+          }
+        }
+      }
+    },
+    "Feet per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英尺/秒"
+          }
+        }
+      }
+    },
+    "Flags" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旗帜"
+          }
+        }
+      }
+    },
+    "Fluid Ounces" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "液量盎司"
+          }
+        }
+      }
+    },
+    "Folders searched when indexing applications." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立应用索引时搜索的文件夹。"
+          }
+        }
+      }
+    },
+    "Food & Drink" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美食佳饮"
+          }
+        }
+      }
+    },
+    "Forever" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永久"
+          }
+        }
+      }
+    },
+    "Frequently Used" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常用"
+          }
+        }
+      }
+    },
+    "Gallons" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加仑"
+          }
+        }
+      }
+    },
+    "General" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通用"
+          }
+        }
+      }
+    },
+    "Get Started" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始使用"
+          }
+        }
+      }
+    },
+    "Gibibytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "吉比字节"
+          }
+        }
+      }
+    },
+    "Gigabits per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "吉比特/秒"
+          }
+        }
+      }
+    },
+    "Gigabytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千兆字节"
+          }
+        }
+      }
+    },
+    "Global Shortcuts" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局快捷键"
+          }
+        }
+      }
+    },
+    "Global shortcuts and startup behaviour." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局快捷键和启动行为。"
+          }
+        }
+      }
+    },
+    "Gradians" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百分度"
+          }
+        }
+      }
+    },
+    "Grams" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克"
+          }
+        }
+      }
+    },
+    "Grant access" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授予权限"
+          }
+        }
+      }
+    },
+    "Grant Access" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授予权限"
+          }
+        }
+      }
+    },
+    "Grant Access…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授予权限…"
+          }
+        }
+      }
+    },
+    "Granted" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已授予"
+          }
+        }
+      }
+    },
+    "Hectares" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公顷"
+          }
+        }
+      }
+    },
+    "Hectopascals" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百帕"
+          }
+        }
+      }
+    },
+    "Hexadecimal" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "十六进制"
+          }
+        }
+      }
+    },
+    "History" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "历史记录"
+          }
+        }
+      }
+    },
+    "Hours" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小时"
+          }
+        }
+      }
+    },
+    "Hyper Key" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hyper Key"
+          }
+        }
+      }
+    },
+    "Hyper Key shortcuts will be shown in Tinycast with ✦." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 会用 ✦ 显示 Hyper Key 快捷键。"
+          }
+        }
+      }
+    },
+    "Hyper Key will remap to the %@ modifier keys." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hyper Key 将重新映射为 %@ 修饰键。"
+          }
+        }
+      }
+    },
+    "If you enjoy my work and would like to support me or buy me Brave Origin, feel free to reach out on Discord, X, or via email." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果你喜欢我的作品并想支持我，或请我喝杯 Brave Origin，欢迎通过 Discord、X 或电子邮件联系我。"
+          }
+        }
+      }
+    },
+    "Image" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片"
+          }
+        }
+      }
+    },
+    "Immediately" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即"
+          }
+        }
+      }
+    },
+    "Import" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入"
+          }
+        }
+      }
+    },
+    "Import Failed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入失败"
+          }
+        }
+      }
+    },
+    "Import from Raycast" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Raycast 导入"
+          }
+        }
+      }
+    },
+    "Import Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入设置"
+          }
+        }
+      }
+    },
+    "Import…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入…"
+          }
+        }
+      }
+    },
+    "Imported %lld clipboard entries." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已导入 %lld 条剪贴板记录。"
+          }
+        }
+      }
+    },
+    "Imported 1 clipboard entry." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已导入 1 条剪贴板记录。"
+          }
+        }
+      }
+    },
+    "Importing…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在导入…"
+          }
+        }
+      }
+    },
+    "Inches" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英寸"
+          }
+        }
+      }
+    },
+    "Include Shift (⇧)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含 Shift 键（⇧）"
+          }
+        }
+      }
+    },
+    "Incorrect passphrase, or the file is corrupted." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码短语不正确，或文件已损坏。"
+          }
+        }
+      }
+    },
+    "Information" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信息"
+          }
+        }
+      }
+    },
+    "Join the Tinycast community" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入 Tinycast 社区"
+          }
+        }
+      }
+    },
+    "Keep history for" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "历史记录保留时间"
+          }
+        }
+      }
+    },
+    "Keep the Tinycast icon in the menu bar. Shortcuts still work when hidden." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在菜单栏中显示 Tinycast 图标。隐藏后快捷键仍然有效。"
+          }
+        }
+      }
+    },
+    "Kelvin" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开尔文"
+          }
+        }
+      }
+    },
+    "Kibibytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千比字节"
+          }
+        }
+      }
+    },
+    "Kilobits per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千比特/秒"
+          }
+        }
+      }
+    },
+    "Kilobytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千字节"
+          }
+        }
+      }
+    },
+    "Kilograms" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千克"
+          }
+        }
+      }
+    },
+    "Kilometers" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千米"
+          }
+        }
+      }
+    },
+    "Kilometers per Hour" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千米/小时"
+          }
+        }
+      }
+    },
+    "Kilopascals" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "千帕"
+          }
+        }
+      }
+    },
+    "Knots" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "节"
+          }
+        }
+      }
+    },
+    "Launch at login" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录时启动"
+          }
+        }
+      }
+    },
+    "Learned ranking" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自适应排序"
+          }
+        }
+      }
+    },
+    "Length" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "长度"
+          }
+        }
+      }
+    },
+    "Let Tinycast paste items back into the app you were using." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许 Tinycast 将内容粘贴回你正在使用的应用。"
+          }
+        }
+      }
+    },
+    "Lets Tinycast paste a clipboard item into the app you were using." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许 Tinycast 将剪贴板内容粘贴到你正在使用的应用中。"
+          }
+        }
+      }
+    },
+    "Light" : {
+      "comment" : "Light emoji skin tone, not interface appearance.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浅色"
+          }
+        }
+      }
+    },
+    "Links" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "链接"
+          }
+        }
+      }
+    },
+    "Liters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "升"
+          }
+        }
+      }
+    },
+    "Loading emoji…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在载入表情符号…"
+          }
+        }
+      }
+    },
+    "Manage in System Settings" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在系统设置中管理"
+          }
+        }
+      }
+    },
+    "Math" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数学"
+          }
+        }
+      }
+    },
+    "Mebibytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "兆比字节"
+          }
+        }
+      }
+    },
+    "Medium" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中等"
+          }
+        }
+      }
+    },
+    "Medium Dark" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中深"
+          }
+        }
+      }
+    },
+    "Medium Light" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中浅"
+          }
+        }
+      }
+    },
+    "Megabits per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "兆比特/秒"
+          }
+        }
+      }
+    },
+    "Megabytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "兆字节"
+          }
+        }
+      }
+    },
+    "Menu-bar icon" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单栏图标"
+          }
+        }
+      }
+    },
+    "Meters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "米"
+          }
+        }
+      }
+    },
+    "Meters per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "米/秒"
+          }
+        }
+      }
+    },
+    "Miles" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英里"
+          }
+        }
+      }
+    },
+    "Miles per Hour" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英里/小时"
+          }
+        }
+      }
+    },
+    "Millibar" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毫巴"
+          }
+        }
+      }
+    },
+    "Milligrams" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毫克"
+          }
+        }
+      }
+    },
+    "Milliliters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毫升"
+          }
+        }
+      }
+    },
+    "Millimeters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毫米"
+          }
+        }
+      }
+    },
+    "Millimeters of Mercury" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毫米汞柱"
+          }
+        }
+      }
+    },
+    "Milliseconds" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毫秒"
+          }
+        }
+      }
+    },
+    "Minutes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分钟"
+          }
+        }
+      }
+    },
+    "Miscellaneous" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        }
+      }
+    },
+    "Multiplication of two unit values is not supported." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支持两个带单位的值相乘。"
+          }
+        }
+      }
+    },
+    "No apps found" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到应用"
+          }
+        }
+      }
+    },
+    "No calculations yet" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无计算记录"
+          }
+        }
+      }
+    },
+    "No emoji found" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到表情符号"
+          }
+        }
+      }
+    },
+    "No exchange rate for %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有 %@ 的汇率。"
+          }
+        }
+      }
+    },
+    "No matches for “%@”." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有与“%@”匹配的结果。"
+          }
+        }
+      }
+    },
+    "No matching calculations" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的计算记录"
+          }
+        }
+      }
+    },
+    "None" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无"
+          }
+        }
+      }
+    },
+    "Not granted" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未授予"
+          }
+        }
+      }
+    },
+    "Not Now" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂不"
+          }
+        }
+      }
+    },
+    "Nothing here yet." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这里暂时没有内容。"
+          }
+        }
+      }
+    },
+    "Nothing to import from this file." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件中没有可导入的内容。"
+          }
+        }
+      }
+    },
+    "Objects" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "物体"
+          }
+        }
+      }
+    },
+    "Octal" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "八进制"
+          }
+        }
+      }
+    },
+    "Open %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 %@"
+          }
+        }
+      }
+    },
+    "Open Application" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开应用"
+          }
+        }
+      }
+    },
+    "Open Command" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行命令"
+          }
+        }
+      }
+    },
+    "Open Settings…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开设置…"
+          }
+        }
+      }
+    },
+    "Open System Setting" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开系统设置"
+          }
+        }
+      }
+    },
+    "Open the clipboard history browser." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开剪贴板历史记录。"
+          }
+        }
+      }
+    },
+    "Open the launcher as a slim search bar that expands into the full list as you type." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以精简搜索栏打开启动器，并在输入时展开完整列表。"
+          }
+        }
+      }
+    },
+    "Open…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开…"
+          }
+        }
+      }
+    },
+    "Opens Privacy & Security › Accessibility." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开“隐私与安全性”›“辅助功能”。"
+          }
+        }
+      }
+    },
+    "Optional — you can enable this later in Settings › Permissions." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可选，你也可以稍后在“设置”›“权限”中启用。"
+          }
+        }
+      }
+    },
+    "Optional — you can import later in Settings › Backup." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可选，你也可以稍后在“设置”›“备份”中导入。"
+          }
+        }
+      }
+    },
+    "Options that don't belong to a single feature." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不属于单一功能的其他选项。"
+          }
+        }
+      }
+    },
+    "Ounces" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "盎司"
+          }
+        }
+      }
+    },
+    "Pascals" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帕"
+          }
+        }
+      }
+    },
+    "Passphrase" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码短语"
+          }
+        }
+      }
+    },
+    "Paste" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴"
+          }
+        }
+      }
+    },
+    "Paste & Keep Window Open" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴并保持窗口打开"
+          }
+        }
+      }
+    },
+    "Paste to %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴到 %@"
+          }
+        }
+      }
+    },
+    "Permanently remove every saved clip and image." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永久移除所有已保存的剪贴内容和图片。"
+          }
+        }
+      }
+    },
+    "Permissions" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "权限"
+          }
+        }
+      }
+    },
+    "Petabytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拍字节"
+          }
+        }
+      }
+    },
+    "Pin Entry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定条目"
+          }
+        }
+      }
+    },
+    "Pin favorite app icons to the right of the compact bar (⌘1–⌘5 to launch)." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将收藏的应用图标固定在紧凑栏右侧（按 ⌘1–⌘5 启动）。"
+          }
+        }
+      }
+    },
+    "Pinned" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已固定"
+          }
+        }
+      }
+    },
+    "Pints" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "品脱"
+          }
+        }
+      }
+    },
+    "Pop to root" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回根搜索"
+          }
+        }
+      }
+    },
+    "Pop to Root Search" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回根搜索"
+          }
+        }
+      }
+    },
+    "Pounds" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磅"
+          }
+        }
+      }
+    },
+    "Press %@ anytime to start using Tinycast." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "随时按 %@ 即可开始使用 Tinycast。"
+          }
+        }
+      }
+    },
+    "Press this shortcut to open Tinycast." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按下此快捷键以打开 Tinycast。"
+          }
+        }
+      }
+    },
+    "Pressing %@ will trigger the left %@ modifier keys." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按下 %@ 将触发左侧的 %@ 修饰键。"
+          }
+        }
+      }
+    },
+    "Pressure" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "压力"
+          }
+        }
+      }
+    },
+    "Provider" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务提供方"
+          }
+        }
+      }
+    },
+    "PSI" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磅力/平方英寸"
+          }
+        }
+      }
+    },
+    "Quarts" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "夸脱"
+          }
+        }
+      }
+    },
+    "Quick Press" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速按下"
+          }
+        }
+      }
+    },
+    "Quit %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 %@"
+          }
+        }
+      }
+    },
+    "Quit %lld applications?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 %lld 个应用？"
+          }
+        }
+      }
+    },
+    "Quit 1 application?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 1 个应用？"
+          }
+        }
+      }
+    },
+    "Quit All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部退出"
+          }
+        }
+      }
+    },
+    "Quit All Applications" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出所有应用"
+          }
+        }
+      }
+    },
+    "Quit Application" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出应用"
+          }
+        }
+      }
+    },
+    "Quit Raycast" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Raycast"
+          }
+        }
+      }
+    },
+    "Quit Tinycast" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Tinycast"
+          }
+        }
+      }
+    },
+    "Radians" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弧度"
+          }
+        }
+      }
+    },
+    "Raycast Export" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raycast 导出文件"
+          }
+        }
+      }
+    },
+    "Raycast is running — quit it to avoid hotkey conflicts." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raycast 正在运行，请退出以避免快捷键冲突。"
+          }
+        }
+      }
+    },
+    "Re-run the first-launch setup: shortcut, permissions, and Raycast import." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新运行首次启动设置：快捷键、权限和 Raycast 导入。"
+          }
+        }
+      }
+    },
+    "Record Shortcut" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录制快捷键"
+          }
+        }
+      }
+    },
+    "Remove from Favorites" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从收藏中移除"
+          }
+        }
+      }
+    },
+    "Replace occurrences of %@ with ✦" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 %@ 替换为 ✦"
+          }
+        }
+      }
+    },
+    "Reset learned launcher ranking?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置自适应排序？"
+          }
+        }
+      }
+    },
+    "Reset Ranking" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置自适应排序"
+          }
+        }
+      }
+    },
+    "Reset to the launcher this long after the window closes." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口关闭达到此时长后返回启动器。"
+          }
+        }
+      }
+    },
+    "Reset…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置…"
+          }
+        }
+      }
+    },
+    "Restore Defaults" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复默认值"
+          }
+        }
+      }
+    },
+    "Restore from a Tinycast backup. Only values in the file are changed." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Tinycast 备份恢复。只会更改文件中包含的值。"
+          }
+        }
+      }
+    },
+    "Result" : {
+      "comment" : "Badge below the calculator's output column.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "结果"
+          }
+        }
+      }
+    },
+    "Results" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "结果"
+          }
+        }
+      }
+    },
+    "Right Command (⌘)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右 Command 键（⌘）"
+          }
+        }
+      }
+    },
+    "Right Control (⌃)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右 Control 键（⌃）"
+          }
+        }
+      }
+    },
+    "Right Option (⌥)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右 Option 键（⌥）"
+          }
+        }
+      }
+    },
+    "Right Shift (⇧)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右 Shift 键（⇧）"
+          }
+        }
+      }
+    },
+    "Save your shortcuts, favorites, and preferences to a JSON file." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将快捷键、收藏和偏好设置保存到 JSON 文件。"
+          }
+        }
+      }
+    },
+    "Search" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索"
+          }
+        }
+      }
+    },
+    "Search applications…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索应用…"
+          }
+        }
+      }
+    },
+    "Search apps…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索应用…"
+          }
+        }
+      }
+    },
+    "Search commands…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索命令…"
+          }
+        }
+      }
+    },
+    "Search Emoji & Symbols" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索表情与符号"
+          }
+        }
+      }
+    },
+    "Search emoji and symbols, and paste them into any app." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索表情与符号，并粘贴到任意应用中。"
+          }
+        }
+      }
+    },
+    "Search emoji and symbols…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索表情与符号…"
+          }
+        }
+      }
+    },
+    "Search for apps and commands…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索应用和命令…"
+          }
+        }
+      }
+    },
+    "Search Scopes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索范围"
+          }
+        }
+      }
+    },
+    "Search System Settings…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索系统设置…"
+          }
+        }
+      }
+    },
+    "Seconds" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秒"
+          }
+        }
+      }
+    },
+    "Select a physical key to remap to the %@ modifier keys simultaneously." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择一个实体按键，同时重新映射为 %@ 修饰键。"
+          }
+        }
+      }
+    },
+    "Select All" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全选"
+          }
+        }
+      }
+    },
+    "Select an action to perform when %@ is pressed without any other keys." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择单独按下 %@ 时执行的操作。"
+          }
+        }
+      }
+    },
+    "Set a shortcut to summon the launcher from anywhere." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置一个可在任意位置呼出启动器的快捷键。"
+          }
+        }
+      }
+    },
+    "Settings" : {
+      "comment" : "The app's Settings window or command.",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置"
+          }
+        }
+      }
+    },
+    "Settings Imported" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置已导入"
+          }
+        }
+      }
+    },
+    "Settings..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置…"
+          }
+        }
+      }
+    },
+    "Shapes & Punctuation" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "形状与标点"
+          }
+        }
+      }
+    },
+    "Shortcut" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快捷键"
+          }
+        }
+      }
+    },
+    "Shortcuts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快捷键"
+          }
+        }
+      }
+    },
+    "Shortcuts containing the Hyper Key modifiers are shown with ✦." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含 Hyper Key 修饰键的快捷键会显示为 ✦。"
+          }
+        }
+      }
+    },
+    "Show all  ⌘%lld" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示全部  ⌘%lld"
+          }
+        }
+      }
+    },
+    "Show favorites in compact mode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在紧凑模式中显示收藏"
+          }
+        }
+      }
+    },
+    "Show Hyper Key as ✦" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 Hyper Key 显示为 ✦"
+          }
+        }
+      }
+    },
+    "Show in Finder" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Finder 中显示"
+          }
+        }
+      }
+    },
+    "Show in launcher" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在启动器中显示"
+          }
+        }
+      }
+    },
+    "Show in menu bar" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在菜单栏中显示"
+          }
+        }
+      }
+    },
+    "Show…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示…"
+          }
+        }
+      }
+    },
+    "Size" : {
+      "comment" : "File size in the clipboard item's information panel.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
+          }
+        }
+      }
+    },
+    "Skip" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳过"
+          }
+        }
+      }
+    },
+    "Smileys & People" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "笑脸与人物"
+          }
+        }
+      }
+    },
+    "Source" : {
+      "comment" : "Source application in clipboard item information.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源"
+          }
+        }
+      }
+    },
+    "Speed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "速度"
+          }
+        }
+      }
+    },
+    "Square Centimeters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方厘米"
+          }
+        }
+      }
+    },
+    "Square Feet" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方英尺"
+          }
+        }
+      }
+    },
+    "Square Inches" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方英寸"
+          }
+        }
+      }
+    },
+    "Square Kilometers" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方千米"
+          }
+        }
+      }
+    },
+    "Square Meters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方米"
+          }
+        }
+      }
+    },
+    "Square Miles" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方英里"
+          }
+        }
+      }
+    },
+    "Square Millimeters" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方毫米"
+          }
+        }
+      }
+    },
+    "Square Yards" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平方码"
+          }
+        }
+      }
+    },
+    "Start Tinycast automatically when you log in." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录时自动启动 Tinycast。"
+          }
+        }
+      }
+    },
+    "Summon the emoji and symbols palette." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "呼出表情与符号面板。"
+          }
+        }
+      }
+    },
+    "Summon the fuzzy app launcher." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "呼出模糊搜索应用启动器。"
+          }
+        }
+      }
+    },
+    "Symbols" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符号"
+          }
+        }
+      }
+    },
+    "System Setting" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统设置"
+          }
+        }
+      }
+    },
+    "System Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统设置"
+          }
+        }
+      }
+    },
+    "Tablespoons" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "汤匙"
+          }
+        }
+      }
+    },
+    "Teaspoons" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "茶匙"
+          }
+        }
+      }
+    },
+    "Tebibytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "太比字节"
+          }
+        }
+      }
+    },
+    "Temperature" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "温度"
+          }
+        }
+      }
+    },
+    "Terabits per Second" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "太比特/秒"
+          }
+        }
+      }
+    },
+    "Terabytes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "太字节"
+          }
+        }
+      }
+    },
+    "Text" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本"
+          }
+        }
+      }
+    },
+    "The password you set when exporting from Raycast." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出 Raycast 配置时设置的密码。"
+          }
+        }
+      }
+    },
+    "The Raycast export could not be read." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法读取 Raycast 导出文件。"
+          }
+        }
+      }
+    },
+    "This can't be undone." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作无法撤销。"
+          }
+        }
+      }
+    },
+    "This doesn't look like a Raycast export (.rayconfig)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这似乎不是 Raycast 导出文件（.rayconfig）。"
+          }
+        }
+      }
+    },
+    "This location no longer exists." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此位置已不存在。"
+          }
+        }
+      }
+    },
+    "This Month" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本月"
+          }
+        }
+      }
+    },
+    "This Week" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本周"
+          }
+        }
+      }
+    },
+    "Time" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时间"
+          }
+        }
+      }
+    },
+    "Tinycast downloads exchange rates from %@ once a day and keeps a copy on your Mac. No account, no identifiers, nothing you type. Turning it off deletes the cached rates." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 每天从 %@ 下载一次汇率并在你的 Mac 上保留副本。无需账户，不会发送标识符或你输入的任何内容。关闭后会删除缓存的汇率。"
+          }
+        }
+      }
+    },
+    "Tinycast is ready. Set a shortcut in Settings to summon it." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 已准备就绪。请在“设置”中设置呼出快捷键。"
+          }
+        }
+      }
+    },
+    "Tinycast needs Accessibility access to remap keys." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 需要辅助功能权限才能重新映射按键。"
+          }
+        }
+      }
+    },
+    "Tinycast privately learns which results you choose for each query. Reset all learned choices to restore the default order." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 会在本机自适应学习你对每次搜索选择的结果。重置后将恢复默认顺序。"
+          }
+        }
+      }
+    },
+    "Tinycast will relearn your preferred results as you use the launcher." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinycast 会在你使用启动器时重新进行自适应排序。"
+          }
+        }
+      }
+    },
+    "Tip: unset the matching Raycast shortcuts to avoid conflicts." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示：请取消对应的 Raycast 快捷键以避免冲突。"
+          }
+        }
+      }
+    },
+    "Today" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今天"
+          }
+        }
+      }
+    },
+    "Torr" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托"
+          }
+        }
+      }
+    },
+    "Travel & Places" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旅行与地点"
+          }
+        }
+      }
+    },
+    "Trigger Caps Lock (⇪)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触发大写锁定键（⇪）"
+          }
+        }
+      }
+    },
+    "Trigger Escape" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触发 Esc 键"
+          }
+        }
+      }
+    },
+    "Turn on currency conversion?" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用货币换算？"
+          }
+        }
+      }
+    },
+    "Turns" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圈"
+          }
+        }
+      }
+    },
+    "Type" : {
+      "comment" : "Clipboard content type in the information panel.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "类型"
+          }
+        }
+      }
+    },
+    "Type shortcut…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按下快捷键…"
+          }
+        }
+      }
+    },
+    "Type to filter entries…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入以筛选条目…"
+          }
+        }
+      }
+    },
+    "Unpin Entry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消固定条目"
+          }
+        }
+      }
+    },
+    "Update Now" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即更新"
+          }
+        }
+      }
+    },
+    "Updating…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新…"
+          }
+        }
+      }
+    },
+    "Used by %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已被 %@ 使用"
+          }
+        }
+      }
+    },
+    "Version %@ (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本 %1$@（%2$@）"
+          }
+        }
+      }
+    },
+    "Volume" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "体积"
+          }
+        }
+      }
+    },
+    "Website" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网站"
+          }
+        }
+      }
+    },
+    "Weeks" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周"
+          }
+        }
+      }
+    },
+    "Weight" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重量"
+          }
+        }
+      }
+    },
+    "Welcome Guide" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欢迎指南"
+          }
+        }
+      }
+    },
+    "Welcome to Tinycast" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欢迎使用 Tinycast"
+          }
+        }
+      }
+    },
+    "Without it Tinycast can still copy, but it can't paste a clipboard or emoji item back into the app you were using." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有此权限，Tinycast 仍可复制内容，但无法将剪贴板或表情内容粘贴回你正在使用的应用。"
+          }
+        }
+      }
+    },
+    "Words" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字数"
+          }
+        }
+      }
+    },
+    "Yards" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "码"
+          }
+        }
+      }
+    },
+    "Yesterday" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昨天"
+          }
+        }
+      }
+    },
+    "You can change these anytime in Settings." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你可以随时在“设置”中更改这些选项。"
+          }
+        }
+      }
+    },
+    "You're all set" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一切准备就绪"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tools/localization-test.swift
+++ b/Tools/localization-test.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+struct StringUnit: Decodable {
+    let state: String
+    let value: String
+}
+
+struct Localization: Decodable {
+    let stringUnit: StringUnit?
+}
+
+struct CatalogEntry: Decodable {
+    let comment: String?
+    let localizations: [String: Localization]?
+    let shouldTranslate: Bool?
+}
+
+struct Catalog: Decodable {
+    let sourceLanguage: String
+    let strings: [String: CatalogEntry]
+    let version: String
+}
+
+let catalogURL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("Tinycast/Localizable.xcstrings")
+let catalog = try JSONDecoder().decode(Catalog.self, from: Data(contentsOf: catalogURL))
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+    exit(1)
+}
+
+guard catalog.sourceLanguage == "en" else { fail("sourceLanguage must be en") }
+guard catalog.version == "1.0" else { fail("unsupported catalog version \(catalog.version)") }
+guard catalog.strings.count >= 250 else {
+    fail("catalog unexpectedly small (\(catalog.strings.count) entries)")
+}
+
+let formatPattern = try NSRegularExpression(
+    pattern: #"%(?:\d+\$)?(?:lld|llu|ld|lu|d|u|f|g|@)"#)
+
+func placeholders(in string: String) -> [String] {
+    let range = NSRange(string.startIndex..., in: string)
+    return formatPattern.matches(in: string, range: range).compactMap { match in
+        guard let swiftRange = Range(match.range, in: string) else { return nil }
+        return String(string[swiftRange]).replacingOccurrences(
+            of: #"%\d+\$"#, with: "%", options: .regularExpression)
+    }.sorted()
+}
+
+for (key, entry) in catalog.strings.sorted(by: { $0.key < $1.key }) {
+    if entry.shouldTranslate == false { continue }
+    guard let chinese = entry.localizations?["zh-Hans"]?.stringUnit else {
+        fail("missing zh-Hans translation for \(key)")
+    }
+    guard chinese.state == "translated", !chinese.value.trimmingCharacters(in: .whitespaces).isEmpty
+    else { fail("unfinished zh-Hans translation for \(key)") }
+    guard placeholders(in: key) == placeholders(in: chinese.value) else {
+        fail("placeholder mismatch for \(key): \(chinese.value)")
+    }
+}
+
+let required = [
+    "Accessibility", "Actions", "Clipboard history is empty", "Copy Answer",
+    "Exchange rates unavailable — check your connection.", "No apps found", "Not granted",
+    "Paste to %@", "Permissions", "Quit %lld applications?", "Search for apps and commands…",
+    "Settings", "This can't be undone.", "Welcome to Tinycast",
+]
+for key in required where catalog.strings[key] == nil { fail("missing required key \(key)") }
+
+let commentRequired = ["Actions", "Currency", "Default", "Light", "Result", "Size", "Source", "Type"]
+for key in commentRequired {
+    guard let comment = catalog.strings[key]?.comment, !comment.isEmpty else {
+        fail("ambiguous key needs a developer comment: \(key)")
+    }
+}
+
+let repositoryURL = catalogURL.deletingLastPathComponent().deletingLastPathComponent()
+let sourceURL = repositoryURL.appendingPathComponent("Tinycast")
+let visibleLiteralPatterns = [
+    #"\b(?:Text|Button|Label|Picker|Toggle|SecureField|TextField|SettingsCard|PopoverMenuItem|InfoRow|caption)\s*\(\s*(?:(?:title|label):\s*)?\"((?:\\.|[^\"\\])*)\""#,
+    #"\b(?:title|subtitle|header|message):\s*\"((?:\\.|[^\"\\])*)\""#,
+    #"\.init\([^\n]*\blabel:\s*\"((?:\\.|[^\"\\])*)\""#,
+    #"\.help\s*\(\s*\"((?:\\.|[^\"\\])*)\""#,
+    #"String\s*\(\s*localized:\s*\"((?:\\.|[^\"\\])*)\""#,
+    #"UnitDef\s*\(\s*\"[^\"]+\"\s*,\s*\"((?:\\.|[^\"\\])*)\""#,
+].map { try! NSRegularExpression(pattern: $0) }
+
+let sourceFiles = FileManager.default.enumerator(
+    at: sourceURL, includingPropertiesForKeys: nil
+)!.compactMap { $0 as? URL }.filter {
+    $0.pathExtension == "swift" && !$0.lastPathComponent.hasSuffix(".generated.swift")
+}
+
+var missingSourceKeys: [String] = []
+var checkedInterpolatedKeys = 0
+
+func decodeFragment(_ raw: String) -> String? {
+    try? JSONDecoder().decode(String.self, from: Data("\"\(raw)\"".utf8))
+}
+
+func catalogKey(for raw: String) -> String? {
+    guard raw.contains(#"\("#) else {
+        guard let key = decodeFragment(raw) else { return nil }
+        return catalog.strings[key] == nil ? nil : key
+    }
+
+    var fragments: [String] = []
+    var current = ""
+    var index = raw.startIndex
+    while index < raw.endIndex {
+        let next = raw.index(after: index)
+        if raw[index] == "\\", next < raw.endIndex, raw[next] == "(" {
+            fragments.append(current)
+            current = ""
+            var depth = 1
+            index = raw.index(after: next)
+            while index < raw.endIndex, depth > 0 {
+                if raw[index] == "(" { depth += 1 }
+                if raw[index] == ")" { depth -= 1 }
+                index = raw.index(after: index)
+            }
+            guard depth == 0 else { return nil }
+        } else {
+            current.append(raw[index])
+            index = next
+        }
+    }
+    fragments.append(current)
+    var decoded: [String] = []
+    for fragment in fragments {
+        guard let value = decodeFragment(fragment) else { return nil }
+        decoded.append(value)
+    }
+
+    let placeholder = #"%(?:\d+\$)?(?:lld|llu|ld|lu|d|u|f|g|@)"#
+    let pattern = "^" + decoded.map(NSRegularExpression.escapedPattern(for:))
+        .joined(separator: placeholder) + "$"
+    guard let expression = try? NSRegularExpression(pattern: pattern) else { return nil }
+    let matches = catalog.strings.keys.filter { key in
+        expression.firstMatch(
+            in: key, range: NSRange(key.startIndex..., in: key)) != nil
+    }
+    return matches.count == 1 ? matches[0] : nil
+}
+
+let interpolationChecks: [(raw: String, key: String)] = [
+    (#"Paste to \(name)"#, "Paste to %@"),
+    (#"Quit \(count) applications?"#, "Quit %lld applications?"),
+    (#"Version \(short) (\(build))"#, "Version %@ (%@)"),
+]
+for check in interpolationChecks {
+    guard catalogKey(for: check.raw) == check.key else {
+        fail("could not normalize interpolated source key: \(check.raw)")
+    }
+}
+guard catalogKey(for: #"__missing_localization_probe__ \(value)"#) == nil else {
+    fail("missing interpolated catalog keys must be rejected")
+}
+
+for file in sourceFiles {
+    let source = try String(contentsOf: file, encoding: .utf8)
+    let fullRange = NSRange(source.startIndex..., in: source)
+    for pattern in visibleLiteralPatterns {
+        for match in pattern.matches(in: source, range: fullRange) {
+            guard let range = Range(match.range(at: 1), in: source) else { continue }
+            let raw = String(source[range])
+            guard !raw.isEmpty else { continue }
+            if raw.contains(#"\("#) { checkedInterpolatedKeys += 1 }
+            guard catalogKey(for: raw) == nil else { continue }
+            let line = source[..<range.lowerBound].reduce(into: 1) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            let relative = file.path.replacingOccurrences(of: repositoryURL.path + "/", with: "")
+            missingSourceKeys.append("\(relative):\(line): \(raw)")
+        }
+    }
+}
+guard missingSourceKeys.isEmpty else {
+    fail("user-visible source keys missing from catalog:\n" + missingSourceKeys.sorted().joined(separator: "\n"))
+}
+
+let translatedCount = catalog.strings.values.filter { $0.shouldTranslate != false }.count
+print(
+    "PASS: \(translatedCount) English keys have complete zh-Hans translations; "
+        + "source keys covered (\(checkedInterpolatedKeys) interpolated)")

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,7 @@ swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.
     -o /tmp/clipboard-test && /tmp/clipboard-test                 # clipboard store
 swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift \
     -o /tmp/scopes-test && /tmp/scopes-test                       # launcher search scopes
+swift Tools/localization-test.swift                               # localization completeness
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —

--- a/project.yml
+++ b/project.yml
@@ -18,6 +18,7 @@ settings:
     CODE_SIGN_IDENTITY: "Tinycast Self-Signed"
     ENABLE_HARDENED_RUNTIME: NO
     SWIFT_STRICT_CONCURRENCY: complete
+    SWIFT_EMIT_LOC_STRINGS: YES
   configs:
     Release:
       # Strip the shipped binary (dSYM is still generated first) and drop unused code.


### PR DESCRIPTION
## Summary

This establishes Tinycast's native localization foundation for the current 2026 SwiftUI and macOS 26 toolchain. It is an application-wide framework, not a small set of translated labels.

- Add an English-source Apple String Catalog with complete Simplified Chinese (`zh-Hans`) coverage for 408 translatable keys.
- Use SwiftUI's localization-aware initializers and Foundation's `String(localized:)` / `LocalizedStringResource` path for view, model, AppKit, error, and interpolated text.
- Add `DisplayText` to make the boundary between catalog keys and runtime or user-provided content explicit in generic UI components.
- Localize launcher, clipboard, emoji, settings, onboarding, permissions, backup/import, menu, and calculator surfaces, including unit, currency, date/time, plural-like count, and structured error output.
- Enable compiler localization extraction with `SWIFT_EMIT_LOC_STRINGS` and keep the generated Xcode project in sync with `project.yml`.
- Document how contributors can add more languages without adding a parallel in-app language system.

The implementation uses only Apple platform facilities and adds no third-party dependencies.

## Integrity checks

`Tools/localization-test.swift` verifies that:

- every translatable catalog entry has a completed `zh-Hans` value;
- source and translation format placeholders match;
- visible source literals and calculator unit names exist in the catalog;
- interpolated Swift source is normalized to catalog placeholders (`%@`, `%lld`, and related forms) instead of being skipped;
- missing interpolated catalog keys fail validation;
- ambiguous short keys retain translator comments.

## Validation

Command-line validation completed successfully:

- `swift Tools/localization-test.swift` — 408 complete English/zh-Hans keys; 58 interpolated source uses checked.
- `xcrun xcstringstool compile --dry-run --output-directory <tmp> Tinycast/Localizable.xcstrings`.
- `xcodegen generate`.
- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug -derivedDataPath <tmp> CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES build` — `BUILD SUCCEEDED`.
- `xcodebuild -exportLocalizations` with a fresh DerivedData directory, followed by catalog completeness validation.
- `swift Tools/fuzz-test.swift`.
- Launcher ranking harness — all passed.
- Calculator harness — 426/426 passed.
- Clipboard harness — 23/23 passed.
- Search scopes harness — all passed.
- `git diff --check`.
- Independent static review of the complete Simplified Chinese catalog — PASS.

Validation was command-line and static only; this PR does not claim GUI acceptance testing.

## Apple references

- [Localizing and varying text with a String Catalog](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog)
- [Preparing views for localization](https://developer.apple.com/documentation/swiftui/preparing-views-for-localization)
- [`LocalizedStringResource`](https://developer.apple.com/documentation/foundation/localizedstringresource)
