### PR TITLE
Handle palette command shortcuts at the panel level

### DIFF
--- a/Tinycast/Core/PalettePanel.swift
+++ b/Tinycast/Core/PalettePanel.swift
@@ -6,6 +6,8 @@ import SwiftUI
 final class PalettePanel: NSPanel {
     /// Called for a bare backspace before it reaches the field editor (return true to consume); the field editor swallows plain backspace itself, so SwiftUI `onKeyPress` up the hierarchy never sees it.
     var onBareBackspace: (() -> Bool)?
+    /// Called for command-key chords before they reach the field editor; return true to consume the event. The field editor swallows some `⌘` chords (e.g. `⌘,`) before SwiftUI `.onKeyPress` can see them, and `LSUIElement` apps have no main menu to handle standard window equivalents like `⌘W`.
+    var onCommandShortcut: ((NSEvent) -> Bool)?
     /// Arms the hover highlight from `sendEvent` — the one place both event streams pass through, so a keyboard-driven scroll under a still pointer never fires `.mouseMoved` and hover stays disarmed. Also carries the caret-hide hook fired when a footer menu opens.
     weak var paletteViewModel: PaletteViewModel? {
         didSet {
@@ -44,6 +46,13 @@ final class PalettePanel: NSPanel {
             Int(event.keyCode) == kVK_Delete,
             event.modifierFlags.isDisjoint(with: [.command, .option, .control, .shift]),
             onBareBackspace?() == true {
+            return
+        }
+        // The field editor swallows some command chords (e.g. `⌘,`) before SwiftUI `.onKeyPress` can fire, and `LSUIElement` apps have no main menu for standard equivalents like `⌘W`. Let the controller own those so the rest still reach SwiftUI.
+        if event.type == .keyDown,
+            event.modifierFlags.contains(.command),
+            onCommandShortcut?(event) == true
+        {
             return
         }
         super.sendEvent(event)

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 
 @MainActor
@@ -131,6 +132,24 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             }
             vm.prepare(mode: .launcher)
             return true
+        }
+        // The field editor swallows some `⌘` chords (e.g. `⌘,`) before SwiftUI `.onKeyPress` can fire, and `LSUIElement` apps have no main menu for `⌘W` or `⌘Esc`. Handle them at the panel level.
+        panel.onCommandShortcut = { [weak self] event in
+            let commandOnly = event.modifierFlags.intersection([.command, .option, .control, .shift]) == .command
+            guard commandOnly, let self else { return false }
+            switch Int(event.keyCode) {
+            case kVK_ANSI_Comma:
+                self.core.showSettings()
+                return true
+            case kVK_ANSI_W:
+                self.core.hidePalette()
+                return true
+            case kVK_Escape:
+                self.core.palette.prepare(mode: .launcher)
+                return true
+            default:
+                return false
+            }
         }
         self.panel = panel
         return panel

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -135,17 +135,22 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         }
         // The field editor swallows some `⌘` chords (e.g. `⌘,`) before SwiftUI `.onKeyPress` can fire, and `LSUIElement` apps have no main menu for `⌘W` or `⌘Esc`. Handle them at the panel level.
         panel.onCommandShortcut = { [weak self] event in
-            let commandOnly = event.modifierFlags.intersection([.command, .option, .control, .shift]) == .command
-            guard commandOnly, let self else { return false }
-            switch Int(event.keyCode) {
-            case kVK_ANSI_Comma:
+            guard let self, !event.isARepeat,
+                event.modifierFlags.intersection([.command, .option, .control, .shift]) == .command
+            else { return false }
+            // Escape has no character, so it matches by key code.
+            if Int(event.keyCode) == kVK_Escape {
+                self.core.palette.prepare(mode: .launcher)
+                return true
+            }
+            // `⌘,` and `⌘W` are character chords like the rest of the palette's (⌘K, ⌘P): matching their QWERTY key codes would fire the wrong action on Dvorak, where the two are transposed.
+            guard let character = event.charactersIgnoringModifiers?.lowercased() else { return false }
+            switch character {
+            case ",":
                 self.core.showSettings()
                 return true
-            case kVK_ANSI_W:
+            case "w":
                 self.core.hidePalette()
-                return true
-            case kVK_Escape:
-                self.core.palette.prepare(mode: .launcher)
                 return true
             default:
                 return false

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -414,11 +414,6 @@ struct RootPaletteView: View {
             toggleMode()
             return .handled
         }
-        .onKeyPress(keys: [","], phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
-            core.showSettings()
-            return .handled
-        }
         // ⌘K toggles the actions panel for the current selection.
         .onKeyPress(keys: ["k"], phases: .down) { press in
             guard press.modifiers.contains(.command) else { return .ignored }


### PR DESCRIPTION
## Related issue

Closes #115

## What changed

The palette's search field consumes `⌘,` and other character-producing command chords before SwiftUI `.onKeyPress` can see them. Because Tinycast is an `LSUIElement` accessory app, there is also no main menu to provide standard equivalents like `⌘W`.

- `PalettePanel.sendEvent` now calls an `onCommandShortcut` hook for any `.command` `keyDown` before `super.sendEvent`.
- `PaletteWindowController` supplies the hook and handles:
  - `⌘,` → `core.showSettings()`
  - `⌘W` → `core.hidePalette()`
  - `⌘Esc` → `core.palette.prepare(mode: .launcher)` (pop to root)
- The old, ineffective `.onKeyPress(keys: [","])` handler in `RootPaletteView` is removed.

All other command chords (`⌘K`, `⌘P`, `⌘↵`, etc.) still flow through to the existing SwiftUI `onKeyPress` handlers.

## Memory footprint

No expected change. The new hook is a closure reference and a short `switch` on key events; no persistent allocations. Not formally re-measured for this diff.

## Demo

No visual change.

## Drawbacks

`⌘Esc` currently calls `prepare(mode: .launcher)` unconditionally. When already at the root launcher with an empty query this is a no-op reset of `focusToken`/`resetToken`; it is harmless but not strictly Raycast's "do nothing" behavior.

## Tests & validation

- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug build CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO` builds successfully.
- Verified the touched files compile with no Swift warnings introduced by this change.
