### PR TITLE
Add sleep and lock screen commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there
 - **Clipboard history** — text and images, searchable, pasted back into the app you were using.
 - **Global hotkey** — one shortcut summons the palette from anywhere.
 - **Per-app hotkeys** — bind a key to an app; press it to toggle (focus/hide).
+- **System commands** — lock the screen or put the Mac to sleep from the launcher or a hotkey.
 
 ## Install
 
@@ -50,9 +51,9 @@ directly from Releases instead, clear it once: `xattr -dr com.apple.quarantine
 
 ## Permissions
 
-**Accessibility** — needed only so Tinycast can paste a clipboard item back into the app you
-came from. You're prompted the first time you paste; grant it in **System Settings → Privacy &
-Security → Accessibility**.
+**Accessibility** — needed so Tinycast can paste a clipboard item back into the app you came from
+and invoke **Lock Screen**. You're prompted the first time either action needs it; grant access in
+**System Settings → Privacy & Security → Accessibility**.
 
 ## Using it
 

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		441CF705AE1D03F6E236A61E /* ClipboardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */; };
 		4F3D96E59E117459153336F4 /* SettingsPaneScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */; };
 		4F740AF85545CF4133C89B82 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4802942FF89B327A76432A9B /* AboutView.swift */; };
+		54C5A5EF76F4290EFAA9A86E /* SystemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8549CF4317F8D6CCE97D3C /* SystemActions.swift */; };
 		5568D02AE095293A15A7F30D /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9ACD504E016DFF6FE6C1B /* RightClick.swift */; };
 		57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */; };
 		649961AA51BA4D87626C27D5 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09093BF10EA97BDCA45A241F /* CalcFormatter.swift */; };
@@ -130,6 +131,7 @@
 		6BB7C545EFD9589A77AD7BE2 /* LauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherView.swift; sourceTree = "<group>"; };
 		74F450E10D107C1E30EA2BC6 /* EmojiIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiIndex.swift; sourceTree = "<group>"; };
 		79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiData.generated.swift; sourceTree = "<group>"; };
+		7A8549CF4317F8D6CCE97D3C /* SystemActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActions.swift; sourceTree = "<group>"; };
 		7BC2DEA0A052116A92F9A539 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityStore.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				4B432D84D8F9C10521342199 /* RunningApps.swift */,
 				9AA0E1FD530C764A021E6053 /* SearchScopes.swift */,
 				C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */,
+				7A8549CF4317F8D6CCE97D3C /* SystemActions.swift */,
 				7BC2DEA0A052116A92F9A539 /* Theme.swift */,
 				A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */,
 				825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */,
@@ -534,6 +537,7 @@
 				CFB516312C4694DDFD99DBCA /* SettingsRootView.swift in Sources */,
 				57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */,
 				05561CD36EF1A0775A282165 /* ShortcutsSettingsView.swift in Sources */,
+				54C5A5EF76F4290EFAA9A86E /* SystemActions.swift in Sources */,
 				72ACD144841BF1117CD4E705 /* Theme.swift in Sources */,
 				85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */,
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -258,7 +258,8 @@ final class AppCore: ObservableObject {
         }
         // Commands dispatch before the palette hides: mode-switching commands keep it open.
         if app.kind == .command {
-            runCommand(app)
+            guard let command = CommandRegistry.command(for: app) else { return }
+            runCommand(command)
             return
         }
         hidePalette(restoreFocus: false)
@@ -308,8 +309,8 @@ final class AppCore: ObservableObject {
         return alert.runModal() == .alertFirstButtonReturn
     }
 
-    private func runCommand(_ entry: AppEntry) {
-        switch CommandRegistry.command(for: entry) {
+    func runCommand(_ command: CommandID) {
+        switch command {
         case .calculatorHistory:
             showPalette(mode: .calculatorHistory)
         case .clipboardHistory:
@@ -325,6 +326,11 @@ final class AppCore: ObservableObject {
         case .importFromRaycast:
             hidePalette(restoreFocus: false)
             showBackupSettings()
+        case .lockScreen, .sleep:
+            hidePalette(restoreFocus: false)
+            guard let action = command.systemAction else { return }
+            let result = SystemActions.perform(action)
+            if result != .success { showSystemActionFailure(action, result: result) }
         case .settings:
             hidePalette(restoreFocus: false)
             showSettings()
@@ -337,7 +343,36 @@ final class AppCore: ObservableObject {
             quitAllApps()
         case .quit:
             NSApp.terminate(nil)
-        case nil:
+        }
+    }
+
+    private func showSystemActionFailure(
+        _ action: SystemAction, result: SystemActionResult
+    ) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        switch (action, result) {
+        case (.lockScreen, .permissionDenied):
+            alert.messageText = "Tinycast needs permission to lock the screen."
+            alert.informativeText =
+                "Allow Tinycast in System Settings → Privacy & Security → Accessibility, then try again."
+            alert.addButton(withTitle: "Open Settings")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() == .alertFirstButtonReturn {
+                Permissions.openAccessibilitySettings()
+            }
+        case (.lockScreen, .systemFailure):
+            alert.messageText = "Tinycast couldn’t lock the screen."
+            alert.informativeText = "macOS couldn’t create the lock request. Try ⌃⌘Q or press Touch ID."
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        case (.sleep, .permissionDenied), (.sleep, .systemFailure):
+            alert.messageText = "Tinycast couldn’t put this Mac to sleep."
+            alert.informativeText = "macOS rejected the sleep request. Try again or use the Apple menu."
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        case (_, .success):
             break
         }
     }

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -25,13 +25,18 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         }
     }
 
-    /// The global-hotkey action that opens this entry, or `nil` when it has no bundle ID to key the binding on.
+    /// The global-hotkey action that opens this entry, keyed by bundle ID or stable command ID.
     var hotKeyAction: HotKeyAction? {
-        guard let bundleID else { return nil }
         switch kind {
-        case .application: return .app(bundleID: bundleID)
-        case .systemSettings: return .settingsPane(bundleID: bundleID)
-        case .command: return nil
+        case .application:
+            guard let bundleID else { return nil }
+            return .app(bundleID: bundleID)
+        case .systemSettings:
+            guard let bundleID else { return nil }
+            return .settingsPane(bundleID: bundleID)
+        case .command:
+            guard let command = CommandRegistry.command(for: self) else { return nil }
+            return .command(id: command)
         }
     }
 

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -33,6 +33,7 @@ struct SettingsBackup: Codable {
         var toggleEmoji: KeyShortcut?
         var apps: [String: KeyShortcut]?
         var panes: [String: KeyShortcut]?
+        var commands: [String: KeyShortcut]?
     }
 
     /// A tally of what an import touched, for user-facing confirmation.
@@ -80,6 +81,10 @@ extension SettingsBackup {
         hotkeys.panes = Dictionary(
             uniqueKeysWithValues: hk.boundPaneBundleIDs.compactMap { id in
                 hk.shortcut(for: .settingsPane(bundleID: id)).map { (id, $0) }
+            })
+        hotkeys.commands = Dictionary(
+            uniqueKeysWithValues: hk.boundCommandIDs.compactMap { id in
+                hk.shortcut(for: .command(id: id)).map { (id.rawValue, $0) }
             })
         backup.hotkeys = hotkeys
 
@@ -185,6 +190,10 @@ extension SettingsBackup {
         if let s = hotkeys.toggleEmoji { apply(s, .toggleEmoji) }
         for (id, s) in hotkeys.apps ?? [:] { apply(s, .app(bundleID: id)) }
         for (id, s) in hotkeys.panes ?? [:] { apply(s, .settingsPane(bundleID: id)) }
+        for (rawID, s) in hotkeys.commands ?? [:] {
+            guard let id = CommandID(rawValue: rawID) else { continue }
+            apply(s, .command(id: id))
+        }
         return count
     }
 }

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -1,14 +1,16 @@
 import Foundation
 
 /// App-internal launcher actions surfaced as a "Commands" category; each is a synthetic `AppEntry` (kind `.command`, no bundle ID) so existing `AppEntry` plumbing applies, with dispatch in `AppCore.runCommand`.
-enum CommandID: String, CaseIterable, Sendable {
+enum CommandID: String, CaseIterable, Hashable, Sendable {
     case calculatorHistory = "command:calculator-history"
     case clipboardHistory = "command:clipboard-history"
     case searchEmoji = "command:search-emoji"
     case exportSettings = "command:export-settings"
     case importSettings = "command:import-settings"
     case importFromRaycast = "command:import-from-raycast"
+    case lockScreen = "command:lock-screen"
     case settings = "command:settings"
+    case sleep = "command:sleep"
     case about = "command:about"
     case quitAllApps = "command:quit-all-apps"
     case quit = "command:quit"
@@ -21,10 +23,20 @@ enum CommandID: String, CaseIterable, Sendable {
         case .exportSettings: return "Export Settings"
         case .importSettings: return "Import Settings"
         case .importFromRaycast: return "Import from Raycast"
+        case .lockScreen: return "Lock Screen"
         case .settings: return "Settings"
+        case .sleep: return "Sleep"
         case .about: return "About Tinycast"
         case .quitAllApps: return "Quit All Applications"
         case .quit: return "Quit Tinycast"
+        }
+    }
+
+    var systemAction: SystemAction? {
+        switch self {
+        case .lockScreen: return .lockScreen
+        case .sleep: return .sleep
+        default: return nil
         }
     }
 
@@ -36,7 +48,9 @@ enum CommandID: String, CaseIterable, Sendable {
         case .exportSettings: return "square.and.arrow.up"
         case .importSettings: return "square.and.arrow.down"
         case .importFromRaycast: return "arrow.down.doc"
+        case .lockScreen: return "lock.fill"
         case .settings: return "gearshape"
+        case .sleep: return "moon.zzz.fill"
         case .about: return "info.circle"
         case .quitAllApps: return "xmark.circle"
         case .quit: return "power"

--- a/Tinycast/Core/HotKey/KeyShortcut.swift
+++ b/Tinycast/Core/HotKey/KeyShortcut.swift
@@ -152,6 +152,7 @@ enum HotKeyAction: Hashable, Sendable {
     case toggleEmoji
     case app(bundleID: String)
     case settingsPane(bundleID: String)
+    case command(id: CommandID)
 
     /// UserDefaults key holding the shortcut JSON; the `KeyboardShortcuts_` prefix is a fossil of the replaced package, kept verbatim so existing bindings need no migration.
     var defaultsKey: String {
@@ -161,6 +162,7 @@ enum HotKeyAction: Hashable, Sendable {
         case .toggleEmoji: "KeyboardShortcuts_toggleEmoji"
         case .app(let bundleID): "KeyboardShortcuts_appHotkey." + bundleID
         case .settingsPane(let bundleID): "KeyboardShortcuts_paneHotkey." + bundleID
+        case .command(let id): "KeyboardShortcuts_commandHotkey." + id.rawValue
         }
     }
 }

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -15,6 +15,7 @@ final class HotKeyManager: ObservableObject {
     private let center = HotKeyCenter()
     private let boundKey = "boundAppBundleIDs"
     private let boundPaneKey = "boundPaneBundleIDs"
+    private let boundCommandKey = "boundCommandIDs"
 
     func start() {
         register(.togglePalette)
@@ -22,6 +23,7 @@ final class HotKeyManager: ObservableObject {
         register(.toggleEmoji)
         for bundleID in boundBundleIDs { register(.app(bundleID: bundleID)) }
         for bundleID in boundPaneBundleIDs { register(.settingsPane(bundleID: bundleID)) }
+        for id in boundCommandIDs { register(.command(id: id)) }
     }
 
     /// Bundle IDs that currently have a per-app hotkey — lets `start()` know which records to load and lets launcher rows show keycaps.
@@ -32,6 +34,12 @@ final class HotKeyManager: ObservableObject {
     /// Settings-pane bundle IDs with a hotkey — same role as `boundBundleIDs`, own namespace.
     var boundPaneBundleIDs: [String] {
         UserDefaults.standard.stringArray(forKey: boundPaneKey) ?? []
+    }
+
+    /// Stable command IDs with a hotkey; unknown IDs from a newer or removed build are ignored.
+    var boundCommandIDs: [CommandID] {
+        (UserDefaults.standard.stringArray(forKey: boundCommandKey) ?? [])
+            .compactMap(CommandID.init(rawValue:))
     }
 
     func shortcut(for action: HotKeyAction) -> KeyShortcut? {
@@ -65,6 +73,10 @@ final class HotKeyManager: ObservableObject {
             var set = Set(boundPaneBundleIDs)
             if shortcut == nil { set.remove(bundleID) } else { set.insert(bundleID) }
             UserDefaults.standard.set(Array(set), forKey: boundPaneKey)
+        case .command(let id):
+            var set = Set(boundCommandIDs)
+            if shortcut == nil { set.remove(id) } else { set.insert(id) }
+            UserDefaults.standard.set(set.map(\.rawValue), forKey: boundCommandKey)
         case .togglePalette, .toggleClipboard, .toggleEmoji:
             break
         }
@@ -75,6 +87,7 @@ final class HotKeyManager: ObservableObject {
         var candidates: [HotKeyAction] = [.togglePalette, .toggleClipboard, .toggleEmoji]
         candidates += boundBundleIDs.map { .app(bundleID: $0) }
         candidates += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
+        candidates += boundCommandIDs.map { .command(id: $0) }
         for candidate in candidates
         where candidate != action && self.shortcut(for: candidate) == shortcut {
             return displayName(of: candidate)
@@ -98,6 +111,8 @@ final class HotKeyManager: ObservableObject {
             let apps = AppCore.shared.appIndex.apps
             return apps.first { $0.kind == .systemSettings && $0.bundleID == bundleID }?.name
                 ?? bundleID
+        case .command(let id):
+            return id.name
         }
     }
 
@@ -115,6 +130,7 @@ final class HotKeyManager: ObservableObject {
         case .toggleEmoji: onToggleEmoji?()
         case .app(let bundleID): AppLauncher.toggle(bundleID: bundleID)
         case .settingsPane(let bundleID): AppLauncher.openSettingsPane(bundleID: bundleID)
+        case .command(let id): AppCore.shared.runCommand(id)
         }
     }
 }

--- a/Tinycast/Core/SystemActions.swift
+++ b/Tinycast/Core/SystemActions.swift
@@ -1,0 +1,61 @@
+import Carbon.HIToolbox
+import CoreGraphics
+import IOKit.pwr_mgt
+
+enum SystemAction: Sendable {
+    case lockScreen
+    case sleep
+}
+
+enum SystemActionResult: Equatable, Sendable {
+    case success
+    case permissionDenied
+    case systemFailure
+}
+
+enum SystemActions {
+    @discardableResult
+    static func perform(_ action: SystemAction) -> SystemActionResult {
+        perform(action, lockScreen: postLockScreenShortcut, sleep: requestSystemSleep)
+    }
+
+    /// Injectable handlers keep command routing testable without locking or sleeping the test Mac.
+    @discardableResult
+    static func perform(
+        _ action: SystemAction,
+        lockScreen: () -> SystemActionResult,
+        sleep: () -> SystemActionResult
+    ) -> SystemActionResult {
+        switch action {
+        case .lockScreen: return lockScreen()
+        case .sleep: return sleep()
+        }
+    }
+
+    private static func postLockScreenShortcut() -> SystemActionResult {
+        guard CGPreflightPostEventAccess() || CGRequestPostEventAccess() else {
+            return .permissionDenied
+        }
+        guard
+            let source = CGEventSource(stateID: .hidSystemState),
+            let keyDown = CGEvent(
+                keyboardEventSource: source, virtualKey: CGKeyCode(kVK_ANSI_Q), keyDown: true),
+            let keyUp = CGEvent(
+                keyboardEventSource: source, virtualKey: CGKeyCode(kVK_ANSI_Q), keyDown: false)
+        else { return .systemFailure }
+
+        let flags: CGEventFlags = [.maskControl, .maskCommand]
+        keyDown.flags = flags
+        keyUp.flags = flags
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+        return .success
+    }
+
+    private static func requestSystemSleep() -> SystemActionResult {
+        let connection = IOPMFindPowerManagement(mach_port_t(MACH_PORT_NULL))
+        guard connection != 0 else { return .systemFailure }
+        defer { IOServiceClose(connection) }
+        return IOPMSleepSystem(connection) == kIOReturnSuccess ? .success : .systemFailure
+    }
+}

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -156,7 +156,7 @@ struct OnboardingView: View {
                 SettingsRow(
                     title: "Accessibility",
                     subtitle:
-                        "Without it Tinycast can still copy, but it can't paste a clipboard or emoji item back into the app you were using.",
+                        "Without it Tinycast can still copy, but it can't paste back into another app or lock the screen.",
                     systemImage: "accessibility", tint: .blue
                 ) {
                     statusBadge

--- a/Tinycast/Features/Settings/PermissionsSettingsView.swift
+++ b/Tinycast/Features/Settings/PermissionsSettingsView.swift
@@ -13,7 +13,7 @@ struct PermissionsSettingsView: View {
             SettingsCard(header: "Accessibility") {
                 SettingsRow(
                     title: "Accessibility",
-                    subtitle: "Lets Tinycast paste a clipboard item into the app you were using.",
+                    subtitle: "Lets Tinycast paste into other apps and lock the screen.",
                     systemImage: "accessibility",
                     tint: .blue
                 ) {

--- a/Tools/commands-test.swift
+++ b/Tools/commands-test.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Minimal test double: `CommandRegistry` only needs the launcher entry's value shape.
+struct AppEntry: Identifiable, Hashable, Sendable {
+    enum Kind: String, Sendable {
+        case application
+        case systemSettings
+        case command
+    }
+
+    let id: String
+    let name: String
+    let url: URL
+    let bundleID: String?
+    let kind: Kind
+}
+
+@main
+struct CommandsTest {
+    static func main() {
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        check(
+            "lock screen has a stable command ID",
+            CommandID.lockScreen.rawValue == "command:lock-screen")
+        check("lock screen has the expected title", CommandID.lockScreen.name == "Lock Screen")
+        check("lock screen has an SF Symbol", CommandID.lockScreen.sfSymbol == "lock.fill")
+        check("lock screen maps to its system action", CommandID.lockScreen.systemAction == .lockScreen)
+
+        check("sleep has a stable command ID", CommandID.sleep.rawValue == "command:sleep")
+        check("sleep has the expected title", CommandID.sleep.name == "Sleep")
+        check("sleep has an SF Symbol", CommandID.sleep.sfSymbol == "moon.zzz.fill")
+        check("sleep maps to its system action", CommandID.sleep.systemAction == .sleep)
+
+        let names = CommandRegistry.all.map(\.name)
+        check(
+            "the registry includes both system commands",
+            names.contains("Lock Screen") && names.contains("Sleep"))
+        check(
+            "the registry remains alphabetically sorted",
+            names == names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+        check(
+            "registry entries round-trip to command IDs",
+            CommandRegistry.all.allSatisfy { CommandRegistry.command(for: $0) != nil })
+
+        var calls: [SystemAction] = []
+        let lockSucceeded = SystemActions.perform(
+            .lockScreen,
+            lockScreen: {
+                calls.append(.lockScreen)
+                return .success
+            },
+            sleep: {
+                calls.append(.sleep)
+                return .systemFailure
+            })
+        check("lock dispatch reports the selected handler result", lockSucceeded == .success)
+        check("lock dispatch invokes only the lock handler", calls == [.lockScreen])
+
+        calls.removeAll()
+        let sleepSucceeded = SystemActions.perform(
+            .sleep,
+            lockScreen: {
+                calls.append(.lockScreen)
+                return .systemFailure
+            },
+            sleep: {
+                calls.append(.sleep)
+                return .success
+            })
+        check("sleep dispatch reports the selected handler result", sleepSucceeded == .success)
+        check("sleep dispatch invokes only the sleep handler", calls == [.sleep])
+
+        calls.removeAll()
+        let denied = SystemActions.perform(
+            .lockScreen,
+            lockScreen: {
+                calls.append(.lockScreen)
+                return .permissionDenied
+            },
+            sleep: {
+                calls.append(.sleep)
+                return .success
+            })
+        check("a rejected system action preserves the reason", denied == .permissionDenied)
+        check("a rejected action still invokes only its handler", calls == [.lockScreen])
+
+        let failed = SystemActions.perform(
+            .sleep,
+            lockScreen: { .success },
+            sleep: { .systemFailure })
+        check("a system failure remains distinct from permission denial", failed == .systemFailure)
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,8 @@ swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.
     -o /tmp/clipboard-test && /tmp/clipboard-test                 # clipboard store
 swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift \
     -o /tmp/scopes-test && /tmp/scopes-test                       # launcher search scopes
+swiftc -swift-version 6 Tinycast/Core/SystemActions.swift Tinycast/Core/CommandRegistry.swift \
+    Tools/commands-test.swift -o /tmp/commands-test && /tmp/commands-test  # built-in commands
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -10,8 +10,9 @@
 ## Persistence
 
 Shortcuts persist as JSON strings under `KeyboardShortcuts_<name>` UserDefaults keys — a **legacy
-format** from the removed KeyboardShortcuts package, kept so old bindings survive. The set of bound
-bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch.
+format** from the removed KeyboardShortcuts package, kept so old bindings survive. Bound app bundle
+IDs, settings-pane bundle IDs, and stable command IDs live in separate arrays and are re-registered
+on launch. Unknown command IDs are ignored so removing or downgrading a build stays safe.
 
 ## Recorder
 

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -54,6 +54,16 @@ paths; see the command in `development.md`.
 
 Icons go through a count-capped `NSCache` (`IconCache`).
 
+## System commands
+
+`CommandRegistry` exposes **Lock Screen** and **Sleep** alongside the other built-in commands. Both
+hide the palette before dispatch. Sleep uses the public IOKit power-management API; Lock Screen posts
+the standard macOS **⌃⌘Q** shortcut through CoreGraphics and requests event-posting access when
+needed. Neither action shells out or relies on the removed `CGSession` helper.
+
+Command entries use their stable `CommandID` for global-hotkey persistence, so commands can be
+searched, favorited, hidden, or bound in Settings just like apps and System Settings panes.
+
 ## Quitting apps
 
 `RunningAppsMonitor` (live from `NSWorkspace` launch/terminate notifications) drives both the row's


### PR DESCRIPTION
## Related issue

Closes #96

## What changed

- Adds `Lock Screen` and `Sleep` as native launcher commands.
- Makes command entries assignable to global shortcuts, including launch-time re-registration and settings backup/restore.
- Uses public macOS APIs: CoreGraphics posts the standard `⌃⌘Q` lock shortcut, while IOKit requests system sleep.
- Hides the palette before dispatch and distinguishes permission denial from system-action failure.
- Updates Accessibility copy in README, onboarding, and Permissions settings.

## Memory footprint

Measured with `footprint` on macOS 26 after an optimized arm64 build.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 21 MB  |
| Palette open            | 21 MB  |
| Feature in use (peak)   | 21 MB  |
| Palette closed, settled | 20 MB  |

Leak-tested: 20 palette open/close cycles; settled back to 20 MB with a 21 MB peak.

## Demo

[Watch the side-by-side demo](https://github.com/chlins/tinycast/releases/download/pr-97-demo/pr-demo-before-after.mp4): existing stable build on the left, this branch on the right. Both search `lock`, then `sleep`, at the same window size.

## Drawbacks

Lock Screen needs Accessibility permission because macOS gates synthetic keyboard events. Tinycast requests access and reports permission denial separately from event-construction failure.

## Tests & validation

- `xcodegen generate` reproduces the committed project with no diff.
- Swift 6 strict-concurrency typecheck with warnings as errors passes for all app sources.
- All documented standalone harnesses pass: fuzzy matching, ranking, calculator (426), clipboard (23), and search scopes.
- New command harness passes 18 cases without invoking real lock or sleep actions.
- Search/display paths, command icons, and palette open/close behavior exercised by hand.
- Full optimized arm64 app compiled, ad-hoc signed, launched, and memory-tested.
- Full `xcodebuild` was not available because this machine has Command Line Tools but no full Xcode app.
