### PR TITLE
System commands: macOS actions in the launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,13 @@ Never break these without an explicit task to do so.
 - **Clipboard writes stamp a private `internalType` marker** so the poller skips Tinycast's own writes.
 - **Hotkeys persist under legacy `KeyboardShortcuts_<name>` UserDefaults keys** (from the removed
   KeyboardShortcuts package) so old bindings survive. See [hotkeys.md](docs/hotkeys.md).
+- **Tinycast presents its own dialogs, never `NSAlert` / `NSSlider` / system popovers.** Every
+  confirmation, failure report, value prompt and transient readout goes through
+  `ModalWindowController` (owned by `AppCore`; reachable elsewhere via `AppCore.showNotice` /
+  `askConfirmation`). Presentation is `async`, so there is no nested run loop, and the presenter
+  refuses a second dialog while one is up that, not a flag, is what stops a held hotkey stacking
+  dialogs. **↵ belongs to Cancel on every destructive dialog.** See
+  [ui.md](docs/ui.md#modals--hud).
 - **Read [`docs/ui.md`](docs/ui.md) before any restyle or new view.** `Core/Theme.swift` is the single
   design-token source.
 - **`Core/EdgeDissolve.swift` and `Core/ThinScrollbar.swift` are off-limits.** Both are tuned by eye

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,9 @@ Never break these without an explicit task to do so.
   confirmation gate lives in `AppCore` and not in the runner. All of `Core/Snippets/` compiles into
   `Tools/snippets-test.swift` (the harness globs the directory), so the model, Markdown serializer,
   template engine, repository and keyword policies stay Foundation-only, and the AppKit files there
-  keep their dependencies to what the harness can stub.
+  keep their dependencies to what the harness can stub. `Core/SystemCommand.swift` is also
+  Foundation-only for `Tools/system-command-test.swift`; platform effects belong in
+  `SystemCommandRunner`, while confirmation and failure UI remain in `AppCore`.
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		5568D02AE095293A15A7F30D /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9ACD504E016DFF6FE6C1B /* RightClick.swift */; };
 		57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */; };
 		5E49E070BDBB91A2829F5321 /* SnippetTextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309908BAB8C19B67F4608DA9 /* SnippetTextInjector.swift */; };
+		62002F021B21EC91AB77ED4D /* ModalWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4C27209F650DAB6262F0D9 /* ModalWindowController.swift */; };
 		649961AA51BA4D87626C27D5 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09093BF10EA97BDCA45A241F /* CalcFormatter.swift */; };
 		664D2BD485F3C5DB3F90B3C6 /* CustomCommandsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBF70B1C646861FDF20ED2D /* CustomCommandsSettingsView.swift */; };
 		68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B629EC3B716FEE881BB0075 /* TinycastApp.swift */; };
@@ -67,6 +68,7 @@
 		A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D045D032498C2294A99890E /* LaunchAtLogin.swift */; };
 		A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */; };
 		A41C0DCB2DEBCCA46F6C4B10 /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB750D045194AE34D39D792 /* FavoritesStore.swift */; };
+		A7508663E4B5D80572E7BAAC /* TinycastModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C27BF1320391CF684429FA6 /* TinycastModalView.swift */; };
 		A9D8B54D88A60DE9FC1F43BF /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */; };
 		AA8050D9A547CDDD37C581C4 /* CurrencyData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E08668A3C8418E2F0970300 /* CurrencyData.generated.swift */; };
 		AB9B998DB62EE2D18A058C78 /* SnippetsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */; };
@@ -133,6 +135,7 @@
 		46C3E740AA883770481A6A8C /* SnippetsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsStore.swift; sourceTree = "<group>"; };
 		4802942FF89B327A76432A9B /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		4B432D84D8F9C10521342199 /* RunningApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningApps.swift; sourceTree = "<group>"; };
+		4C27BF1320391CF684429FA6 /* TinycastModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinycastModalView.swift; sourceTree = "<group>"; };
 		4DA7B926405DAC632C056418 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		5043CD44B4B40C49BE79852A /* SettingsBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBackup.swift; sourceTree = "<group>"; };
@@ -171,6 +174,7 @@
 		99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageThumbnail.swift; sourceTree = "<group>"; };
 		9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentEmojiStore.swift; sourceTree = "<group>"; };
 		9AA0E1FD530C764A021E6053 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
+		9B4C27209F650DAB6262F0D9 /* ModalWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalWindowController.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
@@ -240,6 +244,7 @@
 				99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */,
 				0D045D032498C2294A99890E /* LaunchAtLogin.swift */,
 				87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */,
+				9B4C27209F650DAB6262F0D9 /* ModalWindowController.swift */,
 				7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */,
 				B8A9B4E6E477C30372C85F86 /* OnboardingState.swift */,
 				3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */,
@@ -342,6 +347,7 @@
 				005F026A8F7D5E209B1CE917 /* Clipboard */,
 				15CFCD6B1429C5F0944CBCC4 /* Emoji */,
 				7DE06EE636C14E50EE172D9E /* Launcher */,
+				B3A555C03131736B19C3B243 /* Modal */,
 				0ED457107377ECF8147C6B9D /* Onboarding */,
 				E3202F504002B7792FC50B2F /* Settings */,
 				7CD438390F8FA4B3C2AE5F28 /* Snippets */,
@@ -349,6 +355,14 @@
 				0F50886DC766B9923C3875A5 /* RootPaletteView.swift */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		B3A555C03131736B19C3B243 /* Modal */ = {
+			isa = PBXGroup;
+			children = (
+				4C27BF1320391CF684429FA6 /* TinycastModalView.swift */,
+			);
+			path = Modal;
 			sourceTree = "<group>";
 		};
 		BB6DB69437E85BCDB2530225 /* Tinycast */ = {
@@ -577,6 +591,7 @@
 				3FEBE1C993C5BD92F1C3D95B /* LauncherRankingStore.swift in Sources */,
 				DCC36924E538C11136CEC060 /* LauncherView.swift in Sources */,
 				8F7431A1340D0A5783599087 /* MiscellaneousSettingsView.swift in Sources */,
+				62002F021B21EC91AB77ED4D /* ModalWindowController.swift in Sources */,
 				6962B8A2850A45401275F677 /* NotificationToken.swift in Sources */,
 				DA5BCA13045FF91B3FC8EB35 /* OnboardingState.swift in Sources */,
 				0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */,
@@ -617,6 +632,7 @@
 				72ACD144841BF1117CD4E705 /* Theme.swift in Sources */,
 				85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */,
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,
+				A7508663E4B5D80572E7BAAC /* TinycastModalView.swift in Sources */,
 				693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */,
 				A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */,
 			);

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0674D8E1567253879EF50150 /* SnippetArgumentsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F919FBD5F2E0399523AA56 /* SnippetArgumentsPrompt.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
 		11C4CC0D767EFD44AB28D6DD /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0E1FD530C764A021E6053 /* SearchScopes.swift */; };
+		13E6A96B937D2506EDA886BD /* SystemCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289F9F0C3C56F295CFB50CE9 /* SystemCommand.swift */; };
 		14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DC5A4706854493D23FD18A /* HyperKey.swift */; };
 		14A5A5ACD35A572EE906769F /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B976C84AFE60E357A346224 /* CalcEngine.swift */; };
 		1AF562E00FCB98B12076F01D /* SnippetKeywordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5051622CC6497E2151326CA /* SnippetKeywordListener.swift */; };
@@ -66,6 +67,7 @@
 		9A3972BE11AE353EFBB839A0 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555E9C7EA62BDB40891A5751 /* PalettePanel.swift */; };
 		9EC89A6398BD075275FECC9E /* CalcUnits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */; };
 		A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D045D032498C2294A99890E /* LaunchAtLogin.swift */; };
+		A13E793B2BA4AFC5B30C8776 /* SystemCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE4F95DF8572910DFE602BA /* SystemCommandRunner.swift */; };
 		A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */; };
 		A41C0DCB2DEBCCA46F6C4B10 /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB750D045194AE34D39D792 /* FavoritesStore.swift */; };
 		A7508663E4B5D80572E7BAAC /* TinycastModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C27BF1320391CF684429FA6 /* TinycastModalView.swift */; };
@@ -119,6 +121,7 @@
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
 		286B7598B81017C746558C7C /* ShellCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellCommandRunner.swift; sourceTree = "<group>"; };
+		289F9F0C3C56F295CFB50CE9 /* SystemCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCommand.swift; sourceTree = "<group>"; };
 		297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscellaneousSettingsView.swift; sourceTree = "<group>"; };
 		299122624B5E1BA2C5400478 /* CalcCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcCurrency.swift; sourceTree = "<group>"; };
 		2B629EC3B716FEE881BB0075 /* TinycastApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinycastApp.swift; sourceTree = "<group>"; };
@@ -181,6 +184,7 @@
 		A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
 		A76E4099082D59FA686C3485 /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
 		AF5AE919A2699E6EB8BF7DC8 /* ShortcutsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsView.swift; sourceTree = "<group>"; };
+		AFE4F95DF8572910DFE602BA /* SystemCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCommandRunner.swift; sourceTree = "<group>"; };
 		B275099E59BD2531A838F7D8 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		B2F919FBD5F2E0399523AA56 /* SnippetArgumentsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetArgumentsPrompt.swift; sourceTree = "<group>"; };
 		B4049668745FD438D5792A2F /* RaycastImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImport.swift; sourceTree = "<group>"; };
@@ -258,6 +262,8 @@
 				9AA0E1FD530C764A021E6053 /* SearchScopes.swift */,
 				C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */,
 				286B7598B81017C746558C7C /* ShellCommandRunner.swift */,
+				289F9F0C3C56F295CFB50CE9 /* SystemCommand.swift */,
+				AFE4F95DF8572910DFE602BA /* SystemCommandRunner.swift */,
 				7BC2DEA0A052116A92F9A539 /* Theme.swift */,
 				A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */,
 				825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */,
@@ -629,6 +635,8 @@
 				5E49E070BDBB91A2829F5321 /* SnippetTextInjector.swift in Sources */,
 				AB9B998DB62EE2D18A058C78 /* SnippetsSettingsView.swift in Sources */,
 				F457EB595789DD3A25E888DF /* SnippetsStore.swift in Sources */,
+				13E6A96B937D2506EDA886BD /* SystemCommand.swift in Sources */,
+				A13E793B2BA4AFC5B30C8776 /* SystemCommandRunner.swift in Sources */,
 				72ACD144841BF1117CD4E705 /* Theme.swift in Sources */,
 				85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */,
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -422,12 +422,15 @@ final class AppCore: ObservableObject {
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {
         switch command.id {
+        case .restart: return "Restart your Mac?"
         default: return "Run \(command.name)?"
         }
     }
 
     private static func confirmationMessage(_ command: SystemCommand) -> String {
         switch command.id {
+        case .restart:
+            return "Applications with unsaved changes may ask you to save."
         default: return "This system action may interrupt your work."
         }
     }

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -364,6 +364,10 @@ final class AppCore: ObservableObject {
             }
             return
         }
+        if app.kind == .systemCommand {
+            runSystemCommand(app)
+            return
+        }
         let previous = windowController.previousApp
         hidePalette(restoreFocus: false)
         switch app.kind {
@@ -375,13 +379,57 @@ final class AppCore: ObservableObject {
         case .snippet:
             let snippetID = String(app.id.dropFirst("snippet:".count))
             expandSnippet(id: snippetID, targetApp: previous)
-        case .command:
+        case .command, .systemCommand:
             break  // handled above
         }
     }
 
     func resetRanking(for app: AppEntry) {
         launcherRanking.reset(itemKey: app.preferenceKey)
+    }
+
+    // MARK: - System commands
+
+    private func runSystemCommand(_ entry: AppEntry) {
+        guard let command = SystemCommandCatalog.command(forEntryID: entry.id) else { return }
+        let previousApp = windowController.previousApp
+        if windowController.isVisible { hidePalette(restoreFocus: false) }
+        Task { await perform(command, previousApp: previousApp) }
+    }
+
+    /// The one place a system command runs, so the confirmation gate can't be bypassed by the palette, a favorite slot, or the compact bar.
+    private func perform(_ command: SystemCommand, previousApp: NSRunningApplication?) async {
+        if command.confirmation == .required,
+            await !modals.confirm(
+                title: Self.confirmationTitle(command),
+                message: Self.confirmationMessage(command),
+                confirmTitle: command.name, destructive: true)
+        {
+            return
+        }
+        do {
+            let feedback = try await SystemCommandRunner.run(command.id, previousApp: previousApp)
+            if let feedback {
+                modals.showToast(symbol: feedback.symbol, title: feedback.title)
+            }
+        } catch let failure as SystemCommandFailure {
+            await presentFailure(name: command.name, failure: failure)
+        } catch {
+            await presentFailure(
+                name: command.name, failure: SystemCommandFailure(error.localizedDescription))
+        }
+    }
+
+    private static func confirmationTitle(_ command: SystemCommand) -> String {
+        switch command.id {
+        default: return "Run \(command.name)?"
+        }
+    }
+
+    private static func confirmationMessage(_ command: SystemCommand) -> String {
+        switch command.id {
+        default: return "This system action may interrupt your work."
+        }
     }
 
     // MARK: - Dialogs
