### PR TITLE
Add Ctrl-N/P palette navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Security → Accessibility**.
 
 1. Open **Settings → General** and record a global shortcut to summon Tinycast.
 2. Press it anywhere → the palette floats in. Type to filter, **↵** to launch.
-3. **Tab** switches between Apps and Clipboard; **↑/↓** move, **Esc** dismisses.
+3. **Tab** switches between Apps and Clipboard; **↑/↓** (or **⌃P/⌃N**) move, **Esc** dismisses.
 4. **Settings → Shortcuts** — search an app or custom command and record a global shortcut.
 
 ## Building from source

--- a/Tinycast/Core/PalettePanel.swift
+++ b/Tinycast/Core/PalettePanel.swift
@@ -33,6 +33,16 @@ final class PalettePanel: NSPanel {
         case .keyDown: paletteViewModel?.hoverHighlightArmed = false
         default: break
         }
+        // ⌃N/⌃P alias ↓/↑, rewritten into real arrow events before any routing: the field editor's standard key bindings would otherwise consume them as moveDown:/moveUp:, and rewriting keeps the arrows the single navigation path (list, emoji grid, open menu, compact expand all inherit for free).
+        if event.type == .keyDown,
+            event.modifierFlags.contains(.control),
+            event.modifierFlags.intersection([.command, .option, .shift]).isEmpty,
+            let arrow = Self.arrowAlias(for: event.charactersIgnoringModifiers),
+            let rewritten = arrowKeyDown(arrow, from: event)
+        {
+            super.sendEvent(rewritten)
+            return
+        }
         // A footer menu owns the keyboard: the search field stays first responder (no focus swap, so nothing reflows) with only its caret hidden; swallow text-editing keystrokes before the field editor consumes them, but let shortcut chords (⌘K, ⌘⌫) and menu-nav keys reach SwiftUI's onKeyPress.
         if event.type == .keyDown,
             paletteViewModel?.menuOpen == true,
@@ -50,6 +60,33 @@ final class PalettePanel: NSPanel {
         }
         super.sendEvent(event)
     }
+
+    /// The arrow a bare-⌃ chord aliases, matched on the typed character so non-QWERTY layouts follow the letter, not the key position.
+    private static func arrowAlias(for characters: String?) -> (keyCode: Int, character: Int)? {
+        switch characters {
+        case "n": (kVK_DownArrow, NSDownArrowFunctionKey)
+        case "p": (kVK_UpArrow, NSUpArrowFunctionKey)
+        default: nil
+        }
+    }
+
+    /// A synthetic keyDown indistinguishable from the physical arrow (function-key character, arrow keyCode, repeat flag carried over), so the existing arrow handling — menu-nav passthrough included — treats it as the real thing.
+    private func arrowKeyDown(_ arrow: (keyCode: Int, character: Int), from event: NSEvent) -> NSEvent? {
+        guard let scalar = UnicodeScalar(UInt32(arrow.character)) else { return nil }
+        let character = String(scalar)
+        return NSEvent.keyEvent(
+            with: .keyDown,
+            location: event.locationInWindow,
+            modifierFlags: [.function, .numericPad],
+            timestamp: event.timestamp,
+            windowNumber: event.windowNumber,
+            context: nil,
+            characters: character,
+            charactersIgnoringModifiers: character,
+            isARepeat: event.isARepeat,
+            keyCode: UInt16(arrow.keyCode))
+    }
+
     init<Content: View>(rootView: Content) {
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 750, height: 475),


### PR DESCRIPTION
## Related issue

Closes #101

## What changed

⌃N / ⌃P now alias ↓ / ↑ everywhere the arrows already work — the results list, the emoji grid, an open Actions menu, and ⌃N expanding the compact bar — with held-chord repeat.

`PalettePanel.sendEvent` rewrites a bare-⌃ N/P keyDown into a synthetic arrow keyDown and dispatches that instead. The always-focused search field maps ⌃N/⌃P to `moveDown:`/`moveUp:` via the standard key bindings, and nothing guarantees a SwiftUI `onKeyPress` would see them first — rewriting at the window's single event entry point sidesteps that and keeps the arrows the only navigation path. Matched on the typed character so non-QWERTY layouts follow the letter; ⇧/⌘/⌥ variants stay with the field editor.

## Memory footprint

Measured on the Debug build with `footprint(1)` (`phys_footprint`), macOS 26, Apple Silicon.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 20 MB  |
| Palette open            | 35 MB  |
| Feature in use (peak)   | 37 MB  |
| Palette closed, settled | 36 MB  |

Settled stays at the palette-open level by design — the panel is kept resident after first summon (`isReleasedWhenClosed = false`); a second open/close cycle returned to 36 MB with no growth.

Leak-tested: `leaks` on the live process after summon → navigate → dismiss — 0 leaks for 0 bytes.

## Drawbacks

⌃N/⌃P are Emacs caret bindings inside text fields; in the single-line search field `moveDown:`/`moveUp:` are no-ops, so claiming them loses nothing. ⌃F/⌃B (the other Emacs pair) are deliberately not taken — those really move the caret.

## Tests & validation

- Manual pass on the running app: ⌃N/⌃P navigation in the list / emoji grid / open Actions menu / compact bar, held-chord repeat; arrows, plain typing of n/p, and ⌃A/⌃E editing unaffected.
- Debug build clean, no new warnings. No `Tools/` harness covers window event routing (AppKit/view layer); no engine sources touched.