### PR TITLE
refactor: Fill bare-unit coverage gaps and allow an expression before

### DIFF
--- a/Tinycast/Core/Calculator/CalcEngine.swift
+++ b/Tinycast/Core/Calculator/CalcEngine.swift
@@ -244,27 +244,36 @@ enum CalcEngine {
 
     // MARK: - Number bases
 
-    /// `255 to hex`, `0xff to decimal`, `0b1010 to binary` — exactly source → connector → target.
+    /// `255 to hex`, `0xff to decimal`, `0b1010 to binary`, `2*128 to hex` — value expression,
+    /// connector, target; mirrors how `CalcUnits.parseConversion` allows an expression on the left
+    /// (`2*5 km to mi`) rather than only a bare literal.
     private static func baseConversion(_ tokens: [CalcToken], query: String) -> CalcResult? {
-        guard tokens.count == 3, CalcUnits.isConnector(tokens[1]),
-            case .ident(let target) = tokens[2]
+        guard tokens.count >= 3, CalcUnits.isConnector(tokens[tokens.count - 2]),
+            case .ident(let target) = tokens[tokens.count - 1]
         else { return nil }
 
+        let valueTokens = Array(tokens[0..<(tokens.count - 2)])
+        let literalText = query.split(whereSeparator: \.isWhitespace).first.map(String.init) ?? query
         let source: UInt64
         let sourceBadge: String
-        switch tokens[0] {
-        case .intLiteral(let value, let radix):
+        let sourceText: String
+        if valueTokens.count == 1, case .intLiteral(let value, let radix) = valueTokens[0] {
             source = value
             sourceBadge = baseName(forRadix: radix)
-        case .number(let value)
-        where value >= 0 && value.rounded() == value && value <= 9_007_199_254_740_992:
+            sourceText = literalText
+        } else if valueTokens.count == 1, let value = decimalLiteral(valueTokens[0]),
+            value >= 0, value.rounded() == value, value <= 9_007_199_254_740_992
+        {
             source = UInt64(value)
             sourceBadge = "Decimal"
-        case .compactNumber(let value)
-        where value >= 0 && value.rounded() == value && value <= 9_007_199_254_740_992:
+            sourceText = literalText
+        } else if let value = CalcParser.evaluate(valueTokens),
+            value >= 0, value.rounded() == value, value <= 9_007_199_254_740_992
+        {
             source = UInt64(value)
             sourceBadge = "Decimal"
-        default:
+            sourceText = CalcFormatter.grouped(String(source))
+        } else {
             return nil
         }
 
@@ -286,13 +295,20 @@ enum CalcEngine {
         default:
             return nil
         }
-        let sourceText = query.split(whereSeparator: \.isWhitespace).first.map(String.init) ?? query
         return CalcResult(
             expression: sourceText,
             sourceBadge: sourceBadge,
             targetBadge: targetBadge,
             payload: .value(
                 display: output, copyText: output.replacingOccurrences(of: ",", with: "")))
+    }
+
+    // Both spellings of a plain decimal literal — "255" and the compact "10k" — echo verbatim.
+    private static func decimalLiteral(_ token: CalcToken) -> Double? {
+        switch token {
+        case .number(let value), .compactNumber(let value): return value
+        default: return nil
+        }
     }
 
     private static func baseName(forRadix radix: Int) -> String {

--- a/Tinycast/Core/Calculator/CalcUnits.swift
+++ b/Tinycast/Core/Calculator/CalcUnits.swift
@@ -148,8 +148,11 @@ enum CalcUnits {
         "kn": ("kmh", false), "ft/s": ("mph", false),
         // Pressure
         "bar": ("psi", false), "psi": ("bar", false), "atm": ("psi", false),
+        "mbar": ("psi", false), "kPa": ("psi", false), "hPa": ("psi", false),
+        "mmHg": ("psi", false), "Torr": ("psi", false),
         // Data transfer rate
         "Mbps": ("kbps", false), "Gbps": ("mbps", false), "Kbps": ("bps", false),
+        "bps": ("kbps", false), "Tbps": ("gbps", false),
     ]
 
     /// Lookup by lowercased, `²`-folded name (the tokenizer's ident form).

--- a/Tools/calc-test.swift
+++ b/Tools/calc-test.swift
@@ -418,6 +418,20 @@ struct CalcTests {
         expectDisplay("100 mbps to kbps", "100,000 Kbps")
         expectBadges("100 kmh to mph", source: "Kilometers per Hour", target: "Miles per Hour")
 
+        // Bare-unit auto-conversion coverage gaps: bar/psi/atm/Mbps/Gbps/Kbps had it, their
+        // neighbors didn't — same category, same treatment.
+        expectDisplay("5 mbar", "0.07251886887 psi")
+        expectDisplay("5 kPa", "0.7251886887 psi")
+        expectDisplay("5 hPa", "0.07251886887 psi")
+        expectDisplay("5 mmHg", "0.0966838873 psi")
+        expectDisplay("5 Torr", "0.09668387352 psi")
+        expectDisplay("100 bps", "0.1 Kbps")
+        expectDisplay("1 Tbps", "1,000 Gbps")
+
+        // Base conversion accepts an expression on the value side, like unit conversion already does
+        expectDisplay("2*128 to hex", "0x100")
+        expectDisplay("10*5 to hex", "0x32")
+
         // Percentage phrasings
         expectDisplay("20% off 500", "400")
         expectDisplay("50 as % of 200", "25%")


### PR DESCRIPTION
Closes #87.

## Bug

Two gaps, both the same shape — "some unit in the category works, its sibling doesn't":

**A — `autoTargets` coverage.** `5 bar` gives a card, but its neighbors in the same pressure/data-rate categories don't:

| input | today |
|---|---|
| `5 bar` | `0.07... psi` ✓ |
| `5 mbar` / `5 kPa` / `5 hPa` / `5 mmHg` / `5 Torr` | no card |
| `100 mbps to kbps` (explicit) | works ✓ |
| `100 bps` / `1 Tbps` (bare) | no card |

**B — base conversion only accepts a bare literal.** `255 to hex` works but `2*128 to hex` doesn't — even though unit conversion already accepts an expression on the left (`2*5 km to mi` works today).

## Fix

**A:** `CalcUnits.autoTargets` gets the missing entries, mapping to the same counterpart their siblings already use — `mbar`/`kPa`/`hPa`/`mmHg`/`Torr` → `psi` (matching `bar`/`atm`), `bps` → `kbps` and `Tbps` → `gbps` (completing the ladder `Kbps`/`Mbps`/`Gbps` already started).

**B:** `CalcEngine.baseConversion` no longer requires exactly 3 tokens. It now looks at the connector/target from the *end* of the token list (mirroring `CalcUnits.parseConversion`'s shape) and, when more than one token precedes the connector, evaluates them through `CalcParser` — same as unit conversion already does. The single-literal path (an exact radix literal like `0xff`, or a bare decimal) is untouched: same badge, same echoed source text. Only the new multi-token path gets a computed-value echo (`2*128 to hex` shows `256` on the left, matching how unit conversion echoes the computed input rather than the raw expression).

`5 mbar` → `0.07251886887 psi`, `1 Tbps` → `1,000 Gbps`, `2*128 to hex` → `0x100`.

## Tests

Added to `Tools/calc-test.swift`: the seven bare-unit gap cases and two base-conversion-with-expression cases.

- `Tools/calc-test.swift` — **257 passed, 0 failed**
- `Tools/fuzz-test.swift` — all passed
- `Tools/emoji-test.swift` — all passed (2054 records)
- `xcodebuild -scheme Tinycast -configuration Debug` — **BUILD SUCCEEDED**, no new warnings

## Memory

Debug build, idle RSS sampled over ~15 s after launch: **79.0 MB**, against **79.6 MB** for `main` built from the same base — unchanged within noise. Part A adds nine entries to a static table; part B is parse-time work on tokens already in hand. No separate peak figure.

## Notes

Non-visual change. Flagging one judgment call for review: in part B I chose to echo the *computed* value on the left for the new multi-token path (`2*128 to hex` shows `256 = 0x100`) rather than the raw expression, because that's what unit conversion already does for `2*5 km to mi`. The single-literal path deliberately keeps its existing verbatim echo, so `0xff to dec` looks exactly as it does today — worth a look if you'd rather the two paths matched each other instead.
