### PR TITLE
Add app uninstall with leftover file selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,8 @@ Full detail: [`docs/architecture.md`](docs/architecture.md).
   `AuxWindowController`. SwiftUI `Settings` / `Window` scenes are deliberately avoided (unreliable for
   accessory apps).
 - **Subsystems:** [palette](docs/palette.md) · [launcher & fuzzy match](docs/launcher.md) ·
-  [calculator](docs/calculator.md) · [clipboard](docs/clipboard.md) · [emoji](docs/emoji.md) ·
-  [snippets](docs/snippets.md) · [window management](docs/window-management.md) ·
+  [uninstall](docs/uninstall.md) · [calculator](docs/calculator.md) · [clipboard](docs/clipboard.md) ·
+  [emoji](docs/emoji.md) · [snippets](docs/snippets.md) · [window management](docs/window-management.md) ·
   [hotkeys](docs/hotkeys.md) · [UI & design system](docs/ui.md).
 
 ## Critical Invariants
@@ -74,7 +74,11 @@ Never break these without an explicit task to do so.
   `Core/CustomCommand.swift` and `Core/ShellCommandRunner.swift` must likewise stay free of AppKit /
   SwiftUI (Foundation plus Combine for `ObservableObject` and Darwin for `mkstemp`) so
   `Tools/custom-command-test.swift` can compile them standalone — which is why the custom-command
-  confirmation gate lives in `AppCore` and not in the runner. All of `Core/Snippets/` compiles into
+  confirmation gate lives in `AppCore` and not in the runner. `Core/AppLeftovers.swift` is the same
+  deal for `Tools/leftovers-test.swift` — Foundation only and pure, with the home directory and the
+  sibling-install flag injected, which is why the LaunchServices lookup and the trashing orchestration
+  live in `UninstallSession` (the `trashItem` / `removeItem` primitive itself stays in `AppLeftovers`,
+  so the harness can drive it). All of `Core/Snippets/` compiles into
   `Tools/snippets-test.swift` (the harness globs the directory), so the model, Markdown serializer,
   template engine, repository and keyword policies stay Foundation-only, and the AppKit files there
   keep their dependencies to what the harness can stub. `Core/SystemCommand.swift` is also
@@ -122,6 +126,18 @@ Never break these without an explicit task to do so.
   via `Task.detached` / `nonisolated`. Keep that boundary. House idioms: `NotificationToken` (RAII) for
   block observers, `isolated deinit` for `ClipboardStore`'s SQLite teardown, decode raw Carbon / C
   pointers to plain values before crossing into actor code.
+- **Uninstall only ever moves user-level paths to the Trash.** `AppLeftovers` may return nothing that
+  isn't a proper descendant of one of its `allowedRoots` under `~/Library`, never a root itself; a
+  bundle id that isn't plain reverse-DNS is refused rather than sanitized; and a shared bundle id (a
+  surviving sibling install) drops *all* keyed paths. `canUninstall` refuses `/System`, `/usr`, every
+  `com.apple.*` id (`isProtectedVendor`) and every Tinycast channel — the action is not offered for those
+  at all. Within an eligible app, removability is decided **per row**: `isRemovable` checks that the
+  parent permits deletion and that no immutable / SIP-restricted flag is set, and a locked row can never
+  be checked or toggled. The default removal is
+  `trashItem` — the list ships with every removable row checked, so ↵ has to be recoverable; `removeItem`
+  is reachable only from the explicit Permanently Delete row (⇧⌘⌫), the one action in the flow that
+  confirms first. Nothing system-level (LaunchDaemons, privileged helpers, system extensions) is
+  discovered or removed. See [uninstall.md](docs/uninstall.md).
 - **Clipboard writes stamp a private `internalType` marker** so the poller skips Tinycast's own writes.
 - **Hotkeys persist under legacy `KeyboardShortcuts_<name>` UserDefaults keys** (from the removed
   KeyboardShortcuts package) so old bindings survive. See [hotkeys.md](docs/hotkeys.md).
@@ -147,7 +163,7 @@ Never break these without an explicit task to do so.
   standalone-harness input in full; `Core/WindowManagement/` is a pure geometry layer plus its one AX
   file; `Core/Theme.swift` is the design-token source; `Core/HotKey/` is the in-house hotkey stack.
 - `Tinycast/Features/` — SwiftUI views: `RootPaletteView`, `Launcher/`, `Clipboard/`, `Calculator/`,
-  `Emoji/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`.
+  `Emoji/`, `Uninstall/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`.
 - `Tinycast/App/` — `@main` app + delegate.
 - `Tools/` — standalone test harnesses and the emoji generator.
 - `.github/workflows/release.yml` — the entire release pipeline (see `docs/development.md`).
@@ -156,6 +172,7 @@ Never break these without an explicit task to do so.
 
 - [`docs/architecture.md`](docs/architecture.md) — core ownership, windows, concurrency.
 - [`docs/palette.md`](docs/palette.md) — palette state flow, menu-open freeze, focus restoration.
+- [`docs/uninstall.md`](docs/uninstall.md) — leftover discovery, guards, removal.
 - [`docs/launcher.md`](docs/launcher.md) · [`docs/calculator.md`](docs/calculator.md) ·
   [`docs/clipboard.md`](docs/clipboard.md) · [`docs/emoji.md`](docs/emoji.md) ·
   [`docs/snippets.md`](docs/snippets.md) ·

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there
 
 - **App launcher** — fuzzy-search and launch anything, pin favorites, see what's running, quit an app
   or every app at once.
+- **Uninstall apps** — remove an app and the support files it left behind: pick what goes, and it goes to
+  the Trash by default, so a mistake is recoverable.
 - **Custom commands** — run named shell commands through fuzzy search or their own global hotkeys.
 - **Calculator** — do math, unit and live currency conversions inline, right in the palette.
 - **Clipboard history** — text and images, searchable, pasted back into the app you were using.

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		05561CD36EF1A0775A282165 /* ShortcutsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5AE919A2699E6EB8BF7DC8 /* ShortcutsSettingsView.swift */; };
 		0674D8E1567253879EF50150 /* SnippetArgumentsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F919FBD5F2E0399523AA56 /* SnippetArgumentsPrompt.swift */; };
+		0962E9575CBF40B6F908031C /* UninstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D08C3AEAFB224866F23C3E /* UninstallView.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
 		11C4CC0D767EFD44AB28D6DD /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0E1FD530C764A021E6053 /* SearchScopes.swift */; };
 		13E6A96B937D2506EDA886BD /* SystemCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289F9F0C3C56F295CFB50CE9 /* SystemCommand.swift */; };
@@ -24,6 +25,7 @@
 		212B9B44D7EED18A0DEF47AF /* ShellCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286B7598B81017C746558C7C /* ShellCommandRunner.swift */; };
 		21736CC104E158BC194B1094 /* WindowMover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8859C0E99A2125D85B1233C /* WindowMover.swift */; };
 		24842144273FF92228540DBE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */; };
+		2CF59F841A77BD0792CA0A90 /* AppLeftovers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EE5E25331BD70E28763897 /* AppLeftovers.swift */; };
 		32697AB3853D043A12888B96 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */; };
 		344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */; };
 		34CD5C2F15B1011434182CA7 /* SearchScopesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */; };
@@ -96,6 +98,7 @@
 		D322804853973E1C19F2A408 /* AppIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CE23482F7DF563A268806 /* AppIndex.swift */; };
 		D3CA50C1CFABC31E6BC7B73C /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A65B4EC5AE7E22594BFC5E /* CalcPercent.swift */; };
 		D3D2ACD2D94588786C2185AE /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299122624B5E1BA2C5400478 /* CalcCurrency.swift */; };
+		D52E923F376D64FF07323BC0 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD80B0CC9C88D30D2CC68FDD /* UninstallSession.swift */; };
 		DA2EBB18F026BD055E0270CD /* AppLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */; };
 		DA5BCA13045FF91B3FC8EB35 /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9B4E6E477C30372C85F86 /* OnboardingState.swift */; };
 		DB04CC2AFEDD69D0676CA1D1 /* CalculatorCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64C87569634E26E1BE99A91 /* CalculatorCardView.swift */; };
@@ -153,6 +156,7 @@
 		5392500F86E23C099D33561D /* Tinycast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tinycast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		555E9C7EA62BDB40891A5751 /* PalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePanel.swift; sourceTree = "<group>"; };
 		596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
+		59D08C3AEAFB224866F23C3E /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
 		5A002AC0DE601E1F65D20C4A /* SnippetTemplateEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplateEngine.swift; sourceTree = "<group>"; };
 		5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLauncher.swift; sourceTree = "<group>"; };
 		5D3E4F8A2BCECFF0E11441BE /* RaycastSnippetImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastSnippetImport.swift; sourceTree = "<group>"; };
@@ -216,11 +220,13 @@
 		DCBF70B1C646861FDF20ED2D /* CustomCommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandsSettingsView.swift; sourceTree = "<group>"; };
 		E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateTime.swift; sourceTree = "<group>"; };
 		E5051622CC6497E2151326CA /* SnippetKeywordListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordListener.swift; sourceTree = "<group>"; };
+		E9EE5E25331BD70E28763897 /* AppLeftovers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftovers.swift; sourceTree = "<group>"; };
 		EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		EDE084FDBE22B01204E7BEDA /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		EDE0C0DC05F958A4B4DCAA8C /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
 		F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Permissions.swift; sourceTree = "<group>"; };
 		F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
+		FD80B0CC9C88D30D2CC68FDD /* UninstallSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSession.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -244,6 +250,7 @@
 				3A64EF5A07D459753998F78C /* AppCore.swift */,
 				BA7CE23482F7DF563A268806 /* AppIndex.swift */,
 				5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */,
+				E9EE5E25331BD70E28763897 /* AppLeftovers.swift */,
 				B275099E59BD2531A838F7D8 /* AppSettings.swift */,
 				D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */,
 				F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */,
@@ -277,6 +284,7 @@
 				AFE4F95DF8572910DFE602BA /* SystemCommandRunner.swift */,
 				7BC2DEA0A052116A92F9A539 /* Theme.swift */,
 				A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */,
+				FD80B0CC9C88D30D2CC68FDD /* UninstallSession.swift */,
 				825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */,
 				EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */,
 			);
@@ -350,6 +358,14 @@
 			path = About;
 			sourceTree = "<group>";
 		};
+		5EC7DD3F09EBCC7AC71C230B /* Uninstall */ = {
+			isa = PBXGroup;
+			children = (
+				59D08C3AEAFB224866F23C3E /* UninstallView.swift */,
+			);
+			path = Uninstall;
+			sourceTree = "<group>";
+		};
 		7CD438390F8FA4B3C2AE5F28 /* Snippets */ = {
 			isa = PBXGroup;
 			children = (
@@ -379,6 +395,7 @@
 				0ED457107377ECF8147C6B9D /* Onboarding */,
 				E3202F504002B7792FC50B2F /* Settings */,
 				7CD438390F8FA4B3C2AE5F28 /* Snippets */,
+				5EC7DD3F09EBCC7AC71C230B /* Uninstall */,
 				98B7211D27EDF764EC477A0F /* PopoverMenu.swift */,
 				0F50886DC766B9923C3875A5 /* RootPaletteView.swift */,
 			);
@@ -574,6 +591,7 @@
 				C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */,
 				D322804853973E1C19F2A408 /* AppIndex.swift in Sources */,
 				DA2EBB18F026BD055E0270CD /* AppLauncher.swift in Sources */,
+				2CF59F841A77BD0792CA0A90 /* AppLeftovers.swift in Sources */,
 				FEA05585E8AA58506D378CAF /* AppSettings.swift in Sources */,
 				AE0D0C53004C65D65BE89B6F /* BackupActions.swift in Sources */,
 				8631543D8E0E008E7C541345 /* BackupSettingsView.swift in Sources */,
@@ -664,6 +682,8 @@
 				85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */,
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,
 				A7508663E4B5D80572E7BAAC /* TinycastModalView.swift in Sources */,
+				D52E923F376D64FF07323BC0 /* UninstallSession.swift in Sources */,
+				0962E9575CBF40B6F908031C /* UninstallView.swift in Sources */,
 				693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */,
 				A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */,
 				C7D8BB669C3DBC0D26EB6E32 /* WindowActionMemory.swift in Sources */,

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -13,7 +13,12 @@ struct TinycastApp: App {
         MenuBarExtra(
             appName, systemImage: "macwindow.on.rectangle", isInserted: $showInMenuBar
         ) {
-            Button("Open \(appName)") { AppCore.shared.showPalette(mode: .launcher) }
+            // `restoreAnyMode`, like the global hotkey: "Open Tinycast" is a generic summon, so it
+            // restores whatever screen was up (a pending uninstall list, a within-timeout sub-screen)
+            // rather than forcing a reset root search.
+            Button("Open \(appName)") {
+                AppCore.shared.showPalette(mode: .launcher, restoreAnyMode: true)
+            }
             Button("Clipboard History") { AppCore.shared.showPalette(mode: .clipboard) }
             Divider()
             Button("Settings...") { AppCore.shared.showSettings() }

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -7,6 +7,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     case clipboard
     case calculatorHistory
     case emoji
+    case uninstall
 
     var id: String { rawValue }
     var title: String {
@@ -15,6 +16,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .clipboard: return "Clipboard"
         case .calculatorHistory: return "Calculator History"
         case .emoji: return "Emoji & Symbols"
+        case .uninstall: return "Uninstall"
         }
     }
     var systemImage: String {
@@ -23,6 +25,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .clipboard: return "doc.on.doc"
         case .calculatorHistory: return "plus.forwardslash.minus"
         case .emoji: return "face.smiling"
+        case .uninstall: return "trash"
         }
     }
     var placeholder: String {
@@ -31,6 +34,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .clipboard: return "Type to filter entries…"
         case .calculatorHistory: return "Do math, convert units, or search your past calculations…"
         case .emoji: return "Search emoji and symbols…"
+        case .uninstall: return "Filter files and folders by name…"
         }
     }
 }