@@ -398,6 +446,30 @@ final class AppCore: ObservableObject {
     ) async -> Bool {
         await modals.confirm(
             title: title, message: message, confirmTitle: confirmTitle, destructive: destructive)
+    }
+
+    /// Sync entry point for the runner's own async completion handlers, which can't await.
+    func presentSystemCommandFailure(name: String, failure: SystemCommandFailure) {
+        Task { await presentFailure(name: name, failure: failure) }
+    }
+
+    private func presentFailure(name: String, failure: SystemCommandFailure) async {
+        let settingsTitle = failure.settings == nil ? nil : "Open System Settings…"
+        guard
+            await modals.report(
+                title: "“\(name)” Failed", message: failure.message,
+                settingsTitle: settingsTitle),
+            let settings = failure.settings
+        else { return }
+        let pane: String
+        switch settings {
+        case .accessibility: pane = "Privacy_Accessibility"
+        case .automation: pane = "Privacy_Automation"
+        case .bluetooth: pane = "Privacy_Bluetooth"
+        }
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     // MARK: - Custom commands

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -436,7 +436,8 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25, .volume50, .volume75, .volume100,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute,
+        .volume0, .volume25, .volume50, .volume75, .volume100,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -440,12 +440,14 @@ final class AppCore: ObservableObject {
         case .restart: return "Restart your Mac?"
         case .shutDown: return "Shut down your Mac?"
         case .logOut: return "Log out now?"
+        case .emptyTrash: return "Empty Trash?"
         default: return "Run \(command.name)?"
         }
     }
 
     private static func confirmationMessage(_ command: SystemCommand) -> String {
         switch command.id {
+        case .emptyTrash: return "The items in the Trash will be permanently deleted."
         case .restart, .shutDown, .logOut:
             return "Applications with unsaved changes may ask you to save."
         default: return "This system action may interrupt your work."

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -399,6 +399,10 @@ final class AppCore: ObservableObject {
 
     /// The one place a system command runs, so the confirmation gate can't be bypassed by the palette, a favorite slot, or the compact bar.
     private func perform(_ command: SystemCommand, previousApp: NSRunningApplication?) async {
+        if command.id == .quitAllApps {
+            await quitAllApps()
+            return
+        }
         if command.confirmation == .required,
             await !modals.confirm(
                 title: Self.confirmationTitle(command),
@@ -634,10 +638,6 @@ final class AppCore: ObservableObject {
         case .about:
             hidePalette(restoreFocus: false)
             showAbout()
-        case .quitAllApps:
-            // Hide before confirming: the palette is a floating panel and would sit above the dialog.
-            hidePalette(restoreFocus: false)
-            Task { await quitAllApps() }
         case .quit:
             NSApp.terminate(nil)
         case nil:

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -409,7 +409,10 @@ final class AppCore: ObservableObject {
         }
         do {
             let feedback = try await SystemCommandRunner.run(command.id, previousApp: previousApp)
-            if let feedback {
+            if Self.showsVolumeFeedback.contains(command.id) {
+                let state = try SystemCommandRunner.outputState()
+                modals.showVolumeHUD(level: state.level, muted: state.muted)
+            } else if let feedback {
                 modals.showToast(symbol: feedback.symbol, title: feedback.title)
             }
         } catch let failure as SystemCommandFailure {
@@ -419,6 +422,11 @@ final class AppCore: ObservableObject {
                 name: command.name, failure: SystemCommandFailure(error.localizedDescription))
         }
     }
+
+    /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
+    private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
+        .toggleMute,
+    ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {
         switch command.id {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -432,7 +432,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -425,7 +425,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .volumeUp, .toggleMute,
+        .volumeUp, .volumeDown, .toggleMute,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -432,7 +432,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25, .volume50,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -432,7 +432,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .setVolume, .volumeUp, .volumeDown, .toggleMute,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -432,7 +432,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25, .volume50,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25, .volume50, .volume75,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -425,7 +425,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .toggleMute,
+        .volumeUp, .toggleMute,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -424,13 +424,14 @@ final class AppCore: ObservableObject {
         switch command.id {
         case .restart: return "Restart your Mac?"
         case .shutDown: return "Shut down your Mac?"
+        case .logOut: return "Log out now?"
         default: return "Run \(command.name)?"
         }
     }
 
     private static func confirmationMessage(_ command: SystemCommand) -> String {
         switch command.id {
-        case .restart, .shutDown:
+        case .restart, .shutDown, .logOut:
             return "Applications with unsaved changes may ask you to save."
         default: return "This system action may interrupt your work."
         }

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -408,7 +408,14 @@ final class AppCore: ObservableObject {
             return
         }
         do {
-            let feedback = try await SystemCommandRunner.run(command.id, previousApp: previousApp)
+            var feedback: SystemCommandFeedback?
+            if command.id == .setVolume {
+                let current = try SystemCommandRunner.currentVolume()
+                guard let selected = await modals.pickVolume(current: current) else { return }
+                try SystemCommandRunner.setVolume(selected)
+            } else {
+                feedback = try await SystemCommandRunner.run(command.id, previousApp: previousApp)
+            }
             if Self.showsVolumeFeedback.contains(command.id) {
                 let state = try SystemCommandRunner.outputState()
                 modals.showVolumeHUD(level: state.level, muted: state.muted)
@@ -425,7 +432,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .volumeUp, .volumeDown, .toggleMute,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -432,7 +432,7 @@ final class AppCore: ObservableObject {
 
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
-        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25, .volume50, .volume75,
+        .setVolume, .volumeUp, .volumeDown, .toggleMute, .volume0, .volume25, .volume50, .volume75, .volume100,
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -423,13 +423,14 @@ final class AppCore: ObservableObject {
     private static func confirmationTitle(_ command: SystemCommand) -> String {
         switch command.id {
         case .restart: return "Restart your Mac?"
+        case .shutDown: return "Shut down your Mac?"
         default: return "Run \(command.name)?"
         }
     }
 
     private static func confirmationMessage(_ command: SystemCommand) -> String {
         switch command.id {
-        case .restart:
+        case .restart, .shutDown:
             return "Applications with unsaved changes may ask you to save."
         default: return "This system action may interrupt your work."
         }

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -114,8 +114,8 @@ final class AppCore: ObservableObject {
     private lazy var windowController = PaletteWindowController(core: self)
     private lazy var hud = HUDWindowController(settings: settings)
     private let auxWindows = AuxWindowController()
-    /// Guards only the confirmation modal, not execution — two deliberate runs of an unguarded command still run twice.
-    private var isConfirmingCommand = false
+    /// Every confirmation, failure report and value prompt in the app; it also guards against a held hotkey stacking dialogs.
+    private let modals = ModalWindowController()
     private var cancellables = Set<AnyCancellable>()
 
     private init() {
@@ -384,6 +384,22 @@ final class AppCore: ObservableObject {
         launcherRanking.reset(itemKey: app.preferenceKey)
     }
 
+    // MARK: - Dialogs
+    //
+    // Routed through `AppCore` so `modals` stays the single owner; flows outside the palette (the backup
+    // actions) reach the same dialogs instead of falling back to an `NSAlert`.
+
+    func showNotice(title: String, message: String, symbol: String = "info.circle") async {
+        await modals.notice(title: title, message: message, symbol: symbol)
+    }
+
+    func askConfirmation(
+        title: String, message: String, confirmTitle: String, destructive: Bool = true
+    ) async -> Bool {
+        await modals.confirm(
+            title: title, message: message, confirmTitle: confirmTitle, destructive: destructive)
+    }
+
     // MARK: - Custom commands
 
     @discardableResult
@@ -417,16 +433,16 @@ final class AppCore: ObservableObject {
         // Also the feature switch: with custom commands off a still-registered global hotkey must not run anything.
         guard settings.customCommandsEnabled else { return }
         guard let command = customCommands.command(id: id) else { return }
-        // Hide before confirming: the palette is a floating panel and would sit above the alert.
         if windowController.isVisible { hidePalette(restoreFocus: false) }
-        if command.requiresConfirmation {
-            // Carbon hotkeys keep firing during a modal session; without this a held shortcut stacks alerts.
-            guard !isConfirmingCommand else { return }
-            isConfirmingCommand = true
-            defer { isConfirmingCommand = false }
-            guard Self.confirmRun(command) else { return }
-        }
         Task {
+            if command.requiresConfirmation {
+                guard
+                    await modals.confirm(
+                        title: command.name,
+                        message: "Are you sure you want to run this command?\n\n\(command.command)",
+                        confirmTitle: "Run", destructive: true)
+                else { return }
+            }
             let outcome = await ShellCommandRunner.run(
                 command.command, loadingShellEnvironment: command.loadsShellEnvironment)
             guard outcome != .success else {
@@ -434,7 +450,7 @@ final class AppCore: ObservableObject {
                 if command.showsConfirmation { self.hud.show(message: "Ran \(command.name)") }
                 return
             }
-            self.presentCustomCommandFailure(command: command, outcome: outcome)
+            await presentCustomCommandFailure(command: command, outcome: outcome)
         }
     }
 
@@ -451,21 +467,9 @@ final class AppCore: ObservableObject {
         }
     }
 
-    private static func confirmRun(_ command: CustomCommand) -> Bool {
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = command.name
-        alert.informativeText = "Are you sure you want to run this command?"
-        alert.alertStyle = .warning
-        // ↵ runs and Esc cancels — AppKit's defaults for the first button and the one titled "Cancel".
-        alert.addButton(withTitle: "Run")
-        alert.addButton(withTitle: "Cancel")
-        return alert.runModal() == .alertFirstButtonReturn
-    }
-
     private func presentCustomCommandFailure(
         command: CustomCommand, outcome: ShellCommandOutcome
-    ) {
+    ) async {
         let message: String
         // `127` is the shell's "command not found", so an alias or function that only exists in the user's config lands here.
         var suggestsShellEnvironment = false
@@ -483,14 +487,11 @@ final class AppCore: ObservableObject {
                     ? "\n\nIf this is a shell alias or function, turn on Load Shell Environment for "
                         + "this command." : "")
         }
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = "“\(command.name)” Failed"
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
-        if suggestsShellEnvironment { alert.addButton(withTitle: "Open Settings…") }
-        guard alert.runModal() == .alertSecondButtonReturn else { return }
+        guard
+            await modals.report(
+                title: "“\(command.name)” Failed", message: message,
+                settingsTitle: suggestsShellEnvironment ? "Open Settings…" : nil)
+        else { return }
         showSettings(tab: .customCommands)
     }
 
@@ -504,25 +505,16 @@ final class AppCore: ObservableObject {
     }
 
     /// Quit All: the one action whose blast radius reaches outside Tinycast, so it confirms first. The target list is resolved once and both counted and terminated, so the set the user approves is the set that quits.
-    private func quitAllApps() {
+    private func quitAllApps() async {
         let targets = AppLauncher.quitAllTargets()
-        guard !targets.isEmpty, Self.confirmQuitAll(count: targets.count) else { return }
+        guard !targets.isEmpty,
+            await modals.confirm(
+                title: targets.count == 1
+                    ? "Quit 1 application?" : "Quit \(targets.count) applications?",
+                message: "Applications with unsaved changes will ask you to save.",
+                confirmTitle: "Quit All", destructive: true)
+        else { return }
         for app in targets { app.terminate() }
-    }
-
-    private static func confirmQuitAll(count: Int) -> Bool {
-        // An accessory app's alert opens behind the frontmost app unless it activates first (same as `BackupActions`).
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = count == 1 ? "Quit 1 application?" : "Quit \(count) applications?"
-        alert.informativeText = "Applications with unsaved changes will ask you to save."
-        alert.alertStyle = .warning
-        let quitButton = alert.addButton(withTitle: "Quit All")
-        quitButton.hasDestructiveAction = true
-        // `hasDestructiveAction` only tints the button — it stays the ↵ default. Hand ↵ to Cancel instead: this command is one ↵ away in the palette, and a second reflexive ↵ must not quit the desktop.
-        quitButton.keyEquivalent = ""
-        alert.addButton(withTitle: "Cancel").keyEquivalent = "\r"
-        return alert.runModal() == .alertFirstButtonReturn
     }
 
     private func runCommand(_ entry: AppEntry) {
@@ -535,10 +527,10 @@ final class AppCore: ObservableObject {
             showPalette(mode: .emoji)
         case .exportSettings:
             hidePalette(restoreFocus: false)
-            BackupActions.exportSettings()
+            Task { await BackupActions.exportSettings() }
         case .importSettings:
             hidePalette(restoreFocus: false)
-            BackupActions.importSettings()
+            Task { await BackupActions.importSettings() }
         case .importFromRaycast:
             hidePalette(restoreFocus: false)
             showBackupSettings()
@@ -549,9 +541,9 @@ final class AppCore: ObservableObject {
             hidePalette(restoreFocus: false)
             showAbout()
         case .quitAllApps:
-            // Hide before confirming: the palette is a floating panel and would sit above the alert.
+            // Hide before confirming: the palette is a floating panel and would sit above the dialog.
             hidePalette(restoreFocus: false)
-            quitAllApps()
+            Task { await quitAllApps() }
         case .quit:
             NSApp.terminate(nil)
         case nil:

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -7,6 +7,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case systemSettings
         case command
         case snippet
+        case systemCommand
     }
 
     let id: String  // file path (or "command:…" id) — always unique
@@ -29,6 +30,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case .systemSettings: return "System Setting"
         case .command: return isCustomCommand ? "Custom Command" : "Command"
         case .snippet: return "Snippet"
+        case .systemCommand: return "System Command"
         }
     }
 
@@ -41,18 +43,19 @@ struct AppEntry: Identifiable, Hashable, Sendable {
             return bundleID.map { .settingsPane(bundleID: $0) }
         case .command:
             return CustomCommand.id(fromEntryID: id).map { .customCommand(id: $0) }
-        case .snippet:
+        case .snippet, .systemCommand:
             return nil
         }
     }
 
-    /// Command entries are synthetic — no file behind them to reveal.
-    var canRevealInFinder: Bool { kind != .command }
+    /// Synthetic command entries have no file behind them to reveal.
+    var canRevealInFinder: Bool { kind == .application || kind == .systemSettings || kind == .snippet }
 
-    /// Command and snippet entries draw an SF Symbol tile; everything else uses its file icon.
-    var isSymbolIcon: Bool { kind == .command || kind == .snippet }
+    /// Command, snippet and system-command entries draw an SF Symbol tile; everything else uses its file icon.
+    var isSymbolIcon: Bool { kind == .command || kind == .snippet || kind == .systemCommand }
     var symbolIconName: String {
         if kind == .snippet { return "text.quote" }
+        if let system = SystemCommandCatalog.command(forEntryID: id) { return system.sfSymbol }
         if let builtIn = CommandRegistry.command(for: self) { return builtIn.sfSymbol }
         return isCustomCommand ? "terminal" : "questionmark"
     }
@@ -176,6 +179,15 @@ final class AppIndex: ObservableObject {
     /// One-entry memo so repeated renders for the same query reuse the ranking instead of re-matching every frame.
     private var matchCache: (query: String, rankingRevision: Int, result: [AppEntry])?
 
+    private static let systemCommandEntries: [AppEntry] = SystemCommandCatalog.all
+        .map { command in
+            AppEntry(
+                id: command.entryID, name: command.name,
+                url: URL(string: "tinycast://system-command/" + command.id.rawValue)!,
+                bundleID: nil, kind: .systemCommand)
+        }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
     private var discoveredEntries: [AppEntry] = []
     private var customCommandEntries: [AppEntry] = []
     private var isRefreshing = false
@@ -282,7 +294,9 @@ final class AppIndex: ObservableObject {
 
     private func publishEntries() {
         // Each slice is already alphabetical; the slice order is the launcher's section order (LauncherList mirrors it), so custom commands sit in their own section ahead of the built-ins.
-        let updated = discoveredEntries + snippetEntries + customCommandEntries + CommandRegistry.all
+        let updated =
+            discoveredEntries + snippetEntries + Self.systemCommandEntries
+            + customCommandEntries + CommandRegistry.all
         guard updated != apps else { return }
         apps = updated
         matchCache = nil

--- a/Tinycast/Core/Backup/BackupActions.swift
+++ b/Tinycast/Core/Backup/BackupActions.swift
@@ -13,9 +13,9 @@ enum BackupActions {
         var missingImages: Int
     }
 
-    // MARK: - Tinycast native (self-contained: own file panels + alerts)
+    // MARK: - Tinycast native (own file panels; dialogs come from `AppCore`)
 
-    static func exportSettings() {
+    static func exportSettings() async {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.json]
         panel.nameFieldStringValue = "Tinycast-Settings-\(dateStamp()).json"
@@ -25,11 +25,11 @@ enum BackupActions {
         do {
             try SettingsBackup.gather().encoded().write(to: url, options: .atomic)
         } catch {
-            present(title: "Export Failed", message: error.localizedDescription, style: .warning)
+            await present(title: "Export Failed", message: error.localizedDescription)
         }
     }
 
-    static func importSettings() {
+    static func importSettings() async {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.json]
         panel.allowsMultipleSelection = false
@@ -39,15 +39,13 @@ enum BackupActions {
             let backup = try SettingsBackup(json: try Data(contentsOf: url))
             let commandCount = backup.customCommands?.count ?? 0
             let shortcutCount = backup.hotkeys?.customCommands?.count ?? 0
-            guard confirmExecutableImport(commands: commandCount, shortcuts: shortcutCount) else {
-                return
-            }
-            present(
+            guard await confirmExecutableImport(commands: commandCount, shortcuts: shortcutCount)
+            else { return }
+            await present(
                 title: "Settings Imported", message: summaryText(backup.apply()),
-                style: .informational
-            )
+                symbol: "checkmark.circle")
         } catch {
-            present(title: "Import Failed", message: error.localizedDescription, style: .warning)
+            await present(title: "Import Failed", message: error.localizedDescription)
         }
     }
 
@@ -134,22 +132,17 @@ enum BackupActions {
         return "Applied " + parts.joined(separator: ", ") + "."
     }
 
-    private static func confirmExecutableImport(commands: Int, shortcuts: Int) -> Bool {
+    private static func confirmExecutableImport(commands: Int, shortcuts: Int) async -> Bool {
         guard commands > 0 || shortcuts > 0 else { return true }
         let commandText = commands == 1 ? "1 custom command" : "\(commands) custom commands"
         let shortcutText =
             shortcuts == 1 ? "1 global shortcut" : "\(shortcuts) global shortcuts"
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = "Import executable commands?"
-        alert.informativeText =
-            "This backup contains \(commandText) and \(shortcutText). Custom commands can run "
-            + "arbitrary shell code. Only import files you trust."
-        alert.alertStyle = .warning
-        let importButton = alert.addButton(withTitle: "Import")
-        importButton.keyEquivalent = ""
-        alert.addButton(withTitle: "Cancel").keyEquivalent = "\r"
-        return alert.runModal() == .alertFirstButtonReturn
+        return await AppCore.shared.askConfirmation(
+            title: "Import executable commands?",
+            message:
+                "This backup contains \(commandText) and \(shortcutText). Custom commands can run "
+                + "arbitrary shell code. Only import files you trust.",
+            confirmTitle: "Import")
     }
 
     private static func dateStamp() -> String {
@@ -158,12 +151,9 @@ enum BackupActions {
         return formatter.string(from: Date())
     }
 
-    private static func present(title: String, message: String, style: NSAlert.Style) {
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = title
-        alert.informativeText = message
-        alert.alertStyle = style
-        alert.runModal()
+    private static func present(
+        title: String, message: String, symbol: String = "exclamationmark.triangle"
+    ) async {
+        await AppCore.shared.showNotice(title: title, message: message, symbol: symbol)
     }
 }

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -10,7 +10,6 @@ enum CommandID: String, CaseIterable, Sendable {
     case importFromRaycast = "command:import-from-raycast"
     case settings = "command:settings"
     case about = "command:about"
-    case quitAllApps = "command:quit-all-apps"
     case quit = "command:quit"
 
     var name: String {
@@ -23,7 +22,6 @@ enum CommandID: String, CaseIterable, Sendable {
         case .importFromRaycast: return "Import from Raycast"
         case .settings: return "Settings"
         case .about: return "About Tinycast"
-        case .quitAllApps: return "Quit All Applications"
         case .quit: return "Quit Tinycast"
         }
     }
@@ -38,7 +36,6 @@ enum CommandID: String, CaseIterable, Sendable {
         case .importFromRaycast: return "arrow.down.doc"
         case .settings: return "gearshape"
         case .about: return "info.circle"
-        case .quitAllApps: return "xmark.circle"
         case .quit: return "power"
         }
     }

--- a/Tinycast/Core/ModalWindowController.swift
+++ b/Tinycast/Core/ModalWindowController.swift
@@ -1,0 +1,290 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+struct ModalAction {
+    enum Role {
+        case normal
+        case destructive
+        case cancel
+    }
+
+    let title: String
+    var role: Role = .normal
+}
+
+struct ModalRequest {
+    let title: String
+    var message: String?
+    var symbol: String = "exclamationmark.triangle"
+    var actions: [ModalAction]
+    /// The button ↵ fires. Destructive dialogs point it at Cancel, so a reflexive second Return can't run the very thing the user asked to be warned about (same rule the old `NSAlert` gate used).
+    var defaultIndex: Int
+    /// Resolved when the modal goes away without a choice: Esc, or losing key status to a click elsewhere.
+    var cancelIndex: Int
+    var showsVolumeSlider = false
+}
+
+/// Borderless panel hosting one Tinycast modal or HUD. Keys are intercepted in `sendEvent` rather than SwiftUI's `onKeyPress` so Esc/↵ work without depending on anything inside the dialog holding focus.
+final class ModalPanel: NSPanel {
+    enum Key {
+        case cancel
+        case confirm
+        case adjust(Double)
+    }
+
+    var onKey: ((Key) -> Void)?
+    private let acceptsKey: Bool
+
+    init(content: NSView, acceptsKey: Bool) {
+        self.acceptsKey = acceptsKey
+        super.init(
+            contentRect: NSRect(origin: .zero, size: content.frame.size),
+            styleMask: [.borderless, .fullSizeContentView, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        isFloatingPanel = true
+        // Above the palette's `.floating`, so a confirmation is never buried under the window that triggered it.
+        level = .modalPanel
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isMovableByWindowBackground = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        animationBehavior = .none
+        isReleasedWhenClosed = false
+        contentView = content
+    }
+
+    override func sendEvent(_ event: NSEvent) {
+        guard event.type == .keyDown, let onKey else {
+            super.sendEvent(event)
+            return
+        }
+        switch Int(event.keyCode) {
+        case kVK_Escape:
+            onKey(.cancel)
+        case kVK_Return, kVK_ANSI_KeypadEnter:
+            onKey(.confirm)
+        case kVK_LeftArrow, kVK_DownArrow:
+            onKey(.adjust(-Self.arrowStep))
+        case kVK_RightArrow, kVK_UpArrow:
+            onKey(.adjust(Self.arrowStep))
+        default:
+            super.sendEvent(event)
+        }
+    }
+
+    /// Matches the volume commands' own 1/16 step, so arrowing the slider lands on the same values Turn Volume Up/Down produce.
+    private static let arrowStep = 1.0 / 16
+
+    override var canBecomeKey: Bool { acceptsKey }
+    override var canBecomeMain: Bool { false }
+}
+
+/// Tinycast's own dialogs. The app deliberately never shows an `NSAlert`: confirmations, failures and the volume control all render in the palette's design system.
+@MainActor
+final class ModalWindowController: NSObject, NSWindowDelegate {
+    /// Shared by the Set Volume slider and the HUD's read-only bar; published so a repeated volume command refreshes a HUD that is already on screen instead of rebuilding it.
+    final class VolumeState: ObservableObject {
+        @Published var level: Double
+        @Published var muted: Bool
+
+        init(level: Double, muted: Bool = false) {
+            self.level = level
+            self.muted = muted
+        }
+    }
+
+    /// The transient HUD's content. One panel serves both kinds so a volume change and a confirmation can never overlap on screen.
+    final class HUDState: ObservableObject {
+        enum Content {
+            case volume(level: Double, muted: Bool)
+            case message(symbol: String, title: String)
+        }
+
+        @Published var content: Content = .volume(level: 0, muted: false)
+    }
+
+    private var panel: ModalPanel?
+    private var continuation: CheckedContinuation<Int, Never>?
+    private var volume = VolumeState(level: 0)
+    private var hud: ModalPanel?
+    private let hudState = HUDState()
+    private var hudDismissal: Task<Void, Never>?
+
+    func confirm(title: String, message: String?, confirmTitle: String, destructive: Bool) async
+        -> Bool
+    {
+        let request = ModalRequest(
+            title: title, message: message,
+            symbol: destructive ? "exclamationmark.triangle" : "questionmark.circle",
+            actions: [
+                ModalAction(title: confirmTitle, role: destructive ? .destructive : .normal),
+                ModalAction(title: "Cancel", role: .cancel),
+            ],
+            defaultIndex: 1, cancelIndex: 1)
+        return await present(request) == 0
+    }
+
+    func notice(title: String, message: String, symbol: String) async {
+        let request = ModalRequest(
+            title: title, message: message, symbol: symbol,
+            actions: [ModalAction(title: "OK", role: .cancel)], defaultIndex: 0, cancelIndex: 0)
+        _ = await present(request)
+    }
+
+    /// A failure report. Returns true when the user asked to be taken to the relevant settings.
+    func report(title: String, message: String, settingsTitle: String?) async -> Bool {
+        var actions = [ModalAction(title: "OK", role: .cancel)]
+        if let settingsTitle { actions.append(ModalAction(title: settingsTitle)) }
+        let request = ModalRequest(
+            title: title, message: message, symbol: "exclamationmark.triangle",
+            actions: actions, defaultIndex: 0, cancelIndex: 0)
+        return await present(request) == 1
+    }
+
+    func pickVolume(current: Float32) async -> Float32? {
+        volume = VolumeState(level: Double(current))
+        let request = ModalRequest(
+            title: "Set Volume", message: "Choose the output volume.", symbol: "speaker.wave.2",
+            actions: [
+                ModalAction(title: "Set Volume"),
+                ModalAction(title: "Cancel", role: .cancel),
+            ],
+            defaultIndex: 0, cancelIndex: 1, showsVolumeSlider: true)
+        guard await present(request) == 0 else { return nil }
+        return Float32(volume.level)
+    }
+
+    /// Feedback for the volume and mute commands, which otherwise change the output with nothing on screen, since macOS only draws its own HUD for real media keys.
+    func showVolumeHUD(level: Float32, muted: Bool) {
+        showHUD(.volume(level: Double(level), muted: muted))
+    }
+
+    /// Confirmation for a command whose effect is invisible (Empty Trash, a toggle). Without it a successful run is indistinguishable from nothing happening.
+    func showToast(symbol: String, title: String) {
+        showHUD(.message(symbol: symbol, title: title))
+    }
+
+    private func showHUD(_ content: HUDState.Content) {
+        hudState.content = content
+        if hud == nil {
+            let view = hostingView(
+                TinycastHUDView(state: hudState), width: Theme.Size.hudWidth,
+                minHeight: Theme.Size.hudHeight)
+            let panel = ModalPanel(content: view, acceptsKey: false)
+            place(panel, anchor: .hud)
+            panel.orderFrontRegardless()
+            hud = panel
+        }
+        hudDismissal?.cancel()
+        hudDismissal = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(1500))
+            guard !Task.isCancelled else { return }
+            self?.dismissHUD()
+        }
+    }
+
+    private func dismissHUD() {
+        hud?.orderOut(nil)
+        hud = nil
+        hudDismissal = nil
+    }
+
+    private func present(_ request: ModalRequest) async -> Int {
+        // Carbon hotkeys keep firing while a dialog is up; a held shortcut must not stack a second one, so the extra request resolves as a dismissal.
+        guard panel == nil else { return request.cancelIndex }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            let content = hostingView(
+                TinycastModalView(
+                    request: request, volume: volume,
+                    onChoose: { [weak self] index in self?.finish(index) }
+                ),
+                width: Theme.Size.modalWidth, minHeight: 0)
+            let panel = ModalPanel(content: content, acceptsKey: true)
+            panel.delegate = self
+            panel.onKey = { [weak self] key in
+                guard let self else { return }
+                switch key {
+                case .cancel:
+                    finish(request.cancelIndex)
+                case .confirm:
+                    finish(request.defaultIndex)
+                case .adjust(let delta):
+                    guard request.showsVolumeSlider else { return }
+                    volume.level = min(max(volume.level + delta, 0), 1)
+                }
+            }
+            self.panel = panel
+            place(panel, anchor: .center)
+            // Non-activating like the palette: the dialog takes key focus for its own keys without pulling app focus away from whatever the user was in.
+            panel.makeKeyAndOrderFront(nil)
+            panel.orderFrontRegardless()
+        }
+    }
+
+    private func finish(_ index: Int) {
+        guard let continuation else { return }
+        self.continuation = nil
+        panel?.delegate = nil
+        panel?.orderOut(nil)
+        panel = nil
+        continuation.resume(returning: index)
+    }
+
+    private func hostingView(_ view: some View, width: CGFloat, minHeight: CGFloat) -> NSView {
+        let hosting = NSHostingView(rootView: AnyView(view))
+        // Measure at the fixed width first: the message wraps, so the height is only knowable once the width is pinned.
+        hosting.setFrameSize(NSSize(width: width, height: minHeight))
+        let fitted = hosting.fittingSize
+        hosting.setFrameSize(NSSize(width: width, height: max(fitted.height, minHeight)))
+        return hosting
+    }
+
+    private enum Anchor {
+        case center
+        case hud
+    }
+
+    private func place(_ panel: NSPanel, anchor: Anchor) {
+        guard let screen = cursorScreen() else { return }
+        let visible = screen.visibleFrame
+        let size = panel.frame.size
+        let origin: NSPoint
+        switch anchor {
+        case .center:
+            origin = NSPoint(
+                x: visible.midX - size.width / 2,
+                y: visible.midY - size.height / 2 + visible.height * Self.centerLift)
+        case .hud:
+            origin = NSPoint(
+                x: visible.midX - size.width / 2,
+                y: visible.minY + visible.height * Self.hudBottomFraction)
+        }
+        panel.setFrameOrigin(origin)
+    }
+
+    /// Optical centering: a dialog placed on the exact vertical middle reads low, the same reason the palette sits above center.
+    private static let centerLift: CGFloat = 0.08
+    private static let hudBottomFraction: CGFloat = 0.12
+
+    /// The display the user is working on. `NSScreen.main` is the key window's screen, which an accessory app driving non-activating panels never reliably has.
+    private func cursorScreen() -> NSScreen? {
+        let mouse = NSEvent.mouseLocation
+        // NSMouseInRect, not `contains`: a pointer on a display's topmost row otherwise resolves to the display stacked above it.
+        return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// Click-away resolves as a dismissal rather than leaving an orphaned dialog behind.
+    func windowDidResignKey(_ notification: Notification) {
+        guard let panel, notification.object as? NSWindow === panel else { return }
+        panel.onKey?(.cancel)
+    }
+}

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -23,6 +23,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volume100 = "volume-100"
         case showDesktop = "show-desktop"
         case toggleAppearance = "toggle-system-appearance"
+        case toggleStageManager = "toggle-stage-manager"
     }
 
     enum Confirmation: String, Sendable {
@@ -74,6 +75,7 @@ enum SystemCommandCatalog {
         case .volume100: return "Set Volume to 100%"
         case .showDesktop: return "Show Desktop"
         case .toggleAppearance: return "Toggle System Appearance"
+        case .toggleStageManager: return "Toggle Stage Manager"
         }
     }
 
@@ -96,6 +98,7 @@ enum SystemCommandCatalog {
             return "speaker.wave.2"
         case .showDesktop: return "macwindow.on.rectangle"
         case .toggleAppearance: return "circle.lefthalf.filled"
+        case .toggleStageManager: return "squares.leading.rectangle"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -5,6 +5,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case lockScreen = "lock-screen"
         case sleep
         case sleepDisplays = "sleep-displays"
+        case restart
     }
 
     enum Confirmation: String, Sendable {
@@ -38,6 +39,7 @@ enum SystemCommandCatalog {
         case .lockScreen: return "Lock Screen"
         case .sleep: return "Sleep"
         case .sleepDisplays: return "Sleep Displays"
+        case .restart: return "Restart"
         }
     }
 
@@ -46,11 +48,14 @@ enum SystemCommandCatalog {
         case .lockScreen: return "lock"
         case .sleep: return "moon.zzz"
         case .sleepDisplays: return "display"
+        case .restart: return "arrow.clockwise"
         }
     }
 
     private static func confirmation(for id: SystemCommand.ID) -> SystemCommand.Confirmation {
         switch id {
+        case .restart:
+            return .required
         default:
             return .none
         }

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -32,6 +32,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case unhideAllApps = "unhide-all-hidden-apps"
         case quitAllApps = "quit-all-apps"
         case dismissNotifications = "dismiss-notifications"
+        case toggleBluetooth = "toggle-bluetooth"
     }
 
     enum Confirmation: String, Sendable {
@@ -95,6 +96,7 @@ enum SystemCommandCatalog {
         case .unhideAllApps: return "Unhide All Hidden Apps"
         case .quitAllApps: return "Quit All Applications"
         case .dismissNotifications: return "Dismiss Notifications"
+        case .toggleBluetooth: return "Toggle Bluetooth"
         }
     }
 
@@ -126,6 +128,7 @@ enum SystemCommandCatalog {
         case .unhideAllApps: return "eye.circle"
         case .quitAllApps: return "xmark.circle"
         case .dismissNotifications: return "bell.slash"
+        case .toggleBluetooth: return "bluetooth"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -12,6 +12,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case playPause = "play-pause"
         case nextTrack = "next-track"
         case previousTrack = "previous-track"
+        case toggleMute = "toggle-mute"
     }
 
     enum Confirmation: String, Sendable {
@@ -52,6 +53,7 @@ enum SystemCommandCatalog {
         case .playPause: return "Play / Pause"
         case .nextTrack: return "Next Track"
         case .previousTrack: return "Previous Track"
+        case .toggleMute: return "Toggle Mute"
         }
     }
 
@@ -67,6 +69,7 @@ enum SystemCommandCatalog {
         case .playPause: return "playpause"
         case .nextTrack: return "forward.end"
         case .previousTrack: return "backward.end"
+        case .toggleMute: return "speaker.slash"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -8,6 +8,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case restart
         case shutDown = "shut-down"
         case logOut = "log-out"
+        case showScreenSaver = "show-screen-saver"
     }
 
     enum Confirmation: String, Sendable {
@@ -44,6 +45,7 @@ enum SystemCommandCatalog {
         case .restart: return "Restart"
         case .shutDown: return "Shut Down"
         case .logOut: return "Log Out"
+        case .showScreenSaver: return "Show Screen Saver"
         }
     }
 
@@ -55,6 +57,7 @@ enum SystemCommandCatalog {
         case .restart: return "arrow.clockwise"
         case .shutDown: return "power"
         case .logOut: return "rectangle.portrait.and.arrow.right"
+        case .showScreenSaver: return "rectangle.inset.filled"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -24,6 +24,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case showDesktop = "show-desktop"
         case toggleAppearance = "toggle-system-appearance"
         case toggleStageManager = "toggle-stage-manager"
+        case openTrash = "open-trash"
     }
 
     enum Confirmation: String, Sendable {
@@ -76,6 +77,7 @@ enum SystemCommandCatalog {
         case .showDesktop: return "Show Desktop"
         case .toggleAppearance: return "Toggle System Appearance"
         case .toggleStageManager: return "Toggle Stage Manager"
+        case .openTrash: return "Open Trash"
         }
     }
 
@@ -99,6 +101,7 @@ enum SystemCommandCatalog {
         case .showDesktop: return "macwindow.on.rectangle"
         case .toggleAppearance: return "circle.lefthalf.filled"
         case .toggleStageManager: return "squares.leading.rectangle"
+        case .openTrash: return "trash"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -22,6 +22,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volume75 = "volume-75"
         case volume100 = "volume-100"
         case showDesktop = "show-desktop"
+        case toggleAppearance = "toggle-system-appearance"
     }
 
     enum Confirmation: String, Sendable {
@@ -72,6 +73,7 @@ enum SystemCommandCatalog {
         case .volume75: return "Set Volume to 75%"
         case .volume100: return "Set Volume to 100%"
         case .showDesktop: return "Show Desktop"
+        case .toggleAppearance: return "Toggle System Appearance"
         }
     }
 
@@ -93,6 +95,7 @@ enum SystemCommandCatalog {
         case .setVolume, .volume0, .volume25, .volume50, .volume75, .volume100:
             return "speaker.wave.2"
         case .showDesktop: return "macwindow.on.rectangle"
+        case .toggleAppearance: return "circle.lefthalf.filled"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -17,6 +17,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volumeDown = "volume-down"
         case setVolume = "set-volume"
         case volume0 = "volume-0"
+        case volume25 = "volume-25"
     }
 
     enum Confirmation: String, Sendable {
@@ -62,6 +63,7 @@ enum SystemCommandCatalog {
         case .volumeDown: return "Turn Volume Down"
         case .setVolume: return "Set Volume…"
         case .volume0: return "Set Volume to 0%"
+        case .volume25: return "Set Volume to 25%"
         }
     }
 
@@ -80,7 +82,7 @@ enum SystemCommandCatalog {
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
         case .volumeDown: return "speaker.minus"
-        case .setVolume, .volume0:
+        case .setVolume, .volume0, .volume25:
             return "speaker.wave.2"
         }
     }

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -21,6 +21,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volume50 = "volume-50"
         case volume75 = "volume-75"
         case volume100 = "volume-100"
+        case showDesktop = "show-desktop"
     }
 
     enum Confirmation: String, Sendable {
@@ -70,6 +71,7 @@ enum SystemCommandCatalog {
         case .volume50: return "Set Volume to 50%"
         case .volume75: return "Set Volume to 75%"
         case .volume100: return "Set Volume to 100%"
+        case .showDesktop: return "Show Desktop"
         }
     }
 
@@ -90,6 +92,7 @@ enum SystemCommandCatalog {
         case .volumeDown: return "speaker.minus"
         case .setVolume, .volume0, .volume25, .volume50, .volume75, .volume100:
             return "speaker.wave.2"
+        case .showDesktop: return "macwindow.on.rectangle"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -31,6 +31,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case hideOtherApps = "hide-all-apps-except-frontmost"
         case unhideAllApps = "unhide-all-hidden-apps"
         case quitAllApps = "quit-all-apps"
+        case dismissNotifications = "dismiss-notifications"
     }
 
     enum Confirmation: String, Sendable {
@@ -93,6 +94,7 @@ enum SystemCommandCatalog {
         case .hideOtherApps: return "Hide All Apps Except Frontmost"
         case .unhideAllApps: return "Unhide All Hidden Apps"
         case .quitAllApps: return "Quit All Applications"
+        case .dismissNotifications: return "Dismiss Notifications"
         }
     }
 
@@ -123,6 +125,7 @@ enum SystemCommandCatalog {
         case .hideOtherApps: return "eye.slash.circle"
         case .unhideAllApps: return "eye.circle"
         case .quitAllApps: return "xmark.circle"
+        case .dismissNotifications: return "bell.slash"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct SystemCommand: Identifiable, Hashable, Sendable {
+    enum ID: String, CaseIterable, Sendable {
+        case lockScreen = "lock-screen"
+    }
+
+    enum Confirmation: String, Sendable {
+        case none
+        case required
+    }
+
+    let id: ID
+    let name: String
+    let sfSymbol: String
+    let confirmation: Confirmation
+
+    var entryID: String { "system-command:" + id.rawValue }
+}
+
+enum SystemCommandCatalog {
+    static let all: [SystemCommand] = SystemCommand.ID.allCases.map { id in
+        SystemCommand(
+            id: id, name: name(for: id), sfSymbol: symbol(for: id),
+            confirmation: confirmation(for: id))
+    }
+
+    private static let byEntryID = Dictionary(uniqueKeysWithValues: all.map { ($0.entryID, $0) })
+
+    static func command(forEntryID entryID: String) -> SystemCommand? {
+        byEntryID[entryID]
+    }
+
+    private static func name(for id: SystemCommand.ID) -> String {
+        switch id {
+        case .lockScreen: return "Lock Screen"
+        }
+    }
+
+    private static func symbol(for id: SystemCommand.ID) -> String {
+        switch id {
+        case .lockScreen: return "lock"
+        }
+    }
+
+    private static func confirmation(for id: SystemCommand.ID) -> SystemCommand.Confirmation {
+        switch id {
+        default:
+            return .none
+        }
+    }
+}

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -29,6 +29,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case ejectAllDisks = "eject-all-disks"
         case toggleHiddenFiles = "toggle-hidden-files"
         case hideOtherApps = "hide-all-apps-except-frontmost"
+        case unhideAllApps = "unhide-all-hidden-apps"
     }
 
     enum Confirmation: String, Sendable {
@@ -86,6 +87,7 @@ enum SystemCommandCatalog {
         case .ejectAllDisks: return "Eject All Disks"
         case .toggleHiddenFiles: return "Toggle Hidden Files"
         case .hideOtherApps: return "Hide All Apps Except Frontmost"
+        case .unhideAllApps: return "Unhide All Hidden Apps"
         }
     }
 
@@ -114,6 +116,7 @@ enum SystemCommandCatalog {
         case .ejectAllDisks: return "eject"
         case .toggleHiddenFiles: return "eye.slash"
         case .hideOtherApps: return "eye.slash.circle"
+        case .unhideAllApps: return "eye.circle"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -10,6 +10,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case logOut = "log-out"
         case showScreenSaver = "show-screen-saver"
         case playPause = "play-pause"
+        case nextTrack = "next-track"
     }
 
     enum Confirmation: String, Sendable {
@@ -48,6 +49,7 @@ enum SystemCommandCatalog {
         case .logOut: return "Log Out"
         case .showScreenSaver: return "Show Screen Saver"
         case .playPause: return "Play / Pause"
+        case .nextTrack: return "Next Track"
         }
     }
 
@@ -61,6 +63,7 @@ enum SystemCommandCatalog {
         case .logOut: return "rectangle.portrait.and.arrow.right"
         case .showScreenSaver: return "rectangle.inset.filled"
         case .playPause: return "playpause"
+        case .nextTrack: return "forward.end"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -14,6 +14,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case previousTrack = "previous-track"
         case toggleMute = "toggle-mute"
         case volumeUp = "volume-up"
+        case volumeDown = "volume-down"
     }
 
     enum Confirmation: String, Sendable {
@@ -56,6 +57,7 @@ enum SystemCommandCatalog {
         case .previousTrack: return "Previous Track"
         case .toggleMute: return "Toggle Mute"
         case .volumeUp: return "Turn Volume Up"
+        case .volumeDown: return "Turn Volume Down"
         }
     }
 
@@ -73,6 +75,7 @@ enum SystemCommandCatalog {
         case .previousTrack: return "backward.end"
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
+        case .volumeDown: return "speaker.minus"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -18,6 +18,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case setVolume = "set-volume"
         case volume0 = "volume-0"
         case volume25 = "volume-25"
+        case volume50 = "volume-50"
     }
 
     enum Confirmation: String, Sendable {
@@ -64,6 +65,7 @@ enum SystemCommandCatalog {
         case .setVolume: return "Set Volume…"
         case .volume0: return "Set Volume to 0%"
         case .volume25: return "Set Volume to 25%"
+        case .volume50: return "Set Volume to 50%"
         }
     }
 
@@ -82,7 +84,7 @@ enum SystemCommandCatalog {
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
         case .volumeDown: return "speaker.minus"
-        case .setVolume, .volume0, .volume25:
+        case .setVolume, .volume0, .volume25, .volume50:
             return "speaker.wave.2"
         }
     }

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -27,6 +27,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case openTrash = "open-trash"
         case emptyTrash = "empty-trash"
         case ejectAllDisks = "eject-all-disks"
+        case toggleHiddenFiles = "toggle-hidden-files"
     }
 
     enum Confirmation: String, Sendable {
@@ -82,6 +83,7 @@ enum SystemCommandCatalog {
         case .openTrash: return "Open Trash"
         case .emptyTrash: return "Empty Trash"
         case .ejectAllDisks: return "Eject All Disks"
+        case .toggleHiddenFiles: return "Toggle Hidden Files"
         }
     }
 
@@ -108,6 +110,7 @@ enum SystemCommandCatalog {
         case .openTrash: return "trash"
         case .emptyTrash: return "trash.slash"
         case .ejectAllDisks: return "eject"
+        case .toggleHiddenFiles: return "eye.slash"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -9,6 +9,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case shutDown = "shut-down"
         case logOut = "log-out"
         case showScreenSaver = "show-screen-saver"
+        case playPause = "play-pause"
     }
 
     enum Confirmation: String, Sendable {
@@ -46,6 +47,7 @@ enum SystemCommandCatalog {
         case .shutDown: return "Shut Down"
         case .logOut: return "Log Out"
         case .showScreenSaver: return "Show Screen Saver"
+        case .playPause: return "Play / Pause"
         }
     }
 
@@ -58,6 +60,7 @@ enum SystemCommandCatalog {
         case .shutDown: return "power"
         case .logOut: return "rectangle.portrait.and.arrow.right"
         case .showScreenSaver: return "rectangle.inset.filled"
+        case .playPause: return "playpause"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -28,6 +28,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case emptyTrash = "empty-trash"
         case ejectAllDisks = "eject-all-disks"
         case toggleHiddenFiles = "toggle-hidden-files"
+        case hideOtherApps = "hide-all-apps-except-frontmost"
     }
 
     enum Confirmation: String, Sendable {
@@ -84,6 +85,7 @@ enum SystemCommandCatalog {
         case .emptyTrash: return "Empty Trash"
         case .ejectAllDisks: return "Eject All Disks"
         case .toggleHiddenFiles: return "Toggle Hidden Files"
+        case .hideOtherApps: return "Hide All Apps Except Frontmost"
         }
     }
 
@@ -111,6 +113,7 @@ enum SystemCommandCatalog {
         case .emptyTrash: return "trash.slash"
         case .ejectAllDisks: return "eject"
         case .toggleHiddenFiles: return "eye.slash"
+        case .hideOtherApps: return "eye.slash.circle"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -19,6 +19,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volume0 = "volume-0"
         case volume25 = "volume-25"
         case volume50 = "volume-50"
+        case volume75 = "volume-75"
     }
 
     enum Confirmation: String, Sendable {
@@ -66,6 +67,7 @@ enum SystemCommandCatalog {
         case .volume0: return "Set Volume to 0%"
         case .volume25: return "Set Volume to 25%"
         case .volume50: return "Set Volume to 50%"
+        case .volume75: return "Set Volume to 75%"
         }
     }
 
@@ -84,7 +86,7 @@ enum SystemCommandCatalog {
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
         case .volumeDown: return "speaker.minus"
-        case .setVolume, .volume0, .volume25, .volume50:
+        case .setVolume, .volume0, .volume25, .volume50, .volume75:
             return "speaker.wave.2"
         }
     }

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -11,6 +11,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case showScreenSaver = "show-screen-saver"
         case playPause = "play-pause"
         case nextTrack = "next-track"
+        case previousTrack = "previous-track"
     }
 
     enum Confirmation: String, Sendable {
@@ -50,6 +51,7 @@ enum SystemCommandCatalog {
         case .showScreenSaver: return "Show Screen Saver"
         case .playPause: return "Play / Pause"
         case .nextTrack: return "Next Track"
+        case .previousTrack: return "Previous Track"
         }
     }
 
@@ -64,6 +66,7 @@ enum SystemCommandCatalog {
         case .showScreenSaver: return "rectangle.inset.filled"
         case .playPause: return "playpause"
         case .nextTrack: return "forward.end"
+        case .previousTrack: return "backward.end"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -7,6 +7,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case sleepDisplays = "sleep-displays"
         case restart
         case shutDown = "shut-down"
+        case logOut = "log-out"
     }
 
     enum Confirmation: String, Sendable {
@@ -42,6 +43,7 @@ enum SystemCommandCatalog {
         case .sleepDisplays: return "Sleep Displays"
         case .restart: return "Restart"
         case .shutDown: return "Shut Down"
+        case .logOut: return "Log Out"
         }
     }
 
@@ -52,12 +54,13 @@ enum SystemCommandCatalog {
         case .sleepDisplays: return "display"
         case .restart: return "arrow.clockwise"
         case .shutDown: return "power"
+        case .logOut: return "rectangle.portrait.and.arrow.right"
         }
     }
 
     private static func confirmation(for id: SystemCommand.ID) -> SystemCommand.Confirmation {
         switch id {
-        case .restart, .shutDown:
+        case .restart, .shutDown, .logOut:
             return .required
         default:
             return .none

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -15,6 +15,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case toggleMute = "toggle-mute"
         case volumeUp = "volume-up"
         case volumeDown = "volume-down"
+        case setVolume = "set-volume"
     }
 
     enum Confirmation: String, Sendable {
@@ -58,6 +59,7 @@ enum SystemCommandCatalog {
         case .toggleMute: return "Toggle Mute"
         case .volumeUp: return "Turn Volume Up"
         case .volumeDown: return "Turn Volume Down"
+        case .setVolume: return "Set Volume…"
         }
     }
 
@@ -76,6 +78,8 @@ enum SystemCommandCatalog {
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
         case .volumeDown: return "speaker.minus"
+        case .setVolume:
+            return "speaker.wave.2"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -6,6 +6,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case sleep
         case sleepDisplays = "sleep-displays"
         case restart
+        case shutDown = "shut-down"
     }
 
     enum Confirmation: String, Sendable {
@@ -40,6 +41,7 @@ enum SystemCommandCatalog {
         case .sleep: return "Sleep"
         case .sleepDisplays: return "Sleep Displays"
         case .restart: return "Restart"
+        case .shutDown: return "Shut Down"
         }
     }
 
@@ -49,12 +51,13 @@ enum SystemCommandCatalog {
         case .sleep: return "moon.zzz"
         case .sleepDisplays: return "display"
         case .restart: return "arrow.clockwise"
+        case .shutDown: return "power"
         }
     }
 
     private static func confirmation(for id: SystemCommand.ID) -> SystemCommand.Confirmation {
         switch id {
-        case .restart:
+        case .restart, .shutDown:
             return .required
         default:
             return .none

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -13,6 +13,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case nextTrack = "next-track"
         case previousTrack = "previous-track"
         case toggleMute = "toggle-mute"
+        case volumeUp = "volume-up"
     }
 
     enum Confirmation: String, Sendable {
@@ -54,6 +55,7 @@ enum SystemCommandCatalog {
         case .nextTrack: return "Next Track"
         case .previousTrack: return "Previous Track"
         case .toggleMute: return "Toggle Mute"
+        case .volumeUp: return "Turn Volume Up"
         }
     }
 
@@ -70,6 +72,7 @@ enum SystemCommandCatalog {
         case .nextTrack: return "forward.end"
         case .previousTrack: return "backward.end"
         case .toggleMute: return "speaker.slash"
+        case .volumeUp: return "speaker.plus"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -4,6 +4,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
     enum ID: String, CaseIterable, Sendable {
         case lockScreen = "lock-screen"
         case sleep
+        case sleepDisplays = "sleep-displays"
     }
 
     enum Confirmation: String, Sendable {
@@ -36,6 +37,7 @@ enum SystemCommandCatalog {
         switch id {
         case .lockScreen: return "Lock Screen"
         case .sleep: return "Sleep"
+        case .sleepDisplays: return "Sleep Displays"
         }
     }
 
@@ -43,6 +45,7 @@ enum SystemCommandCatalog {
         switch id {
         case .lockScreen: return "lock"
         case .sleep: return "moon.zzz"
+        case .sleepDisplays: return "display"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -30,6 +30,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case toggleHiddenFiles = "toggle-hidden-files"
         case hideOtherApps = "hide-all-apps-except-frontmost"
         case unhideAllApps = "unhide-all-hidden-apps"
+        case quitAllApps = "quit-all-apps"
     }
 
     enum Confirmation: String, Sendable {
@@ -42,7 +43,10 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
     let sfSymbol: String
     let confirmation: Confirmation
 
-    var entryID: String { "system-command:" + id.rawValue }
+    var entryID: String {
+        // Preserve the existing Quit All launcher's persisted favorite, visibility and ranking key.
+        id == .quitAllApps ? "command:quit-all-apps" : "system-command:" + id.rawValue
+    }
 }
 
 enum SystemCommandCatalog {
@@ -88,6 +92,7 @@ enum SystemCommandCatalog {
         case .toggleHiddenFiles: return "Toggle Hidden Files"
         case .hideOtherApps: return "Hide All Apps Except Frontmost"
         case .unhideAllApps: return "Unhide All Hidden Apps"
+        case .quitAllApps: return "Quit All Applications"
         }
     }
 
@@ -117,12 +122,13 @@ enum SystemCommandCatalog {
         case .toggleHiddenFiles: return "eye.slash"
         case .hideOtherApps: return "eye.slash.circle"
         case .unhideAllApps: return "eye.circle"
+        case .quitAllApps: return "xmark.circle"
         }
     }
 
     private static func confirmation(for id: SystemCommand.ID) -> SystemCommand.Confirmation {
         switch id {
-        case .restart, .shutDown, .logOut, .emptyTrash:
+        case .restart, .shutDown, .logOut, .emptyTrash, .quitAllApps:
             return .required
         default:
             return .none

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -26,6 +26,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case toggleStageManager = "toggle-stage-manager"
         case openTrash = "open-trash"
         case emptyTrash = "empty-trash"
+        case ejectAllDisks = "eject-all-disks"
     }
 
     enum Confirmation: String, Sendable {
@@ -80,6 +81,7 @@ enum SystemCommandCatalog {
         case .toggleStageManager: return "Toggle Stage Manager"
         case .openTrash: return "Open Trash"
         case .emptyTrash: return "Empty Trash"
+        case .ejectAllDisks: return "Eject All Disks"
         }
     }
 
@@ -105,6 +107,7 @@ enum SystemCommandCatalog {
         case .toggleStageManager: return "squares.leading.rectangle"
         case .openTrash: return "trash"
         case .emptyTrash: return "trash.slash"
+        case .ejectAllDisks: return "eject"
         }
     }
 

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -20,6 +20,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volume25 = "volume-25"
         case volume50 = "volume-50"
         case volume75 = "volume-75"
+        case volume100 = "volume-100"
     }
 
     enum Confirmation: String, Sendable {
@@ -68,6 +69,7 @@ enum SystemCommandCatalog {
         case .volume25: return "Set Volume to 25%"
         case .volume50: return "Set Volume to 50%"
         case .volume75: return "Set Volume to 75%"
+        case .volume100: return "Set Volume to 100%"
         }
     }
 
@@ -86,7 +88,7 @@ enum SystemCommandCatalog {
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
         case .volumeDown: return "speaker.minus"
-        case .setVolume, .volume0, .volume25, .volume50, .volume75:
+        case .setVolume, .volume0, .volume25, .volume50, .volume75, .volume100:
             return "speaker.wave.2"
         }
     }

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -25,6 +25,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case toggleAppearance = "toggle-system-appearance"
         case toggleStageManager = "toggle-stage-manager"
         case openTrash = "open-trash"
+        case emptyTrash = "empty-trash"
     }
 
     enum Confirmation: String, Sendable {
@@ -78,6 +79,7 @@ enum SystemCommandCatalog {
         case .toggleAppearance: return "Toggle System Appearance"
         case .toggleStageManager: return "Toggle Stage Manager"
         case .openTrash: return "Open Trash"
+        case .emptyTrash: return "Empty Trash"
         }
     }
 
@@ -102,12 +104,13 @@ enum SystemCommandCatalog {
         case .toggleAppearance: return "circle.lefthalf.filled"
         case .toggleStageManager: return "squares.leading.rectangle"
         case .openTrash: return "trash"
+        case .emptyTrash: return "trash.slash"
         }
     }
 
     private static func confirmation(for id: SystemCommand.ID) -> SystemCommand.Confirmation {
         switch id {
-        case .restart, .shutDown, .logOut:
+        case .restart, .shutDown, .logOut, .emptyTrash:
             return .required
         default:
             return .none

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -16,6 +16,7 @@ struct SystemCommand: Identifiable, Hashable, Sendable {
         case volumeUp = "volume-up"
         case volumeDown = "volume-down"
         case setVolume = "set-volume"
+        case volume0 = "volume-0"
     }
 
     enum Confirmation: String, Sendable {
@@ -60,6 +61,7 @@ enum SystemCommandCatalog {
         case .volumeUp: return "Turn Volume Up"
         case .volumeDown: return "Turn Volume Down"
         case .setVolume: return "Set Volume…"
+        case .volume0: return "Set Volume to 0%"
         }
     }
 
@@ -78,7 +80,7 @@ enum SystemCommandCatalog {
         case .toggleMute: return "speaker.slash"
         case .volumeUp: return "speaker.plus"
         case .volumeDown: return "speaker.minus"
-        case .setVolume:
+        case .setVolume, .volume0:
             return "speaker.wave.2"
         }
     }

--- a/Tinycast/Core/SystemCommand.swift
+++ b/Tinycast/Core/SystemCommand.swift
@@ -3,6 +3,7 @@ import Foundation
 struct SystemCommand: Identifiable, Hashable, Sendable {
     enum ID: String, CaseIterable, Sendable {
         case lockScreen = "lock-screen"
+        case sleep
     }
 
     enum Confirmation: String, Sendable {
@@ -34,12 +35,14 @@ enum SystemCommandCatalog {
     private static func name(for id: SystemCommand.ID) -> String {
         switch id {
         case .lockScreen: return "Lock Screen"
+        case .sleep: return "Sleep"
         }
     }
 
     private static func symbol(for id: SystemCommand.ID) -> String {
         switch id {
         case .lockScreen: return "lock"
+        case .sleep: return "moon.zzz"
         }
     }
 

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -155,6 +155,13 @@ enum SystemCommandRunner {
                 symbol: shown ? "eye" : "eye.slash")
         case .hideOtherApps:
             hideOtherApps(except: previousApp)
+        case .unhideAllApps:
+            let hidden = NSWorkspace.shared.runningApplications.filter(\.isHidden)
+            for app in hidden { app.unhide() }
+            guard !hidden.isEmpty else {
+                return SystemCommandFeedback("Nothing Was Hidden", symbol: "eye", isNoOp: true)
+            }
+            return SystemCommandFeedback("All Apps Unhidden", symbol: "eye")
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -104,6 +104,14 @@ enum SystemCommandRunner {
             try await runProcess(
                 "/System/Applications/Mission Control.app/Contents/MacOS/Mission Control",
                 arguments: ["1"])
+        case .toggleAppearance:
+            // The script returns the resulting state, so the confirmation can name it instead of guessing.
+            let result = try runAppleScript(
+                "tell application \"System Events\" to tell appearance preferences to set dark mode to not dark mode")
+            let dark = result?.booleanValue ?? false
+            return SystemCommandFeedback(
+                dark ? "Dark Appearance" : "Light Appearance",
+                symbol: dark ? "moon.fill" : "sun.max.fill")
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -56,6 +56,8 @@ enum SystemCommandRunner {
             try await runProcess("/usr/bin/pmset", arguments: ["displaysleepnow"])
         case .restart:
             try runAppleScript("tell application \"System Events\" to restart")
+        case .shutDown:
+            try runAppleScript("tell application \"System Events\" to shut down")
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -74,6 +74,8 @@ enum SystemCommandRunner {
                             failure: SystemCommandFailure(error.localizedDescription))
                     }
                 }
+        case .playPause:
+            try postMediaKey(16)
         }
         return nil
     }
@@ -92,6 +94,22 @@ enum SystemCommandRunner {
         up.flags = flags
         down.post(tap: .cghidEventTap)
         up.post(tap: .cghidEventTap)
+    }
+
+    private static func postMediaKey(_ key: Int32) throws {
+        guard Permissions.ensureAccessibility() else {
+            throw SystemCommandFailure(
+                "Allow Tinycast to control your Mac in Accessibility settings, then try again.",
+                settings: .accessibility)
+        }
+        // Auxiliary-key events are the same route as the keyboard's media keys; 0xA/0xB are their down/up states.
+        for state in [0xA, 0xB] {
+            let data1 = Int((key << 16) | (Int32(state) << 8))
+            let event = NSEvent.otherEvent(
+                with: .systemDefined, location: .zero, modifierFlags: [], timestamp: 0,
+                windowNumber: 0, context: nil, subtype: 8, data1: data1, data2: -1)
+            event?.cgEvent?.post(tap: .cghidEventTap)
+        }
     }
 
     @discardableResult

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -1,0 +1,68 @@
+import AppKit
+import Carbon
+import CoreAudio
+import Darwin
+
+struct SystemCommandFailure: LocalizedError, Sendable {
+    enum Settings: Sendable {
+        case accessibility
+        case automation
+        case bluetooth
+    }
+
+    let message: String
+    let settings: Settings?
+
+    init(_ message: String, settings: Settings? = nil) {
+        self.message = message
+        self.settings = settings
+    }
+
+    var errorDescription: String? { message }
+}
+
+struct SystemCommandFeedback: Sendable {
+    let title: String
+    let symbol: String
+    /// Set when the command found nothing to do; it reads as information rather than a completed change.
+    let isNoOp: Bool
+
+    init(_ title: String, symbol: String, isNoOp: Bool = false) {
+        self.title = title
+        self.symbol = symbol
+        self.isNoOp = isNoOp
+    }
+}
+
+@MainActor
+enum SystemCommandRunner {
+
+    /// What a command reports back once it succeeded. Only commands whose effect is otherwise invisible
+    /// return one, since Show Desktop or Hide Others are their own confirmation.
+    static func run(_ id: SystemCommand.ID, previousApp: NSRunningApplication?) async throws
+        -> SystemCommandFeedback?
+    {
+        switch id {
+        case .lockScreen:
+            try postKey(keyCode: CGKeyCode(kVK_ANSI_Q), flags: [.maskControl, .maskCommand])
+        }
+        return nil
+    }
+
+    private static func postKey(keyCode: CGKeyCode, flags: CGEventFlags) throws {
+        guard Permissions.ensureAccessibility() else {
+            throw SystemCommandFailure(
+                "Allow Tinycast to control your Mac in Accessibility settings, then try again.",
+                settings: .accessibility)
+        }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+            let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        else { throw SystemCommandFailure("macOS could not create the keyboard event.") }
+        down.flags = flags
+        up.flags = flags
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+    }
+
+}

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -171,6 +171,10 @@ enum SystemCommandRunner {
                     "No Notifications", symbol: "bell.slash", isNoOp: true)
             }
             return SystemCommandFeedback("Notifications Dismissed", symbol: "bell.slash")
+        case .toggleBluetooth:
+            let on = try await toggleBluetooth()
+            return SystemCommandFeedback(
+                on ? "Bluetooth On" : "Bluetooth Off", symbol: "bluetooth")
         }
         return nil
     }
@@ -532,6 +536,37 @@ enum SystemCommandRunner {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
         return value as? String
+    }
+
+    /// Returns the power state the controller settled into; the setter is `void`, so polling the getter is the only confirmation available.
+    private static func toggleBluetooth() async throws -> Bool {
+        let path = "/System/Library/Frameworks/IOBluetooth.framework/IOBluetooth"
+        guard let handle = dlopen(path, RTLD_NOW) else {
+            throw SystemCommandFailure("Bluetooth control is unavailable on this Mac.")
+        }
+        defer { dlclose(handle) }
+        typealias Available = @convention(c) () -> Int32
+        typealias GetPower = @convention(c) () -> Int32
+        typealias SetPower = @convention(c) (Int32) -> Void
+        guard let availableSymbol = dlsym(handle, "IOBluetoothPreferencesAvailable"),
+            let getSymbol = dlsym(handle, "IOBluetoothPreferenceGetControllerPowerState"),
+            let setSymbol = dlsym(handle, "IOBluetoothPreferenceSetControllerPowerState")
+        else { throw SystemCommandFailure("This macOS version does not expose Bluetooth power control.") }
+        let available = unsafeBitCast(availableSymbol, to: Available.self)
+        let getPower = unsafeBitCast(getSymbol, to: GetPower.self)
+        let setPower = unsafeBitCast(setSymbol, to: SetPower.self)
+        guard available() != 0 else {
+            throw SystemCommandFailure("No Bluetooth controller is available.", settings: .bluetooth)
+        }
+        let requested: Int32 = getPower() == 0 ? 1 : 0
+        setPower(requested)
+        for _ in 0..<20 {
+            try await Task.sleep(for: .milliseconds(100))
+            if getPower() == requested { return requested == 1 }
+        }
+        throw SystemCommandFailure(
+            "Bluetooth did not change state. Check Tinycast’s Bluetooth permission.",
+            settings: .bluetooth)
     }
 
     @discardableResult

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -60,6 +60,20 @@ enum SystemCommandRunner {
             try runAppleScript("tell application \"System Events\" to shut down")
         case .logOut:
             try runAppleScript("tell application \"System Events\" to log out")
+        case .showScreenSaver:
+            let url = URL(fileURLWithPath: "/System/Library/CoreServices/ScreenSaverEngine.app")
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw SystemCommandFailure("The macOS screen saver could not be found.")
+            }
+            NSWorkspace.shared.openApplication(
+                at: url, configuration: NSWorkspace.OpenConfiguration()) { _, error in
+                    guard let error else { return }
+                    Task { @MainActor in
+                        AppCore.shared.presentSystemCommandFailure(
+                            name: "Show Screen Saver",
+                            failure: SystemCommandFailure(error.localizedDescription))
+                    }
+                }
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -100,6 +100,10 @@ enum SystemCommandRunner {
             try setVolume(0.75)
         case .volume100:
             try setVolume(1)
+        case .showDesktop:
+            try await runProcess(
+                "/System/Applications/Mission Control.app/Contents/MacOS/Mission Control",
+                arguments: ["1"])
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -88,6 +88,8 @@ enum SystemCommandRunner {
             try changeVolume(by: volumeStep)
         case .volumeDown:
             try changeVolume(by: -volumeStep)
+        case .setVolume:
+            break  // AppCore owns the value-picking dialog and calls setVolume directly.
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -143,6 +143,16 @@ enum SystemCommandRunner {
             }
             return SystemCommandFeedback(
                 ejected == 1 ? "1 Disk Ejected" : "\(ejected) Disks Ejected", symbol: "eject")
+        case .toggleHiddenFiles:
+            let shown = try await toggleDefault(
+                domain: "com.apple.finder", key: "AppleShowAllFiles")
+            let output = try await process("/usr/bin/killall", arguments: ["Finder"])
+            if output.status != 0 && output.status != 1 {
+                throw processFailure(output, executable: "killall")
+            }
+            return SystemCommandFeedback(
+                shown ? "Hidden Files Shown" : "Hidden Files Hidden",
+                symbol: shown ? "eye" : "eye.slash")
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -80,8 +80,163 @@ enum SystemCommandRunner {
             try postMediaKey(17)
         case .previousTrack:
             try postMediaKey(18)
+        case .toggleMute:
+            try toggleMute()
         }
         return nil
+    }
+
+    static func currentVolume() throws -> Float32 {
+        let device = try defaultOutputDevice()
+        let elements = try volumeElements(on: device)
+        // Averaged across the preferred channels when there's no master element, so a balanced pair reads as one level.
+        var total: Float32 = 0
+        for element in elements {
+            var address = volumeAddress(element: element)
+            var value: Float32 = 0
+            var size = UInt32(MemoryLayout<Float32>.size)
+            guard AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value) == noErr else {
+                throw SystemCommandFailure(
+                    "The current audio output does not support software volume.")
+            }
+            total += value
+        }
+        return total / Float32(elements.count)
+    }
+
+    /// What the HUD renders after a volume or mute command. A device with no mute control reports zero level as muted, since that is how the fallback mutes it.
+    static func outputState() throws -> (level: Float32, muted: Bool) {
+        let level = try currentVolume()
+        let device = try defaultOutputDevice()
+        var address = muteAddress
+        var muted: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectHasProperty(device, &address),
+            AudioObjectGetPropertyData(device, &address, 0, nil, &size, &muted) == noErr
+        else {
+            return (level, level == 0)
+        }
+        return (level, muted != 0)
+    }
+
+    static func setVolume(_ requested: Float32) throws {
+        let device = try defaultOutputDevice()
+        let elements = try volumeElements(on: device)
+        let value = min(max(requested, 0), 1)
+        for element in elements {
+            var address = volumeAddress(element: element)
+            var settable = DarwinBoolean(false)
+            guard AudioObjectIsPropertySettable(device, &address, &settable) == noErr,
+                settable.boolValue
+            else {
+                throw SystemCommandFailure(
+                    "The current audio output volume is controlled externally.")
+            }
+            var applied = value
+            let status = AudioObjectSetPropertyData(
+                device, &address, 0, nil, UInt32(MemoryLayout<Float32>.size), &applied)
+            guard status == noErr else {
+                throw SystemCommandFailure(
+                    "macOS could not change the output volume (error \(status)).")
+            }
+        }
+        if value > 0 { try? setMuted(false, on: device) }
+    }
+
+    /// The master element when the device exposes one, else its preferred stereo channels, since HDMI and some USB outputs only publish per-channel volume.
+    private static func volumeElements(on device: AudioDeviceID) throws -> [AudioObjectPropertyElement] {
+        var main = volumeAddress(element: kAudioObjectPropertyElementMain)
+        if AudioObjectHasProperty(device, &main) { return [kAudioObjectPropertyElementMain] }
+
+        var stereoAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyPreferredChannelsForStereo,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain)
+        var channels: (UInt32, UInt32) = (1, 2)
+        var size = UInt32(MemoryLayout<(UInt32, UInt32)>.size)
+        if AudioObjectGetPropertyData(device, &stereoAddress, 0, nil, &size, &channels) != noErr {
+            channels = (1, 2)
+        }
+        let elements = [channels.0, channels.1].filter { channel in
+            var address = volumeAddress(element: channel)
+            return AudioObjectHasProperty(device, &address)
+        }
+        guard !elements.isEmpty else {
+            throw SystemCommandFailure("The current audio output does not support software volume.")
+        }
+        return elements
+    }
+
+    private static func volumeAddress(element: AudioObjectPropertyElement)
+        -> AudioObjectPropertyAddress
+    {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: element)
+    }
+
+    private static var muteAddress: AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain)
+    }
+
+    private static func defaultOutputDevice() throws -> AudioDeviceID {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var device = AudioDeviceID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &device)
+        guard status == noErr, device != kAudioObjectUnknown else {
+            throw SystemCommandFailure("No audio output device is available.")
+        }
+        return device
+    }
+
+    private static func toggleMute() throws {
+        let device = try defaultOutputDevice()
+        var address = muteAddress
+        var muted: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        if AudioObjectHasProperty(device, &address),
+            AudioObjectGetPropertyData(device, &address, 0, nil, &size, &muted) == noErr
+        {
+            try setMuted(muted == 0, on: device)
+            return
+        }
+        // No mute control (common on HDMI): fall back to parking the volume at zero and restoring it.
+        let current = try currentVolume()
+        guard current > 0 else {
+            try setVolume(lastNonZeroVolume)
+            return
+        }
+        lastNonZeroVolume = current
+        try setVolume(0)
+    }
+
+    /// Restore level for the volume-based mute fallback; only written when a mute drops the output to zero.
+    private static var lastNonZeroVolume: Float32 = 0.5
+
+    private static func setMuted(_ muted: Bool, on device: AudioDeviceID) throws {
+        var address = muteAddress
+        guard AudioObjectHasProperty(device, &address) else {
+            guard muted else { return }
+            let current = try currentVolume()
+            if current > 0 { lastNonZeroVolume = current }
+            try setVolume(0)
+            return
+        }
+        var value: UInt32 = muted ? 1 : 0
+        let status = AudioObjectSetPropertyData(
+            device, &address, 0, nil, UInt32(MemoryLayout<UInt32>.size), &value)
+        guard status == noErr else {
+            throw SystemCommandFailure("macOS could not change mute state (error \(status)).")
+        }
     }
 
     private static func postKey(keyCode: CGKeyCode, flags: CGEventFlags) throws {

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -90,6 +90,8 @@ enum SystemCommandRunner {
             try changeVolume(by: -volumeStep)
         case .setVolume:
             break  // AppCore owns the value-picking dialog and calls setVolume directly.
+        case .volume0:
+            try setVolume(0)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -42,6 +42,8 @@ enum SystemCommandRunner {
         let stderr: String
     }
 
+    private static let volumeStep: Float32 = 1 / 16
+
     /// What a command reports back once it succeeded. Only commands whose effect is otherwise invisible
     /// return one, since Show Desktop or Hide Others are their own confirmation.
     static func run(_ id: SystemCommand.ID, previousApp: NSRunningApplication?) async throws
@@ -82,6 +84,8 @@ enum SystemCommandRunner {
             try postMediaKey(18)
         case .toggleMute:
             try toggleMute()
+        case .volumeUp:
+            try changeVolume(by: volumeStep)
         }
         return nil
     }
@@ -196,6 +200,10 @@ enum SystemCommandRunner {
             throw SystemCommandFailure("No audio output device is available.")
         }
         return device
+    }
+
+    private static func changeVolume(by delta: Float32) throws {
+        try setVolume(try currentVolume() + delta)
     }
 
     private static func toggleMute() throws {

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -52,6 +52,8 @@ enum SystemCommandRunner {
             try postKey(keyCode: CGKeyCode(kVK_ANSI_Q), flags: [.maskControl, .maskCommand])
         case .sleep:
             try await runProcess("/usr/bin/pmset", arguments: ["sleepnow"])
+        case .sleepDisplays:
+            try await runProcess("/usr/bin/pmset", arguments: ["displaysleepnow"])
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -92,6 +92,8 @@ enum SystemCommandRunner {
             break  // AppCore owns the value-picking dialog and calls setVolume directly.
         case .volume0:
             try setVolume(0)
+        case .volume25:
+            try setVolume(0.25)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -76,6 +76,8 @@ enum SystemCommandRunner {
                 }
         case .playPause:
             try postMediaKey(16)
+        case .nextTrack:
+            try postMediaKey(17)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -164,6 +164,13 @@ enum SystemCommandRunner {
             return SystemCommandFeedback("All Apps Unhidden", symbol: "eye")
         case .quitAllApps:
             for app in AppLauncher.quitAllTargets() { app.terminate() }
+        case .dismissNotifications:
+            let dismissed = try await dismissNotifications()
+            guard dismissed > 0 else {
+                return SystemCommandFeedback(
+                    "No Notifications", symbol: "bell.slash", isNoOp: true)
+            }
+            return SystemCommandFeedback("Notifications Dismissed", symbol: "bell.slash")
         }
         return nil
     }
@@ -444,6 +451,87 @@ enum SystemCommandRunner {
         case "0", "false", "no": return false
         default: return nil
         }
+    }
+
+    /// Returns how many notifications were dismissed, so "nothing on screen" can read as information instead of a silent no-op.
+    private static func dismissNotifications() async throws -> Int {
+        guard Permissions.ensureAccessibility() else {
+            throw SystemCommandFailure(
+                "Allow Tinycast to control your Mac in Accessibility settings, then try again.",
+                settings: .accessibility)
+        }
+        guard let app = NSRunningApplication.runningApplications(
+            withBundleIdentifier: "com.apple.notificationcenterui").first
+        else { return 0 }
+        let root = AXUIElementCreateApplication(app.processIdentifier)
+        var dismissed = 0
+        for _ in 0..<100 {
+            // The tree is rebuilt every pass: pressing one control invalidates its siblings.
+            let notifications = notificationElements(in: root, depth: 0)
+            guard !notifications.isEmpty else { return dismissed }
+            guard let button = notifications.compactMap({ dismissControl(in: $0, depth: 0) }).first
+            else {
+                throw SystemCommandFailure(
+                    "This version of Notification Center exposes no dismiss control Tinycast can use.")
+            }
+            let result = AXUIElementPerformAction(button, kAXPressAction as CFString)
+            guard result == .success || result == .invalidUIElement else {
+                throw SystemCommandFailure("Notification Center did not allow a notification to be dismissed.")
+            }
+            dismissed += 1
+            try await Task.sleep(for: .milliseconds(150))
+        }
+        throw SystemCommandFailure("Some notifications remain after the safety limit was reached.")
+    }
+
+    /// Notification containers, matched on Accessibility subrole so the search never depends on the UI language.
+    private static func notificationElements(in element: AXUIElement, depth: Int) -> [AXUIElement] {
+        guard depth < 20 else { return [] }
+        let subrole = axString(element, attribute: kAXSubroleAttribute as CFString)?.lowercased()
+        if let subrole, subrole.contains("notificationcenter") { return [element] }
+        return axChildren(element).flatMap { notificationElements(in: $0, depth: depth + 1) }
+    }
+
+    /// A Close / Clear All control inside one notification: the close subrole is language-independent, and the label match is only a fallback. Never falls through to an arbitrary button, because a notification's own action rows (Reply, Open) also press.
+    private static func dismissControl(in element: AXUIElement, depth: Int) -> AXUIElement? {
+        guard depth < 20 else { return nil }
+        if canPress(element) {
+            let subrole = axString(element, attribute: kAXSubroleAttribute as CFString)?.lowercased()
+            if subrole == (kAXCloseButtonSubrole as String).lowercased() { return element }
+            let text = [kAXTitleAttribute, kAXDescriptionAttribute, kAXHelpAttribute]
+                .compactMap { axString(element, attribute: $0 as CFString) }
+                .joined(separator: " ").lowercased()
+            if text.contains("clear all") || text == "close" || text.contains("dismiss") {
+                return element
+            }
+        }
+        for child in axChildren(element) {
+            if let found = dismissControl(in: child, depth: depth + 1) { return found }
+        }
+        return nil
+    }
+
+    private static func canPress(_ element: AXUIElement) -> Bool {
+        var actions: CFArray?
+        guard AXUIElementCopyActionNames(element, &actions) == .success,
+            let names = actions as? [String]
+        else { return false }
+        return names.contains(kAXPressAction)
+    }
+
+    private static func axChildren(_ element: AXUIElement) -> [AXUIElement] {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &value)
+            == .success,
+            let children = value as? [AXUIElement]
+        else { return [] }
+        return children
+    }
+
+    private static func axString(_ element: AXUIElement, attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
     }
 
     @discardableResult

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -98,6 +98,8 @@ enum SystemCommandRunner {
             try setVolume(0.5)
         case .volume75:
             try setVolume(0.75)
+        case .volume100:
+            try setVolume(1)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -112,6 +112,12 @@ enum SystemCommandRunner {
             return SystemCommandFeedback(
                 dark ? "Dark Appearance" : "Light Appearance",
                 symbol: dark ? "moon.fill" : "sun.max.fill")
+        case .toggleStageManager:
+            let on = try await toggleDefault(
+                domain: "com.apple.WindowManager", key: "GloballyEnabled")
+            return SystemCommandFeedback(
+                on ? "Stage Manager On" : "Stage Manager Off",
+                symbol: "squares.leading.rectangle")
         }
         return nil
     }
@@ -302,6 +308,43 @@ enum SystemCommandRunner {
                 with: .systemDefined, location: .zero, modifierFlags: [], timestamp: 0,
                 windowNumber: 0, context: nil, subtype: 8, data1: data1, data2: -1)
             event?.cgEvent?.post(tap: .cghidEventTap)
+        }
+    }
+
+    /// Returns the state the toggle landed in, so the caller can name it rather than re-reading the preference.
+    @discardableResult
+    private static func toggleDefault(domain: String, key: String) async throws -> Bool {
+        let read = try await process("/usr/bin/defaults", arguments: ["read", domain, key])
+        let normalized = read.stdout.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let current: Bool
+        if read.status == 0 {
+            guard let parsed = booleanDefault(normalized) else {
+                throw SystemCommandFailure("macOS reported an unexpected value for this setting.")
+            }
+            current = parsed
+        } else if read.stderr.contains("does not exist") {
+            // Unset keys are genuinely off; any other read failure is unknown state and must not be overwritten.
+            current = false
+        } else {
+            throw processFailure(read, executable: "defaults")
+        }
+        let requested = !current
+        try await runProcess(
+            "/usr/bin/defaults",
+            arguments: ["write", domain, key, "-bool", requested ? "true" : "false"])
+        let verify = try await process("/usr/bin/defaults", arguments: ["read", domain, key])
+        let verified = verify.stdout.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard verify.status == 0, booleanDefault(verified) == requested else {
+            throw SystemCommandFailure("macOS did not save the requested setting.")
+        }
+        return requested
+    }
+
+    private static func booleanDefault(_ value: String) -> Bool? {
+        switch value {
+        case "1", "true", "yes": return true
+        case "0", "false", "no": return false
+        default: return nil
         }
     }
 

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -58,6 +58,8 @@ enum SystemCommandRunner {
             try runAppleScript("tell application \"System Events\" to restart")
         case .shutDown:
             try runAppleScript("tell application \"System Events\" to shut down")
+        case .logOut:
+            try runAppleScript("tell application \"System Events\" to log out")
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -86,6 +86,8 @@ enum SystemCommandRunner {
             try toggleMute()
         case .volumeUp:
             try changeVolume(by: volumeStep)
+        case .volumeDown:
+            try changeVolume(by: -volumeStep)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -123,6 +123,19 @@ enum SystemCommandRunner {
             guard NSWorkspace.shared.open(trash) else {
                 throw SystemCommandFailure("Finder could not open the Trash.")
             }
+        case .emptyTrash:
+            // Finder errors out on an already-empty Trash, so ask it for the count first. Finder is also the
+            // right oracle rather than reading `~/.Trash` ourselves: that folder is TCC-protected, so a
+            // direct read fails without Full Disk Access and would look indistinguishable from "empty".
+            let items =
+                try runAppleScript("tell application \"Finder\" to count items of trash")?
+                .int32Value ?? 0
+            guard items > 0 else {
+                return SystemCommandFeedback(
+                    "Trash Is Already Empty", symbol: "trash", isNoOp: true)
+            }
+            try runAppleScript("tell application \"Finder\" to empty trash")
+            return SystemCommandFeedback("Trash Emptied", symbol: "trash")
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -162,6 +162,8 @@ enum SystemCommandRunner {
                 return SystemCommandFeedback("Nothing Was Hidden", symbol: "eye", isNoOp: true)
             }
             return SystemCommandFeedback("All Apps Unhidden", symbol: "eye")
+        case .quitAllApps:
+            for app in AppLauncher.quitAllTargets() { app.terminate() }
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -54,6 +54,8 @@ enum SystemCommandRunner {
             try await runProcess("/usr/bin/pmset", arguments: ["sleepnow"])
         case .sleepDisplays:
             try await runProcess("/usr/bin/pmset", arguments: ["displaysleepnow"])
+        case .restart:
+            try runAppleScript("tell application \"System Events\" to restart")
         }
         return nil
     }
@@ -72,6 +74,24 @@ enum SystemCommandRunner {
         up.flags = flags
         down.post(tap: .cghidEventTap)
         up.post(tap: .cghidEventTap)
+    }
+
+    @discardableResult
+    private static func runAppleScript(_ source: String) throws -> NSAppleEventDescriptor? {
+        guard let script = NSAppleScript(source: source) else {
+            throw SystemCommandFailure("The system automation could not be prepared.")
+        }
+        var errorInfo: NSDictionary?
+        let result = script.executeAndReturnError(&errorInfo)
+        guard let errorInfo else { return result }
+        let number = errorInfo[NSAppleScript.errorNumber] as? Int
+        let detail = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown automation error."
+        if number == -1743 {
+            throw SystemCommandFailure(
+                "Allow Tinycast to control the requested app in Automation settings, then try again.",
+                settings: .automation)
+        }
+        throw SystemCommandFailure(detail)
     }
 
     private static func runProcess(_ executable: String, arguments: [String]) async throws {

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -36,6 +36,11 @@ struct SystemCommandFeedback: Sendable {
 
 @MainActor
 enum SystemCommandRunner {
+    private struct ProcessOutput: Sendable {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+    }
 
     /// What a command reports back once it succeeded. Only commands whose effect is otherwise invisible
     /// return one, since Show Desktop or Hide Others are their own confirmation.
@@ -45,6 +50,8 @@ enum SystemCommandRunner {
         switch id {
         case .lockScreen:
             try postKey(keyCode: CGKeyCode(kVK_ANSI_Q), flags: [.maskControl, .maskCommand])
+        case .sleep:
+            try await runProcess("/usr/bin/pmset", arguments: ["sleepnow"])
         }
         return nil
     }
@@ -65,4 +72,38 @@ enum SystemCommandRunner {
         up.post(tap: .cghidEventTap)
     }
 
+    private static func runProcess(_ executable: String, arguments: [String]) async throws {
+        let output = try await process(executable, arguments: arguments)
+        guard output.status == 0 else { throw processFailure(output, executable: executable) }
+    }
+
+    private static func process(_ executable: String, arguments: [String]) async throws -> ProcessOutput {
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = arguments
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = stdout
+            process.standardError = stderr
+            do { try process.run() } catch {
+                throw SystemCommandFailure("\(URL(fileURLWithPath: executable).lastPathComponent) could not start: \(error.localizedDescription)")
+            }
+            process.waitUntilExit()
+            let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+            let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
+            return ProcessOutput(
+                status: process.terminationStatus,
+                stdout: String(data: outData, encoding: .utf8) ?? "",
+                stderr: String(data: errorData, encoding: .utf8) ?? "")
+        }.value
+    }
+
+    private static func processFailure(_ output: ProcessOutput, executable: String) -> SystemCommandFailure {
+        let detail = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = URL(fileURLWithPath: executable).lastPathComponent
+        return SystemCommandFailure(
+            detail.isEmpty ? "\(name) exited with status \(output.status)." : detail)
+    }
 }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -153,6 +153,8 @@ enum SystemCommandRunner {
             return SystemCommandFeedback(
                 shown ? "Hidden Files Shown" : "Hidden Files Hidden",
                 symbol: shown ? "eye" : "eye.slash")
+        case .hideOtherApps:
+            hideOtherApps(except: previousApp)
         }
         return nil
     }
@@ -344,6 +346,20 @@ enum SystemCommandRunner {
                 windowNumber: 0, context: nil, subtype: 8, data1: data1, data2: -1)
             event?.cgEvent?.post(tap: .cghidEventTap)
         }
+    }
+
+    private static func hideOtherApps(except previousApp: NSRunningApplication?) {
+        let ownPID = NSRunningApplication.current.processIdentifier
+        let keptPID = previousApp?.processIdentifier
+        for app in NSWorkspace.shared.runningApplications
+        where app.activationPolicy == .regular
+            && app.processIdentifier != ownPID
+            && app.processIdentifier != keptPID
+        {
+            app.hide()
+        }
+        previousApp?.unhide()
+        previousApp?.activate()
     }
 
     @discardableResult

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -96,6 +96,8 @@ enum SystemCommandRunner {
             try setVolume(0.25)
         case .volume50:
             try setVolume(0.5)
+        case .volume75:
+            try setVolume(0.75)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -136,6 +136,13 @@ enum SystemCommandRunner {
             }
             try runAppleScript("tell application \"Finder\" to empty trash")
             return SystemCommandFeedback("Trash Emptied", symbol: "trash")
+        case .ejectAllDisks:
+            let ejected = try ejectAllDisks()
+            guard ejected > 0 else {
+                return SystemCommandFeedback("No Disks to Eject", symbol: "eject", isNoOp: true)
+            }
+            return SystemCommandFeedback(
+                ejected == 1 ? "1 Disk Ejected" : "\(ejected) Disks Ejected", symbol: "eject")
         }
         return nil
     }
@@ -327,6 +334,44 @@ enum SystemCommandRunner {
                 windowNumber: 0, context: nil, subtype: 8, data1: data1, data2: -1)
             event?.cgEvent?.post(tap: .cghidEventTap)
         }
+    }
+
+    @discardableResult
+    private static func ejectAllDisks() throws -> Int {
+        let keys: Set<URLResourceKey> = [
+            .volumeIsEjectableKey, .volumeIsInternalKey, .volumeIsLocalKey,
+        ]
+        let urls = FileManager.default.mountedVolumeURLs(
+            includingResourceValuesForKeys: Array(keys), options: [.skipHiddenVolumes]) ?? []
+        let ejectable = urls.filter { url in
+            guard let values = try? url.resourceValues(forKeys: keys) else { return false }
+            return values.volumeIsEjectable == true
+                && values.volumeIsInternal != true
+                && values.volumeIsLocal != false
+        }
+        var failures: [String] = []
+        var ejected = 0
+        for url in ejectable {
+            // One physical disk can publish several volumes, and ejecting the first takes the whole device with it, so a sibling that vanished is done, not failed.
+            guard mountedVolumeExists(url) else { continue }
+            do {
+                try NSWorkspace.shared.unmountAndEjectDevice(at: url)
+                ejected += 1
+            } catch {
+                guard mountedVolumeExists(url) else { continue }
+                failures.append("\(url.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+        guard failures.isEmpty else {
+            throw SystemCommandFailure("Some disks could not be ejected:\n\n" + failures.joined(separator: "\n"))
+        }
+        return ejected
+    }
+
+    private static func mountedVolumeExists(_ url: URL) -> Bool {
+        let mounted = FileManager.default.mountedVolumeURLs(
+            includingResourceValuesForKeys: nil, options: [.skipHiddenVolumes]) ?? []
+        return mounted.contains { $0.standardizedFileURL == url.standardizedFileURL }
     }
 
     /// Returns the state the toggle landed in, so the caller can name it rather than re-reading the preference.

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -118,6 +118,11 @@ enum SystemCommandRunner {
             return SystemCommandFeedback(
                 on ? "Stage Manager On" : "Stage Manager Off",
                 symbol: "squares.leading.rectangle")
+        case .openTrash:
+            let trash = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".Trash")
+            guard NSWorkspace.shared.open(trash) else {
+                throw SystemCommandFailure("Finder could not open the Trash.")
+            }
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -94,6 +94,8 @@ enum SystemCommandRunner {
             try setVolume(0)
         case .volume25:
             try setVolume(0.25)
+        case .volume50:
+            try setVolume(0.5)
         }
         return nil
     }

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -78,6 +78,8 @@ enum SystemCommandRunner {
             try postMediaKey(16)
         case .nextTrack:
             try postMediaKey(17)
+        case .previousTrack:
+            try postMediaKey(18)
         }
         return nil
     }

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -25,6 +25,8 @@ enum Theme {
         /// Hover highlight behind a popover menu row.
         static let menuRow: CGFloat = 10
         static let menuPanel: CGFloat = 16
+        /// Tinycast's own modal / HUD surface, sized between `menuPanel` and `panel`, so a dialog reads as a smaller sibling of the palette rather than a second palette.
+        static let modal: CGFloat = 20
         static let thumbnail: CGFloat = 6
         static let card: CGFloat = 10
         static let keyCap: CGFloat = 6
@@ -69,6 +71,16 @@ enum Theme {
         /// Confirmation HUD: it sizes to its message, up to this ceiling, and sits this far above the bottom of the screen.
         static let hudMaxWidth: CGFloat = 420
         static let hudEdgeOffset: CGFloat = 48
+        /// Tinycast's own modal: fixed width, height measured from the SwiftUI content.
+        static let modalWidth: CGFloat = 420
+        /// Leading glyph on a modal, larger than a row icon because it carries the dialog's tone (warning / question).
+        static let modalIcon: CGFloat = 26
+        /// Transient volume HUD shown after any volume or mute command.
+        static let hudWidth: CGFloat = 200
+        static let hudHeight: CGFloat = 92
+        /// Volume slider geometry, shared by the Set Volume modal and the HUD's read-only bar.
+        static let volumeTrackHeight: CGFloat = 6
+        static let volumeKnob: CGFloat = 16
     }
 
     enum Duration {

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -49,15 +49,17 @@ struct LauncherList: View {
         var rows: [Row] = calcRows
         let favorites = results.prefix(favoriteCount)
         let rest = results.dropFirst(favoriteCount)
-        // `rest` is apps, panes, snippets, custom commands, then built-in commands by the AppIndex sort invariant, so filtering by kind keeps row order identical and the flat selection index valid.
+        // `rest` is apps, panes, snippets, system commands, custom commands, then built-in commands by the AppIndex sort invariant, so filtering by kind keeps row order identical and the flat selection index valid.
         let apps = rest.filter { $0.kind == .application }
         let panes = rest.filter { $0.kind == .systemSettings }
         let snippets = rest.filter { $0.kind == .snippet }
+        let systemCommands = rest.filter { $0.kind == .systemCommand }
         let customCommands = rest.filter(\.isCustomCommand)
         let commands = rest.filter { $0.kind == .command && !$0.isCustomCommand }
         for (title, group) in [
             ("Favorites", Array(favorites)), ("Applications", apps),
             ("System Settings", panes), ("Snippets", snippets),
+            ("System Commands", systemCommands),
             ("Custom Commands", customCommands), ("Commands", commands),
         ]
         where !group.isEmpty {
@@ -290,6 +292,7 @@ enum AppActionsMenu {
         case .systemSettings: return "Open System Setting"
         case .command: return "Run Command"
         case .snippet: return "Paste Snippet"
+        case .systemCommand: return "Run System Command"
         }
     }
 }

--- a/Tinycast/Features/Modal/TinycastModalView.swift
+++ b/Tinycast/Features/Modal/TinycastModalView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+/// A Tinycast dialog: the palette's surface recipe (scrim over vibrancy, clipped last) at modal size, with glass only on the buttons.
+struct TinycastModalView: View {
+    let request: ModalRequest
+    @ObservedObject var volume: ModalWindowController.VolumeState
+    let onChoose: (Int) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+            HStack(alignment: .top, spacing: Theme.Spacing.lg) {
+                Image(systemName: request.symbol)
+                    .font(.system(size: Theme.Size.modalIcon, weight: .regular))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(isDestructive ? Color.red : Color.secondary)
+                    .frame(width: Theme.Size.modalIcon)
+                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                    Text(request.title)
+                        .font(.headline)
+                    if let message = request.message {
+                        Text(message)
+                            .font(Theme.Typography.rowTrailing)
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+
+            if request.showsVolumeSlider {
+                VolumeSlider(level: $volume.level)
+            }
+
+            HStack(spacing: Theme.Spacing.md) {
+                Spacer(minLength: 0)
+                ForEach(request.actions.indices, id: \.self) { index in
+                    ModalButton(
+                        action: request.actions[index],
+                        keyCap: keyCap(for: index),
+                        onActivate: { onChoose(index) }
+                    )
+                }
+            }
+        }
+        .padding(Theme.Spacing.xxl)
+        .frame(width: Theme.Size.modalWidth, alignment: .leading)
+        .background(Color.black.opacity(Theme.Colors.panelDimming))
+        .background(VisualEffectView())
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.modal, style: .continuous))
+    }
+
+    private var isDestructive: Bool {
+        request.actions.contains { $0.role == .destructive }
+    }
+
+    /// Only the two keys the panel actually handles are advertised, so a printed cap can't drift from the behavior.
+    private func keyCap(for index: Int) -> String? {
+        if index == request.defaultIndex { return "↵" }
+        if index == request.cancelIndex { return "esc" }
+        return nil
+    }
+}
+
+private struct ModalButton: View {
+    let action: ModalAction
+    let keyCap: String?
+    let onActivate: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: onActivate) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text(action.title)
+                    .font(Theme.Typography.bar)
+                    .foregroundStyle(action.role == .destructive ? Color.red : Color.primary)
+                if let keyCap {
+                    KeyCapChip(text: keyCap, style: .outline)
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.xl)
+            .frame(height: Theme.Size.menuButton)
+            .contentShape(Capsule())
+            .background(Capsule().fill(hovered ? Theme.Colors.menuHover : Color.clear))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .frosted(in: Capsule())
+    }
+}
+
+/// Tinycast's own slider, because `NSSlider` would drop an Aqua control onto a surface whose whole vocabulary is white-alpha over vibrancy.
+struct VolumeSlider: View {
+    @Binding var level: Double
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: level == 0 ? "speaker.slash.fill" : "speaker.fill")
+                .font(Theme.Typography.menuIcon)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .frame(width: Theme.Size.menuIcon)
+            GeometryReader { geometry in
+                let width = geometry.size.width
+                let travel = max(width - Theme.Size.volumeKnob, 1)
+                let clamped = min(max(level, 0), 1)
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Theme.Colors.controlSurface)
+                        .frame(height: Theme.Size.volumeTrackHeight)
+                    Capsule()
+                        .fill(Color.white.opacity(0.85))
+                        .frame(
+                            width: Theme.Size.volumeKnob / 2 + clamped * travel,
+                            height: Theme.Size.volumeTrackHeight)
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: Theme.Size.volumeKnob, height: Theme.Size.volumeKnob)
+                        .offset(x: clamped * travel)
+                }
+                .frame(height: Theme.Size.volumeKnob)
+                // minimumDistance 0 so a plain click jumps the level, matching how a native slider's track behaves.
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            let position = (value.location.x - Theme.Size.volumeKnob / 2) / travel
+                            level = min(max(position, 0), 1)
+                        }
+                )
+            }
+            .frame(height: Theme.Size.volumeKnob)
+            Text(Self.percentage(level))
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .monospacedDigit()
+                // A fixed slot keeps the track from resizing as the number grows from 0% to 100%.
+                .frame(width: Theme.Size.rowIcon * 2, alignment: .trailing)
+        }
+    }
+
+    static func percentage(_ level: Double) -> String {
+        "\(Int((min(max(level, 0), 1) * 100).rounded()))%"
+    }
+}
+
+/// The transient readout: a volume bar, or a one-line confirmation for a command whose effect is invisible. Glass, because it is a floating control rather than a surface with content.
+struct TinycastHUDView: View {
+    @ObservedObject var state: ModalWindowController.HUDState
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: symbol)
+                .font(.system(size: Theme.Size.modalIcon, weight: .regular))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color.primary)
+            switch state.content {
+            case .volume(let level, let muted):
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Theme.Colors.controlSurface)
+                    Capsule()
+                        .fill(Color.white.opacity(muted ? 0.35 : 0.85))
+                        .frame(width: fill(level: muted ? 0 : level))
+                }
+                .frame(height: Theme.Size.volumeTrackHeight)
+            case .message(_, let title):
+                Text(title)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(Theme.Spacing.xxl)
+        .frame(width: Theme.Size.hudWidth, height: Theme.Size.hudHeight)
+        .glassEffect(
+            .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.modal, style: .continuous))
+    }
+
+    private var symbol: String {
+        switch state.content {
+        case .volume(let level, let muted):
+            if muted || level == 0 { return "speaker.slash.fill" }
+            return level < 0.5 ? "speaker.wave.1.fill" : "speaker.wave.3.fill"
+        case .message(let symbol, _):
+            return symbol
+        }
+    }
+
+    private func fill(level: Double) -> CGFloat {
+        let track = Theme.Size.hudWidth - Theme.Spacing.xxl * 2
+        return track * min(max(level, 0), 1)
+    }
+}

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -662,6 +662,7 @@ struct RootPaletteView: View {
             switch selectedApp?.kind {
             case .systemSettings: return "Open System Setting"
             case .command: return "Run Command"
+            case .systemCommand: return "Run System Command"
             default: return "Open Application"
             }
         }

