### PR TITLE
Support implicit multiplication before parens, constants, and functions

### DIFF
--- a/Tinycast/Core/Calculator/CalcParser.swift
+++ b/Tinycast/Core/Calculator/CalcParser.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum CalcToken: Equatable, Sendable {
     case number(Double)
-    /// An attached thousands suffix (`10k` / `2.5K`), kept distinct so a lone shorthand still earns a calculator card.
+    /// A number written in shorthand (`10k` / `2.5K`, `1e5`), kept distinct so a lone one still earns a calculator card.
     case compactNumber(Double)
     /// Radix-prefixed integer literal (0xff / 0b1010 / 0o777), kept exact for base conversion.
     case intLiteral(UInt64, radix: Int)
@@ -59,11 +59,29 @@ enum CalcTokenizer {
                     }
                     i += 1
                 }
-                guard let value = Double(text) else { return nil }
+                // Scientific notation, but only while the exponent hugs the mantissa — a spaced `2 e` stays 2 × e.
+                var isShorthand = false
+                if i < chars.count, chars[i] == "e" || chars[i] == "E" {
+                    var digits = i + 1
+                    if digits < chars.count, chars[digits] == "+" || chars[digits] == "-" {
+                        digits += 1
+                    }
+                    var end = digits
+                    while end < chars.count, isDigit(chars[end]) { end += 1 }
+                    if end > digits {
+                        text += String(chars[i..<end])
+                        i = end
+                        isShorthand = true
+                    }
+                }
+                // An overflowing literal ("1e400") isn't calculator input at all, so no card rather than a bogus one.
+                guard let value = Double(text), value.isFinite else { return nil }
                 // Attached `k` means ×1,000; whitespace keeps Kelvin explicit, and `10kg` remains a unit literal.
                 if i < chars.count, chars[i] == "k" || chars[i] == "K", isCompactSuffix(chars, i) {
                     tokens.append(.compactNumber(value * 1_000))
                     i += 1
+                } else if isShorthand {
+                    tokens.append(.compactNumber(value))
                 } else {
                     tokens.append(.number(value))
                 }