@@ -62,6 +66,17 @@ final class PaletteViewModel: ObservableObject {
     @Published var resetToken = UUID()
     /// Changes when an action reorders the list under the selection (pinning a clip lifts it into the Pinned section), so the list scrolls the highlight back into view.
     @Published var followToken = UUID()
+    /// An app the launcher should re-select once it is back on screen — set when a sub-screen that was
+    /// opened *for* one app hands control back, so the user lands where they left. Consumed (and cleared)
+    /// by `RootPaletteView` a turn after the list mounts.
+    @Published var pendingSelectionID: AppEntry.ID?
+    /// The launcher's live scroll offset, mirrored from the list itself. Plain, not `@Published` — it
+    /// changes on every scroll tick and must never drive a re-render.
+    var launcherScrollOffset: CGFloat = 0
+    /// The offset to put the launcher back to when it next mounts, captured when a sub-screen replaced it.
+    /// Restoring by *row* isn't equivalent: a minimal scroll lands the row against a viewport edge rather
+    /// than where the user was looking.
+    var restoreLauncherOffset: CGFloat?
     /// Set by the compact bar's "…" overflow to expand into the full launcher without a query; cleared on every `prepare`.
     @Published var forceExpanded = false
     /// The app a paste would land in, mirrored from `PaletteWindowController.previousApp` on every show. Deliberately *not* cleared by `prepare` — pop-to-root resets the screen, not the paste target.
@@ -77,6 +92,9 @@ final class PaletteViewModel: ObservableObject {
         self.mode = mode
         query = ""
         selection = 0
+        // Cleared here so a request nobody consumed (the palette was hidden before the list mounted) can't
+        // move the selection on some later summon; the uninstall exits set theirs *after* calling this.
+        pendingSelectionID = nil
         forceExpanded = false
         hoverHighlightArmed = false
         menuOpen = false
@@ -110,6 +128,7 @@ final class AppCore: ObservableObject {
     let emojiIndex = EmojiIndex()
     let frequentEmoji = FrequentEmojiStore()
     let runningApps = RunningAppsMonitor()
+    let uninstall = UninstallSession()
     let palette = PaletteViewModel()
 
     private lazy var windowController = PaletteWindowController(core: self)
@@ -290,6 +309,21 @@ final class AppCore: ObservableObject {
 
     /// Shows the palette, honoring Pop to Root Search: a reopen within the timeout restores the pre-close state — any mode for the generic summon (`restoreAnyMode`), else only when the preserved mode already matches the requested one.
     func showPalette(mode: PaletteMode, restoreAnyMode: Bool = false) {
+        // A live uninstall screen outlives a dismissal: the scan cost real time and the checkboxes are
+        // the user's work, so a click-away then re-summon lands back on the list instead of a reset
+        // root search. Asking for another screen *by name* (a clipboard/emoji hotkey) abandons it — that
+        // is an explicit request for something else, unlike the generic summon.
+        if hasLivePaletteSession {
+            if restoreAnyMode || mode == .uninstall {
+                // Consumed for its side effect only: cancel the pending pop-to-root, since this screen
+                // is being restored either way.
+                _ = windowController.consumePreservedState()
+                palette.mode = .uninstall
+                windowController.show()
+                return
+            }
+            uninstall.end()
+        }
         let preserved = windowController.consumePreservedState()
         if !(preserved && (restoreAnyMode || palette.mode == mode)) {
             palette.prepare(mode: mode)
@@ -302,6 +336,10 @@ final class AppCore: ObservableObject {
     func hidePalette(restoreFocus: Bool = true) {
         windowController.hide(restoreFocus: restoreFocus)
     }
+
+    /// True while a sub-screen holds state that must outlive a dismissal — the uninstall flow's scan and
+    /// checkboxes. Pop-to-root skips its timer for these, and the generic summon restores them.
+    var hasLivePaletteSession: Bool { uninstall.target != nil }
 
     /// True when the palette should render as the slim compact bar: compact mode on, launcher root, empty query, and not force-expanded via the "…" overflow.
     var paletteIsCollapsed: Bool {
@@ -539,8 +577,125 @@ final class AppCore: ObservableObject {
         case .automation: pane = "Privacy_Automation"
         case .bluetooth: pane = "Privacy_Bluetooth"
         }
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)")
+        {
             NSWorkspace.shared.open(url)
+        }
+    }
+
+    // MARK: - Uninstall
+
+    /// Opens the uninstall screen for an app and starts its scan. The palette stays open — the list
+    /// itself is the confirmation, so nothing is removed until the user submits it.
+    func beginUninstall(_ app: AppEntry) {
+        guard app.kind == .application,
+            AppLeftovers.canUninstall(url: app.url, bundleID: app.bundleID)
+        else { return }
+        uninstall.begin(app: app)
+        // The launcher is torn down while this screen is up, so remember where it was sitting.
+        palette.restoreLauncherOffset = palette.launcherScrollOffset
+        // Mode first, then the query: clearing it while still on the launcher would flip
+        // `paletteIsCollapsed` and bounce the window through its compact height on the way in.
+        palette.mode = .uninstall
+        palette.query = ""
+        palette.selection = 0
+    }
+
+    /// Back out of the uninstall screen to a fresh root search, dropping the scan, and land back on the
+    /// app the screen was opened for rather than at the top of the list.
+    func cancelUninstall() {
+        let returningTo = uninstall.target?.id
+        uninstall.end()
+        palette.prepare(mode: .launcher)
+        palette.pendingSelectionID = returningTo
+    }
+
+    /// Submit the uninstall list: remove every checked path, then stay on screen and report what
+    /// happened — a destructive action that ends by silently closing the window gives the user nothing
+    /// to check. `forgetUninstalledApp` and the re-index run once the removal lands.
+    ///
+    /// `permanently` unlinks instead of trashing, and is the one path that confirms first — the ↵ /
+    /// footer default stays the recoverable one, so only the deliberate chord reaches a deletion
+    /// nothing can undo.
+    func confirmUninstall(permanently: Bool = false) {
+        guard let app = uninstall.target, !uninstall.checkedItems.isEmpty,
+            uninstall.phase == .selecting
+        else { return }
+        // Snapshot the approved set: what the confirmation counts is what gets removed — the rule
+        // `quitAllApps` already follows.
+        let targets = uninstall.checkedItems
+        // The real bundle, not just any `.bundle` row: a cask install also contributes its /Applications
+        // symlink, and that one failing while the bundle itself went must not strand the app's state.
+        let bundlePath = app.url.resolvingSymlinksInPath().path
+        let removedBundle = targets.contains { $0.url.path == bundlePath }
+        Task {
+            if permanently {
+                // The palette is a float panel and would sit above the dialog, so it steps aside for the
+                // one confirmation in the flow and comes straight back — cancelled or not.
+                hidePalette(restoreFocus: false)
+                let confirmed = await modals.confirm(
+                    title: targets.count == 1
+                        ? "Permanently delete 1 item?"
+                        : "Permanently delete \(targets.count) items?",
+                    message:
+                        "“\(app.name)” and the files you checked will be erased immediately. "
+                        + "This can’t be undone.",
+                    confirmTitle: "Delete", destructive: true)
+                showPalette(mode: .uninstall)
+                guard confirmed else { return }
+            }
+            let outcome = await uninstall.remove(targets, permanently: permanently)
+            if removedBundle, !outcome.failures.contains(where: { $0.url.path == bundlePath }) {
+                forgetUninstalledApp(app)
+            }
+            // The screen now shows the summary; the session ends when the user dismisses it.
+            await appIndex.refresh()
+        }
+    }
+
+    /// The uninstall screen's ⎋ / back-chevron / ⌫ exit, which has to respect the phase.
+    func exitUninstall() {
+        switch uninstall.phase {
+        case .selecting: cancelUninstall()
+        // A removal in flight can't be called back, and it lands on the summary in a moment — so this
+        // does nothing rather than hiding the one screen that reports what happened.
+        case .removing: break
+        case .done: finishUninstall()
+        }
+    }
+
+    /// Dismiss the summary back to a fresh root search — never by closing the palette. Ending the flow
+    /// is not the same as being done with Tinycast; the user closes it when they want to.
+    func finishUninstall() {
+        // Also aims at the app it acted on: after a successful uninstall that row is gone, and the
+        // consumer falls back to the top of the list.
+        let returningTo = uninstall.target?.id
+        uninstall.end()
+        palette.prepare(mode: .launcher)
+        palette.pendingSelectionID = returningTo
+    }
+
+    /// Re-orders the uninstall list from the header control; the highlight goes back to the first row
+    /// rather than chasing whichever row the old index now points at. The caller scrolls to match.
+    func setUninstallSort(_ sort: UninstallSort) {
+        uninstall.setSort(sort)
+        palette.selection = 0
+    }
+
+    func showLeftoverInFinder(_ item: LeftoverItem) {
+        hidePalette(restoreFocus: false)
+        AppLauncher.showInFinder(item.url)
+    }
+
+    /// Drop the per-app state Tinycast itself keeps once the bundle is gone, so the app doesn't linger
+    /// as a favorite, a hidden entry, a learned ranking or a bound hotkey.
+    private func forgetUninstalledApp(_ app: AppEntry) {
+        favorites.remove(keys: [app.preferenceKey])
+        visibility.removeItemKeys([app.preferenceKey])
+        launcherRanking.reset(itemKey: app.preferenceKey)
+        if let action = app.hotKeyAction {
+            if hotKeys.recordingAction == action { hotKeys.recordingAction = nil }
+            hotKeys.setShortcut(nil, for: action)
         }
     }
 
@@ -852,9 +1007,12 @@ final class AppCore: ObservableObject {
         }
         // The automatic path was gated by `beginAutomaticExpansion` in the same turn, and `deliver` gates both again. Only the interactive path needs a check here: it must fail before the argument prompt, not after it.
         if automaticGeneration == nil {
-            guard snippetTextInjector.prepareInteractiveExpansion(targetApp: targetApp) else { return }
+            guard snippetTextInjector.prepareInteractiveExpansion(targetApp: targetApp) else {
+                return
+            }
         }
-        let confirmation = record.snippet.showsConfirmation ? "Inserted \(record.snippet.name)" : nil
+        let confirmation =
+            record.snippet.showsConfirmation ? "Inserted \(record.snippet.name)" : nil
         let context = snippetTextInjector.captureExpansionContext(
             targetApp: targetApp,
             clipboardHistory: clipboardHistoryForExpansion())
@@ -895,9 +1053,10 @@ final class AppCore: ObservableObject {
         automaticGeneration: UInt?,
         confirmation: String?
     ) {
-        guard let arguments = SnippetArgumentsPrompt.run(
-            snippetName: record.snippet.name,
-            arguments: missingArgs)
+        guard
+            let arguments = SnippetArgumentsPrompt.run(
+                snippetName: record.snippet.name,
+                arguments: missingArgs)
         else {
             snippetTextInjector.cancelArgumentPrompt(
                 automaticGeneration: automaticGeneration,

--- a/Tinycast/Core/AppLeftovers.swift
+++ b/Tinycast/Core/AppLeftovers.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+/// One thing an uninstall would remove: the app bundle itself, or a support file it left behind.
+struct LeftoverItem: Identifiable, Hashable, Sendable {
+    /// Which group the row belongs to, and the order the two groups render in.
+    enum Kind: Int, Sendable {
+        case bundle
+        case support
+    }
+
+    let url: URL
+    let kind: Kind
+    /// Bytes on disk, or nil when the size couldn't be measured.
+    let size: Int64?
+    /// False for a path this app can't remove — a locked row: shown for what it is, never checked, and
+    /// not togglable. Cheaper on the user than checking it and reporting the failure afterwards.
+    var isRemovable: Bool = true
+    /// Whether the path is a directory, resolved once at discovery. Carried on the row because the only
+    /// consumer is the trailing glyph, and asking the filesystem from a view body would stat on every
+    /// re-render — a bundle-id name like `com.acme.app` says nothing about this on its own.
+    var isDirectory: Bool = false
+
+    var id: String { url.path }
+
+    /// Tilde-abbreviated path, the form the list shows (`~/Library/Caches/com.acme.app`).
+    var displayPath: String { (url.path as NSString).abbreviatingWithTildeInPath }
+}
+
+/// Discovery of the files an app leaves outside its bundle. Foundation-only and pure — every input
+/// (home directory, sibling-install flag) is injected, so `Tools/leftovers-test.swift` can compile it
+/// standalone and drive it against a throwaway home.
+///
+/// The policy is deliberately conservative: only the `~/Library` subtrees below are ever searched,
+/// only exact bundle-id / app-name keyed children of those roots match, and every result is
+/// re-verified to be a proper descendant of a known root before it is returned. Anything that would
+/// widen a match beyond one app's own data belongs nowhere near this file.
+enum AppLeftovers {
+
+    // MARK: - Uninstall eligibility
+
+    /// Whether the uninstall screen may open for an app at all. Apple's own apps are refused outright —
+    /// the action doesn't appear for them — as is Tinycast itself, where uninstalling the running app
+    /// from inside it has no sane outcome.
+    ///
+    /// Offering a screen on which nothing can be removed is worse than not offering it: it invites the
+    /// user to try. Removability of the paths that *do* get listed is a separate, per-row question
+    /// (`isRemovable`), for the third-party cases — a root-owned bundle, an immutable file.
+    static func canUninstall(url: URL, bundleID: String?) -> Bool {
+        let path = url.path
+        guard path.hasSuffix(".app") else { return false }
+        if path.hasPrefix("/System/") || path.hasPrefix("/usr/") { return false }
+        guard let bundleID else { return true }
+        if isProtectedVendor(bundleID: bundleID) { return false }
+        // Every channel of Tinycast (dev / beta / stable) shares this prefix.
+        return bundleID != "com.tinycast.app" && !bundleID.hasPrefix("com.tinycast.app.")
+    }
+
+    /// Apps Tinycast never uninstalls: Apple's own. Their bundles are SIP-held and their support folders
+    /// are system-managed, so a half-removed system app isn't a state a launcher should be able to create.
+    static func isProtectedVendor(bundleID: String?) -> Bool {
+        bundleID?.hasPrefix("com.apple.") == true
+    }
+
+    /// What a row needs to know about a path, from a single `lstat`: whether it can actually be removed
+    /// (the parent must permit deletion — that is what protects `/System` and anything root owns — and the
+    /// file must carry neither the immutable nor the SIP-restricted flag), and whether it is a directory.
+    static func facts(for url: URL) -> (isRemovable: Bool, isDirectory: Bool) {
+        var status = stat()
+        guard lstat(url.path, &status) == 0 else { return (false, false) }
+        let locked = UInt32(SF_RESTRICTED) | UInt32(SF_IMMUTABLE) | UInt32(UF_IMMUTABLE)
+        let removable =
+            status.st_flags & locked == 0
+            && FileManager.default.isDeletableFile(atPath: url.path)
+        return (removable, status.st_mode & S_IFMT == S_IFDIR)
+    }
+
+    /// Whether this path can actually be removed. Locked rows come from here.
+    static func isRemovable(_ url: URL) -> Bool { facts(for: url).isRemovable }
+
+    // MARK: - Discovery
+
+    /// Every support path keyed by this app's bundle id or name. When `siblingBundleExists` (another
+    /// install shares the bundle id, e.g. `Xcode.app` beside `Xcode-beta.app`) every keyed path could
+    /// belong to the survivor, so all of them are dropped and only the bundle is offered.
+    ///
+    /// Returns paths only — sizes are measured by the caller, which owns the off-main walk.
+    static func supportPaths(
+        appName: String, bundleID: String?, home: URL, siblingBundleExists: Bool = false
+    ) -> [URL] {
+        let bundleID = validBundleID(bundleID)
+        // With a surviving sibling the bundle id is shared, so nothing keyed on it is safely ours.
+        let identifiers = siblingBundleExists ? [] : bundleID.map { [$0] } ?? []
+        let names = siblingBundleExists ? [] : nameVariants(appName)
+
+        var found: [URL] = []
+        var seen = Set<String>()
+        func add(_ url: URL?) {
+            guard let url, isSafeResult(url, home: home) else { return }
+            let fm = FileManager.default
+            guard fm.fileExists(atPath: url.path), seen.insert(url.path).inserted else { return }
+            found.append(url)
+        }
+
+        for name in names {
+            add(child(home, "Library/Application Support", name))
+            add(child(home, "Library/Caches", name))
+            add(child(home, "Library/Logs", name))
+            add(child(home, "Library/Preferences", name + ".plist"))
+            add(child(home, "Library/Saved Application State", name + ".savedState"))
+        }
+
+        for id in identifiers {
+            add(child(home, "Library/Application Support", id))
+            add(child(home, "Library/Application Scripts", id))
+            add(child(home, "Library/Application Support/CrashReporter", id))
+            add(child(home, "Library/Autosave Information", id))
+            add(child(home, "Library/Caches", id))
+            add(child(home, "Library/Caches/com.apple.nsurlsessiond/Downloads", id))
+            add(child(home, "Library/Containers", id))
+            add(child(home, "Library/Cookies", id + ".binarycookies"))
+            add(child(home, "Library/HTTPStorages", id))
+            add(child(home, "Library/HTTPStorages", id + ".binarycookies"))
+            add(child(home, "Library/LaunchAgents", id + ".plist"))
+            add(child(home, "Library/Logs", id))
+            add(child(home, "Library/Preferences", id + ".plist"))
+            add(child(home, "Library/Saved Application State", id + ".savedState"))
+            add(child(home, "Library/SyncedPreferences", id + ".plist"))
+            add(child(home, "Library/WebKit", id))
+            add(child(home, "Library/WebKit/com.apple.WebKit.WebContent", id))
+
+            // Helper bundles, XPC services and app extensions key their own data on ids derived from
+            // the app's — `com.acme.app.helper` — so these roots match on a dotted-boundary prefix.
+            for root in ["Library/Application Scripts", "Library/Containers", "Library/WebKit"] {
+                for url in children(of: child(home, root), where: { $0.hasPrefix(id + ".") }) {
+                    add(url)
+                }
+            }
+            // Group containers are prefixed with the vendor's team id (`5HD2ARTBFS.com.acme.app`)
+            // and can also be suffixed for a sub-group, so both boundaries count.
+            for url in children(
+                of: child(home, "Library/Group Containers"),
+                where: { $0 == id || $0.hasSuffix("." + id) || $0.hasPrefix(id + ".") })
+            {
+                add(url)
+            }
+            // Per-host preferences carry a hardware UUID between the id and `.plist`.
+            for url in children(
+                of: child(home, "Library/Preferences/ByHost"),
+                where: { $0.hasPrefix(id + ".") && $0.hasSuffix(".plist") })
+            {
+                add(url)
+            }
+            // Login-item and helper launch agents (`com.acme.app.updater.plist`).
+            for url in children(
+                of: child(home, "Library/LaunchAgents"),
+                where: { $0.hasPrefix(id + ".") && $0.hasSuffix(".plist") })
+            {
+                add(url)
+            }
+        }
+
+        return found.sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+    }
+
+    // MARK: - Guards
+
+    /// The only subtrees a support path may live in. A result outside every root is dropped, so a
+    /// malformed name or bundle id can never widen discovery beyond the user's own app data.
+    private static let allowedRoots = [
+        "Library/Application Scripts",
+        "Library/Application Support",
+        "Library/Autosave Information",
+        "Library/Caches",
+        "Library/Containers",
+        "Library/Cookies",
+        "Library/Group Containers",
+        "Library/HTTPStorages",
+        "Library/LaunchAgents",
+        "Library/Logs",
+        "Library/Preferences",
+        "Library/Saved Application State",
+        "Library/SyncedPreferences",
+        "Library/WebKit",
+    ]
+
+    /// A result must be a *proper* descendant of an allowed root — never a root itself, never home,
+    /// and never reachable by traversal (`..`) out of one.
+    private static func isSafeResult(_ url: URL, home: URL) -> Bool {
+        let path = url.standardizedFileURL.path
+        let homePath = home.standardizedFileURL.path
+        guard path != homePath, !path.contains("/../"), !path.hasSuffix("/..") else { return false }
+        for root in allowedRoots {
+            let rootPath = homePath + "/" + root
+            if path == rootPath { return false }
+            if path.hasPrefix(rootPath + "/") {
+                // One more component at least, and it must not be empty (`…/Caches//`).
+                return path.count > rootPath.count + 1
+            }
+        }
+        return false
+    }
+
+    /// Bundle ids are used to build paths and prefix matches, so anything that isn't plain
+    /// reverse-DNS is refused rather than sanitized: a path separator or glob metacharacter in a
+    /// hand-edited `Info.plist` must not be able to reach outside a root or broaden a match.
+    private static func validBundleID(_ bundleID: String?) -> String? {
+        guard let bundleID, bundleID.count >= 3, bundleID.contains("."),
+            !bundleID.hasPrefix("."), !bundleID.hasSuffix("."), !bundleID.contains("..")
+        else { return nil }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz")
+            .union(CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_"))
+        guard bundleID.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return bundleID
+    }
+
+    /// Naming variants an app might use for its support folders — "Maestro Studio" also writes
+    /// "MaestroStudio", "Maestro-Studio", "Maestro_Studio". Short names are refused outright: a
+    /// two-letter folder match is far more likely to be another app's data than this one's.
+    private static func nameVariants(_ appName: String) -> [String] {
+        let name = appName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard name.count >= 3, !name.contains("/"), !name.contains(":") else { return [] }
+        var variants = [name]
+        if name.contains(" ") {
+            for separator in ["", "-", "_"] {
+                let variant = name.replacingOccurrences(of: " ", with: separator)
+                if variant.count >= 3 { variants.append(variant) }
+            }
+        }
+        var seen = Set<String>()
+        return variants.filter { seen.insert($0).inserted }
+    }
+
+    /// A named child of a root, or nil when the name can't form one safely.
+    private static func child(_ home: URL, _ root: String, _ name: String) -> URL? {
+        guard !name.isEmpty, !name.hasPrefix("."), !name.contains("/") else { return nil }
+        return home.appendingPathComponent(root).appendingPathComponent(name)
+    }
+
+    private static func child(_ home: URL, _ root: String) -> URL {
+        home.appendingPathComponent(root)
+    }
+
+    /// Direct children of `root` whose last path component passes `predicate`. One flat listing, no
+    /// recursion, and a missing or unreadable root yields nothing.
+    private static func children(of root: URL, where predicate: (String) -> Bool) -> [URL] {
+        guard
+            let items = try? FileManager.default.contentsOfDirectory(
+                at: root, includingPropertiesForKeys: nil, options: [])
+        else { return [] }
+        return items.filter { predicate($0.lastPathComponent) }
+    }
+
+    // MARK: - Sizing
+
+    /// Bytes on disk for a file or directory tree, or nil when it can't be measured. Directories are
+    /// walked with allocated sizes (what the user gets back), skipping nothing — this runs off-main.
+    static func size(of url: URL) -> Int64? {
+        let fm = FileManager.default
+        let keys: Set<URLResourceKey> = [
+            .totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isDirectoryKey,
+            .isSymbolicLinkKey,
+        ]
+        guard let values = try? url.resourceValues(forKeys: keys) else { return nil }
+        // A symlink is reported as unmeasured, never followed: the link itself costs nothing worth
+        // showing, and its target is not what removal takes — sizing through it would count a tree that
+        // stays on disk (a cask's `/Applications` alias points at the same bundle already listed).
+        guard values.isSymbolicLink != true else { return nil }
+        guard values.isDirectory == true else { return allocatedSize(values) }
+
+        var total: Int64 = 0
+        // No `skipsHiddenFiles`: dotfiles inside a support folder are part of what gets removed.
+        guard
+            let walker = fm.enumerator(
+                at: url, includingPropertiesForKeys: Array(keys), options: [])
+        else { return nil }
+        for case let child as URL in walker {
+            guard let childValues = try? child.resourceValues(forKeys: keys) else { continue }
+            total += allocatedSize(childValues) ?? 0
+        }
+        return total
+    }
+
+    private static func allocatedSize(_ values: URLResourceValues) -> Int64? {
+        if let allocated = values.totalFileAllocatedSize { return Int64(allocated) }
+        if let allocated = values.fileAllocatedSize { return Int64(allocated) }
+        return nil
+    }
+
+    // MARK: - Removal
+
+    /// Removes each path and returns the ones that failed, keyed by path. One item failing never stops
+    /// the rest — a root-owned bundle shouldn't leave the support files it came with behind.
+    ///
+    /// `permanently` unlinks; the default trashes, which is what the ↵ / footer path uses so a
+    /// fully-checked list stays recoverable. Lives here (not in `UninstallSession`) so
+    /// `Tools/leftovers-test.swift` can drive it against throwaway fixtures.
+    static func remove(_ urls: [URL], permanently: Bool) -> Set<String> {
+        var failed = Set<String>()
+        for url in urls {
+            do {
+                if permanently {
+                    try FileManager.default.removeItem(at: url)
+                } else {
+                    try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+                }
+            } catch {
+                failed.insert(url.path)
+            }
+        }
+        return failed
+    }
+}

--- a/Tinycast/Core/PalettePanel.swift
+++ b/Tinycast/Core/PalettePanel.swift
@@ -6,6 +6,8 @@ import SwiftUI
 final class PalettePanel: NSPanel {
     /// Called for a bare backspace before it reaches the field editor (return true to consume); the field editor swallows plain backspace itself, so SwiftUI `onKeyPress` up the hierarchy never sees it.
     var onBareBackspace: (() -> Bool)?
+    /// Same deal for a bare space (the uninstall list's check/uncheck): the field editor would insert it into the query, so it is swallowed before SwiftUI ever sees the press.
+    var onBareSpace: (() -> Bool)?
     /// Arms the hover highlight from `sendEvent` — the one place both event streams pass through, so a keyboard-driven scroll under a still pointer never fires `.mouseMoved` and hover stays disarmed. Also carries the caret-hide hook fired when a footer menu opens.
     weak var paletteViewModel: PaletteViewModel? {
         didSet {
@@ -33,18 +35,20 @@ final class PalettePanel: NSPanel {
         case .keyDown: paletteViewModel?.hoverHighlightArmed = false
         default: break
         }
+        let bare = event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty
+        // Bare backspace / space are resolved before the field editor sees them: backspace backs out of
+        // a sub-screen, and space checks the uninstall list's highlighted row (its field is a filter, so
+        // the only cost is that a literal space can't be typed there). An open menu owns the keyboard
+        // outright, so neither hook runs while one is up.
+        if event.type == .keyDown, bare, paletteViewModel?.menuOpen != true {
+            if Int(event.keyCode) == kVK_Delete, onBareBackspace?() == true { return }
+            if Int(event.keyCode) == kVK_Space, onBareSpace?() == true { return }
+        }
         // A footer menu owns the keyboard: the search field stays first responder (no focus swap, so nothing reflows) with only its caret hidden; swallow text-editing keystrokes before the field editor consumes them, but let shortcut chords (⌘K, ⌘⌫) and menu-nav keys reach SwiftUI's onKeyPress.
         if event.type == .keyDown,
-            paletteViewModel?.menuOpen == true,
+            let vm = paletteViewModel, vm.menuOpen,
             event.modifierFlags.intersection([.command, .control]).isEmpty,
             !Self.menuNavKeys.contains(Int(event.keyCode))
-        {
-            return
-        }
-        if event.type == .keyDown,
-            Int(event.keyCode) == kVK_Delete,
-            event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty,
-            onBareBackspace?() == true
         {
             return
         }

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -56,6 +56,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// Pop to Root Search: reset immediately (also releases heavy sub-screens — a fully scrolled emoji grid is ~2k realized views), or keep state and reset after the configured delay unless a reopen consumes it first.
     private func schedulePopToRoot() {
         popToRootTimer?.invalidate()
+        // A live uninstall screen is exempt at any timeout: popping to root would throw away a scan and
+        // a set of checkboxes the user built, and `showPalette` restores that screen on the next summon.
+        guard !core.hasLivePaletteSession else {
+            popToRootTimer = nil
+            return
+        }
         let timeout = core.settings.popToRootTimeout
         guard timeout != .immediately else {
             core.palette.prepare(mode: .launcher)
@@ -121,15 +127,33 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             .environmentObject(core.frequentEmoji)
             .environmentObject(core.runningApps)
             .environmentObject(core.hotKeys)
+            .environmentObject(core.uninstall)
         let panel = PalettePanel(rootView: root)
         panel.delegate = self
         panel.paletteViewModel = core.palette
         // Backspace in an already-empty search backs out of a sub-screen to a fresh root launcher; `prepare` clears state and re-focuses the field.
         panel.onBareBackspace = { [weak self] in
-            guard let vm = self?.core.palette, vm.mode != .launcher, vm.query.isEmpty else {
+            guard let self, core.palette.mode != .launcher, core.palette.query.isEmpty else {
                 return false
             }
-            vm.prepare(mode: .launcher)
+            // The uninstall screen owns state beyond the palette's, so it backs out through `AppCore`.
+            if core.palette.mode == .uninstall {
+                core.exitUninstall()
+            } else {
+                core.palette.prepare(mode: .launcher)
+            }
+            return true
+        }
+        // Space checks/unchecks the highlighted uninstall row; every other screen lets it type.
+        panel.onBareSpace = { [weak self] in
+            guard let self, core.palette.mode == .uninstall,
+                core.uninstall.phase == .selecting
+            else { return false }
+            if let item = core.uninstall.highlightedItem(
+                selection: core.palette.selection, query: core.palette.query)
+            {
+                core.uninstall.toggle(item)
+            }
             return true
         }
         self.panel = panel

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -30,6 +30,8 @@ enum Theme {
         static let thumbnail: CGFloat = 6
         static let card: CGFloat = 10
         static let keyCap: CGFloat = 6
+        /// The uninstall list's checkbox — tighter than `row`, so a 16pt box reads as a checkbox and not a tile.
+        static let checkbox: CGFloat = 4
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
         static let recorderKeyCap: CGFloat = 4
     }
@@ -48,6 +50,11 @@ enum Theme {
         static let compactHeight: CGFloat = headerHeight + headerPadding * 2
         static let bottomBarHeight: CGFloat = 52
         static let rowIcon: CGFloat = 24
+        /// Square box of the uninstall list's checkbox.
+        static let checkbox: CGFloat = 16
+        /// Height of a control sharing the header row with the search field (the uninstall sort button),
+        /// matching the footer's `BarButton` so the two read as one control family.
+        static let headerControl: CGFloat = 28
         static let keyCap: CGFloat = 18
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
         static let recorderKeyCap: CGFloat = 16

--- a/Tinycast/Core/UninstallSession.swift
+++ b/Tinycast/Core/UninstallSession.swift
@@ -1,0 +1,288 @@
+import AppKit
+import Combine
+
+/// Row order of the uninstall list, chosen from the header control.
+enum UninstallSort: String, CaseIterable, Sendable {
+    case path
+    case size
+    case name
+
+    /// Header-control label ("Sort by Path").
+    var title: String {
+        switch self {
+        case .path: return "Sort by Path"
+        case .size: return "Sort by Size"
+        case .name: return "Sort by Name"
+        }
+    }
+    var systemImage: String {
+        switch self {
+        case .path: return "folder"
+        case .size: return "externaldrive"
+        case .name: return "textformat"
+        }
+    }
+}
+
+/// What a finished removal actually did — the screen reports this instead of the palette just closing.
+struct UninstallOutcome: Equatable, Sendable {
+    let removedCount: Int
+    /// Bytes belonging to the paths that really went, so a partial failure can't overstate the total.
+    let reclaimed: Int64
+    let failures: [LeftoverItem]
+    /// Trashed or unlinked — the summary has to name which, since only one of them is recoverable.
+    let permanently: Bool
+}
+
+/// Where the uninstall screen is in its one-way flow. The palette stays open across all three, so the
+/// user sees the removal happen and what it did rather than the window vanishing.
+enum UninstallPhase: Equatable, Sendable {
+    case selecting
+    /// Carries which removal is running, so the progress line names it accurately.
+    case removing(permanently: Bool)
+    case done(UninstallOutcome)
+}
+
+/// State for the palette's uninstall screen: the app being removed, what would go to the Trash, and
+/// which of those rows are checked. Owned by `AppCore` and reset on every `begin` — the screen is a
+/// one-shot flow, so nothing here outlives the palette session that started it.
+@MainActor
+final class UninstallSession: ObservableObject {
+    @Published private(set) var target: AppEntry?
+    /// Every discovered path in the current sort order. `filtered(_:)` narrows this to what the list
+    /// actually shows, which is what the palette's flat selection indexes.
+    @Published private(set) var items: [LeftoverItem] = []
+    @Published private(set) var sort: UninstallSort = .path
+    @Published private(set) var isScanning = false
+    /// Checked rows, keyed by `LeftoverItem.id`. Everything starts checked, as in Raycast.
+    @Published private(set) var checked: Set<String> = []
+    /// Drives which of the three screens renders; `.removing` also stops the footer firing twice.
+    @Published private(set) var phase: UninstallPhase = .selecting
+
+    /// Invalidates an in-flight scan whose results arrive after the user backed out or started another.
+    private var scanToken = UUID()
+
+    var checkedItems: [LeftoverItem] { items.filter { checked.contains($0.id) } }
+    /// Rows the user may act on — the denominator of the header's count, since a locked row is never
+    /// something they can select.
+    var removableItems: [LeftoverItem] { items.filter(\.isRemovable) }
+    var checkedSize: Int64 { checkedItems.reduce(0) { $0 + ($1.size ?? 0) } }
+    func isChecked(_ item: LeftoverItem) -> Bool { checked.contains(item.id) }
+
+    /// Rows matching the header's filter field — a plain case-insensitive substring over the file name
+    /// and its path, so what the user types reads the way the placeholder promises. An empty query
+    /// shows everything. Checked state is keyed by path, so filtering never disturbs it.
+    func filtered(_ query: String) -> [LeftoverItem] {
+        let needle = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !needle.isEmpty else { return items }
+        return items.filter {
+            $0.url.lastPathComponent.lowercased().contains(needle)
+                || $0.displayPath.lowercased().contains(needle)
+        }
+    }
+
+    /// The row a flat selection index points at, filtered and clamped — the one place that rule lives, so
+    /// the SwiftUI list and the AppKit key handler can't drift apart on it.
+    func highlightedItem(selection: Int, query: String) -> LeftoverItem? {
+        let visible = filtered(query)
+        guard !visible.isEmpty else { return nil }
+        return visible[min(max(selection, 0), visible.count - 1)]
+    }
+
+    func setSort(_ sort: UninstallSort) {
+        guard sort != self.sort else { return }
+        self.sort = sort
+        items = Self.sorted(items, by: sort)
+    }
+
+    /// Path order puts the bundle first for free (`/Applications` sorts above `/Users`); size is
+    /// largest-first, which is the order someone reclaiming disk space is reading for.
+    private static func sorted(_ items: [LeftoverItem], by sort: UninstallSort) -> [LeftoverItem] {
+        switch sort {
+        case .path:
+            return items.sorted {
+                $0.url.path.localizedStandardCompare($1.url.path) == .orderedAscending
+            }
+        case .name:
+            return items.sorted {
+                $0.url.lastPathComponent.localizedStandardCompare($1.url.lastPathComponent)
+                    == .orderedAscending
+            }
+        case .size:
+            // Unmeasurable paths sort last rather than as zero, so a failed size reads as unknown.
+            return items.sorted { ($0.size ?? -1) > ($1.size ?? -1) }
+        }
+    }
+
+    /// Starts a fresh scan for `app`, in two stages so the list is usable immediately.
+    ///
+    /// Discovery is a handful of `stat`s and lands at once. **Sizes are measured afterwards**, one path
+    /// at a time, because a size is a full tree walk: cold, a 3.5 GB bundle measured 32s here (116ms
+    /// warm), and making the whole screen wait on that would read as a hang. Rows therefore appear with
+    /// no size and fill in as each measurement returns.
+    func begin(app: AppEntry) {
+        let token = UUID()
+        scanToken = token
+        target = app
+        items = []
+        checked = []
+        phase = .selecting
+        isScanning = true
+
+        let name = app.name
+        let bundleID = app.bundleID
+        // Resolve the bundle: some apps are only symlinked into /Applications (a Homebrew cask points
+        // at its Caskroom payload), and trashing the link alone would take the app out of the launcher
+        // while leaving every byte of it installed.
+        let url = app.url.resolvingSymlinksInPath()
+        // …and take the link with it, so /Applications isn't left holding a dangling alias.
+        let link = url == app.url ? nil : app.url
+        // Resolved on the main actor: LaunchServices lookups aren't safe to move off it, and a
+        // surviving install sharing this bundle id makes every id-keyed path ambiguous.
+        let hasSibling = Self.hasSiblingInstall(
+            bundleID: bundleID, excluding: [app.url, url])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+
+        Task { [weak self] in
+            let discovered = await Task.detached(priority: .userInitiated) { () -> [LeftoverItem] in
+                func item(_ url: URL, _ kind: LeftoverItem.Kind) -> LeftoverItem {
+                    let facts = AppLeftovers.facts(for: url)
+                    return LeftoverItem(
+                        url: url, kind: kind, size: nil,
+                        isRemovable: facts.isRemovable, isDirectory: facts.isDirectory)
+                }
+                var found = [item(url, .bundle)]
+                if let link { found.append(item(link, .bundle)) }
+                let support = AppLeftovers.supportPaths(
+                    appName: name, bundleID: bundleID, home: home,
+                    siblingBundleExists: hasSibling)
+                found += support.map { item($0, .support) }
+                return found
+            }.value
+            guard let self, scanToken == token else { return }
+            items = Self.sorted(discovered, by: sort)
+            // Everything removable starts checked; locked rows never do.
+            checked = Set(discovered.filter(\.isRemovable).map(\.id))
+            isScanning = false
+            await measureSizes(token: token)
+        }
+    }
+
+    /// Fills in the row sizes once they are all measured. The walks run concurrently — they are
+    /// independent tree reads, so the wait is the slowest one rather than their sum — and land in a single
+    /// assignment: publishing per row would re-render the whole list once per leftover path found.
+    private func measureSizes(token: UUID) async {
+        let pending = items.filter { $0.size == nil }.map(\.url)
+        guard !pending.isEmpty else { return }
+        let sizes = await Task.detached(priority: .utility) { () -> [String: Int64] in
+            await withTaskGroup(of: (String, Int64?).self) { group in
+                for url in pending {
+                    group.addTask { (url.path, AppLeftovers.size(of: url)) }
+                }
+                var measured: [String: Int64] = [:]
+                for await (path, size) in group {
+                    if let size { measured[path] = size }
+                }
+                return measured
+            }
+        }.value
+        // The session may have been ended (or restarted for another app) mid-walk.
+        guard scanToken == token else { return }
+        var updated = items
+        for index in updated.indices {
+            guard let size = sizes[updated[index].url.path] else { continue }
+            updated[index] = LeftoverItem(
+                url: updated[index].url, kind: updated[index].kind, size: size,
+                isRemovable: updated[index].isRemovable, isDirectory: updated[index].isDirectory)
+        }
+        // Only the size order depends on what just landed; re-applying any other sort would be a no-op.
+        items = sort == .size ? Self.sorted(updated, by: .size) : updated
+    }
+
+    /// Drops the session (backing out of the screen), so a late scan result can't repopulate it.
+    func end() {
+        scanToken = UUID()
+        target = nil
+        items = []
+        checked = []
+        isScanning = false
+        phase = .selecting
+    }
+
+    func toggle(_ item: LeftoverItem) {
+        // A locked row is display-only: it exists so the user can see what stays behind and why.
+        guard item.isRemovable else { return }
+        if checked.contains(item.id) {
+            checked.remove(item.id)
+        } else {
+            checked.insert(item.id)
+        }
+    }
+
+    /// Removes `targets`, quitting the app first when its bundle is among them, and lands the screen on
+    /// a summary of what happened. Returns the outcome so the caller can act on the failures too.
+    ///
+    /// The caller passes the set it approved rather than letting this re-read `checkedItems`, so what a
+    /// confirmation counted is exactly what gets removed. `permanently` unlinks instead of trashing and
+    /// is only ever reached from the Permanently Delete row, which confirms first (`AppCore`) — the ↵ /
+    /// footer default stays the recoverable one.
+    @discardableResult
+    func remove(_ targets: [LeftoverItem], permanently: Bool = false) async -> UninstallOutcome {
+        guard phase == .selecting else {
+            return UninstallOutcome(
+                removedCount: 0, reclaimed: 0, failures: [], permanently: permanently)
+        }
+        // Retires the scan token so an in-flight `measureSizes` walk exits at its next check: it must not
+        // keep mutating rows (or re-sorting them) while the removal runs or the summary is up.
+        scanToken = UUID()
+        phase = .removing(permanently: permanently)
+
+        // Only when the bundle itself is going: unchecking it to clear caches alone shouldn't force-quit
+        // an app the user is still using.
+        if targets.contains(where: { $0.kind == .bundle }), let bundleID = target?.bundleID {
+            await Self.quitAndWait(bundleID: bundleID)
+        }
+
+        let paths = targets.map(\.url)
+        let failedPaths = await Task.detached(priority: .userInitiated) {
+            AppLeftovers.remove(paths, permanently: permanently)
+        }.value
+
+        let failures = targets.filter { failedPaths.contains($0.url.path) }
+        let removed = targets.filter { !failedPaths.contains($0.url.path) }
+        let outcome = UninstallOutcome(
+            removedCount: removed.count,
+            reclaimed: removed.reduce(0) { $0 + ($1.size ?? 0) },
+            failures: failures,
+            permanently: permanently)
+        phase = .done(outcome)
+        return outcome
+    }
+
+    /// Another registered install claiming the same bundle id (`Xcode.app` beside `Xcode-beta.app`).
+    /// Every bundle-id-keyed support path would then be ambiguous, so discovery drops them all.
+    private static func hasSiblingInstall(bundleID: String?, excluding urls: [URL]) -> Bool {
+        guard let bundleID else { return false }
+        // The target counts under both its own path and its symlink resolution, so a cask linked into
+        // /Applications isn't mistaken for two installs.
+        let own = Set(
+            urls.flatMap { [$0.standardizedFileURL.path, $0.resolvingSymlinksInPath().path] })
+        return NSWorkspace.shared.urlsForApplications(withBundleIdentifier: bundleID)
+            .contains {
+                !own.contains($0.standardizedFileURL.path)
+                    && !own.contains($0.resolvingSymlinksInPath().path)
+            }
+    }
+
+    /// Graceful terminate plus a bounded wait — trashing a bundle out from under a running process
+    /// leaves a zombie, and `trashItem` can fail outright while the app holds its own files open.
+    private static func quitAndWait(bundleID: String) async {
+        guard AppLauncher.quit(bundleID: bundleID) else { return }
+        for _ in 0..<30 {
+            if NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+    }
+}

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -14,7 +14,18 @@ struct LauncherList: View {
     var onCalcActions: () -> Void = {}
     let onActivate: (AppEntry) -> Void
     let onActions: (AppEntry) -> Void
+    /// Reports the live content offset so a screen that replaces this list can put it back exactly where
+    /// it was. Writes to plain (non-published) storage — this fires on every scroll tick.
+    var onScrollOffset: (CGFloat) -> Void = { _ in }
+    /// An offset to restore when this list mounts, from a screen that replaced it (the uninstall flow).
+    /// Read at mount rather than pushed in as an intent: the list has to exist before it can scroll, and
+    /// owning the timing here is what saves every caller from having to wait a turn for it.
+    var restoreOffset: CGFloat?
+    /// Fired once the restore has been applied, so the caller can drop it and not re-apply on a later mount.
+    var onRestored: () -> Void = {}
     @EnvironmentObject private var runningApps: RunningAppsMonitor
+    /// Needed for `.offset` restores: `ScrollViewProxy` can only scroll to a row, never to a position.
+    @State private var scrollPosition = ScrollPosition()
 
     private nonisolated static let calcRowID = "calc-card"
 
@@ -108,6 +119,18 @@ struct LauncherList: View {
                         .padding(.bottom, Theme.Spacing.md)
                         .hideNativeScrollers()
                         .scrollOriginAnchor()
+                    }
+                    .scrollPosition($scrollPosition)
+                    .onAppear {
+                        guard let restoreOffset else { return }
+                        scrollPosition.scrollTo(y: restoreOffset)
+                        onRestored()
+                    }
+                    .onScrollGeometryChange(for: CGFloat.self) {
+                        $0.contentOffset.y
+                    } action: {
+                        _, y in
+                        onScrollOffset(y)
                     }
                     .edgeDissolve()
                     .thinScrollbar()
@@ -284,6 +307,19 @@ enum AppActionsMenu {
                     isDestructive: true
                 ) {
                     core.quit(app)
+                })
+        }
+        // Opens the uninstall screen — nothing is removed until that list is submitted. Apple's own
+        // apps and Tinycast itself are never offered; `canUninstall` is the one rule the menu row and
+        // the ⌃⌫ chord both read, so the advertised chord can't drift from the menu.
+        if app.kind == .application, AppLeftovers.canUninstall(url: app.url, bundleID: app.bundleID)
+        {
+            items.append(
+                PopoverMenuItem(
+                    title: "Uninstall Application…", systemImage: "trash", shortcut: "⌃⌫",
+                    isDestructive: true
+                ) {
+                    core.beginUninstall(app)
                 })
         }
         return PopoverMenuContent(header: app.name, items: items)

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -13,11 +13,13 @@ struct RootPaletteView: View {
     @EnvironmentObject private var currencyRates: CurrencyRateStore
     @EnvironmentObject private var emojiIndex: EmojiIndex
     @EnvironmentObject private var frequentEmoji: FrequentEmojiStore
+    @EnvironmentObject private var uninstall: UninstallSession
     /// Observed so a skin tone changed in Settings re-renders the grid glyphs immediately.
     @ObservedObject private var settings = AppCore.shared.settings
     @FocusState private var searchFocused: Bool
-    @State private var showActions = false
-    @State private var showAppMenu = false
+    /// Whichever popover menu is open, or nil. One field rather than a flag each: they are mutually
+    /// exclusive by design, and three booleans made that a rule to re-enforce at every call site.
+    @State private var openMenu: PaletteMenu?
     /// The selection's running state, sampled once by `openActions` — an app launching or quitting elsewhere must not add or drop the Quit row while the menu is up. `RunningAppsMonitor` is deliberately not observed here: only `LauncherList` needs live running state, and observing it would re-render the whole palette on every workspace launch/terminate.
     @State private var selectionIsRunning = false
     /// Highlighted row of whichever popover menu is open; reset to the first row on open, moved by ↑/↓ and hover, activated by ↵/click.
@@ -46,6 +48,9 @@ struct RootPaletteView: View {
         return split.favorites + split.rest
     }
     private var clipResults: [ClipboardItem] { store.search(vm.query) }
+    /// The uninstall rows the header's filter field leaves visible — the single source of truth for that
+    /// screen's row order, selection and activation.
+    private var uninstallResults: [LeftoverItem] { uninstall.filtered(vm.query) }
     private var histResults: [CalcHistoryEntry] { calcHistory.search(vm.query) }
     private var emojiSections: [EmojiGridSection] {
         EmojiGrid.sections(query: vm.query, index: emojiIndex, frequent: frequentEmoji)
@@ -66,12 +71,13 @@ struct RootPaletteView: View {
         case .clipboard: return clipResults.count
         case .calculatorHistory: return histResults.count + calcCount
         case .emoji: return emojiResults.count
+        case .uninstall: return uninstall.phase == .selecting ? uninstallResults.count : 0
         }
     }
     /// Selection clamped into the current results — the single source of truth for highlight, preview and activation so the list and preview can never disagree.
     private var selection: Int { resultCount == 0 ? 0 : min(max(vm.selection, 0), resultCount - 1) }
 
-    private var menuOpen: Bool { showActions || showAppMenu }
+    private var menuOpen: Bool { openMenu != nil }
 
     // MARK: - Popover menu content
     //
@@ -142,6 +148,19 @@ struct RootPaletteView: View {
                     entry: emoji, core: core, target: vm.pasteTarget)
             }
             return nil
+        case .uninstall:
+            guard uninstall.phase == .selecting, !uninstallResults.isEmpty else { return nil }
+            return UninstallActionsMenu.content(
+                session: uninstall, visible: uninstallResults, selection: selection, core: core)
+        }
+    }
+
+    /// The uninstall header's sort menu. Re-ordering moves the selection to the first row, so the list
+    /// scrolls back to the origin with it.
+    private var sortMenuContent: PopoverMenuContent {
+        UninstallActionsMenu.sortContent(session: uninstall) { sort in
+            core.setUninstallSort(sort)
+            scroll = ScrollIntent(kind: .top)
         }
     }
 
@@ -159,9 +178,12 @@ struct RootPaletteView: View {
 
     /// Whichever menu is open (Actions takes precedence; the two are kept mutually exclusive) — the source for keyboard navigation and activation.
     private var menuContent: PopoverMenuContent? {
-        if showActions { return actionsContent }
-        if showAppMenu { return appMenuContent }
-        return nil
+        switch openMenu {
+        case .actions: return actionsContent
+        case .app: return appMenuContent
+        case .sort: return sortMenuContent
+        case nil: return nil
+        }
     }
 
     var body: some View {
@@ -171,13 +193,18 @@ struct RootPaletteView: View {
         let hist = vm.mode == .calculatorHistory ? histResults : []
         let emojiSections = vm.mode == .emoji ? emojiSections : []
         let emojis = emojiSections.flatMap(\.entries)
+        // Phase-gated exactly like `resultCount`: the removing/done screens render no rows, so counting
+        // them would leave the flat selection index describing a list that isn't on screen.
+        let uninstallItems =
+            vm.mode == .uninstall && uninstall.phase == .selecting ? uninstallResults : []
         // Newest stored clip + the reorder token: the pair changes only when the store mutates, never when a query filters the list.
         let clipFollow = ClipFollowKey(id: store.items.first?.id, token: vm.followToken)
         // Every count/selection below derives from this one calc/offset pair — the flat selection index must always match the visible row order, calc card included.
         let calc = calcResult
         let offset = calc == nil ? 0 : 1
         // Only the active mode is non-empty.
-        let count = apps.count + offset + clips.count + hist.count + emojis.count
+        let count =
+            apps.count + offset + clips.count + hist.count + emojis.count + uninstallItems.count
         let sel = count == 0 ? 0 : min(max(vm.selection, 0), count - 1)
         let calcSelected = calc != nil && sel == 0
         // An error card is selectable but has no action: it must not drive the Copy Answer pill, ⌘K menu, or Enter.
@@ -188,7 +215,8 @@ struct RootPaletteView: View {
         let selectedApp = apps.indices.contains(sel - offset) ? apps[sel - offset] : nil
         // Derive the footer label from the already-resolved selection so `bottomBar` doesn't re-run `appResults` (its filter/sort aren't memoized). The primary/Actions group is hidden when there's nothing to act on: no results in any mode, or an error calc card (selectable but action-less).
         let pillLabel = actionPillLabel(selectedApp: selectedApp, calcActionable: calcActionable)
-        let showActionGroup = count > 0 && !(calcSelected && !calcActionable)
+        let showActionGroup = showsActionGroup(
+            count: count, calcBlocked: calcSelected && !calcActionable)
 
         // The `header` (and its single search field) is always attached in the same position via safeAreaInset so its focus survives the compact↔expanded swap — only the results below it toggle. Collapsed shows the bar alone; expanded floats header + action bar over the list with edge-dissolve (see docs/ui.md).
         return Group {
@@ -196,7 +224,8 @@ struct RootPaletteView: View {
                 Color.clear
             } else {
                 content(
-                    apps: apps, clips: clips, hist: hist, emojiSections: emojiSections, calc: calc,
+                    apps: apps, clips: clips, hist: hist, emojiSections: emojiSections,
+                    uninstallItems: uninstallItems, calc: calc,
                     selection: sel, favoriteCount: favoriteCount, showSections: showSections
                 )
             }
@@ -207,35 +236,11 @@ struct RootPaletteView: View {
                 bottomBar(pillLabel: pillLabel, showActionGroup: showActionGroup)
             }
         }
-        // Menus are in-window overlays anchored to a bottom corner, so they stay clipped inside the panel — never a system popover spilling outside the window.
-        .overlay {
-            if showAppMenu || showActions {
-                Color.black.opacity(0.001)
-                    .contentShape(Rectangle())
-                    .onTapGesture(perform: closeMenus)
-            }
-        }
-        .overlay(alignment: .bottomLeading) {
-            if showAppMenu {
-                let content = appMenuContent
-                PopoverMenu(
-                    header: content.header, items: content.items, selection: $menuSelection,
-                    onActivate: activateMenuItem
-                )
-                .padding(Self.menuInset)
-                .transition(Self.menuTransition(.bottomLeading))
-            }
-        }
-        .overlay(alignment: .bottomTrailing) {
-            if showActions, let content = actionsContent {
-                PopoverMenu(
-                    header: content.header, items: content.items, selection: $menuSelection,
-                    onActivate: activateMenuItem
-                )
-                .padding(Self.menuInset)
-                .transition(Self.menuTransition(.bottomTrailing))
-            }
-        }
+        // Menus are in-window overlays anchored to a panel corner, so they stay clipped inside the panel — never a system popover spilling outside the window.
+        .overlay { menuDismissCatcher }
+        .overlay(alignment: .bottomLeading) { appMenuOverlay }
+        .overlay(alignment: .topTrailing) { sortMenuOverlay }
+        .overlay(alignment: .bottomTrailing) { actionsMenuOverlay }
         // The window's own frame (driven by `PaletteWindowController`) is the size source of truth; filling it keeps the glass background and corner clip matched to the current compact/expanded window height.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.black.opacity(Theme.Colors.panelDimming))
@@ -244,8 +249,7 @@ struct RootPaletteView: View {
         // Every show bumps focusToken — refocus search and drop any menu left open from last time (e.g. dismissed by clicking away with a context menu up).
         .onChange(of: vm.focusToken) {
             searchFocused = true
-            showActions = false
-            showAppMenu = false
+            openMenu = nil
         }
         .onChange(of: vm.query) {
             vm.selection = 0
@@ -253,28 +257,24 @@ struct RootPaletteView: View {
         }
         .onChange(of: vm.mode) {
             vm.selection = 0
-            showActions = false
+            // The sort control only exists on the uninstall screen, so no menu outlives a mode change.
+            openMenu = nil
             scroll = ScrollIntent(kind: .top)
         }
-        // Pop-to-root: `prepare` clears query/selection, but if both were already at their defaults the handlers above never fire — this intent guarantees the scroll itself snaps back to the origin.
-        .onChange(of: vm.resetToken) {
-            scroll = ScrollIntent(kind: .top)
+        // Coming back from the uninstall screen: put the highlight back on the app it was opened for.
+        // The scroll position is restored by `LauncherList` itself when it mounts, so nothing here has to
+        // wait for that.
+        .onChange(of: vm.pendingSelectionID) { _, id in
+            guard let id else { return }
+            vm.pendingSelectionID = nil
+            // Missing means the app is the one that was just uninstalled; the list keeps its position and
+            // simply has one fewer row.
+            guard let index = appResults.firstIndex(where: { $0.id == id }) else { return }
+            vm.selection = index + calcCount
         }
-        // Opening either menu highlights its first row and closes the other, so exactly one menu is ever open and always has a highlight.
-        .onChange(of: showActions) {
-            if showActions {
-                showAppMenu = false
-                menuSelection = 0
-            }
-            vm.menuOpen = menuOpen
-        }
-        .onChange(of: showAppMenu) {
-            if showAppMenu {
-                showActions = false
-                menuSelection = 0
-            }
-            vm.menuOpen = menuOpen
-        }
+        // Mutual exclusion and the first-row highlight are enforced by the `open…`/`toggle…` helpers, so
+        // this only has to mirror the aggregate state into the view model (which freezes text input).
+        .onChange(of: menuOpen) { vm.menuOpen = menuOpen }
         // Follow a row the store moved: a fresh capture (or promote-on-paste) lands at the head of its section, and pinning lifts a row into the Pinned section. With a query typed the highlight stays put; `AppCore` has already placed it for pin/paste.
         .onChange(of: clipFollow) { old, new in
             // A nil `old.id` is the first load landing, not a row that moved.
@@ -370,12 +370,21 @@ struct RootPaletteView: View {
                 guard command, let app = selectedAppEntry, app.canRevealInFinder
                 else { return .ignored }
                 core.showInFinder(app)
+            case .uninstall:
+                guard command, uninstallResults.indices.contains(selection) else { return .ignored }
+                core.showLeftoverInFinder(uninstallResults[selection])
             }
             return .handled
         }
         .onKeyPress(.escape) {
-            if showActions || showAppMenu {
+            if menuOpen {
                 closeMenus()
+                return .handled
+            }
+            // Esc on the uninstall screen backs out to the launcher rather than dismissing: the list
+            // took a scan to build, and abandoning it should land somewhere, not nowhere.
+            if vm.mode == .uninstall {
+                core.exitUninstall()
                 return .handled
             }
             core.hidePalette()
@@ -383,6 +392,8 @@ struct RootPaletteView: View {
         }
         .onKeyPress(.tab) {
             if menuOpen { return .handled }
+            // The uninstall screen is a modal step, not part of the launcher↔clipboard cycle.
+            if vm.mode == .uninstall { return .handled }
             toggleMode()
             return .handled
         }
@@ -399,19 +410,36 @@ struct RootPaletteView: View {
             guard resultCount > 0 else { return .handled }
             // An error calc card is the selection but has no actions — don't open an empty panel.
             if calcCount > 0, selection == 0, calcResult?.isActionable != true { return .handled }
-            toggleActions()
+            toggle(.actions)
             return .handled
         }
         // Bare backspace (back out of a sub-screen when the search is empty) is intercepted by PalettePanel.sendEvent — the field editor consumes it before onKeyPress could fire.
         .onKeyPress(keys: [.delete, .deleteForward], phases: .down) { press in
             if menuOpen { return .handled }
+            // ⌃⌫ opens the uninstall screen for the selected launcher app — the chord the Actions menu
+            // advertises. Excluded in the compact bar, like ⌘K: there's no visible selection to aim at.
+            if press.modifiers.contains(.control), !isCollapsed, vm.mode == .launcher,
+                let app = selectedAppEntry, app.kind == .application,
+                AppLeftovers.canUninstall(url: app.url, bundleID: app.bundleID)
+            {
+                core.beginUninstall(app)
+                return .handled
+            }
             guard press.modifiers.contains(.command) else { return .ignored }
+            // ⇧⌘⌫ is Finder's permanent-delete chord, and the uninstall screen's Permanently Delete row
+            // advertises it. `AppCore` puts the one confirmation alert in front of it.
+            if press.modifiers.contains(.shift), vm.mode == .uninstall,
+                uninstall.phase == .selecting
+            {
+                core.confirmUninstall(permanently: true)
+                return .handled
+            }
             switch vm.mode {
             case .clipboard:
                 deleteSelectedClip()
             case .calculatorHistory:
                 deleteSelectedHistoryEntry()
-            case .launcher, .emoji:
+            case .launcher, .emoji, .uninstall:
                 return .ignored
             }
             return .handled
@@ -432,6 +460,53 @@ struct RootPaletteView: View {
             else { return .ignored }
             core.quit(app)
             return .handled
+        }
+    }
+
+    /// Click-anywhere-else dismissal for whichever menu is open.
+    @ViewBuilder private var menuDismissCatcher: some View {
+        if menuOpen {
+            Color.black.opacity(0.001)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: closeMenus)
+        }
+    }
+
+    @ViewBuilder private var appMenuOverlay: some View {
+        if openMenu == .app {
+            let content = appMenuContent
+            PopoverMenu(
+                header: content.header, items: content.items, selection: $menuSelection,
+                onActivate: activateMenuItem
+            )
+            .padding(Self.menuInset)
+            .transition(Self.menuTransition(.bottomLeading))
+        }
+    }
+
+    /// The uninstall header's sort menu — the one menu anchored to a *top* corner, under its control.
+    @ViewBuilder private var sortMenuOverlay: some View {
+        if openMenu == .sort, vm.mode == .uninstall {
+            let content = sortMenuContent
+            PopoverMenu(
+                header: content.header, items: content.items, selection: $menuSelection,
+                onActivate: activateMenuItem
+            )
+            .padding(Self.menuInset)
+            // Hangs below the header rather than over it — it's a dropdown from the control up there.
+            .padding(.top, Theme.Size.headerHeight + Theme.Size.headerPadding)
+            .transition(Self.menuTransition(.topTrailing))
+        }
+    }
+
+    @ViewBuilder private var actionsMenuOverlay: some View {
+        if openMenu == .actions, let content = actionsContent {
+            PopoverMenu(
+                header: content.header, items: content.items, selection: $menuSelection,
+                onActivate: activateMenuItem
+            )
+            .padding(Self.menuInset)
+            .transition(Self.menuTransition(.bottomTrailing))
         }
     }
 
@@ -456,17 +531,7 @@ struct RootPaletteView: View {
                     .frame(width: Theme.Size.headerIconSlot)
             }
             searchField
-            // Compact bar pins favorites to the right of the field; expanded shows them as list rows instead.
-            if isCollapsed, settings.showFavoritesInCompactMode {
-                let slots = compactFavoriteSlots
-                if !slots.isEmpty {
-                    CompactFavoritesRow(
-                        slots: slots,
-                        onLaunch: { core.launch($0) },
-                        onOverflow: { core.expandFromCompact() }
-                    )
-                }
-            }
+            headerTrailing
         }
         // Align the search icon with the list rows and section headers below (list inset + row inset).
         .padding(.horizontal, Theme.Spacing.md * 2)
@@ -474,6 +539,24 @@ struct RootPaletteView: View {
         .frame(height: Theme.Size.headerHeight)
         .padding(.top, Theme.Size.headerPadding)
         .frame(maxWidth: .infinity)
+    }
+
+    /// Controls sharing the header row with the field: the uninstall sort control, or the compact bar's
+    /// favorites strip (expanded shows those as list rows instead).
+    @ViewBuilder private var headerTrailing: some View {
+        if vm.mode == .uninstall, uninstall.phase == .selecting, !uninstall.items.isEmpty {
+            UninstallSortButton(sort: uninstall.sort) { toggle(.sort) }
+        }
+        if isCollapsed, settings.showFavoritesInCompactMode {
+            let slots = compactFavoriteSlots
+            if !slots.isEmpty {
+                CompactFavoritesRow(
+                    slots: slots,
+                    onLaunch: { core.launch($0) },
+                    onOverflow: { core.expandFromCompact() }
+                )
+            }
+        }
     }
 
     /// The one search field, kept in a single tree position (the `header`) so its focus survives the compact↔expanded swap.
@@ -492,7 +575,7 @@ struct RootPaletteView: View {
     @ViewBuilder
     private func content(
         apps: [AppEntry], clips: [ClipboardItem], hist: [CalcHistoryEntry],
-        emojiSections: [EmojiGridSection], calc: CalcResult?,
+        emojiSections: [EmojiGridSection], uninstallItems: [LeftoverItem], calc: CalcResult?,
         selection: Int, favoriteCount: Int, showSections: Bool
     ) -> some View {
         switch vm.mode {
@@ -522,7 +605,10 @@ struct RootPaletteView: View {
                 onActions: { app in
                     if let index = apps.firstIndex(of: app) { vm.selection = index + offset }
                     openActions()
-                }
+                },
+                onScrollOffset: { vm.launcherScrollOffset = $0 },
+                restoreOffset: vm.restoreLauncherOffset,
+                onRestored: { vm.restoreLauncherOffset = nil }
             )
         case .clipboard:
             // Empty history: center one message across the whole panel rather than wedging it into the narrow list column beside a blank preview.
@@ -602,6 +688,49 @@ struct RootPaletteView: View {
                     }
                 )
             }
+        case .uninstall:
+            switch uninstall.phase {
+            case .removing(let permanently):
+                UninstallProgressView(
+                    name: uninstall.target?.name ?? "Application", permanently: permanently)
+            case .done(let outcome):
+                UninstallSummaryView(
+                    name: uninstall.target?.name ?? "Application", outcome: outcome)
+            case .selecting:
+                uninstallSelection(items: uninstallItems, selection: selection)
+            }
+        }
+    }
+
+    /// The uninstall screen's list phase: the count line, then the filtered rows.
+    @ViewBuilder
+    private func uninstallSelection(items uninstallItems: [LeftoverItem], selection: Int)
+        -> some View
+    {
+        if uninstall.items.isEmpty {
+            EmptyResults(
+                text: uninstall.isScanning
+                    ? "Looking for files to remove…" : "Nothing found to remove")
+        } else if uninstallItems.isEmpty {
+            EmptyResults(text: "No files match")
+        } else {
+            UninstallList(
+                items: uninstallItems,
+                selection: selection,
+                isChecked: uninstall.isChecked,
+                appIcon: uninstall.target?.icon,
+                header: UninstallHeader.title(
+                    checked: uninstall.checkedItems.count,
+                    removable: uninstall.removableItems.count,
+                    size: uninstall.checkedSize),
+                scroll: scroll,
+                onSelect: { vm.selection = $0 },
+                onToggle: { uninstall.toggle(uninstallItems[$0]) },
+                onActions: { index in
+                    vm.selection = index
+                    openActions()
+                }
+            )
         }
     }
 
@@ -610,7 +739,13 @@ struct RootPaletteView: View {
         HStack(spacing: 0) {
             appMenuButton
             Spacer()
-            if showActionGroup { actionGroup(pillLabel: pillLabel) }
+            if showActionGroup {
+                actionGroup(
+                    pillLabel: pillLabel,
+                    // Red while the list is up; the summary's Done is not a destructive button.
+                    destructive: vm.mode == .uninstall && uninstall.phase == .selecting,
+                    showActionsToggle: vm.mode != .uninstall || uninstall.phase == .selecting)
+            }
         }
         .padding(.horizontal, Theme.Spacing.md)
         .frame(height: Theme.Size.bottomBarHeight)
@@ -618,36 +753,60 @@ struct RootPaletteView: View {
     }
 
     private var appMenuButton: some View {
-        MenuCircleButton {
-            withAnimation(Self.menuAnimation) { showAppMenu.toggle() }
-        }
+        MenuCircleButton { toggle(.app) }
     }
 
     /// The footer control group: primary action and the Actions toggle sharing one glass capsule.
-    private func actionGroup(pillLabel: String) -> some View {
+    private func actionGroup(
+        pillLabel: String, destructive: Bool = false, showActionsToggle: Bool = true
+    ) -> some View {
         HStack(spacing: 2) {
             BarButton(action: activateSelection) {
                 HStack(spacing: Theme.Spacing.sm) {
                     Text(pillLabel)
                         .font(Theme.Typography.bar)
-                        .foregroundStyle(.primary)
+                        // Red carries the same meaning it does on a destructive menu row.
+                        .foregroundStyle(destructive ? Color.red : Color.primary)
                     KeyCapChip(text: "↵", style: .outline)
                 }
             }
-            BarButton(action: toggleActions) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    Text("Actions")
-                        .font(Theme.Typography.bar)
-                        .foregroundStyle(Theme.Colors.textSecondary)
-                    HStack(spacing: Theme.Spacing.xxs) {
-                        KeyCapChip(text: "⌘", style: .outline)
-                        KeyCapChip(text: "K", style: .outline)
-                    }
-                }
+            if showActionsToggle {
+                actionsToggleButton
             }
         }
         .padding(Theme.Spacing.xs)
         .frosted(in: Capsule())
+    }
+
+    private var actionsToggleButton: some View {
+        BarButton {
+            toggle(.actions)
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text("Actions")
+                    .font(Theme.Typography.bar)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                HStack(spacing: Theme.Spacing.xxs) {
+                    KeyCapChip(text: "⌘", style: .outline)
+                    KeyCapChip(text: "K", style: .outline)
+                }
+            }
+        }
+    }
+
+    /// Whether the footer's primary/Actions group is shown: nothing to act on means no group (no results
+    /// in any mode, or an error calc card, which is selectable but action-less). The uninstall screen is
+    /// the exception — its summary has a Done button with no rows behind it, and its progress screen has
+    /// no action at all.
+    private func showsActionGroup(count: Int, calcBlocked: Bool) -> Bool {
+        if vm.mode == .uninstall {
+            switch uninstall.phase {
+            case .selecting: return count > 0
+            case .removing: return false
+            case .done: return true
+            }
+        }
+        return count > 0 && !calcBlocked
     }
 
     /// Pill label for the current selection, derived from the selection already resolved in `body` so it never re-runs the (unmemoized) `appResults` filter/sort.
@@ -657,6 +816,16 @@ struct RootPaletteView: View {
             return vm.pasteTarget?.pasteTitle ?? "Paste"
         case .calculatorHistory:
             return "Copy Answer"
+        case .uninstall:
+            switch uninstall.phase {
+            case .removing: return "Removing…"
+            // Names where ↵ lands, since it goes back to the search rather than closing the palette.
+            case .done: return "Back to Search"
+            case .selecting:
+                // The status line above the list carries the count and the total, so the button just
+                // names the act; nothing checked means nothing to name.
+                return uninstall.checkedItems.isEmpty ? "Nothing Checked" : "Uninstall Application"
+            }
         case .launcher:
             if calcActionable { return "Copy Answer" }
             switch selectedApp?.kind {
@@ -676,22 +845,27 @@ struct RootPaletteView: View {
         } else {
             selectionIsRunning = false
         }
-        withAnimation(Self.menuAnimation) { showActions = true }
+        // Never open an empty panel — a screen with no actions (the uninstall summary) would otherwise
+        // swallow the keyboard behind an invisible menu.
+        guard actionsContent != nil else { return }
+        show(.actions)
     }
 
-    private func toggleActions() {
-        if showActions {
-            withAnimation(Self.menuAnimation) { showActions = false }
-        } else {
-            openActions()
+    /// Opens `menu`, or closes it if it is already the open one. The mutual exclusion and the first-row
+    /// highlight live here, so no caller has to remember either.
+    private func toggle(_ menu: PaletteMenu) {
+        if openMenu == menu { closeMenus() } else { show(menu) }
+    }
+
+    private func show(_ menu: PaletteMenu) {
+        withAnimation(Self.menuAnimation) {
+            menuSelection = 0
+            openMenu = menu
         }
     }
 
     private func closeMenus() {
-        withAnimation(Self.menuAnimation) {
-            showActions = false
-            showAppMenu = false
-        }
+        withAnimation(Self.menuAnimation) { openMenu = nil }
     }
 
     /// Inset of the menu panels from the window's bottom corners, kept just inside the rounded corner so the menu's own corner isn't clipped.
@@ -750,6 +924,11 @@ struct RootPaletteView: View {
 
     /// Back out to a fresh root search — `prepare` is the same reset used when the palette is shown (clears query/selection, bumps focusToken to refocus the field).
     private func exitToLauncher() {
+        // The uninstall screen owns a scan beyond the palette's own state, so it backs out via AppCore.
+        if vm.mode == .uninstall {
+            core.exitUninstall()
+            return
+        }
         vm.prepare(mode: .launcher)
     }
 
@@ -781,8 +960,22 @@ struct RootPaletteView: View {
         case .emoji:
             guard emojiResults.indices.contains(selection) else { return }
             core.pasteEmoji(emojiResults[selection])
+        case .uninstall:
+            switch uninstall.phase {
+            case .selecting: core.confirmUninstall()
+            case .removing: break  // nothing to activate while it runs
+            case .done: core.finishUninstall()
+            }
         }
     }
+}
+
+/// The palette's popover menus. Exactly one can be open, which is why the view tracks the open one
+/// rather than a flag per menu.
+private enum PaletteMenu {
+    case app
+    case actions
+    case sort
 }
 
 /// Change key for the clipboard list's follow-the-moved-row handler: the newest stored clip (a capture or promote puts a different row there) plus the token an action bumps when it reorders the list (pin/unpin). Deliberately read from the store, not the filtered results, so typing a query never reads as a row that moved.

--- a/Tinycast/Features/Uninstall/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UninstallView.swift
@@ -1,0 +1,374 @@
+import SwiftUI
+
+/// The uninstall screen's list: every path an uninstall would remove, each row a checkbox. Flat and
+/// unsectioned (the header's sort control owns the order), so row order is exactly `items` and the
+/// palette's flat selection index maps 1:1 onto it.
+struct UninstallList: View {
+    let items: [LeftoverItem]
+    let selection: Int
+    let isChecked: (LeftoverItem) -> Bool
+    let appIcon: NSImage?
+    /// Count line rendered as this list's section header, so it sits exactly where every other palette
+    /// list's first header sits — same component, same rhythm, no per-screen layout shift.
+    let header: String
+    /// Changes only when the list should scroll (keyboard nav / reset), so mouse selection never yanks
+    /// the scroll position.
+    let scroll: ScrollIntent
+    let onSelect: (Int) -> Void
+    let onToggle: (Int) -> Void
+    let onActions: (Int) -> Void
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    SectionHeader(title: header, isFirst: true)
+                    ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                        UninstallRow(
+                            item: item,
+                            checked: isChecked(item),
+                            selected: index == selection,
+                            icon: item.kind == .bundle ? appIcon : nil
+                        )
+                        .contentShape(Rectangle())
+                        // A click checks or unchecks, like any checkbox list — the destructive action
+                        // stays with ↵ and the footer button.
+                        .onTapGesture {
+                            onSelect(index)
+                            onToggle(index)
+                        }
+                        .onRightClick { onActions(index) }
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.xs)
+                .padding(.bottom, Theme.Spacing.md)
+                .hideNativeScrollers()
+                .scrollOriginAnchor()
+            }
+            .edgeDissolve()
+            .thinScrollbar()
+            .onChange(of: scroll) { _, scroll in
+                switch scroll.kind {
+                case .top:
+                    proxy.scrollToOrigin()
+                case .follow:
+                    // The first row snaps to the origin so the count header comes back into view; a nil
+                    // anchor wouldn't move, the row being visible already.
+                    if selection == 0 {
+                        proxy.scrollToOrigin()
+                    } else if items.indices.contains(selection) {
+                        proxy.reveal(items[selection].id)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The uninstall list's header text: how many rows are checked out of the removable ones, and what
+/// they add up to. Rendered through the shared `SectionHeader`, so it reads as a category label.
+@MainActor
+enum UninstallHeader {
+    static func title(checked: Int, removable: Int, size: Int64) -> String {
+        let files = removable == 1 ? "file" : "files"
+        let count = "\(checked) of \(removable) \(files) selected"
+        return size > 0 ? count + "  ·  " + UninstallFormat.size(size) : count
+    }
+}
+
+/// The in-progress screen. Quitting the app and walking a multi-gigabyte bundle takes a moment, and
+/// that moment is exactly when the palette used to disappear without a word.
+struct UninstallProgressView: View {
+    let name: String
+    let permanently: Bool
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.xl) {
+            ProgressView()
+                .controlSize(.large)
+            Text(permanently ? "Deleting \(name)…" : "Moving \(name) to the Trash…")
+                .font(Theme.Typography.rowTitle)
+                .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// The result screen: what went, how much came back, and anything that didn't go.
+struct UninstallSummaryView: View {
+    let name: String
+    let outcome: UninstallOutcome
+
+    private var title: String {
+        guard outcome.removedCount > 0 else { return "Nothing was removed" }
+        let items = "\(outcome.removedCount) \(outcome.removedCount == 1 ? "item" : "items")"
+        return outcome.permanently
+            ? "Deleted \(items)" : "Moved \(items) to the Trash"
+    }
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(
+                systemName: outcome.failures.isEmpty
+                    ? "checkmark.circle" : "exclamationmark.triangle"
+            )
+            .font(.largeTitle)
+            .symbolRenderingMode(.hierarchical)
+            .foregroundStyle(outcome.failures.isEmpty ? Color.primary : Color.red)
+            VStack(spacing: Theme.Spacing.xs) {
+                Text("\(name) — \(title)")
+                    .font(Theme.Typography.rowTitle)
+                if outcome.reclaimed > 0 {
+                    Text("\(UninstallFormat.size(outcome.reclaimed)) reclaimed")
+                        .font(Theme.Typography.rowTrailing)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .monospacedDigit()
+                }
+                // Trashing is reversible and worth saying so; unlinking isn't, and pretending otherwise
+                // would be the one misleading line on this screen.
+                if outcome.removedCount > 0, !outcome.permanently {
+                    Text("Recoverable from the Trash")
+                        .font(Theme.Typography.rowTrailing)
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                }
+            }
+            if !outcome.failures.isEmpty { failureList }
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, Theme.Spacing.xxl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// What stayed behind, and the two reasons it does: no permission, or the file is still in use.
+    private var failureList: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text(
+                outcome.failures.count == 1
+                    ? "1 item couldn’t be removed — it may need an administrator, or still be in use."
+                    : "\(outcome.failures.count) items couldn’t be removed — they may need an administrator, or still be in use."
+            )
+            .font(Theme.Typography.rowTrailing)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            ForEach(outcome.failures) { failure in
+                Text(failure.displayPath)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.xl)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                .fill(Theme.Colors.cardFill)
+                .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
+        )
+    }
+}
+
+/// The header's sort control: current order plus a disclosure chevron, opening the sort menu.
+struct UninstallSortButton: View {
+    let sort: UninstallSort
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: sort.systemImage)
+                    .symbolRenderingMode(.hierarchical)
+                Text(sort.title)
+                Image(systemName: "chevron.down")
+                    .font(Theme.Typography.keyCap)
+            }
+            .font(Theme.Typography.bar)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            .padding(.horizontal, Theme.Spacing.md)
+            .frame(height: Theme.Size.headerControl)
+            .contentShape(Capsule())
+            .background(Capsule().fill(hovered ? Theme.Colors.rowHover : Color.clear))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .fixedSize()
+    }
+}
+
+/// One uninstall row: checkbox, file name, its directory, size, then the file's own icon — or a padlock
+/// when the path is locked.
+private struct UninstallRow: View {
+    let item: LeftoverItem
+    let checked: Bool
+    let selected: Bool
+    /// The app's own icon for the bundle row; every other row draws a symbol for its kind.
+    let icon: NSImage?
+    @State private var hovered = false
+
+    /// Copy-identical to every other palette row (see docs/ui.md): selection beats hover.
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    /// Directory the item sits in, tilde-abbreviated — the row's name column already carries the leaf.
+    private var directory: String {
+        (item.url.deletingLastPathComponent().path as NSString).abbreviatingWithTildeInPath
+    }
+
+    /// The trailing glyph. A locked row says so with a padlock; otherwise it's what the path *is*, read
+    /// from the row rather than the filesystem — this is evaluated on every re-render.
+    private var trailingSymbol: String {
+        if !item.isRemovable { return "lock" }
+        if item.kind == .bundle { return "app.badge" }
+        return item.isDirectory ? "folder" : "doc"
+    }
+
+    private var titleColor: Color {
+        guard item.isRemovable else { return Theme.Colors.textTertiary }
+        return checked ? Color.primary : Theme.Colors.textSecondary
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            UninstallCheckbox(checked: checked, locked: !item.isRemovable)
+            Text(item.url.lastPathComponent)
+                .font(Theme.Typography.rowTitle)
+                .lineLimit(1)
+                .foregroundStyle(titleColor)
+            Text(directory)
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .lineLimit(1)
+                // The distinguishing part of a long support path is its tail.
+                .truncationMode(.middle)
+            Spacer(minLength: Theme.Spacing.md)
+            // "-" while a size is still being measured or can't be, so the column never blinks in and
+            // out of existence as the walks land.
+            Text(item.size.map(UninstallFormat.size) ?? "-")
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+            Group {
+                if let icon, item.isRemovable {
+                    Image(nsImage: icon).resizable()
+                } else {
+                    Image(systemName: trailingSymbol)
+                        .font(Theme.Typography.menuIcon)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .fill(fill)
+        )
+        .armedHover($hovered)
+        .help(item.isRemovable ? "" : "Locked — Tinycast can’t remove this")
+    }
+}
+
+/// A checkbox drawn from `Theme` tokens rather than `checkmark.square`, so the box matches the panel's
+/// white-alpha ramp (an SF checkbox glyph reads as a hairline outline on this surface).
+private struct UninstallCheckbox: View {
+    let checked: Bool
+    /// A locked row's box is drawn fainter still, so it reads as unavailable rather than merely unchecked.
+    var locked = false
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.Radius.checkbox, style: .continuous)
+        return ZStack {
+            if locked {
+                shape.strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
+            } else if checked {
+                shape.fill(Color.primary.opacity(0.85))
+                Image(systemName: "checkmark")
+                    .font(Theme.Typography.keyCap.weight(.bold))
+                    // Punched out of the filled box: the one place a near-black foreground is correct.
+                    .foregroundStyle(Color.black.opacity(0.8))
+            } else {
+                shape.strokeBorder(Theme.Colors.border, lineWidth: 1)
+            }
+        }
+        .frame(width: Theme.Size.checkbox, height: Theme.Size.checkbox)
+    }
+}
+
+/// Byte formatting for the uninstall screen — one formatter, so row sizes and the status line can
+/// never render the same number two ways.
+@MainActor
+enum UninstallFormat {
+    /// `ByteCountFormatter` isn't `Sendable`; the one instance stays pinned to the main actor, which is
+    /// where every row and the status line render anyway.
+    private static let formatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.allowsNonnumericFormatting = false
+        return formatter
+    }()
+
+    static func size(_ bytes: Int64) -> String {
+        formatter.string(fromByteCount: bytes)
+    }
+}
+
+/// Actions menu content for the uninstall screen, shown bottom-right on right-click or from the pill.
+@MainActor
+enum UninstallActionsMenu {
+    /// `visible` is the filtered list the palette's selection indexes — never `session.items`, which is
+    /// the unfiltered one and would point at a different row the moment a filter is typed.
+    static func content(
+        session: UninstallSession, visible: [LeftoverItem], selection: Int, core: AppCore
+    ) -> PopoverMenuContent {
+        let name = session.target?.name ?? "Application"
+        var items: [PopoverMenuItem] = []
+        // Both removal rows appear only with something checked, so neither can fire on an empty list.
+        if !session.checkedItems.isEmpty {
+            items.append(
+                PopoverMenuItem(
+                    title: "Uninstall Application", systemImage: "trash", shortcut: "↵",
+                    isDestructive: true
+                ) { core.confirmUninstall() })
+            // Finder's own pairing and Finder's own chord: the Trash is the default, permanent deletion
+            // is a separate row on ⇧⌘⌫ — and unlike the Trash path it confirms first.
+            items.append(
+                PopoverMenuItem(
+                    title: "Permanently Delete…", systemImage: "trash.slash", shortcut: "⇧⌘⌫",
+                    isDestructive: true
+                ) { core.confirmUninstall(permanently: true) })
+        }
+        if visible.indices.contains(selection) {
+            let item = visible[selection]
+            items.append(
+                PopoverMenuItem(title: "Show in Finder", systemImage: "folder", shortcut: "⌘↵") {
+                    core.showLeftoverInFinder(item)
+                })
+        }
+        items.append(
+            PopoverMenuItem(title: "Cancel", systemImage: "xmark", shortcut: "⎋") {
+                core.cancelUninstall()
+            })
+        return PopoverMenuContent(header: "Uninstall \(name)", items: items)
+    }
+
+    /// The header sort control's menu: one row per order, the active one marked with a checkmark.
+    /// `onSelect` carries the scroll reset the re-order needs, which only the view owns.
+    static func sortContent(
+        session: UninstallSession, onSelect: @escaping (UninstallSort) -> Void
+    ) -> PopoverMenuContent {
+        PopoverMenuContent(
+            header: "Sort",
+            items: UninstallSort.allCases.map { sort in
+                PopoverMenuItem(
+                    title: sort.title,
+                    systemImage: sort == session.sort ? "checkmark" : sort.systemImage
+                ) { onSelect(sort) }
+            })
+    }
+}

--- a/Tools/leftovers-test.swift
+++ b/Tools/leftovers-test.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+/// Drives the real `AppLeftovers` against a throwaway home directory, so a run can never see — let
+/// alone return — a path in the developer's own Library.
+@main
+struct LeftoversTest {
+    static func main() {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory
+            .appendingPathComponent("tinycast-leftovers-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: home) }
+
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        func makeDir(_ relative: String) -> URL {
+            let url = home.appendingPathComponent(relative)
+            try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+            return url
+        }
+
+        func makeFile(_ relative: String, bytes: Int = 8) -> URL {
+            let url = home.appendingPathComponent(relative)
+            try? fm.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            fm.createFile(atPath: url.path, contents: Data(repeating: 0x41, count: bytes))
+            return url
+        }
+
+        /// The temp home lives under `/var`, a symlink to `/private/var`, and a directory listing
+        /// resolves it while a constructed path doesn't — so every comparison here goes through one
+        /// canonical form. A real home (`/Users/…`) has no such symlink.
+        func canon(_ url: URL) -> String { url.resolvingSymlinksInPath().path }
+
+        func paths(
+            name: String = "Acme Studio", bundleID: String? = "com.acme.studio",
+            sibling: Bool = false
+        ) -> Set<String> {
+            Set(
+                AppLeftovers.supportPaths(
+                    appName: name, bundleID: bundleID, home: home, siblingBundleExists: sibling
+                ).map(canon))
+        }
+
+        // MARK: Eligibility
+
+        check(
+            "a normal app is eligible",
+            AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/Applications/Acme.app"), bundleID: "com.acme.studio"))
+        check(
+            "an app with no bundle id is still eligible",
+            AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/Applications/Acme.app"), bundleID: nil))
+        check(
+            "system apps are refused",
+            !AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/System/Applications/Mail.app"),
+                bundleID: "com.apple.mail"))
+        // Refused by bundle id, not just by path: the cryptex-delivered apps report a `/System/Volumes/…`
+        // location, and an Apple app copied anywhere else is still Apple's.
+        check(
+            "Apple bundle ids are refused wherever they live (cryptex Safari)",
+            !AppLeftovers.canUninstall(
+                url: URL(
+                    fileURLWithPath:
+                        "/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app"),
+                bundleID: "com.apple.Safari")
+                && !AppLeftovers.canUninstall(
+                    url: URL(fileURLWithPath: "/Applications/Safari.app"),
+                    bundleID: "com.apple.Safari")
+        )
+        check(
+            "Tinycast refuses to uninstall itself",
+            !AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/Applications/Tinycast.app"),
+                bundleID: "com.tinycast.app"))
+        check(
+            "every Tinycast channel is refused",
+            !AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/Users/x/build/Tinycast Dev.app"),
+                bundleID: "com.tinycast.app.dev"))
+        check(
+            "a non-bundle path is refused",
+            !AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/Applications/Acme"), bundleID: "com.acme.studio"))
+
+        // MARK: Bundle-id keyed discovery
+
+        let container = makeDir("Library/Containers/com.acme.studio")
+        let httpStorages = makeDir("Library/HTTPStorages/com.acme.studio")
+        let cookies = makeFile("Library/HTTPStorages/com.acme.studio.binarycookies")
+        let prefs = makeFile("Library/Preferences/com.acme.studio.plist")
+        let byHost = makeFile("Library/Preferences/ByHost/com.acme.studio.ABC-123.plist")
+        let agent = makeFile("Library/LaunchAgents/com.acme.studio.plist")
+        let helperAgent = makeFile("Library/LaunchAgents/com.acme.studio.updater.plist")
+        let groupContainer = makeDir("Library/Group Containers/5HD2ARTBFS.com.acme.studio")
+        let helperContainer = makeDir("Library/Containers/com.acme.studio.helper")
+        let webKit = makeDir("Library/WebKit/com.acme.studio")
+        let sessionDownloads = makeDir(
+            "Library/Caches/com.apple.nsurlsessiond/Downloads/com.acme.studio")
+
+        let found = paths()
+        for url in [
+            container, httpStorages, cookies, prefs, byHost, agent, helperAgent, groupContainer,
+            helperContainer, webKit, sessionDownloads,
+        ] {
+            check("finds \(url.lastPathComponent)", found.contains(canon(url)))
+        }
+
+        // MARK: Name-keyed discovery and its variants
+
+        let support = makeDir("Library/Application Support/Acme Studio")
+        let nospaceCaches = makeDir("Library/Caches/AcmeStudio")
+        let hyphenLogs = makeDir("Library/Logs/Acme-Studio")
+        let underscoreSupport = makeDir("Library/Application Support/Acme_Studio")
+        let savedState = makeDir("Library/Saved Application State/Acme Studio.savedState")
+        let named = paths()
+        for url in [support, nospaceCaches, hyphenLogs, underscoreSupport, savedState] {
+            check("finds \(url.lastPathComponent) by name", named.contains(canon(url)))
+        }
+
+        // MARK: Non-matches
+
+        let other = makeDir("Library/Application Support/Acme Studio Pro")
+        let otherBundle = makeDir("Library/Containers/com.acme.studiopro")
+        let unrelatedAgent = makeFile("Library/LaunchAgents/com.other.tool.plist")
+        let siblingGroup = makeDir("Library/Group Containers/5HD2ARTBFS.com.other.tool")
+        let strict = paths()
+        check("a longer neighbouring name isn't matched", !strict.contains(canon(other)))
+        check(
+            "a bundle id without a dot boundary isn't matched", !strict.contains(canon(otherBundle))
+        )
+        check("an unrelated launch agent is left alone", !strict.contains(canon(unrelatedAgent)))
+        check(
+            "another vendor's group container is left alone", !strict.contains(canon(siblingGroup)))
+        check(
+            "documents are never in scope",
+            paths(name: "Documents", bundleID: nil).isEmpty)
+
+        // MARK: Guards
+
+        check(
+            "a surviving sibling install drops every keyed path",
+            paths(sibling: true).isEmpty)
+        check(
+            "a two-letter name matches nothing",
+            paths(name: "Go", bundleID: nil).isEmpty)
+        check(
+            "a bundle id with a path separator is refused",
+            paths(name: "x", bundleID: "../../etc").isEmpty)
+        check(
+            "a bundle id with a glob metacharacter is refused",
+            paths(name: "x", bundleID: "com.acme.*").isEmpty)
+        check(
+            "a bundle id without a dot is refused",
+            paths(name: "x", bundleID: "acme").isEmpty)
+        check(
+            "no result is ever a Library root itself",
+            paths().allSatisfy {
+                !$0.hasSuffix("/Library/Caches") && !$0.hasSuffix("/Library/Preferences")
+                    && !$0.hasSuffix("/Library/Containers")
+                    && !$0.hasSuffix("/Library/Application Support")
+            })
+        check(
+            "every result stays inside the home directory",
+            paths().allSatisfy { $0.hasPrefix(canon(home) + "/Library/") })
+        check(
+            "results are unique",
+            {
+                let list = AppLeftovers.supportPaths(
+                    appName: "Acme Studio", bundleID: "com.acme.studio", home: home)
+                return Set(list.map(\.path)).count == list.count
+            }())
+
+        // MARK: Sizing
+
+        _ = makeFile("Library/Caches/com.acme.studio/blob.bin", bytes: 4096)
+        let fileSize = AppLeftovers.size(of: prefs)
+        let dirSize = AppLeftovers.size(
+            of: home.appendingPathComponent("Library/Caches/com.acme.studio"))
+        check("a file reports a size", (fileSize ?? 0) > 0)
+        check("a directory sums its contents", (dirSize ?? 0) >= 4096)
+        check(
+            "a missing path has no size",
+            AppLeftovers.size(of: home.appendingPathComponent("Library/Caches/gone")) == nil)
+
+        // A symlink must never be sized through: a cask's /Applications alias points at the bundle that
+        // is already its own row, so following it would count the same gigabytes twice.
+        let linkTarget = makeDir("Library/Caches/com.acme.studio")
+        _ = makeFile("Library/Caches/com.acme.studio/big.bin", bytes: 8192)
+        let link = home.appendingPathComponent("Library/Caches/com.acme.studio.alias")
+        try? fm.createSymbolicLink(at: link, withDestinationURL: linkTarget)
+        check("a symlink reports no size", AppLeftovers.size(of: link) == nil)
+        check(
+            "the symlink's target still measures normally",
+            (AppLeftovers.size(of: linkTarget) ?? 0) >= 8192)
+        // And removing the link leaves the target alone — the reason the link gets its own row at all.
+        check(
+            "removing a symlink doesn't touch its target",
+            AppLeftovers.remove([link], permanently: true).isEmpty
+                && !fm.fileExists(atPath: link.path)
+                && fm.fileExists(atPath: linkTarget.path))
+
+        // MARK: Removability (locked rows)
+
+        check(
+            "Tinycast's own channels are refused",
+            !AppLeftovers.canUninstall(
+                url: URL(fileURLWithPath: "/Applications/Tinycast.app"),
+                bundleID: "com.tinycast.app")
+                && !AppLeftovers.canUninstall(
+                    url: URL(fileURLWithPath: "/x/Tinycast Beta.app"),
+                    bundleID: "com.tinycast.app.beta")
+        )
+        check(
+            "a protected vendor is recognised, and nobody else is",
+            AppLeftovers.isProtectedVendor(bundleID: "com.apple.Photos")
+                && !AppLeftovers.isProtectedVendor(bundleID: "com.acme.studio")
+                && !AppLeftovers.isProtectedVendor(bundleID: nil))
+
+        let ordinary = makeFile("Library/Caches/com.acme.studio/ordinary.bin")
+        check("an ordinary file is removable", AppLeftovers.isRemovable(ordinary))
+        check(
+            "a path that doesn't exist isn't removable",
+            !AppLeftovers.isRemovable(home.appendingPathComponent("Library/Caches/nope")))
+
+        // `chflags uchg` is settable without root, so the immutable branch is exercised for real.
+        let immutable = makeFile("Library/Caches/com.acme.studio/immutable.bin")
+        _ = try? Process.run(
+            URL(fileURLWithPath: "/usr/bin/chflags"), arguments: ["uchg", immutable.path]
+        ).waitUntilExit()
+        check("an immutable file is not removable", !AppLeftovers.isRemovable(immutable))
+        _ = try? Process.run(
+            URL(fileURLWithPath: "/usr/bin/chflags"), arguments: ["nouchg", immutable.path]
+        ).waitUntilExit()
+        check("clearing the flag makes it removable again", AppLeftovers.isRemovable(immutable))
+
+        // A read-only parent is what protects /System and anything root owns.
+        let sealedDir = makeDir("Library/Caches/com.acme.studio/sealed")
+        let sealedChild = makeFile("Library/Caches/com.acme.studio/sealed/child.bin")
+        try? fm.setAttributes([.posixPermissions: 0o500], ofItemAtPath: sealedDir.path)
+        check(
+            "a file under a read-only parent is not removable",
+            !AppLeftovers.isRemovable(sealedChild))
+        try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sealedDir.path)
+
+        check(
+            "a locked row is what the item carries, not something the view decides",
+            LeftoverItem(url: ordinary, kind: .support, size: nil, isRemovable: false).isRemovable
+                == false)
+
+        // MARK: Display
+
+        check(
+            "a support path renders tilde-abbreviated",
+            LeftoverItem(
+                url: URL(fileURLWithPath: fm.homeDirectoryForCurrentUser.path)
+                    .appendingPathComponent("Library/Caches/com.acme.studio"),
+                kind: .support, size: nil
+            ).displayPath == "~/Library/Caches/com.acme.studio")
+        check(
+            "a path outside home keeps its absolute form",
+            LeftoverItem(
+                url: URL(fileURLWithPath: "/Applications/Acme Studio.app"), kind: .bundle, size: nil
+            ).displayPath == "/Applications/Acme Studio.app")
+
+        // MARK: Removal
+        //
+        // The permanent path is exercised for real against fixtures. The trash path is too — on a file
+        // whose name carries this run's UUID, and the trashed copy is hunted down and deleted
+        // afterwards, so a test run never leaves litter in the developer's Trash.
+
+        let doomedFile = makeFile("Library/Caches/com.acme.studio/doomed.bin")
+        let doomedTree = makeDir("Library/Application Support/Acme Studio/nested/deeper")
+        _ = makeFile("Library/Application Support/Acme Studio/nested/deeper/leaf.bin")
+        let doomedTreeRoot = home.appendingPathComponent("Library/Application Support/Acme Studio")
+
+        check(
+            "permanent removal reports no failures",
+            AppLeftovers.remove([doomedFile], permanently: true).isEmpty)
+        check("permanent removal erases the file", !fm.fileExists(atPath: doomedFile.path))
+        check(
+            "permanent removal takes a whole tree",
+            AppLeftovers.remove([doomedTreeRoot], permanently: true).isEmpty
+                && !fm.fileExists(atPath: doomedTree.path)
+                && !fm.fileExists(atPath: doomedTreeRoot.path))
+
+        let missing = home.appendingPathComponent("Library/Caches/never-existed")
+        check(
+            "a missing path is reported as a failure",
+            AppLeftovers.remove([missing], permanently: true) == [missing.path])
+
+        // One failure must not strand the rest: a root-owned bundle shouldn't leave its support files behind.
+        let survivor = makeFile("Library/Caches/com.acme.studio/after-failure.bin")
+        let mixed = AppLeftovers.remove([missing, survivor], permanently: true)
+        check("removal continues past a failure", mixed == [missing.path])
+        check("the item after a failure is gone", !fm.fileExists(atPath: survivor.path))
+
+        let trashName = "tinycast-trash-probe-\(UUID().uuidString).bin"
+        let trashed = makeFile("Library/Caches/com.acme.studio/" + trashName)
+        check(
+            "trashing reports no failures",
+            AppLeftovers.remove([trashed], permanently: false).isEmpty
+        )
+        check("trashing removes the original", !fm.fileExists(atPath: trashed.path))
+
+        // The one assertion that actually distinguishes trashing from unlinking — the original is gone
+        // either way. Reading ~/.Trash needs Full Disk Access, which a plain shell doesn't have, so
+        // this reports as skipped rather than failing on a permission the harness can't grant itself.
+        let trashDir = fm.homeDirectoryForCurrentUser.appendingPathComponent(".Trash")
+        if let entries = try? fm.contentsOfDirectory(atPath: trashDir.path) {
+            let landed = entries.first { $0 == trashName || $0.hasPrefix(trashName) }
+            check("trashing puts the item in the Trash, not the void", landed != nil)
+            // Leave no litter behind: the trashed fixture is deleted for real.
+            if let landed { try? fm.removeItem(at: trashDir.appendingPathComponent(landed)) }
+        } else {
+            print(
+                "SKIP  trashing puts the item in the Trash — ~/.Trash unreadable (Full Disk Access)"
+            )
+            // Best-effort tidy at the path macOS uses, in case the read was the only thing blocked.
+            try? fm.removeItem(at: trashDir.appendingPathComponent(trashName))
+        }
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -87,6 +87,8 @@ swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift
 swiftc Tinycast/Core/Emoji/EmojiCatalog.swift Tinycast/Core/Emoji/EmojiGridGeometry.swift \
     Tinycast/Core/Emoji/EmojiData.generated.swift Tools/emoji-test.swift \
     -o /tmp/emoji-test && /tmp/emoji-test                         # emoji catalog + geometry
+swiftc -swift-version 6 Tinycast/Core/AppLeftovers.swift Tools/leftovers-test.swift \
+    -o /tmp/leftovers-test && /tmp/leftovers-test                   # uninstall leftover discovery
 swiftc -swift-version 6 Tinycast/Core/CustomCommand.swift \
     Tinycast/Core/ShellCommandRunner.swift Tools/custom-command-test.swift \
     -o /tmp/custom-command-test && /tmp/custom-command-test        # custom command store + runner
@@ -109,6 +111,14 @@ similarly keeps `SystemCommand.swift` independent from AppKit and all command si
 The clipboard harness likewise compiles the real `ClipboardStore.swift`, so that file must keep to
 Foundation + SQLite3 and depend on no other app source. Each case drives a store rooted in a
 throwaway temp directory (`ClipboardStore(directory:)`), so a run can never reach a real history.
+
+The leftovers harness compiles the real `AppLeftovers.swift` and points it at a throwaway home
+directory, so a run can never see — let alone return — a path in the developer's own Library. It covers
+discovery, the guards (refused bundle ids, short names, the surviving-sibling case, and that no result
+is ever a `~/Library` root itself), sizing, and **removal** — the permanent path erases fixtures for
+real, one failure doesn't strand the items after it, and the trash path is exercised on a
+UUID-named fixture that the harness then deletes from the Trash. The one assertion that needs Full Disk Access — reading
+`~/.Trash` to confirm the item landed there — reports `SKIP` rather than `FAIL` when the shell lacks it.
 
 The custom-command harness spawns **real `/bin/zsh`** processes. Its shell-environment cases point
 `ZDOTDIR` at a throwaway fixture directory (and unset `TERM_PROGRAM`), so a run can never read or write

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -127,6 +127,13 @@ Application and System Settings results expose **Show in Finder** in their ⌘K 
 shortcut is available for them. `AppEntry.canRevealInFinder` is the one rule both the menu row and
 the key handler read, so the advertised chord can't drift from the behavior.
 
+## Uninstalling apps
+
+An `.application` result's ⌘K menu ends with **Uninstall Application…**, also bound to **⌃⌫** on the
+selected row. `AppLeftovers.canUninstall` is the one rule the menu row and the chord both read, so the
+advertised chord can't drift from the menu. It opens the uninstall sub-screen; nothing is removed until
+that list is submitted. Full detail in [uninstall.md](uninstall.md).
+
 ## Quitting apps
 
 `RunningAppsMonitor` (live from `NSWorkspace` launch/terminate notifications) drives both the row's

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -12,9 +12,12 @@ UUID) so the SwiftUI search field re-focuses. `RootPaletteView` switches its con
 - `.launcher` → `LauncherList`
 - `.clipboard` → `ClipboardList` + preview
 - `.calculatorHistory` → `CalculatorHistoryList`
+- `.uninstall` → `UninstallList`
 
 Clipboard and Calculator History are sub-screens reached from the launcher (Tab, a command, or a
-hotkey) and back out to it.
+hotkey) and back out to it. Uninstall is reached from an app's ⌘K menu; its field filters the file list
+rather than searching, and it carries a third popover menu (the sort control's, the only one anchored to
+a top corner). See [uninstall.md](uninstall.md).
 
 The flat `selection` index is the single source of truth for highlight / activation and **must always
 match the visible row order**, including the inline calculator card at index 0 when present (see
@@ -41,6 +44,14 @@ is the CoreGraphics cursor position flipped about the primary display's height, 
 in the half-open interval `(minY, maxY]`: the topmost row is exactly `maxY`, which `contains` excludes,
 while that same value is the `minY` of the display stacked above. `contains` would therefore hand a
 pointer parked at the top of one display to its neighbour. `NSMouseInRect` exists for precisely this.
+
+## Menus
+
+Three popover menus exist — the app menu (bottom-leading), ⌘K Actions (bottom-trailing) and the uninstall
+screen's sort control (top-trailing). `RootPaletteView` tracks *which one* is open in a single
+`PaletteMenu?`, not a flag each: they are mutually exclusive, and one field makes that true by
+construction instead of a rule every call site has to re-enforce. `openActions()` additionally refuses to
+open when the current screen has no actions.
 
 ## Menu-open input freeze
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -61,7 +61,7 @@ section's closing padding). See "Section headers" below.
 
 ### Radius (`Theme.Radius`)
 
-`panel 26` · `row 10` · `card 10` · `modal 20` · `menuPanel 16` · `menu 6` · `menuRow 10` · `thumbnail 6` · `keyCap 6` · `recorderKeyCap 4`
+`panel 26` · `row 10` · `card 10` · `modal 20` · `menuPanel 16` · `menu 6` · `menuRow 10` · `thumbnail 6` · `keyCap 6` · `recorderKeyCap 4` · `checkbox 4`
 
 `modal` sits between `menuPanel` and `panel` so a dialog reads as a smaller sibling of the palette, not a second palette.
 
@@ -72,9 +72,13 @@ Always `RoundedRectangle(cornerRadius:, style: .continuous)` — continuous corn
 ### Size (`Theme.Size`)
 
 `panelWidth 750` · `panelHeight 475` · `headerHeight 44` · `bottomBarHeight 52` · `rowIcon 24` ·
-`keyCap 18` · `recorderKeyCap 16` · `menuButton 36` · `clipboardListWidth 290` · `menuWidth 276` · `menuIcon 16` ·
+`checkbox 16` · `headerControl 28` · `keyCap 18` · `recorderKeyCap 16` · `menuButton 36` · `clipboardListWidth 290` · `menuWidth 276` · `menuIcon 16` ·
 `settingsSidebar 184` · `settingsRowIcon 20` · `modalWidth 420` · `modalIcon 26` · `hudWidth 200` ·
 `hudHeight 92` · `volumeTrackHeight 6` · `volumeKnob 16`
+
+`checkbox` (size and radius) is the uninstall list's check box — deliberately tighter than `row` so it
+reads as a checkbox, not a tile. `headerControl` is the height of a control sharing the header row with
+the search field (the uninstall sort button), matched to the footer's `BarButton`.
 
 `keyCap` sizes the palette's keycap chips; `recorderKeyCap` (both size and radius) is the intentionally-smaller Settings shortcut-recorder chip.
 
@@ -139,6 +143,20 @@ All lists share one row grammar so launcher and clipboard look identical:
 - **Scroll moves only on keyboard nav/reset**, driven by a `ScrollIntent` (`Core/ScrollIntent.swift`) — mouse selection targets a visible row and never yanks scroll. `.follow` is a minimal scroll-to-visible (nil anchor), so the list stays stationary while the selection walks across it and only advances by a row at the viewport edges; `.top` scrolls to the origin anchor that `scrollOriginAnchor()` installs — a zero-height overlay applied to the scrolled content *after* its padding, so it marks offset 0 without joining the layout and the restored origin is exact (targeting the first row instead leaves the top padding hidden under the header). A `.follow` that lands on flat index 0 restores the origin instead, so that row's section header comes back into view. One intent state serves all four modes — they never coexist.
 - **Keycaps** use `KeyCapChip`: `.outline` (white-0.20 border) for hotkey hints on rows, `.filled` (white-0.10 fill) for footer shortcuts.
 
+### The uninstall row
+
+The one list with a different row grammar, because it is a checkbox list rather than a result list
+(see [uninstall.md](uninstall.md)): checkbox, file name, its directory in `textTertiary`, size, then the
+file's own icon on the **trailing** edge. It keeps the shared insets (`horizontal md` / `vertical sm`),
+the shared `row 10` corner and the copy-identical `fill` precedence, so it still reads as one of the
+palette's lists. It carries no *category* headers — the header's sort control owns the order — and its
+checked-count line is rendered through the shared `SectionHeader` as the list's first row, so it lands
+exactly where every other list's first header lands. A locked row — a path this app can't remove, e.g. a root-owned
+bundle — swaps its file icon for a padlock, dims to `textTertiary` and draws an outline-only checkbox. The checkbox is
+drawn from `Theme` tokens rather than `checkmark.square`: an SF checkbox glyph reads as a near-invisible
+hairline on this surface, so checked is a filled box with a punched-out mark, unchecked a `border`
+hairline.
+
 ### Section headers
 
 All four palette lists (App Launcher, Clipboard, Emoji, Calculator History) render category labels
@@ -160,7 +178,7 @@ leading gap. Headers are non-selectable display rows, so selection (keyed by id)
 Glass is **only** for floating controls, never the main surface.
 
 - `View.frosted(in:)` = `glassEffect(.regular.interactive().tint(glassFrost), in:)` + `.tint(.clear)` — interactive lensing with a whitish frost tint (`glassFrost`) so the glass reads brighter than clear. Used on the action-group capsule and the menu circle; tune the frost amount via the `glassFrost` token, not per call site.
-- **Menus are in-window overlays, not system popovers.** `.contextMenu`/`NSMenu` stall clicks for seconds inside a `LazyVStack` and spill outside the panel. Use `PopoverMenu` anchored to a bottom corner via `.overlay`, inset `menuInset` (8pt) so its own corner isn't clipped by the panel's.
+- **Menus are in-window overlays, not system popovers.** `.contextMenu`/`NSMenu` stall clicks for seconds inside a `LazyVStack` and spill outside the panel. Use `PopoverMenu` anchored to a panel corner via `.overlay`, inset `menuInset` (8pt) so its own corner isn't clipped by the panel's. Three exist: the app menu (bottom-leading), ⌘K Actions (bottom-trailing), and the uninstall screen's sort menu — the one anchored **top**-trailing, under the control that opens it, so it also carries `headerHeight + headerPadding` of top padding to hang below the header rather than over it. They are mutually exclusive, enforced in the `toggle…`/`open…` helpers rather than in `onChange`, and `openActions()` refuses to open when the screen has no actions (an empty panel would swallow the keyboard invisibly).
 - **`PopoverMenu`** uses `glassEffect(.regular, in: RoundedRectangle(menuPanel 16))` with **no hand-tuned shadow** — Tahoe glass carries its own elevation; adding a drop shadow reads heavy and non-native.
 - `PopoverMenuRow`: leading glyph, label, trailing shortcut glyph, `menuHover` fill on hover, `menuRow 10` corner. Menus animate in with `.opacity + .scale(0.96)` from the anchored corner, `easeOut 0.14`.
 - The glyph is a `PopoverMenuIcon`: `.symbol` (SF Symbol, `hierarchical`, secondary — or **red** when `isDestructive`) or `.file` (a real app icon via `IconCache`, used by the paste rows to show the paste target). `PopoverMenuItem` keeps a `systemImage:` convenience init, so symbol rows read exactly as before.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,158 @@
+# Uninstalling apps
+
+An application result's ⌘K Actions menu ends with **Uninstall Application…** (also **⌃⌫** on the
+selected row). It opens the palette's uninstall screen: the app bundle plus every support file found
+for it, each row a checkbox, everything checked.
+
+The screen has three phases (`UninstallPhase`), and the palette stays open across all of them — a
+destructive action that ends by silently closing the window leaves the user nothing to check:
+
+1. **Selecting** — the filterable, sortable list of checkboxes.
+2. **Removing** — a progress line naming the app and which removal is running.
+3. **Done** — a summary: how many items went, how much was reclaimed, whether it's recoverable from the
+   Trash, and any paths that couldn't be removed (with the two reasons: needs an administrator, or still
+   in use). `↵` / the footer's **Back to Search** ends the session and returns to a fresh root search —
+   it never closes the palette. Finishing an uninstall isn't the same as being done with Tinycast, so
+   closing stays the user's call (`⎋` from the launcher, as everywhere else).
+
+Two removal paths, pairing the way Finder's do:
+
+- **Move to Trash** (`↵`, the footer default) — recoverable, so it needs no second confirmation: the
+  list *is* the confirmation.
+- **Permanently Delete…** (`⇧⌘⌫`, Finder's own chord) — unlinks outright, and is the one action in the
+  flow that puts up a confirmation alert first, since nothing can walk it back. ↵ in that alert goes to
+  **Cancel**, so a reflexive second Return can't erase anything; cancelling returns to the same screen
+  with the checkboxes intact.
+
+## The screen
+
+`PaletteMode.uninstall` is a sub-screen like Clipboard and Emoji, so it reuses the palette's flat
+selection, footer and ⌘K menu. The header field **filters** the list (`UninstallSession.filtered`, a
+case-insensitive substring over file name and path), and a sort control beside it orders the rows by
+path, size or name. The footer is the standard one — app-menu circle on the left, primary action plus
+Actions on the right — because a screen that swaps out shared chrome reads as a different app.
+
+The checked count and total render through the shared **`SectionHeader`**, as this list's first row inside
+the scroll view. Not a fixed strip above it: the header component *is* the alignment, so the line sits
+exactly where "Favorites" or "Applications" sits in every other list and nothing shifts between screens.
+
+`filtered(_:)` — not `items` — is what the selection, the ⌘K menu and every activation address. Any new
+code path that resolves "the highlighted row" has to go through the same filtered list, or it will act on
+a different row the moment a filter is typed.
+
+Because the field types, **a literal space can't be entered there**: bare space is intercepted as the row
+toggle before the field editor sees it (`PalettePanel.onBareSpace`). Substring matching makes that a
+non-issue in practice.
+
+| Key | Action |
+| --- | --- |
+| `␣` | Check / uncheck the highlighted row (a click does the same) |
+| `↵` | Move every checked path to the Trash |
+| `⇧⌘⌫` | Permanently delete them instead (confirms first) |
+| `⌘↵` | Show the highlighted path in Finder |
+| `⎋` / `⌫` | Back out to the root search — abandons a list, dismisses a summary; ignored while a removal is in flight |
+
+Backing out puts the launcher back **exactly as it was**: `beginUninstall` records the list's live scroll
+offset (`PaletteViewModel.launcherScrollOffset`, mirrored from `LauncherList` and deliberately not
+`@Published` — it changes on every scroll tick), and both exits set `pendingSelectionID` so the row is
+re-selected.
+
+Restoring by *row* isn't equivalent: `ScrollViewProxy` can only scroll to a row, and its minimal scroll
+lands that row against a viewport edge rather than where the user was looking. `LauncherList` therefore
+takes a `restoreOffset` and applies it through `ScrollPosition` **when it mounts**, reporting back so the
+value is dropped and never re-applied — the list owns that timing, so no caller has to wait a turn for it,
+and the shared `ScrollIntent` stays free of a case only one list could use. After a successful uninstall
+the row is gone, so only the position is restored, one row shorter.
+
+The screen **survives a dismissal**. Clicking away or switching apps hides the palette as usual, but
+`schedulePopToRoot` exempts a live session (the scan and the checkboxes are real work), and
+`showPalette` restores the screen on the next generic summon — the palette hotkey, "Open Tinycast" in
+the menu bar, or a Dock reopen. Asking for another screen *by name* (the clipboard or emoji hotkey, a
+palette command) ends the session instead, since that is an explicit request for something else. `⎋`,
+`⌫` and the back chevron are the deliberate exits, and a completed removal clears it. That also makes
+**Show in Finder** usable mid-flow: inspect a path, summon again, carry on with the same list.
+
+Space and bare backspace are intercepted in `PalettePanel.sendEvent` (`onBareSpace`, `onBareBackspace`)
+— the field editor consumes both before SwiftUI's `onKeyPress` could see them.
+Row order is exactly what the sort control produced, so the flat selection index maps 1:1 onto the visible
+rows; the count header is a non-selectable display row, like every other `SectionHeader`.
+
+## Discovery
+
+`AppLeftovers` (`Core/AppLeftovers.swift`) is Foundation-only and pure — home directory and the
+sibling-install flag are injected — so `Tools/leftovers-test.swift` compiles it standalone and drives
+it against a throwaway home. The policy is deliberately narrow, and the guards are the point:
+
+- Only the `~/Library` subtrees in `allowedRoots` are searched (Application Support, Caches, Logs,
+  Preferences (+ ByHost), Saved Application State, Containers, Group Containers, Application Scripts,
+  WebKit, HTTPStorages, Cookies, SyncedPreferences, Autosave Information, LaunchAgents).
+- Matches are keyed on the **bundle id** (exact, plus dotted-boundary prefixes for helper/extension
+  ids such as `com.acme.app.helper`, and the team-id prefix on group containers) or on the **app
+  name** and its no-space / hyphen / underscore variants.
+- Every result is re-checked by `isSafeResult`: it must be a *proper* descendant of an allowed root,
+  never a root itself, never home, never reachable via `..`.
+- A bundle id that isn't plain reverse-DNS is refused outright rather than sanitized, and a name
+  shorter than three characters matches nothing — a short folder name is likelier another app's data.
+- When another registered install shares the bundle id (`Xcode.app` beside `Xcode-beta.app`), *every*
+  keyed path is ambiguous, so `siblingBundleExists` drops all of them and only the bundle is offered.
+- `canUninstall` refuses anything under `/System` or `/usr`, any `com.apple.*` bundle id (by id as well
+  as by path, so the cryptex-delivered apps and a relocated copy are both covered) and every Tinycast
+  channel. **The action isn't offered for those at all** — no ⌘K row, no ⌃⌫. Raycast does show a system
+  app's files as locked rows, but a screen on which nothing can be removed only invites the user to try.
+
+Sizes come from `AppLeftovers.size`, an allocated-size tree walk, and the scan is **two-stage** for that
+reason. Discovery is a handful of `stat`s and lands at once; sizes are measured afterwards, one path at a
+time, and each row fills in as its measurement returns. A size is a full tree walk — cold, a 3.5 GB bundle
+measured 32s on the author's machine against 116ms warm — so making the list wait on it would read as a
+hang. Rows are therefore usable (checkable, sortable, removable) before any size exists, which is also
+why `UninstallRow` renders no size column until one lands.
+
+A **symlink is never sized through**: `size` returns nil for one. A cask's `/Applications` alias points at
+the bundle that already has its own row, so following it would count the same gigabytes twice.
+
+### Locked rows
+
+Eligibility decides whether the screen opens at all; removability then decides, row by row, what may
+actually go. Both matter, because an app Tinycast will happily uninstall can still own a file it can't
+touch:
+
+- `AppLeftovers.isRemovable` asks the filesystem: the parent must permit deletion (which is what protects
+  `/System` and anything root owns) and the path must carry no immutable or SIP-restricted flag.
+- `AppLeftovers.isProtectedVendor` is what keeps Apple's apps out of the flow entirely (read by
+  `canUninstall`), so locks are left to handle the third-party cases: a root-owned bundle, an immutable
+  file, a path whose parent the user can't write.
+- A locked row renders with a padlock instead of its file icon, dimmed, with an outline-only checkbox. It
+  never enters `checked` (`begin` seeds only removable rows) and `toggle` refuses it, so the checkbox
+  can't be forced. The header counts checked rows against **removable** rows, not against every row.
+
+This replaces the old design, which checked everything and reported the failures afterwards — telling the
+user up front what can't go is cheaper than letting them submit and reading an error.
+
+Support-file **deletion is user-level only**. System paths (`/Library/LaunchDaemons`, privileged
+helpers, system extensions) are never discovered and never removed — removing those needs an
+administrator, and leaving them behind is the fail-safe direction.
+
+## Removal
+
+`UninstallSession.remove(_:permanently:)` takes the set the caller approved (so what a confirmation
+counted is what gets removed) and quits the app first **only when its bundle is among those items** —
+unchecking the bundle to clear caches alone never force-quits an app you're still using. The quit is a
+graceful `terminate()` plus a bounded 3s wait: removing a bundle out from under a running process leaves
+a zombie, and the removal can fail outright while the app holds its own files open. It then hands the list to `AppLeftovers.remove(_:permanently:)` off-main
+(`trashItem`, or `removeItem` on the permanent path) and returns whatever failed. That loop lives in
+the Foundation-only core rather than here so the harness can drive it; one item failing never stops the
+rest, since a root-owned bundle shouldn't leave the support files it came with behind.
+
+A bundle that is only a symlink into `/Applications` (a Homebrew cask points at its Caskroom payload)
+is resolved, so the real bundle goes to the Trash and the dangling link goes with it.
+
+`AppCore.confirmUninstall(permanently:)` leaves the palette up (the phase change is the feedback), then
+drops the app's own Tinycast state — favorite, hidden flag, learned ranking, bound hotkey — and
+re-indexes. Failures are reported on the summary screen, not in an alert, and are never retried with
+more force. The one modal in the flow is the permanent-delete confirmation, and only for that does the
+palette step aside — it is a float panel and would otherwise sit above the alert — returning either way.
+
+`AppCore.exitUninstall()` is the single phase-aware exit shared by `⎋`, the back chevron and the bare-`⌫`
+hook: abandoning a list is free, a removal in flight can't be called back (so it does nothing — hiding
+would drop the one screen that reports the result), and a finished one returns to the root search via
+`finishUninstall()`. Neither path closes the palette.


### PR DESCRIPTION
## Related issue

Closes #50

## What changed

An application result's ⌘K Actions menu ends with **Uninstall Application…** (also **⌃⌫** on the row). It opens a new palette sub-screen listing the app bundle plus the support files it left behind — each row a checkbox with its size, everything checked, filterable by the header field and sortable by path / size / name.

Two removal paths, pairing the way Finder's do:

- **Uninstall Application** (`↵`, the footer default) moves the checked paths to the **Trash**, so it needs no second confirmation: the list *is* the confirmation.
- **Permanently Delete…** (`⇧⌘⌫`, Finder's own chord) unlinks instead, and is the one action that puts up an alert first, with `↵` on **Cancel** so a reflexive second Return can't erase anything.

The palette stays open across the whole flow (`UninstallPhase`): the list, a progress screen naming what is being removed, then a summary — how many items went, how much was reclaimed, whether it's recoverable from the Trash, and any paths that couldn't be removed with the two reasons why. Finishing returns to the root search rather than closing the palette. A dismissal mid-flow keeps the session (pop-to-root exempts it, and the generic summon restores it), so a click-away never discards a scan or a set of checkboxes.

**Non-obvious bits in the diff:**

- `AppLeftovers` (`Core/AppLeftovers.swift`) is Foundation-only and pure — home directory and the sibling-install flag are injected — so `Tools/leftovers-test.swift` compiles it standalone and drives it against a throwaway home. The LaunchServices lookup and the trashing live in `UninstallSession` for exactly that reason.
- Discovery is deliberately narrow: only the `~/Library` roots in `allowedRoots`, keyed on an exact bundle id (plus dotted-boundary prefixes for helper/extension ids, and the team-id prefix on group containers) or on the app name and its no-space / hyphen / underscore variants. Every result is re-verified to be a *proper* descendant of a root — never a root itself, never `$HOME`, never reachable via `..`.
- A bundle id that isn't plain reverse-DNS is refused rather than sanitized, and a name under three characters matches nothing.
- When another registered install shares the bundle id (`Xcode.app` beside `Xcode-beta.app`), *every* keyed path is ambiguous, so all of them are dropped and only the bundle is offered.
- `canUninstall` refuses `/System`, `/usr`, every `com.apple.*` id (which also covers the cryptex-delivered apps) and every Tinycast channel. It is the one rule both the menu row and the ⌃⌫ chord read, so the advertised chord can't drift from the menu.
- **Nothing system-level is discovered or removed** — no `/Library/LaunchDaemons`, privileged helpers or system extensions. Those need an administrator, and leaving them is the fail-safe direction.
- The scan is **two-stage**: discovery lands at once, then sizes fill in per row. A size is a full tree walk — cold, a 3.5 GB bundle measured **32 s** here against 116 ms warm — so making the list wait on it read as a hang.
- Symlinks are never sized through or resolved for measurement: a cask's `/Applications` alias points at the bundle that already has its own row. The alias gets its own row so it doesn't dangle, and removal targets the resolved bundle.
- Removal quits the app first (graceful, bounded 3 s wait) **only when the bundle itself is checked** — unchecking it to clear caches alone shouldn't force-quit an app you're using.
- `filtered(_:)`, not `items`, is what the selection and every activation address. New code resolving "the highlighted row" must go through the filtered list.
- Two new `Theme` tokens (`Size.checkbox` 16, `Radius.checkbox` 4) — justified in `docs/ui.md` along with why the checkbox is drawn from tokens instead of `checkmark.square` (an SF checkbox glyph reads as a near-invisible hairline on this surface).
- The sort control adds a third popover menu, and the only one anchored to a **top** corner. Mutual exclusion between the three now lives in the `toggle…`/`open…` helpers rather than three `onChange` handlers, and `openActions()` refuses to open when a screen has no actions (an empty panel would swallow the keyboard invisibly).

## Demo

<!-- VIDEO GOES HERE: drag uninstall.mp4 into this box -->

Caveat on the clip: it shows the **after** state only. CONTRIBUTING asks for side-by-side before/after, same window size, same actions — that's still owed.


https://github.com/user-attachments/assets/9e4cd9cf-fdba-4a1b-8a92-990394298176

## Drawbacks

- **A literal space can't be typed into the filter field.** Bare space is intercepted as the row toggle before the field editor sees it. Substring matching makes it a non-issue in practice, but it is a real asymmetry with the other screens.
- **User-level only.** System paths and privileged helpers are never touched, so a few apps will leave a `/Library` remnant behind. Deliberate: removing those needs an administrator.
- **Homebrew casks aren't special-cased.** Trashing a cask's payload leaves brew's metadata thinking it's installed. The alias is handled, the `brew uninstall` handoff isn't.
- **Sizes appear progressively**, so the status-line total climbs for a moment on a cold cache instead of being right immediately.
- **Permanent delete has no undo** — hence the alert, the `↵`-on-Cancel default, and the Trash being the default path.
- Row order comes from the sort control rather than sections, which makes the uninstall list the one palette list without section headers.

## Tests & validation

New harness `Tools/leftovers-test.swift` (55 checks) compiles the real `AppLeftovers.swift` and drives it against a throwaway home, so a run can never see — let alone return — a path in the developer's own Library. It covers eligibility, bundle-id and name-keyed discovery, the non-matches, every guard (refused bundle ids, short names, the surviving-sibling case, no result ever being a `~/Library` root), sizing, the symlink rules, and removal — the permanent path erases fixtures for real, one failure doesn't strand the items after it, and the trash path runs on a UUID-named fixture the harness then deletes. The one assertion needing Full Disk Access reports `SKIP`, not `FAIL`.

```sh
swiftc -swift-version 6 Tinycast/Core/AppLeftovers.swift Tools/leftovers-test.swift \
    -o /tmp/leftovers-test && /tmp/leftovers-test
```

Every existing harness still passes: fuzz, ranking, calc (426), clipboard (23/23), scopes, emoji (2054 records), custom-command.

By hand: discovery probed read-only against all of `/Applications` on this machine — for Affinity it returns exactly the set in the issue's reference screenshot plus two QuickLook containers, and apps that were never launched correctly return nothing. A disposable fixture app (fake bundle id, 4 MB payload, five real support paths) was used for the end-to-end run so no real app was at risk. Build is clean and warning-free; `xcodegen generate` re-run and the project committed.

Docs: new `docs/uninstall.md`, plus `ui.md` (new tokens, the row grammar, the third menu anchor), `launcher.md`, `palette.md`, `development.md`, `AGENTS.md` (a new Critical Invariant for the removal rules) and the README feature list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app uninstall workflow from the launcher, including selectable leftover files and folders.
  * Added sorting, size estimates, progress feedback, removal summaries, and Finder reveal actions.
  * Supports sending selected items to the Trash or permanently deleting them with confirmation.
  * Added safety checks to restrict removal to eligible user-level paths.

* **Documentation**
  * Added comprehensive uninstall guidance and updated feature, launcher, palette, UI, and development documentation.

* **Tests**
  * Added coverage for leftover discovery, safety rules, sizing, and removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->