### PR TITLE
Add custom commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,10 @@ Never break these without an explicit task to do so.
   `Tools/clipboard-test.swift` can compile it standalone. `Core/LauncherRankingStore.swift` is the
   same deal for `Tools/ranking-test.swift` — Foundation only, with the clock injected via `now` and
   the store path via `fileURL`, as is `Core/SearchScopes.swift` for `Tools/scopes-test.swift`.
+  `Core/CustomCommand.swift` and `Core/ShellCommandRunner.swift` must likewise stay free of AppKit /
+  SwiftUI (Foundation plus Combine for `ObservableObject` and Darwin for `mkstemp`) so
+  `Tools/custom-command-test.swift` can compile them standalone — which is why the custom-command
+  confirmation gate lives in `AppCore` and not in the runner.
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there
 
 - **App launcher** — fuzzy-search and launch anything, pin favorites, see what's running, quit an app
   or every app at once.
+- **Custom commands** — run named shell commands through fuzzy search or their own global hotkeys.
 - **Calculator** — do math, unit and live currency conversions inline, right in the palette.
 - **Clipboard history** — text and images, searchable, pasted back into the app you were using.
 - **Global hotkey** — one shortcut summons the palette from anywhere.
@@ -59,7 +60,7 @@ Security → Accessibility**.
 1. Open **Settings → General** and record a global shortcut to summon Tinycast.
 2. Press it anywhere → the palette floats in. Type to filter, **↵** to launch.
 3. **Tab** switches between Apps and Clipboard; **↑/↓** move, **Esc** dismisses.
-4. **Settings → App Hotkeys** — search an app and record a shortcut to toggle it.
+4. **Settings → Shortcuts** — search an app or custom command and record a global shortcut.
 
 ## Building from source
 

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1F39D145DBE2290532C93614 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */; };
 		2085C9433B7534044E0A8A7D /* PermissionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C36D92A5018B9A7B33775DE /* PermissionsSettingsView.swift */; };
 		20C8E98F5BC0FDDB0F646F3D /* OverlayScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */; };
+		212B9B44D7EED18A0DEF47AF /* ShellCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286B7598B81017C746558C7C /* ShellCommandRunner.swift */; };
 		24842144273FF92228540DBE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */; };
 		32697AB3853D043A12888B96 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */; };
 		344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */; };
@@ -31,6 +32,7 @@
 		5568D02AE095293A15A7F30D /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9ACD504E016DFF6FE6C1B /* RightClick.swift */; };
 		57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */; };
 		649961AA51BA4D87626C27D5 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09093BF10EA97BDCA45A241F /* CalcFormatter.swift */; };
+		664D2BD485F3C5DB3F90B3C6 /* CustomCommandsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBF70B1C646861FDF20ED2D /* CustomCommandsSettingsView.swift */; };
 		68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B629EC3B716FEE881BB0075 /* TinycastApp.swift */; };
 		693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */; };
 		6962B8A2850A45401275F677 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */; };
@@ -66,6 +68,7 @@
 		B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */; };
 		BA76E53A12248B3A9C42B4F9 /* Bundle+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */; };
 		C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37CCD024267EB21876C7E9 /* AppDelegate.swift */; };
+		C526BEAA60A62E9BC78F309E /* CustomCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C105FED5D77A2392FDA3F0 /* CustomCommand.swift */; };
 		C7DD1345A6BFB1D9EB22FCEE /* RunningApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B432D84D8F9C10521342199 /* RunningApps.swift */; };
 		C8F4555ECA895F63A34A327C /* EmojiGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */; };
 		CFB516312C4694DDFD99DBCA /* SettingsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68952539C0BD045BA175CBB6 /* SettingsRootView.swift */; };
@@ -98,6 +101,7 @@
 		1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
+		286B7598B81017C746558C7C /* ShellCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellCommandRunner.swift; sourceTree = "<group>"; };
 		297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscellaneousSettingsView.swift; sourceTree = "<group>"; };
 		299122624B5E1BA2C5400478 /* CalcCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcCurrency.swift; sourceTree = "<group>"; };
 		2B629EC3B716FEE881BB0075 /* TinycastApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinycastApp.swift; sourceTree = "<group>"; };
@@ -140,6 +144,7 @@
 		8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
 		919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKeyTap.swift; sourceTree = "<group>"; };
 		93E9ACD504E016DFF6FE6C1B /* RightClick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClick.swift; sourceTree = "<group>"; };
+		95C105FED5D77A2392FDA3F0 /* CustomCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommand.swift; sourceTree = "<group>"; };
 		98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopesCard.swift; sourceTree = "<group>"; };
 		98B7211D27EDF764EC477A0F /* PopoverMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverMenu.swift; sourceTree = "<group>"; };
 		99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageThumbnail.swift; sourceTree = "<group>"; };
@@ -166,6 +171,7 @@
 		D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppName.swift"; sourceTree = "<group>"; };
 		D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
 		DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridGeometry.swift; sourceTree = "<group>"; };
+		DCBF70B1C646861FDF20ED2D /* CustomCommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandsSettingsView.swift; sourceTree = "<group>"; };
 		E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateTime.swift; sourceTree = "<group>"; };
 		EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		EDE0C0DC05F958A4B4DCAA8C /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
@@ -199,6 +205,7 @@
 				BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */,
 				5D57B0AE44D21035163BD422 /* CommandRegistry.swift */,
 				8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */,
+				95C105FED5D77A2392FDA3F0 /* CustomCommand.swift */,
 				33A13DB27EE627AC08051165 /* EdgeDissolve.swift */,
 				9FB750D045194AE34D39D792 /* FavoritesStore.swift */,
 				D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */,
@@ -216,6 +223,7 @@
 				4B432D84D8F9C10521342199 /* RunningApps.swift */,
 				9AA0E1FD530C764A021E6053 /* SearchScopes.swift */,
 				C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */,
+				286B7598B81017C746558C7C /* ShellCommandRunner.swift */,
 				7BC2DEA0A052116A92F9A539 /* Theme.swift */,
 				A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */,
 				825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */,
