### PR TITLE
Fix Raycast file picker hang and add export-path hint in onboarding

### DIFF
--- a/Tinycast/Core/Backup/BackupActions.swift
+++ b/Tinycast/Core/Backup/BackupActions.swift
@@ -84,12 +84,19 @@ enum BackupActions {
     }
 
     /// Shared `.rayconfig` file picker used by the Backup pane and onboarding.
-    static func pickRaycastFile() -> URL? {
+    /// Runs as a sheet on the current key window; in an LSUIElement app `runModal()` can
+    /// open an orphaned, invisible modal that blocks the UI.
+    static func pickRaycastFile() async -> URL? {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return nil }
         NSApp.activate(ignoringOtherApps: true)
-        return panel.runModal() == .OK ? panel.url : nil
+        return await withCheckedContinuation(isolation: #isolation) { continuation in
+            panel.beginSheetModal(for: window) { response in
+                continuation.resume(returning: response == .OK ? panel.url : nil)
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -194,7 +194,7 @@ struct OnboardingView: View {
             if let status = model.status {
                 importStatus(status)
             } else {
-                caption("Optional — you can import later in Settings › Backup.")
+                caption("Optional — you can import later in Settings › Backup. In Raycast, export from Settings › Advanced › Import / Export.")
             }
         }
     }
@@ -369,9 +369,11 @@ final class OnboardingModel: ObservableObject {
     }
 
     func chooseFile() {
-        guard let url = BackupActions.pickRaycastFile() else { return }
-        file = url
-        status = nil
+        Task {
+            guard let url = await BackupActions.pickRaycastFile() else { return }
+            file = url
+            status = nil
+        }
     }
 
     func run() {

--- a/Tinycast/Features/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Settings/BackupSettingsView.swift
@@ -137,9 +137,11 @@ struct BackupSettingsView: View {
     }
 
     private func chooseRaycastFile() {
-        guard let url = BackupActions.pickRaycastFile() else { return }
-        raycastFile = url
-        status = nil
+        Task {
+            guard let url = await BackupActions.pickRaycastFile() else { return }
+            raycastFile = url
+            status = nil
+        }
     }
 
     private func runRaycastImport() {


### PR DESCRIPTION
Two small Raycast onboarding/backup fixes:

- `BackupActions.pickRaycastFile()` now uses `beginSheetModal(for:)` with `withCheckedContinuation(isolation:)` instead of `NSOpenPanel.runModal()`. In an `LSUIElement` app `runModal()` could open an orphaned, invisible modal that blocked the UI.
- Updated the `OnboardingView` and `BackupSettingsView` call sites to `await` the new async file picker.
- Added the Raycast export path to the onboarding import caption: "In Raycast, export from Settings › Advanced › Import / Export."

## Test plan
- [x] Build passes (`xcrun xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug build CODE_SIGNING_ALLOWED=NO`).
- [x] App launches and the onboarding "Import from Raycast" sheet appears.
- [ ] Manual end-to-end file selection not yet performed.
