### PR TITLE
Fix clipboard image thumbnails stranding on placeholder

### DIFF
--- a/Tinycast/Core/ImageThumbnail.swift
+++ b/Tinycast/Core/ImageThumbnail.swift
@@ -41,13 +41,15 @@ enum ImageThumbnail {
         pick(maxPixel).object(forKey: cacheKey(url, maxPixel))
     }
 
-    /// Decodes off the main thread and reads the result back from the thread-safe cache; the `NSImage` never crosses the actor boundary, keeping it clean under strict concurrency.
+    /// A freshly-decoded, thereafter-immutable `NSImage` is safe to move across the actor boundary.
+    private struct Decoded: @unchecked Sendable { let image: NSImage? }
+
+    /// Decodes off the main thread and returns the decode directly, not a cache re-read — a purge or eviction mid-decode must not strand a thumbnail on its placeholder.
     static func loadAsync(_ url: URL, maxPixel: CGFloat) async -> NSImage? {
         if let cached = cached(url, maxPixel: maxPixel) { return cached }
-        await Task.detached(priority: .userInitiated) {
-            _ = load(url, maxPixel: maxPixel)
-        }.value
-        return cached(url, maxPixel: maxPixel)
+        return await Task.detached(priority: .userInitiated) {
+            Decoded(image: load(url, maxPixel: maxPixel))
+        }.value.image
     }
 
     /// A thumbnail no larger than `maxPixel` on its longest edge, cached per (path, size); decodes synchronously, so call off the main thread for anything user-facing.


### PR DESCRIPTION
## Summary
- `ImageThumbnail.loadAsync` decoded the thumbnail off-main, discarded the result, and re-read it from the `NSCache`. If `purgePreviews()` (fired on every palette hide) or memory-pressure eviction landed between the cache write and that readback, `loadAsync` returned `nil` even though the decode had succeeded.
- `AsyncThumbnail`'s `.task(id: url)` never retries an unchanged URL, so a single stray `nil` left that row/preview stuck on its "photo" placeholder for the rest of the session — only a full app relaunch cleared it, matching the reported symptom.
- Fix: return the decode directly from the detached task (the same pattern `IconCache.loadAsync` already uses, and now documents) instead of re-reading the cache.

Closes #74.

## Test plan
- [x] Standalone `swiftc` harness compiled directly against `ImageThumbnail.swift`: exercised `pixelSize`, `loadAsync` (row + preview sizes), cache hits, a quarantined file, and a truncated PNG — all pass.
- [x] Stranding repro: hammered `purgePreviews()` on spinning threads while `loadAsync` decoded 400 fresh files concurrently — old code stranded 400/400 on the placeholder, fixed code 0/400.
- [x] `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug build` succeeds.
- [x] Reproduced the original bug live: launched the dev build against a fresh `CFFIXED_USER_HOME` (simulating first install), copied an image, confirmed the fix resolves the stuck placeholder.