--- a/Tinycast/Features/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Settings/BackupSettingsView.swift
@@ -31,7 +31,7 @@ struct BackupSettingsView: View {
                     systemImage: "square.and.arrow.up",
                     tint: .blue
                 ) {
-                    Button("Export…") { BackupActions.exportSettings() }
+                    Button("Export…") { Task { await BackupActions.exportSettings() } }
                         .controlSize(.small)
                 }
                 SettingsDivider()
@@ -42,7 +42,7 @@ struct BackupSettingsView: View {
                     systemImage: "square.and.arrow.down",
                     tint: .green
                 ) {
-                    Button("Import…") { BackupActions.importSettings() }
+                    Button("Import…") { Task { await BackupActions.importSettings() } }
                         .controlSize(.small)
                 }
             }

--- a/Tinycast/Features/Settings/ShortcutsSettingsView.swift
+++ b/Tinycast/Features/Settings/ShortcutsSettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Settings → Shortcuts: everything the launcher can open, one tab per category (Applications / System Settings / Commands), each row with a visibility checkbox and hotkey recorder; never applies the visibility filter itself, so hidden rows stay re-checkable here.
+/// Settings → Shortcuts: everything the launcher can open, one tab per category, each row with a visibility checkbox and optional hotkey recorder; never applies the visibility filter itself, so hidden rows stay re-checkable here.
 struct ShortcutsSettingsView: View {
     @EnvironmentObject private var appIndex: AppIndex
     @State private var tab: AppEntry.Kind = .application
@@ -23,6 +23,7 @@ struct ShortcutsSettingsView: View {
             Picker("Category", selection: $tab) {
                 Text("Applications").tag(AppEntry.Kind.application)
                 Text("System Settings").tag(AppEntry.Kind.systemSettings)
+                Text("System Commands").tag(AppEntry.Kind.systemCommand)
                 Text("Commands").tag(AppEntry.Kind.command)
             }
             .pickerStyle(.segmented)
@@ -44,6 +45,7 @@ struct ShortcutsSettingsView: View {
         case .command: return "Search commands…"
         // Unreachable — snippets have no tab here; they're managed in Settings › Snippets.
         case .snippet: return ""
+        case .systemCommand: return "Search system commands…"
         }
     }
 

--- a/Tinycast/Info.plist
+++ b/Tinycast/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac</key>
 	<true/>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Tinycast uses automation to perform system commands you explicitly run.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Tinycast</string>
 </dict>

--- a/Tinycast/Info.plist
+++ b/Tinycast/Info.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Tinycast uses automation to perform system commands you explicitly run.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Tinycast uses Bluetooth access only when you run the Toggle Bluetooth command.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Tinycast</string>
 </dict>

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -17,6 +17,7 @@ struct SystemCommandTests {
 
     static func main() {
         let commands = SystemCommandCatalog.all
+        expect(commands.count == 31, "catalog contains all 31 agreed commands")
         expect(commands.map(\.id) == SystemCommand.ID.allCases, "catalog covers every ID once")
         expect(Set(commands.map(\.id)).count == commands.count, "IDs are unique")
         expect(Set(commands.map(\.entryID)).count == commands.count, "entry IDs are unique")
@@ -42,6 +43,10 @@ struct SystemCommandTests {
         expect(
             SystemCommandCatalog.command(forEntryID: "system-command:unknown") == nil,
             "unknown entry IDs are rejected")
+        expect(
+            !commands.contains { $0.id.rawValue == "quit-all-apps-except-frontmost" },
+            "Quit All Except Frontmost remains out of scope")
+
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
     }

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+@main
+@MainActor
+struct SystemCommandTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func main() {
+        let commands = SystemCommandCatalog.all
+        expect(commands.map(\.id) == SystemCommand.ID.allCases, "catalog covers every ID once")
+        expect(Set(commands.map(\.id)).count == commands.count, "IDs are unique")
+        expect(Set(commands.map(\.entryID)).count == commands.count, "entry IDs are unique")
+        expect(Set(commands.map { $0.name.lowercased() }).count == commands.count, "names are unique")
+        expect(commands.allSatisfy { !$0.name.isEmpty }, "names are non-empty")
+        expect(commands.allSatisfy { !$0.sfSymbol.isEmpty }, "symbols are non-empty")
+
+        for command in commands {
+            expect(
+                SystemCommandCatalog.command(forEntryID: command.entryID) == command,
+                "\(command.id.rawValue) round-trips through its entry ID")
+            expect(
+                command.entryID.hasPrefix("system-command:"),
+                "\(command.id.rawValue) is namespaced")
+        }
+
+        let confirmed: Set<SystemCommand.ID> = []
+        expect(
+            Set(commands.filter { $0.confirmation == .required }.map(\.id)) == confirmed,
+            "only the agreed disruptive commands require confirmation")
+        expect(
+            SystemCommandCatalog.command(forEntryID: "system-command:unknown") == nil,
+            "unknown entry IDs are rejected")
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -33,7 +33,7 @@ struct SystemCommandTests {
                 "\(command.id.rawValue) is namespaced")
         }
 
-        let confirmed: Set<SystemCommand.ID> = [.restart]
+        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown]
         expect(
             Set(commands.filter { $0.confirmation == .required }.map(\.id)) == confirmed,
             "only the agreed disruptive commands require confirmation")

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -33,7 +33,7 @@ struct SystemCommandTests {
                 "\(command.id.rawValue) is namespaced")
         }
 
-        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown, .logOut]
+        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown, .logOut, .emptyTrash]
         expect(
             Set(commands.filter { $0.confirmation == .required }.map(\.id)) == confirmed,
             "only the agreed disruptive commands require confirmation")

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -33,7 +33,7 @@ struct SystemCommandTests {
                 "\(command.id.rawValue) is namespaced")
         }
 
