### PR TITLE
Build release DMGs as universal binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,10 @@ jobs:
 
       # Build the signed .app into an ephemeral DerivedData dir. Channel identity (name, bundle id,
       # version) comes from build-setting overrides so beta/stable ship side-by-side.
+      # ARCHS is passed explicitly: with no -destination, xcodebuild resolves the default one to the
+      # runner's own arch and that narrows ARCHS to it, overriding the config's `arm64 x86_64`. On
+      # this arm64 runner that silently shipped arm64-only DMGs. A command-line value outranks the
+      # destination, so this is what actually pins the universal build.
       - name: Build app
         env:
           VERSION: ${{ steps.meta.outputs.full_version }}
@@ -91,11 +95,27 @@ jobs:
         run: |
           xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Release \
             -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="Tinycast Self-Signed" \
             OTHER_CODE_SIGN_FLAGS="--timestamp=none" \
             PRODUCT_NAME="$DISPLAY_NAME" PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
             MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             build
+
+      # A single-arch slip is invisible until an Intel user reports it, so fail the release here.
+      - name: Verify universal binary
+        env:
+          DISPLAY_NAME: ${{ steps.meta.outputs.display_name }}
+        run: |
+          BIN="$RUNNER_TEMP/DerivedData/Build/Products/Release/${DISPLAY_NAME}.app/Contents/MacOS/${DISPLAY_NAME}"
+          ARCHS_BUILT="$(lipo -archs "$BIN")"
+          echo "Built architectures: $ARCHS_BUILT"
+          for want in arm64 x86_64; do
+            case " $ARCHS_BUILT " in
+              *" $want "*) ;;
+              *) echo "::error::Missing $want slice — got '$ARCHS_BUILT'"; exit 1 ;;
+            esac
+          done
 
       # Pack the .app + an /Applications symlink into a compressed DMG under dist/.
       - name: Package DMG


### PR DESCRIPTION
## Related issue

Closes #116

## What changed

`.github/workflows/release.yml` now passes `ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO` to the release `xcodebuild`, and asserts both slices are present before the DMG is packed.

The non-obvious part is *why* the flag is needed at all, since nothing in `project.yml` restricts the architecture. With no `-destination`, xcodebuild resolves a default one — the host — and **the destination narrows `ARCHS` to the runner's own architecture, overriding the config's `arm64 x86_64`**. On the arm64 `macos-26` runner that silently produced arm64-only DMGs. A command-line build setting outranks the destination, which is why the fix goes on the command line rather than into `project.yml`; a value added there would be narrowed the same way.

The second step is a guard, not part of the fix: a single-arch slip produces a DMG that installs and runs perfectly on the machine that built it, so it stays invisible until an Intel user reports it. `lipo -archs` + an explicit check makes the release fail instead. Easy to drop if you'd rather keep the workflow lean — the one-line `ARCHS` override is the whole fix.

## Memory footprint

N/A — CI-only change, no app source touched. The shipped binary carries a second architecture slice, so the `.app` grows from 3.0 MB to 5.6 MB on disk (DMG ~2 MB → ~3 MB). Runtime memory is unchanged: macOS pages in only the slice it executes.

## Demo

N/A — nothing visual changed.

## Drawbacks

- Release builds take roughly twice as long, since both slices compile.
- Larger download for everyone, to fix launch-at-all for Intel users. The alternative — two per-arch DMGs — means two cask variants and a channel matrix, which seems well out of proportion for 1 MB.
- I can't exercise the arm64 runner path directly. What I verified is the mechanism (below); the CI run itself is yours to confirm on the next release, and the new guard step is what makes that confirmation automatic rather than something you have to remember to check.

## Tests & validation

No `Tools/` harness covers packaging, and no engine code changed, so validation is on the build itself. All on x86_64 / macOS 26.5.2 / Xcode 26.4.1.

**1. Reproduced the mechanism on the opposite host arch.** Ran the workflow's exact `xcodebuild` invocation, unmodified, on an Intel machine:

```
lipo -archs → x86_64
```

Single-arch, mirroring the arm64 runner's output — the release build follows whatever machine it lands on. Adding the override flips it:

```
ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO   →   lipo -archs → x86_64 arm64
```

Incidentally, the unpatched build logs `xcodebuild: WARNING: Using the first of multiple matching destinations` — the destination resolution doing exactly what's described above.

**2. Full release-parity build with the patched flags** — `BUILD SUCCEEDED`, zero compiler warnings:

```
lipo -archs                     x86_64 arm64
codesign -dv                    Format=app bundle with Mach-O universal (x86_64 arm64)
                                Authority=Tinycast Self-Signed
                                Identifier=com.tinycast.app
codesign --verify --deep --strict   OK
```

**3. Exercised the new guard step both ways** by running its shell against both artifacts:

| Input | Result |
| --- | --- |
| universal build | `Built architectures: x86_64 arm64` → pass |
| control single-arch build | `::error::Missing arm64 slice — got 'x86_64'` → exit 1 |

**4. Launched it.** Installed the universal build to `/Applications` and confirmed it launches and stays running natively on x86_64 — the first Tinycast build that runs at all on this machine. To be precise about the limits of that: I verified launch and process health, not a feature-by-feature pass over the palette, clipboard, calculator and emoji picker. Since this PR changes only which architecture slices are compiled, and both slices come from identical sources, I'd expect no behavioural delta — but I'd rather state what I actually checked.

**5. Workflow YAML re-parsed** after the edit: 11 steps, `Verify universal binary` sequenced between `Build app` and `Package DMG`.

## Note on the signing docs

Unrelated to this change, but I hit it during setup and it'll bite anyone with Homebrew's OpenSSL on `PATH`: the `openssl pkcs12 -export` command in [`docs/signing.md`](../blob/main/docs/signing.md) §1 fails under OpenSSL 3.x with `MAC verification failed during PKCS12 import (wrong password?)` — OpenSSL 3 defaults to a SHA-256 MAC that the macOS Security framework won't verify. It works as written under the system LibreSSL. Adding `-keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1` makes it work under both. Left it out of this PR to keep the diff to one concern — say the word and I'll send it separately.