@@ -352,6 +360,7 @@
 			children = (
 				2FC323070A08CD17DFFB2F8A /* BackupSettingsView.swift */,
 				849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */,
+				DCBF70B1C646861FDF20ED2D /* CustomCommandsSettingsView.swift */,
 				041AB49DDB9CA53148BB8A46 /* EmojiSettingsView.swift */,
 				4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */,
 				297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */,
@@ -489,6 +498,8 @@
 				6D3DBE00FCB757C67669CFBA /* CommandRegistry.swift in Sources */,
 				AA8050D9A547CDDD37C581C4 /* CurrencyData.generated.swift in Sources */,
 				6CDCE462405648998CDF1E77 /* CurrencyRateStore.swift in Sources */,
+				C526BEAA60A62E9BC78F309E /* CustomCommand.swift in Sources */,
+				664D2BD485F3C5DB3F90B3C6 /* CustomCommandsSettingsView.swift in Sources */,
 				715F8A70F7A533D2EEEF6135 /* EdgeDissolve.swift in Sources */,
 				344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */,
 				B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */,
@@ -532,6 +543,7 @@
 				86D400D72735A8D0829029DE /* SettingsComponents.swift in Sources */,
 				4F3D96E59E117459153336F4 /* SettingsPaneScanner.swift in Sources */,
 				CFB516312C4694DDFD99DBCA /* SettingsRootView.swift in Sources */,
+				212B9B44D7EED18A0DEF47AF /* ShellCommandRunner.swift in Sources */,
 				57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */,
 				05561CD36EF1A0775A282165 /* ShortcutsSettingsView.swift in Sources */,
 				72ACD144841BF1117CD4E705 /* Theme.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -91,6 +91,7 @@ final class AppCore: ObservableObject {
 
     let launcherRanking: LauncherRankingStore
     let appIndex: AppIndex
+    let customCommands = CustomCommandStore()
     let clipboardStore = ClipboardStore()
     let clipboardManager: ClipboardManager
     let hotKeys = HotKeyManager()
@@ -128,6 +129,10 @@ final class AppCore: ObservableObject {
         clipboardManager.start()
 
         appIndex.start(settings: settings)
+        customCommands.onChange = { [weak self] commands in
+            self?.appIndex.setCustomCommands(commands)
+        }
+        appIndex.setCustomCommands(customCommands.commands)
         Task { await appIndex.refresh() }
         Task { await emojiIndex.load() }
         currencyRates.start()
@@ -135,7 +140,8 @@ final class AppCore: ObservableObject {
         hotKeys.onTogglePalette = { [weak self] in self?.togglePalette() }
         hotKeys.onToggleClipboard = { [weak self] in self?.toggleClipboard() }
         hotKeys.onToggleEmoji = { [weak self] in self?.toggleEmoji() }
-        hotKeys.start()
+        hotKeys.onRunCustomCommand = { [weak self] id in self?.runCustomCommand(id: id) }
+        hotKeys.start(customCommandIDs: Set(customCommands.commands.map(\.id)))
         // Deliberately keeps running while `hotKeys.recordingAction` pauses Carbon: the recorder relies on the tap's rewritten flags to capture Hyper shortcuts.
         hyperKeyTap.start(settings: settings)
 
@@ -220,6 +226,7 @@ final class AppCore: ObservableObject {
             SettingsRootView(initialTab: tab)
                 .environmentObject(self.appIndex)
                 .environmentObject(self.visibility)
+                .environmentObject(self.customCommands)
         }
         if !isNew {
             NotificationCenter.default.post(name: .tinycastSelectSettingsTab, object: tab)
@@ -258,7 +265,11 @@ final class AppCore: ObservableObject {
         }
         // Commands dispatch before the palette hides: mode-switching commands keep it open.
         if app.kind == .command {
-            runCommand(app)
+            if let id = CustomCommand.id(fromEntryID: app.id) {
+                runCustomCommand(id: id)
+            } else {
+                runCommand(app)
+            }
             return
         }
         hidePalette(restoreFocus: false)
@@ -275,6 +286,79 @@ final class AppCore: ObservableObject {
 
     func resetRanking(for app: AppEntry) {
         launcherRanking.reset(itemKey: app.preferenceKey)
+    }
+
+    // MARK: - Custom commands
+
+    @discardableResult
+    func addCustomCommand(name: String, command: String) throws -> CustomCommand {
+        try customCommands.add(name: name, command: command)
+    }
+
+    func updateCustomCommand(id: UUID, name: String, command: String) throws {
+        try customCommands.update(id: id, name: name, command: command)
+    }
+
+    func deleteCustomCommand(id: UUID) {
+        guard let command = customCommands.command(id: id) else { return }
+        removeCustomCommandReferences(ids: [id], entryIDs: [command.entryID])
+        customCommands.remove(id: id)
+    }
+
+    @discardableResult
+    func replaceCustomCommands(_ commands: [CustomCommand]) -> Int {
+        let previous = Dictionary(uniqueKeysWithValues: customCommands.commands.map { ($0.id, $0) })
+        let count = customCommands.replace(with: commands)
+        let liveIDs = Set(customCommands.commands.map(\.id))
+        let removed = Set(previous.keys).subtracting(liveIDs)
+        let removedEntryIDs = Set(removed.compactMap { previous[$0]?.entryID })
+        removeCustomCommandReferences(ids: removed, entryIDs: removedEntryIDs)
+        return count
+    }
+
+    func runCustomCommand(id: UUID) {
+        guard let command = customCommands.command(id: id) else { return }
+        if windowController.isVisible { hidePalette(restoreFocus: false) }
+        Task {
+            let outcome = await ShellCommandRunner.run(command.command)
+            guard outcome != .success else { return }
+            Self.presentCustomCommandFailure(name: command.name, outcome: outcome)
+        }
+    }
+
+    private func removeCustomCommandReferences(ids: Set<UUID>, entryIDs: Set<String>) {
+        for id in ids {
+            let action = HotKeyAction.customCommand(id: id)
+            if hotKeys.recordingAction == action { hotKeys.recordingAction = nil }
+            hotKeys.setShortcut(nil, for: action)
+        }
+        favorites.remove(keys: entryIDs)
+        visibility.removeItemKeys(entryIDs)
+        for entryID in entryIDs {
+            launcherRanking.reset(itemKey: entryID)
+        }
+    }
+
+    private static func presentCustomCommandFailure(
+        name: String, outcome: ShellCommandOutcome
+    ) {
+        let message: String
+        switch outcome {
+        case .success:
+            return
+        case .launchFailure(let detail):
+            message = "The shell could not be started.\n\n\(detail)"
+        case .nonZeroExit(let status, let stderr):
+            message =
+                "The command exited with status \(status)."
+                + (stderr.map { "\n\n" + $0 } ?? "")
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "“\(name)” Failed"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
     }
 
     /// Quits the app behind an entry; a no-op (palette stays put) when it isn't running.

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -108,6 +108,8 @@ final class AppCore: ObservableObject {
 
     private lazy var windowController = PaletteWindowController(core: self)
     private let auxWindows = AuxWindowController()
+    /// Guards only the confirmation modal, not execution — two deliberate runs of an unguarded command still run twice.
+    private var isConfirmingCommand = false
 
     private init() {
         let launcherRanking = LauncherRankingStore()
@@ -291,12 +293,12 @@ final class AppCore: ObservableObject {
     // MARK: - Custom commands
 
     @discardableResult
-    func addCustomCommand(name: String, command: String) throws -> CustomCommand {
-        try customCommands.add(name: name, command: command)
+    func addCustomCommand(_ draft: CustomCommand) throws -> CustomCommand {
+        try customCommands.add(draft)
     }
 
-    func updateCustomCommand(id: UUID, name: String, command: String) throws {
-        try customCommands.update(id: id, name: name, command: command)
+    func updateCustomCommand(_ draft: CustomCommand) throws {
+        try customCommands.update(draft)
     }
 
     func deleteCustomCommand(id: UUID) {
@@ -316,13 +318,23 @@ final class AppCore: ObservableObject {
         return count
     }
 
+    /// The one funnel for both palette activation and the command's global hotkey, so the confirmation gate can't be bypassed by either.
     func runCustomCommand(id: UUID) {
         guard let command = customCommands.command(id: id) else { return }
+        // Hide before confirming: the palette is a floating panel and would sit above the alert.
         if windowController.isVisible { hidePalette(restoreFocus: false) }
+        if command.requiresConfirmation {
+            // Carbon hotkeys keep firing during a modal session; without this a held shortcut stacks alerts.
+            guard !isConfirmingCommand else { return }
+            isConfirmingCommand = true
+            defer { isConfirmingCommand = false }
+            guard Self.confirmRun(command) else { return }
+        }
         Task {
-            let outcome = await ShellCommandRunner.run(command.command)
+            let outcome = await ShellCommandRunner.run(
+                command.command, loadingShellEnvironment: command.loadsShellEnvironment)
             guard outcome != .success else { return }
-            Self.presentCustomCommandFailure(name: command.name, outcome: outcome)
+            self.presentCustomCommandFailure(command: command, outcome: outcome)
         }
     }
 
@@ -339,26 +351,48 @@ final class AppCore: ObservableObject {
         }
     }
 
-    private static func presentCustomCommandFailure(
-        name: String, outcome: ShellCommandOutcome
+    private static func confirmRun(_ command: CustomCommand) -> Bool {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = command.name
+        alert.informativeText = "Are you sure you want to run this command?"
+        alert.alertStyle = .warning
+        let runButton = alert.addButton(withTitle: "Run")
+        // ↵ goes to Cancel, as in `confirmQuitAll`: this command is one ↵ away in the palette.
+        runButton.keyEquivalent = ""
+        alert.addButton(withTitle: "Cancel").keyEquivalent = "\r"
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func presentCustomCommandFailure(
+        command: CustomCommand, outcome: ShellCommandOutcome
     ) {
         let message: String
+        // `127` is the shell's "command not found", so an alias or function that only exists in the user's config lands here.
+        var suggestsShellEnvironment = false
         switch outcome {
         case .success:
             return
         case .launchFailure(let detail):
             message = "The shell could not be started.\n\n\(detail)"
         case .nonZeroExit(let status, let stderr):
+            suggestsShellEnvironment = status == 127 && !command.loadsShellEnvironment
             message =
                 "The command exited with status \(status)."
                 + (stderr.map { "\n\n" + $0 } ?? "")
+                + (suggestsShellEnvironment
+                    ? "\n\nIf this is a shell alias or function, turn on Load Shell Environment for "
+                        + "this command." : "")
         }
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
-        alert.messageText = "“\(name)” Failed"
+        alert.messageText = "“\(command.name)” Failed"
         alert.informativeText = message
         alert.alertStyle = .warning
-        alert.runModal()
+        alert.addButton(withTitle: "OK")
+        if suggestsShellEnvironment { alert.addButton(withTitle: "Open Settings…") }
+        guard alert.runModal() == .alertSecondButtonReturn else { return }
+        showSettings(tab: .customCommands)
     }
 
     /// Quits the app behind an entry; a no-op (palette stays put) when it isn't running.

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -21,23 +21,29 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         switch kind {
         case .application: return "Application"
         case .systemSettings: return "System Setting"
-        case .command: return "Command"
+        case .command:
+            return CustomCommand.id(fromEntryID: id) == nil ? "Command" : "Custom Command"
         }
     }
 
-    /// The global-hotkey action that opens this entry, or `nil` when it has no bundle ID to key the binding on.
+    /// The global-hotkey action for this entry, or `nil` for built-in commands and unaddressable bundles.
     var hotKeyAction: HotKeyAction? {
-        guard let bundleID else { return nil }
         switch kind {
-        case .application: return .app(bundleID: bundleID)
-        case .systemSettings: return .settingsPane(bundleID: bundleID)
-        case .command: return nil
+        case .application:
+            return bundleID.map { .app(bundleID: $0) }
+        case .systemSettings:
+            return bundleID.map { .settingsPane(bundleID: $0) }
+        case .command:
+            return CustomCommand.id(fromEntryID: id).map { .customCommand(id: $0) }
         }
     }
 
     /// Command entries draw an SF Symbol tile; everything else uses its file icon.
     var isSymbolIcon: Bool { kind == .command }
-    var symbolIconName: String { CommandRegistry.command(for: self)?.sfSymbol ?? "questionmark" }
+    var symbolIconName: String {
+        if let builtIn = CommandRegistry.command(for: self) { return builtIn.sfSymbol }
+        return CustomCommand.id(fromEntryID: id) == nil ? "questionmark" : "terminal"
+    }
 
     var icon: NSImage {
         isSymbolIcon
@@ -156,6 +162,8 @@ final class AppIndex: ObservableObject {
     /// One-entry memo so repeated renders for the same query reuse the ranking instead of re-matching every frame.
     private var matchCache: (query: String, rankingRevision: Int, result: [AppEntry])?
 
+    private var discoveredEntries: [AppEntry] = []
+    private var customCommandEntries: [AppEntry] = []
     private var isRefreshing = false
     /// Set when a refresh is requested mid-scan, so a scope edit landing during an in-flight scan isn't silently dropped.
     private var refreshPending = false
@@ -165,6 +173,20 @@ final class AppIndex: ObservableObject {
 
     init(ranking: LauncherRankingStore) {
         self.ranking = ranking
+    }
+
+    /// Replaces the user-authored command slice without rescanning disk so Settings edits reach launcher search immediately.
+    func setCustomCommands(_ commands: [CustomCommand]) {
+        let entries = commands.map { command in
+            AppEntry(
+                id: command.entryID, name: command.name,
+                url: URL(string: "tinycast://custom-command/" + command.id.uuidString)!,
+                bundleID: nil, kind: .command)
+        }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        guard entries != customCommandEntries else { return }
+        customCommandEntries = entries
+        publishEntries()
     }
 
     /// Wires the search scopes, re-indexing when the user edits them so Settings changes land without waiting for the next launcher open.
@@ -195,9 +217,9 @@ final class AppIndex: ObservableObject {
             let scopes = settings?.searchScopes ?? SearchScopes.defaults
             let found = await Task.detached(priority: .utility) { AppIndex.scan(scopes: scopes) }
                 .value
-            guard found != apps else { continue }
-            apps = found
-            matchCache = nil
+            guard found != discoveredEntries else { continue }
+            discoveredEntries = found
+            publishEntries()
         } while refreshPending
     }
 
@@ -219,11 +241,21 @@ final class AppIndex: ObservableObject {
                     id: url.path, name: name, url: url, bundleID: bundleID,
                     kind: .application))
         }
-        // Apps, then Settings panes, then Commands — the sectioned launcher relies on this order so its flat selection index maps 1:1 onto rows.
+        // `publishEntries` appends commands after apps and Settings panes so the sectioned flat selection maps 1:1 onto rows.
         let apps = result.sorted {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
-        return apps + SettingsPaneScanner.scan() + CommandRegistry.all
+        return apps + SettingsPaneScanner.scan()
+    }
+
+    private func publishEntries() {
+        let commands = (CommandRegistry.all + customCommandEntries).sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+        let updated = discoveredEntries + commands
+        guard updated != apps else { return }
+        apps = updated
+        matchCache = nil
     }
 
     /// Ranked matches. Empty query returns the full alphabetical list.

--- a/Tinycast/Core/Backup/BackupActions.swift
+++ b/Tinycast/Core/Backup/BackupActions.swift
@@ -34,6 +34,11 @@ enum BackupActions {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
             let backup = try SettingsBackup(json: try Data(contentsOf: url))
+            let commandCount = backup.customCommands?.count ?? 0
+            let shortcutCount = backup.hotkeys?.customCommands?.count ?? 0
+            guard confirmExecutableImport(commands: commandCount, shortcuts: shortcutCount) else {
+                return
+            }
             present(
                 title: "Settings Imported", message: summaryText(backup.apply()),
                 style: .informational
@@ -95,8 +100,27 @@ enum BackupActions {
         if s.hotkeys > 0 { parts.append("\(s.hotkeys) shortcuts") }
         if s.favorites > 0 { parts.append("\(s.favorites) favorites") }
         if s.hiddenItems > 0 { parts.append("\(s.hiddenItems) hidden items") }
+        if s.customCommands > 0 { parts.append("\(s.customCommands) custom commands") }
         return parts.isEmpty
             ? "Nothing to import from this file." : "Applied " + parts.joined(separator: ", ") + "."
+    }
+
+    private static func confirmExecutableImport(commands: Int, shortcuts: Int) -> Bool {
+        guard commands > 0 || shortcuts > 0 else { return true }
+        let commandText = commands == 1 ? "1 custom command" : "\(commands) custom commands"
+        let shortcutText =
+            shortcuts == 1 ? "1 global shortcut" : "\(shortcuts) global shortcuts"
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "Import executable commands?"
+        alert.informativeText =
+            "This backup contains \(commandText) and \(shortcutText). Custom commands can run "
+            + "arbitrary shell code. Only import files you trust."
+        alert.alertStyle = .warning
+        let importButton = alert.addButton(withTitle: "Import")
+        importButton.keyEquivalent = ""
+        alert.addButton(withTitle: "Cancel").keyEquivalent = "\r"
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     private static func dateStamp() -> String {

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// A passwordless, human-readable snapshot of Tinycast's configuration. Every field is optional so an import applies only the keys actually present (non-destructive merge): a partial file — or one from Raycast — leaves everything it omits untouched.
 struct SettingsBackup: Codable {
-    var version = 1
+    var version = 2
     var settings: SettingsData?
     var hotkeys: HotkeyBackup?
+    var customCommands: [CustomCommand]?
     var favoriteApps: [String]?
     var hiddenLauncherItems: [String]?
     var hiddenLauncherKinds: [String]?
@@ -33,6 +34,7 @@ struct SettingsBackup: Codable {
         var toggleEmoji: KeyShortcut?
         var apps: [String: KeyShortcut]?
         var panes: [String: KeyShortcut]?
+        var customCommands: [String: KeyShortcut]?
     }
 
     /// A tally of what an import touched, for user-facing confirmation.
@@ -41,6 +43,7 @@ struct SettingsBackup: Codable {
         var hotkeys = 0
         var favorites = 0
         var hiddenItems = 0
+        var customCommands = 0
     }
 }
 
@@ -81,8 +84,13 @@ extension SettingsBackup {
             uniqueKeysWithValues: hk.boundPaneBundleIDs.compactMap { id in
                 hk.shortcut(for: .settingsPane(bundleID: id)).map { (id, $0) }
             })
+        hotkeys.customCommands = Dictionary(
+            uniqueKeysWithValues: hk.boundCustomCommandIDs.compactMap { id in
+                hk.shortcut(for: .customCommand(id: id)).map { (id.uuidString.lowercased(), $0) }
+            })
         backup.hotkeys = hotkeys
 
+        backup.customCommands = core.customCommands.commands
         backup.favoriteApps = core.favorites.keys
         backup.hiddenLauncherItems = Array(core.visibility.hiddenItemKeys)
         backup.hiddenLauncherKinds = Array(core.visibility.hiddenKinds)
@@ -93,6 +101,9 @@ extension SettingsBackup {
     func apply(to core: AppCore = .shared) -> ApplySummary {
         var summary = ApplySummary()
         if let s = settings { summary.settingsFields = applySettings(s, to: core) }
+        if let customCommands {
+            summary.customCommands = core.replaceCustomCommands(customCommands)
+        }
         if let hotkeys { summary.hotkeys = applyHotkeys(hotkeys, to: core) }
         if let favoriteApps {
             core.favorites.replace(keys: favoriteApps)
@@ -185,6 +196,12 @@ extension SettingsBackup {
         if let s = hotkeys.toggleEmoji { apply(s, .toggleEmoji) }
         for (id, s) in hotkeys.apps ?? [:] { apply(s, .app(bundleID: id)) }
         for (id, s) in hotkeys.panes ?? [:] { apply(s, .settingsPane(bundleID: id)) }
+        for (rawID, s) in hotkeys.customCommands ?? [:] {
+            guard let id = UUID(uuidString: rawID), core.customCommands.command(id: id) != nil else {
+                continue
+            }
+            apply(s, .customCommand(id: id))
+        }
         return count
     }
 }

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// App-internal launcher actions surfaced as a "Commands" category; each is a synthetic `AppEntry` (kind `.command`, no bundle ID) so existing `AppEntry` plumbing applies, with dispatch in `AppCore.runCommand`.
+/// Built-in launcher actions surfaced alongside user-authored commands, with dispatch in `AppCore.runCommand`.
 enum CommandID: String, CaseIterable, Sendable {
     case calculatorHistory = "command:calculator-history"
     case clipboardHistory = "command:clipboard-history"

--- a/Tinycast/Core/CustomCommand.swift
+++ b/Tinycast/Core/CustomCommand.swift
@@ -7,11 +7,19 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     let id: UUID
     var name: String
     var command: String
+    /// Sources the user's shell config so aliases, functions and `PATH` resolve; opt-in because a heavy `.zshrc` costs far more than the command itself.
+    var loadsShellEnvironment: Bool
+    var requiresConfirmation: Bool
 
-    init(id: UUID = UUID(), name: String, command: String) {
+    init(
+        id: UUID = UUID(), name: String, command: String,
+        loadsShellEnvironment: Bool = false, requiresConfirmation: Bool = false
+    ) {
         self.id = id
         self.name = name
         self.command = command
+        self.loadsShellEnvironment = loadsShellEnvironment
+        self.requiresConfirmation = requiresConfirmation
     }
 
     var entryID: String { Self.entryIDPrefix + id.uuidString.lowercased() }
@@ -63,16 +71,17 @@ final class CustomCommandStore: ObservableObject {
         CustomCommand.id(fromEntryID: entryID).flatMap(command)
     }
 
+    // Takes a whole draft rather than a parameter per field so adding an option doesn't churn every call site.
     @discardableResult
-    func add(name: String, command: String) throws -> CustomCommand {
-        let value = try validated(id: UUID(), name: name, command: command)
+    func add(_ draft: CustomCommand) throws -> CustomCommand {
+        let value = try validated(draft)
         commit(commands + [value])
         return value
     }
 
-    func update(id: UUID, name: String, command: String) throws {
-        guard let index = commands.firstIndex(where: { $0.id == id }) else { return }
-        let value = try validated(id: id, name: name, command: command)
+    func update(_ draft: CustomCommand) throws {
+        guard let index = commands.firstIndex(where: { $0.id == draft.id }) else { return }
+        let value = try validated(draft)
         var updated = commands
         updated[index] = value
         commit(updated)
@@ -95,20 +104,22 @@ final class CustomCommandStore: ObservableObject {
         return updated.count
     }
 
-    private func validated(id: UUID, name: String, command: String) throws -> CustomCommand {
-        let cleanName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        let cleanCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !cleanName.isEmpty else { throw CustomCommandValidationError.emptyName }
-        guard !cleanCommand.isEmpty else { throw CustomCommandValidationError.emptyCommand }
-        guard !cleanName.contains("\0"), !cleanCommand.contains("\0") else {
+    private func validated(_ draft: CustomCommand) throws -> CustomCommand {
+        var value = draft
+        value.name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        value.command = draft.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.name.isEmpty else { throw CustomCommandValidationError.emptyName }
+        guard !value.command.isEmpty else { throw CustomCommandValidationError.emptyCommand }
+        guard !value.name.contains("\0"), !value.command.contains("\0") else {
             throw CustomCommandValidationError.invalidCharacter
         }
         guard
             !commands.contains(where: {
-                $0.id != id && $0.name.compare(cleanName, options: .caseInsensitive) == .orderedSame
+                $0.id != value.id
+                    && $0.name.compare(value.name, options: .caseInsensitive) == .orderedSame
             })
         else { throw CustomCommandValidationError.duplicateName }
-        return CustomCommand(id: id, name: cleanName, command: cleanCommand)
+        return value
     }
 
     private func commit(_ updated: [CustomCommand]) {
@@ -128,13 +139,16 @@ final class CustomCommandStore: ObservableObject {
         var names = Set<String>()
         var result: [CustomCommand] = []
         for value in values {
-            let name = value.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            let command = value.command.trimmingCharacters(in: .whitespacesAndNewlines)
-            let foldedName = name.folding(options: [.caseInsensitive], locale: .current)
-            guard !name.isEmpty, !command.isEmpty, !name.contains("\0"), !command.contains("\0"),
-                ids.insert(value.id).inserted, names.insert(foldedName).inserted
+            // Copy-and-clean rather than rebuild, so a new option can never be dropped on import.
+            var cleaned = value
+            cleaned.name = value.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            cleaned.command = value.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            let foldedName = cleaned.name.folding(options: [.caseInsensitive], locale: .current)
+            guard !cleaned.name.isEmpty, !cleaned.command.isEmpty, !cleaned.name.contains("\0"),
+                !cleaned.command.contains("\0"), ids.insert(cleaned.id).inserted,
+                names.insert(foldedName).inserted
             else { continue }
-            result.append(CustomCommand(id: value.id, name: name, command: command))
+            result.append(cleaned)
         }
         return result
     }

--- a/Tinycast/Core/CustomCommand.swift
+++ b/Tinycast/Core/CustomCommand.swift
@@ -1,0 +1,141 @@
+import Combine
+import Foundation
+
+struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
+    static let entryIDPrefix = "custom-command:"
+
+    let id: UUID
+    var name: String
+    var command: String
+
+    init(id: UUID = UUID(), name: String, command: String) {
+        self.id = id
+        self.name = name
+        self.command = command
+    }
+
+    var entryID: String { Self.entryIDPrefix + id.uuidString.lowercased() }
+
+    static func id(fromEntryID entryID: String) -> UUID? {
+        guard entryID.hasPrefix(entryIDPrefix) else { return nil }
+        return UUID(uuidString: String(entryID.dropFirst(entryIDPrefix.count)))
+    }
+}
+
+enum CustomCommandValidationError: LocalizedError {
+    case emptyName
+    case emptyCommand
+    case duplicateName
+    case invalidCharacter
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName: return "Enter a name for the command."
+        case .emptyCommand: return "Enter a command to run."
+        case .duplicateName: return "A custom command with this name already exists."
+        case .invalidCharacter: return "Names and commands cannot contain null characters."
+        }
+    }
+}
+
+@MainActor
+final class CustomCommandStore: ObservableObject {
+    private static let defaultsKey = "customCommands"
+
+    private let defaults: UserDefaults
+    @Published private(set) var commands: [CustomCommand]
+    var onChange: (([CustomCommand]) -> Void)?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let decoded =
+            defaults.data(forKey: Self.defaultsKey)
+            .flatMap { try? JSONDecoder().decode([CustomCommand].self, from: $0) } ?? []
+        commands = Self.sanitized(decoded)
+        if commands != decoded { persist() }
+    }
+
+    func command(id: UUID) -> CustomCommand? {
+        commands.first { $0.id == id }
+    }
+
+    func command(entryID: String) -> CustomCommand? {
+        CustomCommand.id(fromEntryID: entryID).flatMap(command)
+    }
+
+    @discardableResult
+    func add(name: String, command: String) throws -> CustomCommand {
+        let value = try validated(id: UUID(), name: name, command: command)
+        commit(commands + [value])
+        return value
+    }
+
+    func update(id: UUID, name: String, command: String) throws {
+        guard let index = commands.firstIndex(where: { $0.id == id }) else { return }
+        let value = try validated(id: id, name: name, command: command)
+        var updated = commands
+        updated[index] = value
+        commit(updated)
+    }
+
+    @discardableResult
+    func remove(id: UUID) -> CustomCommand? {
+        guard let index = commands.firstIndex(where: { $0.id == id }) else { return nil }
+        var updated = commands
+        let removed = updated.remove(at: index)
+        commit(updated)
+        return removed
+    }
+
+    /// Replaces the complete set during native-backup import, dropping invalid and duplicate records from hand-edited files.
+    @discardableResult
+    func replace(with newCommands: [CustomCommand]) -> Int {
+        let updated = Self.sanitized(newCommands)
+        commit(updated)
+        return updated.count
+    }
+
+    private func validated(id: UUID, name: String, command: String) throws -> CustomCommand {
+        let cleanName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanName.isEmpty else { throw CustomCommandValidationError.emptyName }
+        guard !cleanCommand.isEmpty else { throw CustomCommandValidationError.emptyCommand }
+        guard !cleanName.contains("\0"), !cleanCommand.contains("\0") else {
+            throw CustomCommandValidationError.invalidCharacter
+        }
+        guard
+            !commands.contains(where: {
+                $0.id != id && $0.name.compare(cleanName, options: .caseInsensitive) == .orderedSame
+            })
+        else { throw CustomCommandValidationError.duplicateName }
+        return CustomCommand(id: id, name: cleanName, command: cleanCommand)
+    }
+
+    private func commit(_ updated: [CustomCommand]) {
+        guard updated != commands else { return }
+        commands = updated
+        persist()
+        onChange?(updated)
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(commands) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+
+    private static func sanitized(_ values: [CustomCommand]) -> [CustomCommand] {
+        var ids = Set<UUID>()
+        var names = Set<String>()
+        var result: [CustomCommand] = []
+        for value in values {
+            let name = value.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let command = value.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            let foldedName = name.folding(options: [.caseInsensitive], locale: .current)
+            guard !name.isEmpty, !command.isEmpty, !name.contains("\0"), !command.contains("\0"),
+                ids.insert(value.id).inserted, names.insert(foldedName).inserted
+            else { continue }
+            result.append(CustomCommand(id: value.id, name: name, command: command))
+        }
+        return result
+    }
+}

--- a/Tinycast/Core/FavoritesStore.swift
+++ b/Tinycast/Core/FavoritesStore.swift
@@ -22,6 +22,14 @@ final class FavoritesStore: ObservableObject {
         defaults.set(keys, forKey: key)
     }
 
+    func remove(keys removedKeys: Set<String>) {
+        guard !removedKeys.isEmpty else { return }
+        let updated = keys.filter { !removedKeys.contains($0) }
+        guard updated != keys else { return }
+        keys = updated
+        defaults.set(keys, forKey: key)
+    }
+
     func toggle(_ app: AppEntry) {
         let k = key(for: app)
         if let index = keys.firstIndex(of: k) {

--- a/Tinycast/Core/HotKey/KeyShortcut.swift
+++ b/Tinycast/Core/HotKey/KeyShortcut.swift
@@ -152,6 +152,7 @@ enum HotKeyAction: Hashable, Sendable {
     case toggleEmoji
     case app(bundleID: String)
     case settingsPane(bundleID: String)
+    case customCommand(id: UUID)
 
     /// UserDefaults key holding the shortcut JSON; the `KeyboardShortcuts_` prefix is a fossil of the replaced package, kept verbatim so existing bindings need no migration.
     var defaultsKey: String {
@@ -161,6 +162,8 @@ enum HotKeyAction: Hashable, Sendable {
         case .toggleEmoji: "KeyboardShortcuts_toggleEmoji"
         case .app(let bundleID): "KeyboardShortcuts_appHotkey." + bundleID
         case .settingsPane(let bundleID): "KeyboardShortcuts_paneHotkey." + bundleID
+        case .customCommand(let id):
+            "KeyboardShortcuts_customCommandHotkey." + id.uuidString.lowercased()
         }
     }
 }

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -6,6 +6,7 @@ final class HotKeyManager: ObservableObject {
     var onTogglePalette: (() -> Void)?
     var onToggleClipboard: (() -> Void)?
     var onToggleEmoji: (() -> Void)?
+    var onRunCustomCommand: ((UUID) -> Void)?
 
     /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses Carbon so the typed combo can't fire a hotkey.
     @Published var recordingAction: HotKeyAction? {
@@ -15,13 +16,21 @@ final class HotKeyManager: ObservableObject {
     private let center = HotKeyCenter()
     private let boundKey = "boundAppBundleIDs"
     private let boundPaneKey = "boundPaneBundleIDs"
+    private let boundCustomCommandKey = "boundCustomCommandIDs"
 
-    func start() {
+    func start(customCommandIDs: Set<UUID>) {
         register(.togglePalette)
         register(.toggleClipboard)
         register(.toggleEmoji)
         for bundleID in boundBundleIDs { register(.app(bundleID: bundleID)) }
         for bundleID in boundPaneBundleIDs { register(.settingsPane(bundleID: bundleID)) }
+        let stale = Set(boundCustomCommandIDs).subtracting(customCommandIDs)
+        for id in stale {
+            UserDefaults.standard.removeObject(forKey: HotKeyAction.customCommand(id: id).defaultsKey)
+        }
+        let live = Set(boundCustomCommandIDs).intersection(customCommandIDs)
+        persistBoundCustomCommandIDs(live)
+        for id in live { register(.customCommand(id: id)) }
     }
 
     /// Bundle IDs that currently have a per-app hotkey — lets `start()` know which records to load and lets launcher rows show keycaps.
@@ -32,6 +41,12 @@ final class HotKeyManager: ObservableObject {
     /// Settings-pane bundle IDs with a hotkey — same role as `boundBundleIDs`, own namespace.
     var boundPaneBundleIDs: [String] {
         UserDefaults.standard.stringArray(forKey: boundPaneKey) ?? []
+    }
+
+    /// Custom-command UUIDs with a Carbon binding, indexed separately so startup can re-register them.
+    var boundCustomCommandIDs: [UUID] {
+        (UserDefaults.standard.stringArray(forKey: boundCustomCommandKey) ?? [])
+            .compactMap(UUID.init(uuidString:))
     }
 
     func shortcut(for action: HotKeyAction) -> KeyShortcut? {
@@ -65,6 +80,10 @@ final class HotKeyManager: ObservableObject {
             var set = Set(boundPaneBundleIDs)
             if shortcut == nil { set.remove(bundleID) } else { set.insert(bundleID) }
             UserDefaults.standard.set(Array(set), forKey: boundPaneKey)
+        case .customCommand(let id):
+            var set = Set(boundCustomCommandIDs)
+            if shortcut == nil { set.remove(id) } else { set.insert(id) }
+            persistBoundCustomCommandIDs(set)
         case .togglePalette, .toggleClipboard, .toggleEmoji:
             break
         }
@@ -75,6 +94,7 @@ final class HotKeyManager: ObservableObject {
         var candidates: [HotKeyAction] = [.togglePalette, .toggleClipboard, .toggleEmoji]
         candidates += boundBundleIDs.map { .app(bundleID: $0) }
         candidates += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
+        candidates += boundCustomCommandIDs.map { .customCommand(id: $0) }
         for candidate in candidates
         where candidate != action && self.shortcut(for: candidate) == shortcut {
             return displayName(of: candidate)
@@ -98,6 +118,8 @@ final class HotKeyManager: ObservableObject {
             let apps = AppCore.shared.appIndex.apps
             return apps.first { $0.kind == .systemSettings && $0.bundleID == bundleID }?.name
                 ?? bundleID
+        case .customCommand(let id):
+            return AppCore.shared.customCommands.command(id: id)?.name ?? "Custom Command"
         }
     }
 
@@ -115,6 +137,12 @@ final class HotKeyManager: ObservableObject {
         case .toggleEmoji: onToggleEmoji?()
         case .app(let bundleID): AppLauncher.toggle(bundleID: bundleID)
         case .settingsPane(let bundleID): AppLauncher.openSettingsPane(bundleID: bundleID)
+        case .customCommand(let id): onRunCustomCommand?(id)
         }
+    }
+
+    private func persistBoundCustomCommandIDs(_ ids: Set<UUID>) {
+        UserDefaults.standard.set(
+            ids.map { $0.uuidString.lowercased() }.sorted(), forKey: boundCustomCommandKey)
     }
 }

--- a/Tinycast/Core/ShellCommandRunner.swift
+++ b/Tinycast/Core/ShellCommandRunner.swift
@@ -9,34 +9,55 @@ enum ShellCommandOutcome: Sendable, Equatable {
 
 enum ShellCommandRunner {
     private static let stderrLimit = 8 * 1024
+    /// `waitUntilExit` blocks for the whole life of the command, so it runs here rather than on a cooperative-pool thread a `brew upgrade` would hold for minutes. Concurrent so two commands don't queue behind each other.
+    private static let queue = DispatchQueue(
+        label: "com.tinycast.shell-command", qos: .userInitiated, attributes: .concurrent)
 
-    nonisolated static func run(_ command: String) async -> ShellCommandOutcome {
-        await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            process.arguments = ["-lc", command]
-            process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
-            process.standardInput = FileHandle.nullDevice
-            process.standardOutput = FileHandle.nullDevice
-
-            let capture = makeStderrCapture()
-            process.standardError = capture?.handle ?? FileHandle.nullDevice
-            defer { capture?.remove() }
-
-            do {
-                try process.run()
-            } catch {
-                return .launchFailure(error.localizedDescription)
+    /// `loadingShellEnvironment` defaults to the fast path, so a caller that forgets it gets the cheap shell rather than the user's whole config.
+    nonisolated static func run(
+        _ command: String, loadingShellEnvironment: Bool = false
+    ) async -> ShellCommandOutcome {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                continuation.resume(
+                    returning: execute(command, loadingShellEnvironment: loadingShellEnvironment))
             }
-            process.waitUntilExit()
+        }
+    }
 
-            guard process.terminationReason == .exit, process.terminationStatus == 0 else {
-                return .nonZeroExit(
-                    status: process.terminationStatus,
-                    stderr: capture?.readSuffix(limit: stderrLimit))
-            }
-            return .success
-        }.value
+    nonisolated private static func execute(
+        _ command: String, loadingShellEnvironment: Bool
+    ) -> ShellCommandOutcome {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        // zsh only reads `.zshrc` for *interactive* shells, so `-l` alone never sees the user's aliases, functions or `PATH`.
+        process.arguments = [loadingShellEnvironment ? "-ilc" : "-lc", command]
+        process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
+        // Lets a shell config skip slow or interactive sections when Tinycast is the caller: `[[ -n $TINYCAST ]] && return`.
+        process.environment = ProcessInfo.processInfo.environment.merging(["TINYCAST": "1"]) {
+            _, new in new
+        }
+        // Load-bearing for the interactive shell: a config that prompts reads EOF and moves on instead of hanging forever.
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+
+        let capture = makeStderrCapture()
+        process.standardError = capture?.handle ?? FileHandle.nullDevice
+        defer { capture?.remove() }
+
+        do {
+            try process.run()
+        } catch {
+            return .launchFailure(error.localizedDescription)
+        }
+        process.waitUntilExit()
+
+        guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+            return .nonZeroExit(
+                status: process.terminationStatus,
+                stderr: capture?.readSuffix(limit: stderrLimit))
+        }
+        return .success
     }
 
     private final class StderrCapture: @unchecked Sendable {
@@ -81,6 +102,6 @@ enum ShellCommandRunner {
     }
 }
 
-private extension String {
-    var nilIfEmpty: String? { isEmpty ? nil : self }
+extension String {
+    fileprivate var nilIfEmpty: String? { isEmpty ? nil : self }
 }

--- a/Tinycast/Core/ShellCommandRunner.swift
+++ b/Tinycast/Core/ShellCommandRunner.swift
@@ -1,0 +1,86 @@
+import Darwin
+import Foundation
+
+enum ShellCommandOutcome: Sendable, Equatable {
+    case success
+    case launchFailure(String)
+    case nonZeroExit(status: Int32, stderr: String?)
+}
+
+enum ShellCommandRunner {
+    private static let stderrLimit = 8 * 1024
+
+    nonisolated static func run(_ command: String) async -> ShellCommandOutcome {
+        await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+            process.arguments = ["-lc", command]
+            process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = FileHandle.nullDevice
+
+            let capture = makeStderrCapture()
+            process.standardError = capture?.handle ?? FileHandle.nullDevice
+            defer { capture?.remove() }
+
+            do {
+                try process.run()
+            } catch {
+                return .launchFailure(error.localizedDescription)
+            }
+            process.waitUntilExit()
+
+            guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+                return .nonZeroExit(
+                    status: process.terminationStatus,
+                    stderr: capture?.readSuffix(limit: stderrLimit))
+            }
+            return .success
+        }.value
+    }
+
+    private final class StderrCapture: @unchecked Sendable {
+        let url: URL
+        let handle: FileHandle
+
+        init(url: URL, handle: FileHandle) {
+            self.url = url
+            self.handle = handle
+        }
+
+        func readSuffix(limit: Int) -> String? {
+            try? handle.synchronize()
+            guard let end = try? handle.seekToEnd() else { return nil }
+            let start = end > UInt64(limit) ? end - UInt64(limit) : 0
+            try? handle.seek(toOffset: start)
+            guard let data = try? handle.readToEnd(), !data.isEmpty else { return nil }
+            return String(decoding: data, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+        }
+
+        func remove() {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    nonisolated private static func makeStderrCapture() -> StderrCapture? {
+        let template = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-command-stderr.XXXXXX").path
+        var bytes = Array(template.utf8CString)
+        let descriptor = bytes.withUnsafeMutableBufferPointer { buffer in
+            mkstemp(buffer.baseAddress!)
+        }
+        guard descriptor >= 0 else { return nil }
+        let path = String(
+            decoding: bytes.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+        return StderrCapture(
+            url: URL(fileURLWithPath: path),
+            handle: FileHandle(fileDescriptor: descriptor, closeOnDealloc: true))
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Tinycast/Core/VisibilityStore.swift
+++ b/Tinycast/Core/VisibilityStore.swift
@@ -40,6 +40,14 @@ final class VisibilityStore: ObservableObject {
         defaults.set(Array(hiddenItemKeys), forKey: itemsKey)
     }
 
+    func removeItemKeys(_ keys: Set<String>) {
+        guard !keys.isEmpty else { return }
+        let previous = hiddenItemKeys
+        hiddenItemKeys.subtract(keys)
+        guard hiddenItemKeys != previous else { return }
+        defaults.set(Array(hiddenItemKeys), forKey: itemsKey)
+    }
+
     func isKindVisible(_ kind: AppEntry.Kind) -> Bool {
         !hiddenKinds.contains(kind.rawValue)
     }

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -268,7 +268,7 @@ enum AppActionsMenu {
         switch app.kind {
         case .application: return "Open Application"
         case .systemSettings: return "Open System Setting"
-        case .command: return "Open Command"
+        case .command: return "Run Command"
         }
     }
 }

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -659,7 +659,7 @@ struct RootPaletteView: View {
             if calcActionable { return "Copy Answer" }
             switch selectedApp?.kind {
             case .systemSettings: return "Open System Setting"
-            case .command: return "Open Command"
+            case .command: return "Run Command"
             default: return "Open Application"
             }
         }

--- a/Tinycast/Features/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Settings/BackupSettingsView.swift
@@ -26,7 +26,8 @@ struct BackupSettingsView: View {
             SettingsCard(header: "Tinycast") {
                 SettingsRow(
                     title: "Export Settings",
-                    subtitle: "Save your shortcuts, favorites, and preferences to a JSON file.",
+                    subtitle:
+                        "Save your shortcuts, custom commands, favorites, and preferences to JSON.",
                     systemImage: "square.and.arrow.up",
                     tint: .blue
                 ) {

--- a/Tinycast/Features/Settings/CustomCommandsSettingsView.swift
+++ b/Tinycast/Features/Settings/CustomCommandsSettingsView.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+
+struct CustomCommandsSettingsView: View {
+    @EnvironmentObject private var store: CustomCommandStore
+    @State private var editor: EditorTarget?
+    @State private var pendingDeletion: CustomCommand?
+
+    var body: some View {
+        SettingsPane(
+            title: "Custom Commands",
+            subtitle: "Run your own shell commands from the launcher or a global shortcut."
+        ) {
+            SettingsCallout(
+                title: "Commands run with your user account.",
+                message:
+                    "Tinycast uses /bin/zsh -lc from your home folder without an interactive "
+                    + "Terminal. Use full executable paths for the most reliable results.",
+                systemImage: "terminal",
+                tint: .green
+            )
+
+            SettingsCard(header: "Commands") {
+                if store.commands.isEmpty {
+                    SettingsRow(
+                        title: "No custom commands",
+                        subtitle: "Add one to make it searchable from the launcher.",
+                        systemImage: "terminal",
+                        tint: .secondary
+                    ) {
+                        EmptyView()
+                    }
+                } else {
+                    ForEach(Array(sortedCommands.enumerated()), id: \.element.id) {
+                        index, command in
+                        if index > 0 { SettingsDivider() }
+                        CustomCommandSettingsRow(
+                            command: command,
+                            onEdit: { editor = EditorTarget(command: command) },
+                            onDelete: { pendingDeletion = command })
+                    }
+                }
+                SettingsDivider()
+
+                SettingsRow(
+                    title: "Add Custom Command",
+                    subtitle: "Give the command a searchable name and optional global shortcut.",
+                    systemImage: "plus.circle",
+                    tint: .green
+                ) {
+                    Button("Add…") { editor = EditorTarget(command: nil) }
+                        .controlSize(.small)
+                }
+            }
+        }
+        .sheet(item: $editor) { target in
+            CustomCommandEditorSheet(command: target.command)
+        }
+        .alert(item: $pendingDeletion) { command in
+            Alert(
+                title: Text("Delete “\(command.name)”?"),
+                message: Text("Its global shortcut and launcher references will also be removed."),
+                primaryButton: .destructive(Text("Delete")) {
+                    AppCore.shared.deleteCustomCommand(id: command.id)
+                },
+                secondaryButton: .cancel())
+        }
+    }
+
+    private var sortedCommands: [CustomCommand] {
+        store.commands.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+}
+
+private struct EditorTarget: Identifiable {
+    let id = UUID()
+    let command: CustomCommand?
+}
+
+private struct CustomCommandSettingsRow: View {
+    let command: CustomCommand
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "terminal")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.green)
+                .frame(width: Theme.Size.settingsRowIcon)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs / 2) {
+                Text(command.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Text(command.command)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(command.command)
+            }
+
+            Spacer(minLength: Theme.Spacing.lg)
+            ShortcutRecorder(action: .customCommand(id: command.id))
+
+            Button(action: onEdit) {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.plain)
+            .help("Edit Command")
+            .accessibilityLabel("Edit \(command.name)")
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .help("Delete Command")
+            .accessibilityLabel("Delete \(command.name)")
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+        .padding(.vertical, Theme.Spacing.lg)
+    }
+}
+
+private struct CustomCommandEditorSheet: View {
+    let command: CustomCommand?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var shellCommand: String
+    @State private var errorMessage: String?
+
+    init(command: CustomCommand?) {
+        self.command = command
+        _name = State(initialValue: command?.name ?? "")
+        _shellCommand = State(initialValue: command?.command ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+            Text(command == nil ? "Add Custom Command" : "Edit Custom Command")
+                .font(.title2.weight(.bold))
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Name")
+                    .font(.callout.weight(.medium))
+                TextField("Sleep Displays", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Command")
+                    .font(.callout.weight(.medium))
+                TextEditor(text: $shellCommand)
+                    .font(.body.monospaced())
+                    .scrollContentBackground(.hidden)
+                    .padding(Theme.Spacing.sm)
+                    .frame(height: 120)
+                    .background(
+                        RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                            .fill(Theme.Colors.cardFill)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                            .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
+                    )
+            }
+
+            Text("Example: /usr/bin/pmset displaysleepnow")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save", action: save)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(
+                        name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || shellCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(Theme.Spacing.xxl)
+        .frame(width: 480)
+    }
+
+    private func save() {
+        do {
+            if let command {
+                try AppCore.shared.updateCustomCommand(
+                    id: command.id, name: name, command: shellCommand)
+            } else {
+                try AppCore.shared.addCustomCommand(name: name, command: shellCommand)
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Tinycast/Features/Settings/CustomCommandsSettingsView.swift
+++ b/Tinycast/Features/Settings/CustomCommandsSettingsView.swift
@@ -13,8 +13,9 @@ struct CustomCommandsSettingsView: View {
             SettingsCallout(
                 title: "Commands run with your user account.",
                 message:
-                    "Tinycast uses /bin/zsh -lc from your home folder without an interactive "
-                    + "Terminal. Use full executable paths for the most reliable results.",
+                    "Tinycast uses /bin/zsh from your home folder without an interactive Terminal, "
+                    + "so your shell config is skipped. Use full executable paths, or turn on Load "
+                    + "Shell Environment for a command needing an alias, function or custom PATH.",
                 systemImage: "terminal",
                 tint: .green
             )
@@ -131,12 +132,16 @@ private struct CustomCommandEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var name: String
     @State private var shellCommand: String
+    @State private var loadsShellEnvironment: Bool
+    @State private var requiresConfirmation: Bool
     @State private var errorMessage: String?
 
     init(command: CustomCommand?) {
         self.command = command
         _name = State(initialValue: command?.name ?? "")
         _shellCommand = State(initialValue: command?.command ?? "")
+        _loadsShellEnvironment = State(initialValue: command?.loadsShellEnvironment ?? false)
+        _requiresConfirmation = State(initialValue: command?.requiresConfirmation ?? false)
     }
 
     var body: some View {
@@ -173,6 +178,19 @@ private struct CustomCommandEditorSheet: View {
                 .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
 
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                optionToggle(
+                    "Load shell environment", isOn: $loadsShellEnvironment,
+                    detail:
+                        "Runs in an interactive login shell so aliases, functions and PATH from "
+                        + "your shell config resolve. Slightly slower to start.")
+                optionToggle(
+                    "Needs confirmation", isOn: $requiresConfirmation,
+                    detail:
+                        "Ask before running, from the launcher and from its global shortcut. Useful "
+                        + "for a command that changes or destroys something.")
+            }
+
             if let errorMessage {
                 Text(errorMessage)
                     .font(.caption)
@@ -194,13 +212,32 @@ private struct CustomCommandEditorSheet: View {
         .frame(width: 480)
     }
 
+    private func optionToggle(
+        _ title: String, isOn: Binding<Bool>, detail: String
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                Text(title)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.checkbox)
+    }
+
     private func save() {
+        // Editing keeps the UUID, and with it the command's favorite, visibility and hotkey references.
+        let draft = CustomCommand(
+            id: command?.id ?? UUID(), name: name, command: shellCommand,
+            loadsShellEnvironment: loadsShellEnvironment,
+            requiresConfirmation: requiresConfirmation)
         do {
-            if let command {
-                try AppCore.shared.updateCustomCommand(
-                    id: command.id, name: name, command: shellCommand)
+            if command == nil {
+                try AppCore.shared.addCustomCommand(draft)
             } else {
-                try AppCore.shared.addCustomCommand(name: name, command: shellCommand)
+                try AppCore.shared.updateCustomCommand(draft)
             }
             dismiss()
         } catch {

--- a/Tinycast/Features/Settings/SettingsRootView.swift
+++ b/Tinycast/Features/Settings/SettingsRootView.swift
@@ -6,7 +6,8 @@ extension Notification.Name {
 }
 
 enum SettingsTab: Int, CaseIterable, Identifiable {
-    case general, clipboard, emoji, permissions, shortcuts, backup, miscellaneous, about
+    case general, clipboard, emoji, permissions, shortcuts, customCommands, backup, miscellaneous,
+        about
     var id: Int { rawValue }
 
     var title: String {
@@ -16,6 +17,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .emoji: return "Emoji & Symbols"
         case .permissions: return "Permissions"
         case .shortcuts: return "Shortcuts"
+        case .customCommands: return "Custom Commands"
         case .backup: return "Backup"
         case .miscellaneous: return "Miscellaneous"
         case .about: return "About"
@@ -29,6 +31,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .emoji: return "face.smiling"
         case .permissions: return "lock.shield"
         case .shortcuts: return "keyboard"
+        case .customCommands: return "terminal"
         case .backup: return "arrow.up.arrow.down.circle"
         case .miscellaneous: return "ellipsis.circle"
         case .about: return "info.circle"
@@ -43,6 +46,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .emoji: return .yellow
         case .permissions: return .blue
         case .shortcuts: return .indigo
+        case .customCommands: return .green
         case .backup: return .teal
         case .miscellaneous: return .purple
         case .about: return .pink
@@ -69,6 +73,7 @@ struct SettingsRootView: View {
                 case .emoji: EmojiSettingsView()
                 case .permissions: PermissionsSettingsView()
                 case .shortcuts: ShortcutsSettingsView()
+                case .customCommands: CustomCommandsSettingsView()
                 case .backup: BackupSettingsView()
                 case .miscellaneous: MiscellaneousSettingsView()
                 case .about: AboutView()

--- a/Tools/custom-command-test.swift
+++ b/Tools/custom-command-test.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+@main
+struct CustomCommandTests {
+    static func main() async throws {
+        let suiteName = "com.tinycast.custom-command-tests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Could not create isolated UserDefaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let original = try await MainActor.run {
+            let store = CustomCommandStore(defaults: defaults)
+            let command = try store.add(
+                name: "  Sleep Displays  ", command: "  /usr/bin/pmset displaysleepnow  ")
+            precondition(command.name == "Sleep Displays")
+            precondition(command.command == "/usr/bin/pmset displaysleepnow")
+            precondition(CustomCommand.id(fromEntryID: command.entryID) == command.id)
+
+            do {
+                _ = try store.add(name: "sleep displays", command: "/usr/bin/true")
+                preconditionFailure("Duplicate names must be rejected")
+            } catch CustomCommandValidationError.duplicateName {
+                // Expected.
+            }
+
+            try store.update(id: command.id, name: "Sleep Screens", command: "/usr/bin/true")
+            precondition(store.command(id: command.id)?.name == "Sleep Screens")
+            return store.command(id: command.id)!
+        }
+
+        await MainActor.run {
+            let reloaded = CustomCommandStore(defaults: defaults)
+            precondition(reloaded.commands == [original])
+        }
+
+        let success = await ShellCommandRunner.run("/usr/bin/true")
+        precondition(success == .success)
+        let homeDirectory = await ShellCommandRunner.run("test \"$PWD\" = \"$HOME\"")
+        precondition(
+            homeDirectory == .success,
+            "Commands must start in the user's home directory")
+
+        let failure = await ShellCommandRunner.run("printf 'expected failure' >&2; exit 7")
+        guard case .nonZeroExit(let status, let stderr) = failure else {
+            preconditionFailure("Expected a non-zero outcome")
+        }
+        precondition(status == 7)
+        precondition(stderr == "expected failure")
+
+        print("All custom command tests passed")
+    }
+}

--- a/Tools/custom-command-test.swift
+++ b/Tools/custom-command-test.swift
@@ -1,54 +1,134 @@
 import Foundation
 
+// Spawns real `/bin/zsh`. The shell-environment cases point `ZDOTDIR` at a throwaway fixture so a run can never read or write the developer's own dotfiles; `/etc/zshrc` is still sourced for interactive shells, so every assertion is relative (the probe resolves with `-i`, not without) rather than absolute.
 @main
 struct CustomCommandTests {
-    static func main() async throws {
+    @MainActor
+    static func main() async {
         let suiteName = "com.tinycast.custom-command-tests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
-            fatalError("Could not create isolated UserDefaults suite")
+            print("FAIL  could not create an isolated UserDefaults suite")
+            exit(1)
         }
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let original = try await MainActor.run {
-            let store = CustomCommandStore(defaults: defaults)
-            let command = try store.add(
-                name: "  Sleep Displays  ", command: "  /usr/bin/pmset displaysleepnow  ")
-            precondition(command.name == "Sleep Displays")
-            precondition(command.command == "/usr/bin/pmset displaysleepnow")
-            precondition(CustomCommand.id(fromEntryID: command.entryID) == command.id)
+        var failures = 0
 
-            do {
-                _ = try store.add(name: "sleep displays", command: "/usr/bin/true")
-                preconditionFailure("Duplicate names must be rejected")
-            } catch CustomCommandValidationError.duplicateName {
-                // Expected.
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
             }
-
-            try store.update(id: command.id, name: "Sleep Screens", command: "/usr/bin/true")
-            precondition(store.command(id: command.id)?.name == "Sleep Screens")
-            return store.command(id: command.id)!
         }
 
-        await MainActor.run {
-            let reloaded = CustomCommandStore(defaults: defaults)
-            precondition(reloaded.commands == [original])
+        // MARK: Store
+
+        let store = CustomCommandStore(defaults: defaults)
+        let added = try? store.add(
+            CustomCommand(
+                name: "  Sleep Displays  ", command: "  /usr/bin/pmset displaysleepnow  ",
+                requiresConfirmation: true))
+        check("add trims the name", added?.name == "Sleep Displays")
+        check("add trims the command", added?.command == "/usr/bin/pmset displaysleepnow")
+        check("add keeps the flags", added?.requiresConfirmation == true)
+        check(
+            "the entry id round-trips to the UUID",
+            added.map { CustomCommand.id(fromEntryID: $0.entryID) == $0.id } == true)
+
+        guard let added else {
+            print("FAIL  add returned nothing; the remaining cases need it")
+            exit(1)
         }
 
-        let success = await ShellCommandRunner.run("/usr/bin/true")
-        precondition(success == .success)
-        let homeDirectory = await ShellCommandRunner.run("test \"$PWD\" = \"$HOME\"")
-        precondition(
-            homeDirectory == .success,
-            "Commands must start in the user's home directory")
+        var duplicateRejected = false
+        do {
+            _ = try store.add(CustomCommand(name: "sleep displays", command: "/usr/bin/true"))
+        } catch CustomCommandValidationError.duplicateName {
+            duplicateRejected = true
+        } catch {}
+        check("a name differing only in case is rejected", duplicateRejected)
 
-        let failure = await ShellCommandRunner.run("printf 'expected failure' >&2; exit 7")
-        guard case .nonZeroExit(let status, let stderr) = failure else {
-            preconditionFailure("Expected a non-zero outcome")
-        }
-        precondition(status == 7)
-        precondition(stderr == "expected failure")
+        try? store.update(
+            CustomCommand(
+                id: added.id, name: "Sleep Screens", command: "/usr/bin/true",
+                loadsShellEnvironment: true))
+        check("update keeps the id", store.command(id: added.id) != nil)
+        check("update applies the new name", store.command(id: added.id)?.name == "Sleep Screens")
+        check(
+            "update applies a flag",
+            store.command(id: added.id)?.loadsShellEnvironment == true)
+        check(
+            "update clears a flag left out of the draft",
+            store.command(id: added.id)?.requiresConfirmation == false)
 
-        print("All custom command tests passed")
+        let expected = store.commands
+        check(
+            "commands survive a reload with their flags",
+            CustomCommandStore(defaults: defaults).commands == expected)
+
+        // `replace` runs the import sanitizer, which must carry every flag through.
+        store.replace(with: [
+            CustomCommand(
+                name: "Imported", command: "/usr/bin/true", loadsShellEnvironment: true,
+                requiresConfirmation: true)
+        ])
+        check(
+            "import preserves both flags",
+            store.commands.first?.loadsShellEnvironment == true
+                && store.commands.first?.requiresConfirmation == true)
+
+        // MARK: Runner
+
+        let succeeded = await ShellCommandRunner.run("/usr/bin/true")
+        check("a zero exit reports success", succeeded == .success)
+
+        let inHome = await ShellCommandRunner.run("test \"$PWD\" = \"$HOME\"")
+        check("commands start in the user's home directory", inHome == .success)
+
+        let marker = await ShellCommandRunner.run("test \"$TINYCAST\" = 1")
+        check("the TINYCAST marker is exported so a shell config can detect us", marker == .success)
+
+        let failed = await ShellCommandRunner.run("printf 'expected failure' >&2; exit 7")
+        check(
+            "a non-zero exit reports its status and stderr",
+            failed == .nonZeroExit(status: 7, stderr: "expected failure"))
+
+        // MARK: Shell environment
+
+        // A throwaway ZDOTDIR proves interactive mode sources an rc file without depending on the developer's own dotfiles.
+        let zdotdir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-zdotdir-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: zdotdir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: zdotdir) }
+        try? Data("alias tinycast_probe=true\n".utf8).write(
+            to: zdotdir.appendingPathComponent(".zshrc"))
+        setenv("ZDOTDIR", zdotdir.path, 1)
+        // `/etc/zshrc` sources `/etc/zshrc_$TERM_PROGRAM`, which starts Terminal's session save/restore and writes to the real home.
+        unsetenv("TERM_PROGRAM")
+
+        let withEnvironment = await ShellCommandRunner.run(
+            "tinycast_probe", loadingShellEnvironment: true)
+        check(
+            "loading the shell environment resolves an rc-file alias",
+            withEnvironment == .success)
+
+        // The exact symptom users reported: an alias that only exists in `.zshrc` is command-not-found.
+        let withoutEnvironment = await ShellCommandRunner.run("tinycast_probe")
+        var notFoundStatus: Int32 = 0
+        if case .nonZeroExit(let status, _) = withoutEnvironment { notFoundStatus = status }
+        check("the default shell exits 127 on an rc-file alias", notFoundStatus == 127)
+
+        // The whole "an interactive shell can't block" argument rests on this: a config or command that prompts reads EOF.
+        let prompted = await ShellCommandRunner.run(
+            "read -r answer", loadingShellEnvironment: true)
+        check("a command reading stdin fails instead of hanging", prompted != .success)
+
+        unsetenv("ZDOTDIR")
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,13 +2,14 @@
 
 How Tinycast is wired together. See the per-subsystem docs for internals:
 [palette](palette.md), [launcher](launcher.md), [calculator](calculator.md),
-[clipboard](clipboard.md), [hotkeys](hotkeys.md), [ui](ui.md).
+[clipboard](clipboard.md), [custom commands](custom-commands.md), [hotkeys](hotkeys.md), [ui](ui.md).
 
 ## Single-owner core
 
 `AppCore.shared` (`Core/AppCore.swift`) is a `@MainActor` singleton that owns every long-lived
 manager — `AppIndex`, `ClipboardStore`, `ClipboardManager`, `HotKeyManager`, `AppSettings`,
-`FavoritesStore`, `VisibilityStore`, `LauncherRankingStore`, `CalculatorHistoryStore`,
+`FavoritesStore`, `VisibilityStore`, `LauncherRankingStore`, `CustomCommandStore`,
+`CalculatorHistoryStore`,
 `CurrencyRateStore`, `RunningAppsMonitor`, `PaletteViewModel` — plus the window controllers.
 `AppDelegate.applicationDidFinishLaunching` calls
 `AppCore.shared.start()` and nothing else; that is the single wiring point. All palette / paste /

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -1,0 +1,43 @@
+# Custom commands
+
+Custom commands let users add a searchable name and a shell command in **Settings → Custom
+Commands**. They appear in the launcher's Commands section, share the normal fuzzy ranking, and run
+from Return, a favorite slot, or an optional global shortcut.
+
+## Ownership and persistence
+
+`CustomCommandStore` is owned by `AppCore` and persists the ordered command array as JSON in
+bundle-scoped `UserDefaults`. Each command has a stable UUID. Its launcher entry id is
+`custom-command:<uuid>`, and its hotkey uses
+`KeyboardShortcuts_customCommandHotkey.<uuid>` plus the `boundCustomCommandIDs` index.
+
+Editing preserves the UUID and therefore its favorite, visibility, and hotkey references. Deleting
+goes through `AppCore`, which unregisters the hotkey and clears those references before removing the
+command. Native settings backups include both commands and bindings; import warns before accepting
+executable content.
+
+## Launcher integration
+
+`AppIndex` owns two slices: applications/System Settings discovered off-main and custom command
+entries supplied on the main actor. It publishes those followed by one alphabetized command slice
+containing both `CommandRegistry` and user commands. This keeps the visible row order identical to
+the flat palette selection while allowing edits to invalidate fuzzy results without rescanning disk.
+
+The command text is deliberately not searchable. Only the user-facing name enters fuzzy matching.
+
+## Execution contract
+
+`ShellCommandRunner` executes asynchronously with:
+
+- `/bin/zsh -lc <command>`
+- the user's home directory as the working directory
+- standard input and output connected to `/dev/null`
+- up to 8 KiB of standard error retained for a failure alert
+
+No Terminal window or pseudo-terminal is created. Interactive prompts and `sudo` therefore fail
+rather than blocking for input. A command should use full executable paths when it depends on tools
+that may not be configured in a login shell.
+
+Tinycast dismisses an open palette before starting a custom command. A zero exit status is silent; a
+launch failure or non-zero status activates Tinycast and shows the bounded error detail. The command
+string itself is never logged.

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -29,15 +29,65 @@ The command text is deliberately not searchable. Only the user-facing name enter
 
 `ShellCommandRunner` executes asynchronously with:
 
-- `/bin/zsh -lc <command>`
+- `/bin/zsh -lc <command>`, or `/bin/zsh -ilc <command>` when the command's **Load shell
+  environment** flag is on
 - the user's home directory as the working directory
 - standard input and output connected to `/dev/null`
+- `TINYCAST=1` added to the inherited environment
 - up to 8 KiB of standard error retained for a failure alert
 
-No Terminal window or pseudo-terminal is created. Interactive prompts and `sudo` therefore fail
-rather than blocking for input. A command should use full executable paths when it depends on tools
-that may not be configured in a login shell.
+No Terminal window or pseudo-terminal is created. `waitUntilExit` blocks for the whole life of the
+command, so it runs on a private concurrent `DispatchQueue` rather than a cooperative-pool thread a
+long `brew upgrade` would hold for minutes.
+
+### Load shell environment
+
+zsh reads `~/.zshrc` **only for interactive shells**, so the default `-lc` sees `.zprofile` and
+`.zlogin` and nothing else — a user's aliases, functions and `PATH` edits are all absent, and the
+command exits **127**. That is the single most common way a custom command fails. The flag switches to
+`-ilc`, which sources the rc file.
+
+It is per-command and off by default, because turning it on runs whatever the user's shell startup
+does — oh-my-zsh's auto-update (`git pull`, network, seconds), powerlevel10k's `gitstatusd`,
+`compinit` rewriting `~/.zcompdump`, or an `exec` that replaces the shell so the command never runs at
+all. `TINYCAST=1` exists so an rc file can skip those sections: `[[ -n $TINYCAST ]] && return`.
+
+Measured cost: ~10 ms for `-lc`, ~65 ms for `-ilc` against a real-world `~/.zshrc` (~11 ms against a
+minimal one — the interactive shell itself is ~2 ms, the rest is the user's own config).
+
+Interactive prompts still cannot block. Standard input is `/dev/null`, so a `read` gets EOF and
+returns non-zero, and a launchd-launched app has no controlling terminal, so `/dev/tty` fails with
+`device not configured`. A dev build launched *from a terminal* inherits that terminal's tty, so an rc
+file reading `/dev/tty` can hang there but not for real users. There is **no timeout** — Tinycast
+never kills a running command, and a command outlives Tinycast quitting.
+
+Because standard error surfaces only on a non-zero exit and only its last 8 KiB, rc-file startup noise
+is dropped while the actual error survives.
+
+### Needs confirmation
+
+`AppCore.runCustomCommand(id:)` is the one funnel both palette activation and the global hotkey reach,
+so the gate lives there and neither path can bypass it. The palette hides before the alert — it is a
+floating panel and would sit above it. The alert shows the command text as well as its name, and ↵ is
+bound to **Cancel**: the command is one ↵ away in the palette, and a reflexive second ↵ must not fire
+something the user asked to be warned about. `NSAlert.runModal` spins a nested run loop where Carbon
+hotkeys keep firing, so a re-entrancy flag stops a held shortcut stacking alerts.
+
+### Reporting
 
 Tinycast dismisses an open palette before starting a custom command. A zero exit status is silent; a
-launch failure or non-zero status activates Tinycast and shows the bounded error detail. The command
-string itself is never logged.
+launch failure or non-zero status activates Tinycast and shows the bounded error detail. When the
+status is 127 and **Load shell environment** is off, the alert adds a one-line hint and an **Open
+Settings…** button that lands on the Custom Commands pane — the hint is gated on the status alone, not
+on grepping stderr, since 127 is equally a plain typo. The command string itself is never logged.
+
+### Manual checks
+
+`requiresConfirmation` lives in `AppCore` (AppKit, `@MainActor`) and so is out of reach of the
+Foundation-only harness. Verify by hand:
+
+1. Activating a gated command from the palette hides the palette *before* the alert appears.
+2. ↵ at the alert cancels; clicking **Run** runs.
+3. Pressing the command's hotkey while its alert is up does not stack a second alert.
+4. A gated command triggered by hotkey with no palette open still confirms.
+5. An rc-file-only alias with the flag off shows the 127 hint, and **Open Settings…** opens the pane.

--- a/docs/development.md
+++ b/docs/development.md
@@ -87,9 +87,9 @@ swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift
 swiftc Tinycast/Core/Emoji/EmojiCatalog.swift Tinycast/Core/Emoji/EmojiGridGeometry.swift \
     Tinycast/Core/Emoji/EmojiData.generated.swift Tools/emoji-test.swift \
     -o /tmp/emoji-test && /tmp/emoji-test                         # emoji catalog + geometry
-swiftc Tinycast/Core/CustomCommand.swift Tinycast/Core/ShellCommandRunner.swift \
-    Tools/custom-command-test.swift -o /tmp/custom-command-test \
-    && /tmp/custom-command-test                                   # custom command store + runner
+swiftc -swift-version 6 Tinycast/Core/CustomCommand.swift \
+    Tinycast/Core/ShellCommandRunner.swift Tools/custom-command-test.swift \
+    -o /tmp/custom-command-test && /tmp/custom-command-test        # custom command store + runner
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —
@@ -99,6 +99,11 @@ sources, which is why `Tinycast/Core/Calculator/` must stay Foundation-only.
 The clipboard harness likewise compiles the real `ClipboardStore.swift`, so that file must keep to
 Foundation + SQLite3 and depend on no other app source. Each case drives a store rooted in a
 throwaway temp directory (`ClipboardStore(directory:)`), so a run can never reach a real history.
+
+The custom-command harness spawns **real `/bin/zsh`** processes. Its shell-environment cases point
+`ZDOTDIR` at a throwaway fixture directory (and unset `TERM_PROGRAM`), so a run can never read or write
+the developer's own dotfiles. `/etc/zshrc` is still sourced for interactive shells, so the assertions
+are relative — the fixture's alias resolves with `-i` and not without — rather than absolute.
 
 ## Generated data
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,12 @@ swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.
     -o /tmp/clipboard-test && /tmp/clipboard-test                 # clipboard store
 swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift \
     -o /tmp/scopes-test && /tmp/scopes-test                       # launcher search scopes
+swiftc Tinycast/Core/Emoji/EmojiCatalog.swift Tinycast/Core/Emoji/EmojiGridGeometry.swift \
+    Tinycast/Core/Emoji/EmojiData.generated.swift Tools/emoji-test.swift \
+    -o /tmp/emoji-test && /tmp/emoji-test                         # emoji catalog + geometry
+swiftc Tinycast/Core/CustomCommand.swift Tinycast/Core/ShellCommandRunner.swift \
+    Tools/custom-command-test.swift -o /tmp/custom-command-test \
+    && /tmp/custom-command-test                                   # custom command store + runner
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -11,7 +11,8 @@
 
 Shortcuts persist as JSON strings under `KeyboardShortcuts_<name>` UserDefaults keys — a **legacy
 format** from the removed KeyboardShortcuts package, kept so old bindings survive. The set of bound
-bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch.
+bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch. System Settings panes use
+`boundPaneBundleIDs`; custom commands use their stable UUIDs in `boundCustomCommandIDs`.
 
 ## Recorder
 

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -45,6 +45,16 @@ Rankings are memoized one query deep and keyed by the ranking store's revision, 
 invalidates the cached order. `rank` resolves the whole learned table for a query up front via
 `boosts(query:)` — one fold and one clock read per pass, not per candidate.
 
+## Custom commands
+
+`CustomCommandStore` supplies user-authored entries to `AppIndex` without joining the off-main
+application scan. Built-in and custom commands are alphabetized into the same final section, so they
+reuse fuzzy ranking, favorites, visibility, keycap rendering and the launcher's flat selection.
+
+Only the display name is indexed. Activation resolves the stable UUID through the store and dispatches
+to `ShellCommandRunner`; see [custom-commands.md](custom-commands.md) for persistence, hotkeys and
+execution semantics.
+
 > **Invariant:** `Tools/fuzz-test.swift` contains a **copy** of `FuzzyMatch` from
 > `Tinycast/Core/AppIndex.swift`. If you change the scoring in one, mirror it in the other or the test
 > is meaningless.


### PR DESCRIPTION
This PR add's custom commands that can be configured in settings and then run from the launcher. https://github.com/abue-ammar/tinycast/issues/41

## Related issue

Closes #41

## Memory footprint

Measured on Apple Silicon running macOS 26.5.1 with Xcode 26.6. Measurements use `footprint`’s `phys_footprint` after one warm-up cycle and five repeated palette open/search/close cycles.

| Step                    | Memory   |
| ----------------------- | -------- |
| Idle after launch       | 42.37 MB |
| Palette open            | 42.62 MB |
| Feature in use (peak)   | 43.04 MB |
| Palette closed, settled | 42.60 MB |

Settled memory was within 0.23 MB of the warmed baseline, with no continuing growth across repeated cycles. The initial cold footprint was 39.54 MB.

Leak-tested: Yes. Apple’s `leaks` tool found no Tinycast-owned leaked types or retain cycles. It reported 19 KB of system Accessibility/XPC allocations (`AXObserverCookie` and `NSXPCConnection`), which were also present in an independently launched control process.

## Drawbacks

- Commands run in a non-interactive login shell. Aliases defined only in `.zshrc`, interactive prompts and `sudo` are therefore not available by default. Users can explicitly invoke an interactive shell when required, for example `/bin/zsh -ic 'alias-name'`.
- Commands execute with the user’s account and permissions. Imported backups therefore warn before accepting executable command content.
- Standard input and output are disconnected deliberately, prioritising predictable execution over support for interactive commands.
- Only the user-facing command name is searchable; command text is intentionally not indexed.

## Manual Testing/Validation
* Created and ran a “Sleep Displays” command using /usr/bin/pmset displaysleepnow.
* Verified the command appears as a Custom Command in launcher results.
* Verified the launcher action is labelled “Run Command”.
* Repeated palette open, custom-command search, clear and close five times while measuring memory.
* Verified success, non-zero exit handling, bounded stderr capture, persistence and home-directory execution through the custom-command harness.

**Example**
Add Custom Command named "Sleep Displays", Command `/usr/bin/pmset displaysleepnow`

<img width="729" height="562" alt="image" src="https://github.com/user-attachments/assets/204ea7cd-c5f1-4893-878a-6b01a49018e0" />

<img width="769" height="490" alt="image" src="https://github.com/user-attachments/assets/ec411622-bc57-4658-94f4-7c567c8a4fb1" />