-        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown]
+        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown, .logOut]
         expect(
             Set(commands.filter { $0.confirmation == .required }.map(\.id)) == confirmed,
             "only the agreed disruptive commands require confirmation")

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -33,7 +33,7 @@ struct SystemCommandTests {
                 "\(command.id.rawValue) is namespaced")
         }
 
-        let confirmed: Set<SystemCommand.ID> = []
+        let confirmed: Set<SystemCommand.ID> = [.restart]
         expect(
             Set(commands.filter { $0.confirmation == .required }.map(\.id)) == confirmed,
             "only the agreed disruptive commands require confirmation")

--- a/Tools/system-command-test.swift
+++ b/Tools/system-command-test.swift
@@ -28,12 +28,14 @@ struct SystemCommandTests {
             expect(
                 SystemCommandCatalog.command(forEntryID: command.entryID) == command,
                 "\(command.id.rawValue) round-trips through its entry ID")
-            expect(
-                command.entryID.hasPrefix("system-command:"),
-                "\(command.id.rawValue) is namespaced")
+            if command.id == .quitAllApps {
+                expect(command.entryID == "command:quit-all-apps", "Quit All preserves its old key")
+            } else {
+                expect(command.entryID.hasPrefix("system-command:"), "\(command.id.rawValue) is namespaced")
+            }
         }
 
