### PR TITLE
Add welcome workflow for new issues and PRs

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,51 @@
+name: Welcome
+
+# Thanks first-touch on every issue and PR, points PR authors at the "open an issue first" rule.
+# pull_request_target (not pull_request) so forked PRs still get a comment — no checkout, so
+# there's no untrusted-code-execution risk from using the _target event.
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on issue
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "Thanks for opening this! A maintainer will review it shortly."
+            });
+
+      - name: Comment on pull request
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = [
+              "Thanks for the PR! A maintainer will review it shortly.",
+              "",
+              "> [!IMPORTANT]",
+              "> **Open an issue before you write code — this is mandatory.** Get the bug or the feature agreed on",
+              "> first; discussing it in the issue (or on [Discord](https://discord.gg/v2Eeb4QQy3)) is strongly",
+              "> encouraged. A PR with no agreed issue behind it gets closed however good the patch is, and the",
+              "> work is wasted. Typo and docs-only fixes are the one exception.",
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that comments on every newly opened issue and PR, thanking the author and noting a maintainer will review shortly
- PR comments also include the "open an issue before you write code" notice from the README's Contributing section

## Test plan
- [ ] Open a test issue/PR against this branch and confirm the workflow comments once, with no duplicate comments on later pushes