### PR TITLE
Accept "**" as an alias for the power operator

### DIFF
--- a/Tinycast/Core/Calculator/CalcParser.swift
+++ b/Tinycast/Core/Calculator/CalcParser.swift
@@ -109,6 +109,13 @@ enum CalcTokenizer {
                 continue
             }
 
+            // "**" is the Python/JS/shell spelling of power, same operator as "^".
+            if ch == "*", i + 1 < chars.count, chars[i + 1] == "*" {
+                tokens.append(.op("^"))
+                i += 2
+                continue
+            }
+
             switch ch {
             case "+", "(", ")", "!", "%", "^":
                 tokens.append(.op(ch))

--- a/Tools/calc-test.swift
+++ b/Tools/calc-test.swift
@@ -15,6 +15,9 @@ struct CalcTests {
         expectDisplay("100/4", "25")
         expectDisplay("2^10", "1,024")
         expectDisplay("2^3^2", "512")  // right-associative
+        expectDisplay("2**2", "4")  // "**" is an alias for "^" (Python/JS/shell spelling)
+        expectDisplay("2**10", "1,024")
+        expectDisplay("2**3**2", "512")  // right-associative, same as "^"
         expectDisplay("(5+2)*3", "21")
         expectDisplay("5!", "120")
         expectDisplay("3!!", "720")  // (3!)! — chained postfix


### PR DESCRIPTION
Closes #83.

## Bug

`2**2` produces no card. `CalcTokenizer` has no special handling for `**`, so it tokenizes as two separate `*` ops. `CalcParser` consumes the first as multiplication, then hits the second where it expects a value (a number, a paren, an ident...) and fails, so the whole expression is rejected.

`**` is the power-operator spelling every mainstream language (Python, JS, Ruby, shell `bc`) uses, so it's a natural thing to type into a scratchpad calculator even though Tinycast already supports `^`.

## Fix

In `CalcTokenizer.tokenize`, when the current character is `*` and the next one is also `*`, emit a single `.op("^")` token and advance past both — reusing exactly the operator `^` already produces, so precedence, right-associativity, etc. all fall out for free.

`2**2` → `4`, `2**10` → `1,024`, `2**3**2` → `512` (right-associative, matching `2^3^2`).

## Tests

Three cases added to `Tools/calc-test.swift` (`2**2`, `2**10`, and `2**3**2` for right-associativity).

- `Tools/calc-test.swift` — **251 passed, 0 failed**
- `Tools/fuzz-test.swift` — all passed
- `Tools/emoji-test.swift` — all passed (2054 records)
- `xcodebuild -scheme Tinycast -configuration Debug` — **BUILD SUCCEEDED**, no new warnings

## Memory

Debug build, idle RSS sampled over ~15 s after launch: **79.0 MB**, against **79.6 MB** for `main` built from the same base — i.e. unchanged within noise. No separate peak figure: the diff is three lines in the tokenizer, adds no allocation and no retained state, so there's no palette interaction that would move it that wouldn't move identically on `main`.

## Notes

Non-visual change — no UI, no new tokens, nothing in `docs/` made wrong by it. The `**` → `^` folding only fires on two adjacent `*` characters, which is not valid input today, so nothing that parses now changes meaning.