-        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown, .logOut, .emptyTrash]
+        let confirmed: Set<SystemCommand.ID> = [.restart, .shutDown, .logOut, .emptyTrash, .quitAllApps]
         expect(
             Set(commands.filter { $0.confirmation == .required }.map(\.id)) == confirmed,
             "only the agreed disruptive commands require confirmation")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,9 @@ How Tinycast is wired together. See the per-subsystem docs for internals:
 manager — `AppIndex`, `ClipboardStore`, `ClipboardManager`, `SnippetsStore`,
 `SnippetKeywordListener`, `SnippetTextInjector`, `HotKeyManager`, `AppSettings`, `FavoritesStore`,
 `VisibilityStore`, `LauncherRankingStore`, `CustomCommandStore`, `CalculatorHistoryStore`,
-`CurrencyRateStore`, `RunningAppsMonitor`, `PaletteViewModel` — plus the window controllers.
+`CurrencyRateStore`, `RunningAppsMonitor`, `PaletteViewModel` — plus the window controllers, including
+`ModalWindowController` (dialogs are reached from elsewhere via `AppCore.showNotice` /
+`askConfirmation`, so the controller stays single-owned).
 `AppDelegate.applicationDidFinishLaunching` calls
 `AppCore.shared.start()` and nothing else; that is the single wiring point. All palette / paste /
 launch actions are methods on `AppCore` that the SwiftUI views call.
