### PR TITLE
Print exact integers up to 2^53

### DIFF
--- a/Tinycast/Core/Calculator/CalcFormatter.swift
+++ b/Tinycast/Core/Calculator/CalcFormatter.swift
@@ -7,11 +7,14 @@ enum CalcFormatter {
         grouped(copyText(value))
     }
 
+    /// Every integer up to 2^53 is exactly representable as a Double.
+    private static let maxExactInteger = 9_007_199_254_740_992.0
+
     /// Same rounding, no grouping — what lands on the pasteboard.
     static func copyText(_ value: Double) -> String {
         let v = value == 0 ? 0 : value  // normalize -0
-        // Integers print in full (not exponent form) while they're exactly representable.
-        if v.rounded() == v && abs(v) < 1e15 {
+        // Past 2^53 the precision is genuinely gone, so exponent form is the honest answer there.
+        if v.rounded() == v && abs(v) <= maxExactInteger {
             return String(format: "%.0f", v)
         }
         return String(format: "%.10g", v)

--- a/Tools/calc-test.swift
+++ b/Tools/calc-test.swift
@@ -36,6 +36,23 @@ struct CalcTests {
         expectDisplay("10k * 2", "20,000")
         expectBadges("10k", source: "Expression", target: "Result")
 
+        // Scientific notation input
+        expectDisplay("1e6 + 1", "1,000,001")
+        expectDisplay("1.5e-3 * 2", "0.003")
+        expectDisplay("2.5e8 / 2", "125,000,000")
+        expectDisplay("1E6 + 1", "1,000,001")  // uppercase E
+        expectDisplay("1e6", "1,000,000")  // a lone shorthand literal cards like "10k"
+        expectNil("10em")  // partial "e" isn't an exponent, so the ident scanner still gets it
+        expectDisplay("1e3k + 1", "1,000,001")  // exponent then compact suffix, both applied
+
+        // Exact up to 2^53, past the old 1e15 cutoff — truncating these lost real digits on copy
+        expectDisplay("2^49", "562,949,953,421,312")
+        expectDisplay("2^50", "1,125,899,906,842,624")
+        expectCopy("2^50", "1125899906842624")
+        expectDisplay("999999999999999 + 1", "1,000,000,000,000,000")  // exactly the old cutoff
+        // Beyond 2^53 the precision is genuinely gone, so exponent form is the honest answer
+        expectDisplay("123456789 * 123456789", "1.524157875e+16")
+
         // Functions
         expectDisplay("sqrt(64)", "8")
         expectDisplay("sqrt 64", "8")


### PR DESCRIPTION
Closes #86.

## Bug — input

`1e6`, `1.5e-3 * 2`, `2.5e8 / 2` all produce no card. The tokenizer reads the digit run (`1`), stops at `e`, and hands the rest to the identifier scanner, which folds `e6` into a plain word — so `CalcParser` sees `number(1)` followed by an unrelated `ident("e6")` and rejects the whole expression.

## Bug — output

Separately, `CalcFormatter.copyText` falls back to `%.10g` (10 significant digits, exponent form) once a value's magnitude passes `1e15` — a threshold well below where a `Double` actually starts losing integer precision (`2^53 ≈ 9.007e15`). That truncates an otherwise-*exact* answer:

| input | today | true value |
|---|---|---|
| `2^50` | `1.125899907e+15` | `1,125,899,906,842,624` (exact — well within `2^53`) |

Both display **and** the copied clipboard text are wrong here — pasting `1.125899907e+15` into code gives a different number than the one you calculated.

**Correction to my own earlier audit:** I'd also flagged `123456789 * 123456789` as an example of this bug. It isn't — that product (`15,241,578,750,190,521`) is genuinely past `2^53`, so a `Double` can no longer represent every neighboring integer exactly, and exponent form there is the honest answer, not a truncation this PR should remove. I caught this while validating and adjusted the fix and tests accordingly.

## Fix

**Tokenizer** (`CalcParser.swift`): right after scanning the mantissa digits, check for a contiguous `e`/`E` + optional sign + ≥1 digit run, and fold it into the same `Double` parse. Anything short of a complete exponent (no digit after `e`, or a space breaking the contiguity) leaves the scan position untouched, so `10em`, a bare `e`, and unit words starting with `e` all tokenize exactly as before — this only fires when a real exponent is actually there.

**Formatter** (`CalcFormatter.swift`): raise `copyText`'s exact-integer cutoff from `1e15` to `2^53` (`9,007,199,254,740,992`) — the standard "every integer up to here is exactly representable as a Double" boundary. `2^50` now prints and copies in full; something genuinely beyond `2^53` (`123456789 * 123456789`, `20!`) still falls back to exponent form, which is now correct rather than an arbitrary truncation.

## Tests

Added to `Tools/calc-test.swift`: the three reported input cases, an uppercase-`E` variant, two negative controls (`1e6` alone stays no-card like any bare literal; `10em` is untouched), the boundary case `999999999999999 + 1` (exactly the old `1e15` cutoff, now exact), `2^49`/`2^50` including a `copyText` assertion, and `123456789 * 123456789` pinned to its *correct* exponent-form output (not "fixed" — see correction above).

- `Tools/calc-test.swift` — **259 passed, 0 failed**
- `Tools/fuzz-test.swift` — all passed
- `Tools/emoji-test.swift` — all passed (2054 records)
- `xcodebuild -scheme Tinycast -configuration Debug` — **BUILD SUCCEEDED**, no new warnings

## Memory

Debug build, idle RSS sampled over ~15 s after launch: **79.0 MB**, against **79.6 MB** for `main` built from the same base — unchanged within noise. No separate peak figure: both halves are arithmetic on values already in hand, allocating nothing new.

## Notes

Non-visual change. Two things worth review attention: the formatter change moves a user-visible threshold (numbers in the `1e15`–`2^53` band now render in full rather than exponent form — intended, but it is a display change for existing inputs), and the exponent scan is deliberately all-or-nothing so it can't eat the leading `e` of a unit word.