@@ -219,8 +237,9 @@ private struct Parser {
     var isAtEnd: Bool { pos == tokens.count }
     private var current: CalcToken? { pos < tokens.count ? tokens[pos] : nil }
 
-    // Binding powers: additive 10, multiplicative (incl. "of") 20, unary minus 25, power 30 (right-assoc), postfix ! % deg tightest.
+    // Binding powers: additive 10, multiplicative (incl. "of" and juxtaposition) 20, unary minus 25, power 30 (right-assoc), postfix ! % deg tightest.
     private static let unaryBP = 25
+    private static let mulBP = 20
 
     mutating func parseExpression(minBP: Int) -> Value? {
         guard var lhs = parseOperand() else { return nil }
@@ -233,8 +252,8 @@ private struct Parser {
                 continue
             }
             // Juxtaposition is the operator here, so there's no token to consume before the rhs.
-            if impliesMultiplication(), 20 >= minBP {
-                guard let rhs = parseExpression(minBP: 21) else { return nil }
+            if impliesMultiplication(), Self.mulBP >= minBP {
+                guard let rhs = parseExpression(minBP: Self.mulBP + 1) else { return nil }
                 guard let combined = apply("*", lhs, rhs) else { return nil }
                 lhs = combined
                 continue
@@ -257,8 +276,8 @@ private struct Parser {
     private func peekBinary() -> (Character, Int, Int)? {
         switch current {
         case .op(let op) where op == "+" || op == "-": return (op, 10, 11)
-        case .op(let op) where op == "*" || op == "/": return (op, 20, 21)
-        case .ident("of"): return ("*", 20, 21)
+        case .op(let op) where op == "*" || op == "/": return (op, Self.mulBP, Self.mulBP + 1)
+        case .ident("of"): return ("*", Self.mulBP, Self.mulBP + 1)
         case .op("^"): return ("^", 30, 30)  // right-associative: 2^3^2 = 512
         default: return nil
         }

--- a/Tinycast/Core/Calculator/CalcParser.swift
+++ b/Tinycast/Core/Calculator/CalcParser.swift
@@ -224,13 +224,33 @@ private struct Parser {
 
     mutating func parseExpression(minBP: Int) -> Value? {
         guard var lhs = parseOperand() else { return nil }
-        while let (op, bp, rightBP) = peekBinary(), bp >= minBP {
-            pos += 1
-            guard let rhs = parseExpression(minBP: rightBP) else { return nil }
-            guard let combined = apply(op, lhs, rhs) else { return nil }
-            lhs = combined
+        while true {
+            if let (op, bp, rightBP) = peekBinary(), bp >= minBP {
+                pos += 1
+                guard let rhs = parseExpression(minBP: rightBP) else { return nil }
+                guard let combined = apply(op, lhs, rhs) else { return nil }
+                lhs = combined
+                continue
+            }
+            // Juxtaposition is the operator here, so there's no token to consume before the rhs.
+            if impliesMultiplication(), 20 >= minBP {
+                guard let rhs = parseExpression(minBP: 21) else { return nil }
+                guard let combined = apply("*", lhs, rhs) else { return nil }
+                lhs = combined
+                continue
+            }
+            break
         }
         return lhs
+    }
+
+    /// Deliberately narrow — no unit or currency ident is a constant or function, so `10km` keeps its own path.
+    private func impliesMultiplication() -> Bool {
+        switch current {
+        case .op("("): return true
+        case .ident(let name): return CalcParser.constants[name] != nil || CalcParser.functions[name] != nil
+        default: return false
+        }
     }
 
     /// (operator, its binding power, minimum bp for its right operand).

--- a/Tinycast/Core/Calculator/CalcQuantity.swift
+++ b/Tinycast/Core/Calculator/CalcQuantity.swift
@@ -343,6 +343,8 @@ private struct QuantityParser {
         case .op("^"):
             return ("^", 30, 30, true)
         default:
+            // Juxtaposition against a bracket multiplies (`$5(2)`, `5(2)$`), matching the scalar parser.
+            if case .op("(") = current { return ("*", 20, 21, false) }
             if !isScalar(left.kind), startsQuantity(current) {
                 return ("+", 10, 11, false)
             }

--- a/Tools/calc-test.swift
+++ b/Tools/calc-test.swift
@@ -57,6 +57,16 @@ struct CalcTests {
         expectDisplay("π*2", "6.283185307")
         expectDisplay("e^2", "7.389056099")
 
+        // Implicit multiplication
+        expectDisplay("4(2+3)", "20")
+        expectDisplay("(2+3)(2+3)", "25")
+        expectDisplay("2pi", "6.283185307")
+        expectDisplay("2π", "6.283185307")
+        expectDisplay("2sqrt(9)", "6")
+        expectDisplay("2(3+1)+1", "9")  // implicit "*" binds like explicit "*", not looser
+        // Units are never mistaken for a constant/function, so this stays untouched
+        expectDisplay("10km to mi", "6.213711922 mi")
+
         // Percent
         expectDisplay("20% of 450", "90")
         expectDisplay("450 + 20%", "540")

--- a/Tools/calc-test.swift
+++ b/Tools/calc-test.swift
@@ -64,8 +64,27 @@ struct CalcTests {
         expectDisplay("2π", "6.283185307")
         expectDisplay("2sqrt(9)", "6")
         expectDisplay("2(3+1)+1", "9")  // implicit "*" binds like explicit "*", not looser
+        expectDisplay("10π ^e", "224.5915772")  // and looser than "^"
         // Units are never mistaken for a constant/function, so this stays untouched
         expectDisplay("10km to mi", "6.213711922 mi")
+        // Juxtaposition against a bracket carries the unit through, matching explicit "*"
+        expectDisplay("2(3)kg", "6 kg")
+        expectDisplay("2*(3)kg", "6 kg")
+
+        // Scientific notation — only when the exponent hugs the mantissa
+        expectDisplay("1e5", "100,000")
+        expectDisplay("2e10", "20,000,000,000")
+        expectDisplay("1E5", "100,000")
+        expectDisplay("1.5e3", "1,500")
+        expectDisplay("3e+2", "300")
+        expectCopy("1e-5", "1e-05")
+        expectDisplay("2e10/2", "10,000,000,000")
+        expectDisplay("1e5 to hex", "0x186A0")
+        expectDisplay("5e-3km", "0.003106855961 mi")
+        expectDisplay("2e", "5.436563657")  // no digits after "e" — still 2 × Euler's e
+        expectDisplay("1 e", "2.718281828")  // detached — never an exponent
+        expectNil("1e400")  // overflows to infinity, so not calculator input
+        expectNil("1e5e5")
 
         // Percent
         expectDisplay("20% of 450", "90")
@@ -489,6 +508,12 @@ struct CalcTests {
         expectDisplay("($10 + $5) to eur", "13.80 EUR")
         expectDisplay("$10 +", "10.00 USD")
         expectBadges("$10 +", source: "Expression", target: "US Dollar")
+        // Juxtaposition multiplies on either side of the amount, same as an explicit "*"
+        expectDisplay("$5(2)", "10.00 USD")
+        expectDisplay("5(2)$", "10.00 USD")
+        expectDisplay("$5(2) to eur", "9.20 EUR")
+        expectNilWithoutConsent("$5(2)")
+        expectNilWithoutConsent("5(2)$")
         expectError("$10 + 5kg", "Cannot add Currency and Weight.")
         expectErrorWithoutRates(
             "$10 + $5", "Exchange rates unavailable — check your connection.")

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -62,6 +62,25 @@ An attached `k` is a thousands suffix (`10k` → `10,000`), while whitespace kee
 (`10 k to c`); the established attached Kelvin conversion form remains valid when the temperature
 target makes the intent unambiguous (`273.15K to C`).
 
+Scientific notation (`1e5` → `100,000`, `5e-3km`, `3e+2`) is read only while the exponent hugs the
+mantissa, which is what keeps `2 e` and `2e` reading as 2 × Euler's *e* — an exponent needs digits
+after the `e`. Like `10k`, it tokenizes as a shorthand rather than a plain literal, so a lone `1e5`
+still earns a card where a lone `100000` deliberately doesn't. A literal that overflows to infinity
+(`1e400`) is treated as non-calculator input, not as a card.
+
+## Implicit multiplication
+
+Juxtaposition means `*` at the same binding power as an explicit one (`4(2+3)` → 20, `2pi`,
+`2sqrt(9)`, `(2+3)(2+3)`), so it binds tighter than `+` and looser than `^`, and `6/2(1+2)` agrees
+with `6/2*(1+2)`. `CalcParser.parseExpression` checks it after `peekBinary()` fails and, unlike a real
+operator, consumes no token before parsing the right operand.
+
+The scalar side is deliberately narrow: only `(` or a name in `CalcParser.constants` / `functions`
+starts an implicit product. Adjacent *numbers* never do — `5 3` stays an app search — and no unit or
+currency name is a constant or function, so `10km` keeps its own path. `QuantityParser.peekBinary`
+carries the same `(` rule so the typed side agrees (`$5(2)` → `10.00 USD`, `2(3)kg` → `6 kg`, matching
+`2*(3)kg`); adjacency there still means the composite-quantity `+` described above, never a product.
+
 A query ending in a binary operator keeps the last complete prefix visible while the next operand is
 being typed: `10 +` shows `10`, `10kg + 500g +` shows `10,500 g`, and `$10 +` shows `10.00 USD`
 when currency is enabled. The prefix must itself be valid, so malformed input and incomplete


### PR DESCRIPTION
Closes #84.

## Bug

Ordinary maths notation drops the `×` between a number and a bracket. None of these produce a card today:

| input | today | with explicit `*` |
|---|---|---|
| `4(2+3)` | no card | `4*(2+3)` → 20 |
| `(2+3)(2+3)` | no card | `(2+3)*(2+3)` → 25 |
| `2pi` / `2π` | no card | `2*pi` → 6.283185307 |
| `2sqrt(9)` | no card | `2*sqrt(9)` → 6 |

`CalcParser`'s precedence-climbing loop only continues past an operand when it recognizes an explicit binary operator next (`peekBinary()`); it returns nil for `(` or an identifier, so the loop stops, `isAtEnd` is false, and the whole expression is rejected.

## Fix

`CalcParser.swift` — `parseExpression`'s loop gets a second check alongside the explicit-operator one: if the next token can *only* be the start of another operand here (`(`, or a name in `constants`/`functions`), treat it as an implicit `*` at the same binding power (20/21, same as explicit `*`) — but, unlike a real operator, don't consume a token first, since there isn't one to consume.

**Why this can't collide with units or currency:** the check is narrowly scoped to `CalcParser.constants` (`pi`, `π`, `e`) and `CalcParser.functions` (`sqrt`, `log`, `ln`, `sin`, `cos`, `tan`, `abs`, `floor`, `ceil`, `round`) — none of which overlap any unit or currency name in `CalcUnits`/`CalcCurrency`. So `10km` still resolves through the existing bare-unit-conversion path untouched; implicit multiplication never even gets a chance to look at it.

## Tests

Added to `Tools/calc-test.swift`: the four reported cases, a precedence check (`2(3+1)+1` → 9, confirming implicit `*` binds tighter than `+`), and a regression pin on `10km to mi` to document the "never touches units" guarantee.

- `Tools/calc-test.swift` — **255 passed, 0 failed**
- `Tools/fuzz-test.swift` — all passed
- `Tools/emoji-test.swift` — all passed (2054 records)
- `xcodebuild -scheme Tinycast -configuration Debug` — **BUILD SUCCEEDED**, no new warnings

## Memory

Debug build, idle RSS sampled over ~15 s after launch: **79.0 MB**, against **79.6 MB** for `main` built from the same base — unchanged within noise. No separate peak figure: the change is a branch inside an existing parse loop, allocating nothing and retaining nothing.

## Notes

Non-visual change — no UI. The one thing worth a second look in review is the scoping argument above: the guarantee that implicit `*` never swallows a unit rests entirely on `constants`/`functions` being disjoint from the unit and currency tables. If a future unit is ever named `e` or `abs`, that assumption needs revisiting — the `10km to mi` test case exists to fail loudly if it ever stops holding.