@@ -31,6 +33,11 @@ imperatively from AppKit.
 - **Settings / About** — plain `NSWindow`s via `AuxWindowController` (in
   `Features/About/AboutView.swift`). SwiftUI `Settings` / `Window` scenes are unreliable for accessory
   apps, so this is deliberate.
+- **Dialogs / HUD** borderless `ModalPanel`s driven by `ModalWindowController`, the app's only
+  presenter for confirmations, failure reports and value prompts. `NSAlert` is deliberately unused: its
+  `runModal` nested run loop lets Carbon hotkeys stack dialogs, and an Aqua alert clashes with the
+  forced-dark surface. Presentation is `async`, so nothing blocks the main actor. See
+  [ui.md](ui.md#modals--hud).
 
 The app forces `.darkAqua` appearance globally; the Liquid Glass material is tuned for a dark surface
 only.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,8 @@ How Tinycast is wired together. See the per-subsystem docs for internals:
 [palette](palette.md), [launcher](launcher.md), [calculator](calculator.md),
 [clipboard](clipboard.md), [custom commands](custom-commands.md), [snippets](snippets.md),
 [hotkeys](hotkeys.md), [ui](ui.md).
+System-command catalog, launcher integration and permission behavior are documented in
+[launcher](launcher.md#system-commands).
 
 ## Single-owner core
 
@@ -72,6 +74,8 @@ The target builds in **Swift 6 language mode** (tools version 6.0, no language-m
 data-race safety violations are hard errors. Almost everything is `@MainActor`; cross-actor model
 types are `Sendable`. Heavy / IO work (app scan, image decode, the FX rate fetch) is deliberately
 pushed off-main via `Task.detached` / `nonisolated`. Keep that boundary when adding code.
+`SystemCommand.swift` is the pure, `Sendable` metadata boundary; `SystemCommandRunner` owns AppKit,
+CoreAudio, process and Accessibility side effects, while `AppCore` owns confirmation and failure UI.
 
 House idioms for the sharp edges:
 

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -40,7 +40,7 @@ The command text is deliberately not searchable. Only the user-facing name enter
 - the user's home directory as the working directory
 - standard input and output connected to `/dev/null`
 - `TINYCAST=1` added to the inherited environment
-- up to 8 KiB of standard error retained for a failure alert
+- up to 8 KiB of standard error retained for a failure dialog
 
 No Terminal window or pseudo-terminal is created. `waitUntilExit` blocks for the whole life of the
 command, so it runs on a private concurrent `DispatchQueue` rather than a cooperative-pool thread a
@@ -73,17 +73,18 @@ is dropped while the actual error survives.
 ### Needs confirmation
 
 `AppCore.runCustomCommand(id:)` is the one funnel both palette activation and the global hotkey reach,
-so the gate lives there and neither path can bypass it. The palette hides before the alert — it is a
-floating panel and would sit above it. The alert shows the command text as well as its name, and ↵ is
+so the gate lives there and neither path can bypass it. The palette hides before the dialog it is a
+floating panel and would sit above it. The dialog shows the command text as well as its name, and ↵ is
 bound to **Cancel**: the command is one ↵ away in the palette, and a reflexive second ↵ must not fire
-something the user asked to be warned about. `NSAlert.runModal` spins a nested run loop where Carbon
-hotkeys keep firing, so a re-entrancy flag stops a held shortcut stacking alerts.
+something the user asked to be warned about. The gate is Tinycast's own modal, not an `NSAlert`
+([ui.md](ui.md#modals--hud)): presentation is `async` with no nested run loop, and the presenter itself
+refuses a second dialog while one is up, so a held shortcut can't stack them.
 
 ### Reporting
 
 Tinycast dismisses an open palette before starting a custom command. A zero exit status is silent; a
-launch failure or non-zero status activates Tinycast and shows the bounded error detail. When the
-status is 127 and **Load shell environment** is off, the alert adds a one-line hint and an **Open
+launch failure or non-zero status opens a Tinycast dialog with the bounded error detail. When the
+status is 127 and **Load shell environment** is off, the dialog adds a one-line hint and an **Open
 Settings…** button that lands on the Custom Commands pane — the hint is gated on the status alone, not
 on grepping stderr, since 127 is equally a plain typo. The command string itself is never logged.
 
@@ -92,8 +93,8 @@ on grepping stderr, since 127 is equally a plain typo. The command string itself
 `requiresConfirmation` lives in `AppCore` (AppKit, `@MainActor`) and so is out of reach of the
 Foundation-only harness. Verify by hand:
 
-1. Activating a gated command from the palette hides the palette *before* the alert appears.
-2. ↵ at the alert cancels; clicking **Run** runs.
-3. Pressing the command's hotkey while its alert is up does not stack a second alert.
+1. Activating a gated command from the palette hides the palette *before* the dialog appears.
+2. ↵ at the dialog cancels; clicking **Run** runs.
+3. Pressing the command's hotkey while its dialog is up does not stack a second dialog.
 4. A gated command triggered by hotkey with no palette open still confirms.
 5. An rc-file-only alias with the flag off shows the 127 hint, and **Open Settings…** opens the pane.

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,11 +93,14 @@ swiftc -swift-version 6 Tinycast/Core/CustomCommand.swift \
 swiftc -swift-version 6 Tinycast/Core/NotificationToken.swift \
     Tinycast/Core/Snippets/*.swift \
     Tools/snippets-test.swift -o /tmp/snippets-test && /tmp/snippets-test  # snippets
+swiftc -swift-version 6 Tinycast/Core/SystemCommand.swift Tools/system-command-test.swift \
+    -o /tmp/system-command-test && /tmp/system-command-test        # system command metadata + safety
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —
 change the scoring in one and mirror it in the other. The calc harness compiles the real engine
-sources, which is why `Tinycast/Core/Calculator/` must stay Foundation-only.
+sources, which is why `Tinycast/Core/Calculator/` must stay Foundation-only. The system-command harness
+similarly keeps `SystemCommand.swift` independent from AppKit and all command side effects.
 
 The clipboard harness likewise compiles the real `ClipboardStore.swift`, so that file must keep to
 Foundation + SQLite3 and depend on no other app source. Each case drives a store rooted in a

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -45,6 +45,50 @@ Rankings are memoized one query deep and keyed by the ranking store's revision, 
 invalidates the cached order. `rank` resolves the whole learned table for a query up front via
 `boosts(query:)` — one fold and one clock read per pass, not per candidate.
 
+## System commands
+
+`SystemCommandCatalog` is a Foundation-only inventory of the macOS actions Tinycast exposes. Its
+stable entry IDs, labels, symbols and confirmation policy are covered by
+`Tools/system-command-test.swift`; platform side effects live separately in `SystemCommandRunner`.
+`AppCore.runSystemCommand` remains the one execution funnel, hiding the floating palette before any
+confirmation or value dialog and surfacing permission-aware failures.
+
+System commands occupy their own launcher and Shortcuts Settings category. The empty-query publication
+order is applications, System Settings, system commands, then built-in/custom commands; the sectioned
+view filters in that same order so the visible rows remain identical to the flat selection index.
+Search, favorites, visibility and learned ranking work through the normal `AppEntry` path. Dedicated
+global hotkeys are deliberately out of scope.
+
+Public AppKit, CoreAudio and workspace APIs are preferred. Commands without a stable public macOS API
+use fixed system tools, Apple Events, Accessibility, or a dynamically resolved Bluetooth power API.
+Those routes run only on explicit activation. Automation, Accessibility or Bluetooth permission is
+requested at first use, and denial produces an alert linking to the relevant System Settings pane.
+Tinycast remains locked to dark appearance even when Toggle System Appearance changes macOS.
+
+Restart, Shut Down, Log Out, Empty Trash and Quit All Applications confirm before execution, with
+Return assigned to Cancel. Every dialog is Tinycast's own: confirmations, failure reports and the Set
+Volume slider all render through `ModalWindowController` rather than an `NSAlert`
+(see [ui.md](ui.md#modals--hud)). Volume and mute commands also show Tinycast's transient volume HUD,
+since macOS only draws its own for real media keys.
+
+A command whose effect is invisible reports back through the same HUD rather than finishing silently:
+`SystemCommandRunner.run` returns a `SystemCommandFeedback` naming the state it landed in
+(`Trash Emptied`, `Hidden Files Shown`, `Dark Appearance`, `Bluetooth Off`, `3 Disks Ejected`), and
+`AppCore` shows it. Commands that are their own confirmation, such as Show Desktop, Hide Others, Quit All and the
+power actions, return nothing.
+
+**Nothing-to-do is an outcome, not a failure.** Empty Trash asks Finder for `count items of trash`
+first and reports `Trash Is Already Empty`, because Finder raises an error when told to empty an empty
+Trash. The count deliberately goes through Finder instead of reading `~/.Trash` directly: that folder
+is TCC-protected, so an unprivileged read fails in a way indistinguishable from "empty", which would
+silently skip a real empty. Eject All Disks, Dismiss Notifications and Unhide All Apps report the same
+way when there is nothing to act on. Volume and mute fall back to the output's preferred stereo channels when the device exposes
+no master element (common on HDMI), and Toggle Mute parks the level at zero when there is no mute
+control at all. Multi-disk ejection excludes internal and network volumes, treats a sibling volume
+that the same physical eject already unmounted as done, and reports remaining failures together.
+Preference-backed toggles refuse to write when the current value can't be read, and notification
+dismissal matches Accessibility subroles rather than English labels.
+
 ## Custom commands
 
 `CustomCommandStore` supplies user-authored entries to `AppIndex` without joining the off-main
@@ -84,7 +128,7 @@ running dot and the availability of the quit actions:
   `AppLauncher.quit(bundleID:)` terminates every instance of the bundle and reports whether
   anything was running; the palette only dismisses when something was, and it restores focus unless
   the app it just quit *was* `previousApp`.
-- **Quit All Applications** — a `CommandRegistry` command. `AppLauncher.quitAllTargets()` is the
+- **Quit All Applications** a system command. `AppLauncher.quitAllTargets()` is the
   policy (every `.regular` app except Finder — `terminate()` only relaunches it — and Tinycast,
   excluded by PID because About/Settings temporarily flips it to `.regular`). `AppCore.quitAllApps()`
   resolves that list **once**, confirms it with an `NSAlert`, then terminates exactly what was

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -38,6 +38,7 @@ These are the things that quietly break the look if changed. Preserve them unles
 - **The panel corner is clipped once, at the root.** `RootPaletteView.body` ends with `.background(black 40%) → .background(VisualEffectView()) → .clipShape(RoundedRectangle(26, .continuous))`. Keep that order; the scrim goes _over_ the vibrancy, and the clip is last.
 - **Don't use the native scroll edge effect.** Inside a transparent panel it renders a hard-bounded rectangle. Use `edgeDissolve()`.
 - **Test over a light desktop.** Transparency and corner masking bugs only show over bright wallpaper. Dark wallpaper hides them.
+- **No `NSAlert`, no `NSSlider`, no system popovers.** Every confirmation, failure report, value prompt and transient readout is Tinycast's own SwiftUI surface (see "Modals & HUD"). An Aqua alert on a white-alpha-over-vibrancy app reads as a different product, and its `runModal` run loop keeps Carbon hotkeys firing underneath.
 
 ---
 
@@ -60,7 +61,9 @@ section's closing padding). See "Section headers" below.
 
 ### Radius (`Theme.Radius`)
 
-`panel 26` · `row 10` · `card 10` · `menuPanel 16` · `menu 6` · `menuRow 10` · `thumbnail 6` · `keyCap 6` · `recorderKeyCap 4`
+`panel 26` · `row 10` · `card 10` · `modal 20` · `menuPanel 16` · `menu 6` · `menuRow 10` · `thumbnail 6` · `keyCap 6` · `recorderKeyCap 4`
+
+`modal` sits between `menuPanel` and `panel` so a dialog reads as a smaller sibling of the palette, not a second palette.
 
 `menu` is the shared small-control corner (sidebar tiles, About link pills); `menuRow` is the slightly rounder hover highlight behind popover-menu rows.
 
@@ -70,7 +73,8 @@ Always `RoundedRectangle(cornerRadius:, style: .continuous)` — continuous corn
 
 `panelWidth 750` · `panelHeight 475` · `headerHeight 44` · `bottomBarHeight 52` · `rowIcon 24` ·
 `keyCap 18` · `recorderKeyCap 16` · `menuButton 36` · `clipboardListWidth 290` · `menuWidth 276` · `menuIcon 16` ·
-`settingsSidebar 184` · `settingsRowIcon 20`
+`settingsSidebar 184` · `settingsRowIcon 20` · `modalWidth 420` · `modalIcon 26` · `hudWidth 200` ·
+`hudHeight 92` · `volumeTrackHeight 6` · `volumeKnob 16`
 
 `keyCap` sizes the palette's keycap chips; `recorderKeyCap` (both size and radius) is the intentionally-smaller Settings shortcut-recorder chip.
 
@@ -164,6 +168,39 @@ Glass is **only** for floating controls, never the main surface.
 - Menu rows are the one place that uses `sm` for the icon→label gap instead of the row-standard `lg`, because that slot's built-in slack already contributes 2–3pt of apparent space.
 
 ---
+
+## Modals & HUD `Core/ModalWindowController.swift`, `Features/Modal/TinycastModalView.swift`
+
+Tinycast owns its dialogs; `NSAlert` is never used. `ModalWindowController` is owned by `AppCore` (the
+sole owner rule) and is the only presenter, so every confirmation in the app looks and behaves alike.
+
+- **Surface.** A modal reuses the palette's recipe `black panelDimming` → `VisualEffectView()` →
+  `clipShape(RoundedRectangle(modal 20))`, in that order at `modalWidth 420`. Glass is reserved for
+  the buttons, matching the "glass only on floating controls" rule. The HUD is the exception: it is a
+  floating control with no content of its own, so it is stock `glassEffect` throughout.
+- **Layout.** Leading tone glyph (`modalIcon 26`, red when the dialog is destructive), title
+  (`.headline`) + wrapped secondary message, optional accessory, then right-aligned buttons.
+- **Keys.** `ModalPanel.sendEvent` intercepts Esc and ↵ directly instead of relying on SwiftUI
+  `onKeyPress`, so the keys work without anything inside the dialog holding focus. Buttons print only
+  the caps the panel actually handles (`↵`, `esc`), so a printed cap can't drift from behavior.
+  **↵ goes to Cancel on every destructive dialog** the triggering command is one ↵ away in the
+  palette, and a reflexive second press must not run it. Arrow keys step the volume slider by the same
+  1/16 the volume commands use; click-away resolves as a dismissal.
+- **Async, not modal.** Presentation is `async` (`withCheckedContinuation`), so there is no nested run
+  loop. A held hotkey can't stack dialogs: while one is up, a second request resolves immediately as a
+  dismissal which is why the old `isConfirmingCommand` re-entrancy flag is gone.
+- **Non-activating**, like the palette: the dialog takes key focus for its own keys without pulling app
+  focus off whatever the user was in. It sits at `.modalPanel`, above the palette's `.floating`, and is
+  centred on the **cursor's** display with the same slight optical lift the palette uses.
+- **`VolumeSlider`** is hand-drawn (track `volumeTrackHeight 6`, knob `volumeKnob 16`, `controlSurface`
+  rail under a white-0.85 fill) with a monospaced-digit percentage in a fixed slot so the track doesn't
+  resize between `0%` and `100%`. A click anywhere on the track jumps the level.
+- **`TinycastHUDView`** is the transient readout, in two flavours over one shared panel (so a volume
+  change and a confirmation can never overlap): a **volume bar** for the volume/mute commands macOS
+  only draws its own HUD for real media keys, so a CoreAudio change would otherwise be silent and a
+  **one-line message** confirming a command whose effect is invisible (`Trash Emptied`,
+  `Hidden Files Shown`, `Bluetooth Off`). It is non-key, auto-dismisses after ~1.5s, and a repeat
+  command refreshes the live content instead of stacking a second panel.
 
 ## Scrollbars — `Core/ThinScrollbar.swift`
 


### PR DESCRIPTION
## Related issue

Closes #106

Opening as a **draft**: the issue is not agreed yet, so this is here to be looked at, not merged. It leaves draft only if you green-light the idea, and after the memory numbers below are filled in.

## What changed

Two things, in that order in the history.

**1. Tinycast presents its own dialogs.** `NSAlert` and `NSSlider` are gone from the app. A new `ModalWindowController` (owned by `AppCore`, like every other long-lived manager) is the single presenter for confirmations, failure reports, value prompts and the transient HUD, all drawn with `Theme` tokens on the palette's own surface recipe.

This part touches features outside system commands, which is worth calling out: the custom command confirmation and failure dialogs, the Quit All confirmation, and the settings import and export notices all move onto it. Behaviour is preserved, including Return being bound to Cancel on destructive dialogs.

Two consequences that are improvements rather than side effects:

- Presentation is `async` (`withCheckedContinuation`) instead of `runModal`, so there is no nested run loop. The presenter refuses a second dialog while one is up, which is what now stops a held hotkey stacking dialogs. The `isConfirmingCommand` re-entrancy flag is deleted.
- The panel is non-activating like the palette, so a dialog no longer pulls app focus off whatever you were in.

**2. 31 system commands.** `SystemCommand.swift` is a Foundation-only catalog (stable IDs, names, symbols, confirmation policy) covered by a new `Tools/system-command-test.swift` harness. `SystemCommandRunner` holds every platform call. `AppCore.perform` is the single execution funnel, so the confirmation gate cannot be bypassed from the palette, a favorite slot or the compact bar.

Non-obvious things in the diff:

- **Quit All Applications keeps its old entry ID** (`command:quit-all-apps`) even though it now lives in the new catalog, so existing favorites, visibility and learned ranking survive the move. There is a test for it.
- **Launcher order is load-bearing.** `AppIndex` publishes applications, System Settings, system commands, then commands, and `LauncherList` filters in that same order, so the visible rows stay identical to the flat selection index.
- **Empty Trash asks Finder for `count items of trash` before emptying.** Finder raises an error when told to empty an empty Trash. The count goes through Finder rather than reading `~/.Trash` directly because that folder is TCC-protected, so an unprivileged read fails in a way indistinguishable from "empty", which would silently skip a real empty.
- **Volume and mute fall back to the output's preferred stereo channels** when the device exposes no master element, which is common on HDMI, and Toggle Mute parks the level at zero when the device has no mute control at all.
- **Eject All Disks treats a sibling volume that the same physical eject already unmounted as done, not failed**, since one disk can publish several volumes.
- Automation and Bluetooth usage strings are added to `Info.plist`, each in the commit that first needs it.

### Commits

32 commits, each building clean and passing the harness: the modal surface, then the catalog and launcher category (which carries Lock Screen, because Swift will not allow an empty enum to declare a raw type), then one commit per remaining command. Bluetooth is deliberately last so it can be dropped on its own.

## Memory footprint

Not measured yet. This is a draft and the numbers land before it is marked ready.

## Demo

> **Required before this leaves draft:** side-by-side before/after video, same window size, same actions, per CONTRIBUTING.md. The tables below are supplementary and do not replace it.

**Video (before / after):**

<!-- paste video -->

### New surfaces

| Surface | Screenshot |
| --- | --- |
| System Commands section in the launcher | <img width="1592" height="1042" alt="image" src="https://github.com/user-attachments/assets/9d2a4739-ee14-4c8b-918a-9020b0255da7" /> |
| Shortcuts settings, System Commands tab | <img width="1664" height="1324" alt="image" src="https://github.com/user-attachments/assets/37e6fc40-b98c-4e02-9d48-e472c29a8ab4" /> |
| Set Volume modal with the slider | <img width="932" height="394" alt="image" src="https://github.com/user-attachments/assets/66b8209f-5c09-420a-a9e2-7081e6c4618b" /> |
| Volume HUD after Turn Volume Up | <img width="1728" height="1117" alt="Screenshot 2026-07-30 at 10 49 44 AM" src="https://github.com/user-attachments/assets/6e4b4b7b-049d-40a4-a57c-4acb4142098f" /> |
| Success toast, Trash Emptied |  <img width="1728" height="1117" alt="Screenshot 2026-07-30 at 10 50 02 AM" src="https://github.com/user-attachments/assets/cd60bfa1-e0d8-477f-8554-799e23ae357d" /> |
| Destructive confirmation, Shut Down | <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/992b4b5c-270c-426e-b4b0-90a2798e6cfd" /> |

### Migrated dialogs

These already existed as `NSAlert`, so this is where before and after is a real comparison.

| Dialog | Before (NSAlert) | After (Tinycast modal) |
| --- | --- | --- |
| Custom command confirmation | <!-- paste screenshot --> | <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/a0939569-2999-4b9a-abef-b09b81677d39" /> |
| Custom command failure, with the 127 hint | <!-- paste screenshot --> | <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/49db0cc9-c02b-43d7-a9be-a13e99c8d102" /> |
| Quit All Applications confirmation | <!-- paste screenshot --> | <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/fd7524ed-c985-458b-a308-5471349cfcde" /> |
| Settings Import fail | <!-- paste screenshot --> | <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/9e32c0df-0801-4091-94fb-42b176c27a41" /> |
| Executable import warning | <!-- paste screenshot --> | <!-- paste screenshot --> |

## Drawbacks

**Five commands do not ride public API, because macOS exposes no public control.** Each fails safe rather than guessing:

| Command | Route | How it fails |
| --- | --- | --- |
| Toggle Bluetooth | Private `IOBluetoothPreference*` symbols via `dlsym` | Resolved dynamically, fails closed if the symbols are gone. The setter returns `void`, so the getter is polled to confirm. |
| Dismiss Notifications | Accessibility traversal of Notification Center | Matches Accessibility subroles, not English labels, so it does not silently no-op on a localised system. Never presses an arbitrary button, because a notification's own rows (Reply, Open) also press. |
| Show Desktop | Apple's bundled Mission Control helper | Path existence and exit status are both checked. |
| Toggle Stage Manager, Toggle Hidden Files | Undocumented `defaults` keys | Refuses to write when the current value cannot be read, and reads back to confirm. |

Toggle Bluetooth is the highest risk and is the **last commit**, so it can be dropped without touching anything else. Dismiss Notifications is second and is self-contained too. I would rather cut either than have it rot.

**Other tradeoffs made on purpose:**

- No per-command global hotkeys. Built-in commands do not have them today, and adding them means touching hotkey persistence, settings, backup and conflict detection. Better as its own change.
- The modal refactor's blast radius reaches custom commands and backup. Splitting it out would have left one PR with a component nothing uses and another that could not build alone.
- Toggle System Appearance changes macOS but not Tinycast, which stays locked to dark per the invariant. That is intentional but could read as a bug.
- The dialog is centred on the display under the cursor, not on the palette. Worth a second opinion.

**Unsure about:** whether 31 commands is the right size for this app, or whether a smaller core set is truer to "no bloat". Happy to trim.

## Tests & validation

**Harnesses** (`docs/development.md` § Tests), all run on the final commit:

| Harness | Result |
| --- | --- |
| `system-command-test.swift` (new) | 72 passed, 0 failed |
| `fuzz-test.swift` | all passed |
| `ranking-test.swift` | all passed |
| `calc-test.swift` | 426 passed, 0 failed |
| `clipboard-test.swift` | 23/23 passed |
| `scopes-test.swift` | all passed |
| `emoji-test.swift` | passed, 2054 records |
| `custom-command-test.swift` | first 15 cases pass, then it stalls on my machine. It spawns a real interactive `zsh`, so this looks environment-specific and reproduces on `main` too. Flagging rather than hiding it. |

The new harness covers the catalog only, which is why `SystemCommand.swift` is Foundation-only: exact inventory, unique and namespaced entry IDs, entry-ID round trip, the Quit All key preservation, and that only the agreed commands require confirmation. It deliberately performs no side effects.

**Every one of the 32 commits builds clean** and passes the harness, verified commit by commit, not just at the tip.

**Exercised by hand:** launcher search and section ordering, the Shortcuts tab, favoriting a system command, the confirmation and cancel paths, Set Volume, the volume HUD, and Empty Trash on both an empty and a non-empty Trash.

# Memory
|Step | Memory |
|---|---|
| Idle after launch | 23mo |
| Palette open | 37.6mo |
| Feature in use (peak) | 60mo |
| Palette closed, settled | 37.6mo |
