### PR TITLE
feat: Match Han-script names by pinyin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,11 @@ Never break these without an explicit task to do so.
   template engine, repository and keyword policies stay Foundation-only, and the AppKit files there
   keep their dependencies to what the harness can stub. `Core/SystemCommand.swift` is also
   Foundation-only for `Tools/system-command-test.swift`; platform effects belong in
-  `SystemCommandRunner`, while confirmation and failure UI remain in `AppCore`.
+  `SystemCommandRunner`, while confirmation and failure UI remain in `AppCore`. `Core/Pinyin.swift` is
+  the same for `Tools/fuzz-test.swift`, which compiles it alongside its `FuzzyMatch` copy.
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
-  scoring in one, mirror it in the other, or the test is meaningless.
+  scoring in one, mirror it in the other, or the test is meaningless. It also compiles the real
+  `Core/Pinyin.swift`, so build it with `swiftc`, not `swift`.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and
   `CurrencyData.generated.swift` by `node Tools/gen-currencies.js`** — never edit either by hand.
   Currency names, signs and uncontested nouns are generated (Frankfurter × CLDR); the only
@@ -130,9 +132,9 @@ Never break these without an explicit task to do so.
 ## Project Layout
 
 - `Tinycast/Core/` — managers, stores, windows, AppKit glue (no view bodies beyond hosting).
-  `Core/Calculator/` and `Core/Emoji/` are Foundation-only engines; `Core/Snippets/` is a
-  standalone-harness input in full; `Core/Theme.swift` is the design-token source;
-  `Core/HotKey/` is the in-house hotkey stack.
+  `Core/Calculator/` and `Core/Emoji/` are Foundation-only engines, as is `Core/Pinyin.swift`;
+  `Core/Snippets/` is a standalone-harness input in full; `Core/Theme.swift` is the design-token
+  source; `Core/HotKey/` is the in-house hotkey stack.
 - `Tinycast/Features/` — SwiftUI views: `RootPaletteView`, `Launcher/`, `Clipboard/`, `Calculator/`,
   `Emoji/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`.
 - `Tinycast/App/` — `@main` app + delegate.

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		34E5FF0B3C9FD2FFE504D87A /* ClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ADC36002F1A5B04D61B4D3 /* ClipboardView.swift */; };
 		36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */ = {isa = PBXBuildFile; fileRef = 6621A88681E993D49EEF07A3 /* tinycast.icon */; };
 		374235D358A127741447551E /* SettingsBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043CD44B4B40C49BE79852A /* SettingsBackup.swift */; };
+		394A31EB763A65CE62A36D23 /* Pinyin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83168382DF1A37D53A425DA1 /* Pinyin.swift */; };
 		3FEBE1C993C5BD92F1C3D95B /* LauncherRankingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */; };
 		42828BD1C5E4E6E7AA1BF103 /* CalculatorHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */; };
 		441CF705AE1D03F6E236A61E /* ClipboardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */; };
@@ -162,6 +163,7 @@
 		7BC2DEA0A052116A92F9A539 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityStore.swift; sourceTree = "<group>"; };
+		83168382DF1A37D53A425DA1 /* Pinyin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pinyin.swift; sourceTree = "<group>"; };
 		849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardSettingsView.swift; sourceTree = "<group>"; };
 		87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		88A65B4EC5AE7E22594BFC5E /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */,
 				6185011A02366B30B48B5B6C /* Paster.swift */,
 				F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */,
+				83168382DF1A37D53A425DA1 /* Pinyin.swift */,
 				93E9ACD504E016DFF6FE6C1B /* RightClick.swift */,
 				4B432D84D8F9C10521342199 /* RunningApps.swift */,
 				8CFD97FB49778B4358FA5189 /* ScrollIntent.swift */,
@@ -607,6 +610,7 @@
 				F2B68DBA258D85DD5C6DC1CC /* Paster.swift in Sources */,
 				32697AB3853D043A12888B96 /* Permissions.swift in Sources */,
 				2085C9433B7534044E0A8A7D /* PermissionsSettingsView.swift in Sources */,
+				394A31EB763A65CE62A36D23 /* Pinyin.swift in Sources */,
 				80F1A591DB0F5385F5C9A06C /* PopoverMenu.swift in Sources */,
 				8EF55652F19A1E0C5FF644B4 /* RaycastImport.swift in Sources */,
 				ABBB2A811EB5C69D55A93B1C /* RaycastImportSelection.swift in Sources */,

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -15,8 +15,24 @@ struct AppEntry: Identifiable, Hashable, Sendable {
     let url: URL
     let bundleID: String?
     let kind: Kind
-    /// Extra strings this entry also matches on in search — a snippet's keyword. Empty for every other kind.
-    var matchAliases: [String] = []
+    /// Extra literal strings this entry also matches on — a snippet's keyword. Scored in the name's own tiers.
+    let literalAliases: [String]
+    /// Latin readings of a Han-script name, scored half a tier below the literal ladder.
+    let romanizedAliases: [String]
+
+    /// Readings are derived here rather than at the call sites, so no entry kind can be added without them.
+    init(
+        id: String, name: String, url: URL, bundleID: String?, kind: Kind,
+        literalAliases: [String] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.url = url
+        self.bundleID = bundleID
+        self.kind = kind
+        self.literalAliases = literalAliases
+        self.romanizedAliases = Pinyin.aliases(for: name)
+    }
 
     /// Stable identity for learned ranking, favorites, and other per-entry preferences.
     var preferenceKey: String { bundleID ?? id }
@@ -225,7 +241,7 @@ final class AppIndex: ObservableObject {
                     url: record.fileURL,
                     bundleID: nil,
                     kind: .snippet,
-                    matchAliases: [record.snippet.keyword].compactMap { $0 })
+                    literalAliases: [record.snippet.keyword].compactMap { $0 })
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         guard entries != snippetEntries else { return }
@@ -319,12 +335,19 @@ final class AppIndex: ObservableObject {
     private func rank(_ q: String, limit: Int) -> [AppEntry] {
         let learned = ranking.boosts(query: q)
         let scored = apps.compactMap { app -> (AppEntry, Int)? in
-            // An entry matches on its name or on any alias it carries (a snippet's keyword), whichever scores best — all inside the same tiers, so an alias can never outrank a better name match.
+            // An entry matches on its name, on a literal alias it carries (a snippet's keyword), or on a reading — whichever scores best.
             var bestScore = FuzzyMatch.score(query: q, candidate: app.name)
-            for candidate in app.matchAliases {
-                guard let aliasScore = FuzzyMatch.score(query: q, candidate: candidate) else { continue }
-                bestScore = max(bestScore ?? aliasScore, aliasScore)
+            func consider(_ candidates: [String], penalty: Int = 0) {
+                for candidate in candidates {
+                    guard let score = FuzzyMatch.score(query: q, candidate: candidate) else {
+                        continue
+                    }
+                    bestScore = max(bestScore ?? score - penalty, score - penalty)
+                }
             }
+            consider(app.literalAliases)
+            // A reading is a weaker claim on the query than the name itself, so it lands below the literal match of the same kind but still above the next kind down: typing "safari" can never lose Safari to something whose pinyin spells it.
+            consider(app.romanizedAliases, penalty: FuzzyMatch.romanizedPenalty)
             guard let score = bestScore else { return nil }
             return (app, score + (learned[app.preferenceKey] ?? 0))
         }
@@ -341,6 +364,9 @@ final class AppIndex: ObservableObject {
 }
 
 enum FuzzyMatch {
+    /// Half the gap between two tiers, subtracted from a transliterated match so it ranks under the literal match of the same kind without falling past the kind below it. It also has to stay above `LauncherRankingStore.maximumBoost`, or learned ranking could lift a reading back over the literal match it sits under.
+    static let romanizedPenalty = 5_000
+
     /// Tiered relevance score (higher is better), or nil when the query doesn't match; tiers are spaced so a better kind always wins.
     static func score(query: String, candidate: String) -> Int? {
         let q = normalized(query)

--- a/Tinycast/Core/Pinyin.swift
+++ b/Tinycast/Core/Pinyin.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Latin search aliases for Han-script names, so a Chinese-named app is reachable from an ASCII keyboard: 微信 answers to "weixin" and to "wx".
+enum Pinyin {
+    /// Full reading first, per-character initials second; nothing at all for a name with no Han character, which is the path that has to stay cheap.
+    static func aliases(for name: String) -> [String] {
+        guard name.unicodeScalars.contains(where: isHan) else { return [] }
+
+        // App metadata carries bidi and zero-width markers, which FuzzyMatch strips for the same reason. Left in, a BOM ends tokenization early and truncates the reading, and any marker inside a token would inflate the character count the syllable cut is measured against.
+        let text = String(
+            String.UnicodeScalarView(
+                name.unicodeScalars.filter { $0.properties.generalCategory != .format }))
+
+        var full = ""
+        var initials = ""
+        for token in tokens(of: text) {
+            // Latin and digits carry through as typed, so "QQ音乐" still answers to "qqyinyue".
+            guard token.raw.unicodeScalars.allSatisfy(isHan) else {
+                let carried = asciiFolded(token.raw)
+                full += carried
+                initials += carried
+                continue
+            }
+            guard let transcription = token.transcription else { continue }
+            let reading = asciiFolded(transcription).filter(\.isLetter)
+            guard !reading.isEmpty else { continue }
+
+            full += reading
+            // A reading that won't cut still searches in full; it just contributes no initial-letter shortcut.
+            guard let parts = syllables(of: reading, count: token.raw.count) else {
+                initials += reading
+                continue
+            }
+            for part in parts where !part.isEmpty { initials.append(part[part.startIndex]) }
+        }
+
+        guard !full.isEmpty else { return [] }
+        // A one-letter alias would match everything it leads, so a single-character name searches by its full reading alone.
+        guard initials.count > 1, initials != full else { return [full] }
+        return [full, initials]
+    }
+
+    private struct Token {
+        let raw: String
+        let transcription: String?
+    }
+
+    /// Readings come from `CFStringTokenizer` rather than `kCFStringTransformMandarinLatin` because it segments words before reading them, which is what resolves a polyphone: 音乐 is "yinyue", not "yinle", and 地图 is "ditu", not "detu".
+    private static func tokens(of name: String) -> [Token] {
+        let text = name as NSString
+        guard
+            let tokenizer = CFStringTokenizerCreate(
+                kCFAllocatorDefault, name as CFString, CFRangeMake(0, text.length),
+                kCFStringTokenizerUnitWord, locale as CFLocale)
+        else { return [] }
+
+        var result: [Token] = []
+        while CFStringTokenizerAdvanceToNextToken(tokenizer) != [] {
+            let range = CFStringTokenizerGetCurrentTokenRange(tokenizer)
+            result.append(
+                Token(
+                    raw: text.substring(
+                        with: NSRange(location: range.location, length: range.length)),
+                    transcription: CFStringTokenizerCopyCurrentTokenAttribute(
+                        tokenizer, kCFStringTokenizerAttributeLatinTranscription) as? String))
+        }
+        return result
+    }
+
+    /// An alias only earns its keep if it can be typed, so tones and accents fold ("yīnyuè" → "yinyue", "café" → "cafe") and anything still not ASCII — emoji, kana, hangul — is dropped rather than embedded in a string no ASCII keyboard can enter.
+    private static func asciiFolded(_ value: String) -> String {
+        value.folding(options: .diacriticInsensitive, locale: nil).lowercased().filter(\.isASCII)
+    }
+
+    /// Cuts a toneless reading into exactly `count` syllables — one per character — or nil when no such cut exists. Pinyin is ambiguous on its own ("xian" is 西安 or 险), so it is the known character count that makes the boundaries decidable.
+    static func syllables(of reading: String, count: Int) -> [String]? {
+        let letters = Array(reading)
+        guard count > 0, letters.count >= count else { return nil }
+
+        // Memoizing the dead ends is what keeps the backtracking linear rather than exponential.
+        var exhausted = Set<Int>()
+        var result: [String] = []
+
+        func cut(from start: Int, into remaining: Int) -> Bool {
+            if remaining == 0 { return start == letters.count }
+            let state = start * (count + 1) + remaining
+            guard !exhausted.contains(state) else { return false }
+            // Longest first: "pingan" is 平安, not 拼干.
+            for length in stride(
+                from: min(longestSyllable, letters.count - start), through: 1, by: -1)
+            {
+                let candidate = String(letters[start..<(start + length)])
+                guard syllableSet.contains(candidate) else { continue }
+                result.append(candidate)
+                if cut(from: start + length, into: remaining - 1) { return true }
+                result.removeLast()
+            }
+            exhausted.insert(state)
+            return false
+        }
+        return cut(from: 0, into: count) ? result : nil
+    }
+
+    /// `isUnifiedIdeograph` covers the unified blocks including the newer extensions; 〇 and the compatibility ideographs sit outside it but the tokenizer still reads them, and 〇 in particular turns 一〇〇 into a wrong reading if it is treated as foreign.
+    private static func isHan(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.properties.isUnifiedIdeograph
+            || scalar.value == 0x3007
+            || (0xF900...0xFAFF).contains(scalar.value)
+            || (0x2_F800...0x2_FA1F).contains(scalar.value)
+    }
+
+    private static let locale = Locale(identifier: "zh_Hans")
+
+    /// Every Mandarin syllable macOS itself transliterates to, read off `kCFStringTransformMandarinLatin` across the CJK ideograph blocks, so a reading it produces can always be cut. The interjection-only readings "m", "n", "ng" and "hm" are left out: they never occur inside a word, and admitting them would cut "xian" as "xia" + "n".
+    private static let syllableSet: Set<String> = Set(
+        """
+        a ai an ang ao ba bai ban bang bao bei ben beng bi bian biao bie bin bing bo bu ca cai can
+        cang cao ce cen ceng cha chai chan chang chao che chen cheng chi chong chou chu chua chuai
+        chuan chuang chui chun chuo ci cong cou cu cuan cui cun cuo da dai dan dang dao de den deng
+        di dia dian diao die ding diu dong dou du duan dui dun duo e ei en eng er fa fan fang fei
+        fen feng fiao fo fou fu ga gai gan gang gao ge gei gen geng gong gou gu gua guai guan guang
+        gui gun guo ha hai han hang hao he hei hen heng hong hou hu hua huai huan huang hui hun
+        huo ji jia jian jiang jiao jie jin jing jiong jiu ju juan jue jun ka kai kan kang kao ke kei
+        ken keng kong kou ku kua kuai kuan kuang kui kun kuo la lai lan lang lao le lei leng li lia
+        lian liang liao lie lin ling liu lo long lou lu luan lue lun luo ma mai man mang mao me
+        mei men meng mi mian miao mie min ming miu mo mou mu na nai nan nang nao ne nei nen neng
+        ni nian niang niao nie nin ning niu nong nou nu nuan nue nun nuo o ou pa pai pan pang pao
+        pei pen peng pi pian piao pie pin ping po pou pu qi qia qian qiang qiao qie qin qing qiong
+        qiu qu quan que qun ran rang rao re ren reng ri rong rou ru rua ruan rui run ruo sa sai san
+        sang sao se sen seng sha shai shan shang shao she shei shen sheng shi shou shu shua shuai
+        shuan shuang shui shun shuo si song sou su suan sui sun suo ta tai tan tang tao te teng ti
+        tian tiao tie ting tong tou tu tuan tui tun tuo wa wai wan wang wei wen weng wo wu xi xia
+        xian xiang xiao xie xin xing xiong xiu xu xuan xue xun ya yan yang yao ye yi yin ying yo
+        yong you yu yuan yue yun za zai zan zang zao ze zei zen zeng zha zhai zhan zhang zhao zhe
+        zhen zheng zhi zhong zhou zhu zhua zhuai zhuan zhuang zhui zhun zhuo zi zong zou zu zuan zui
+        zun zuo
+        """
+        .split(whereSeparator: \.isWhitespace).map(String.init))
+
+    private static let longestSyllable = syllableSet.map(\.count).max() ?? 0
+}

--- a/Tools/fuzz-test.swift
+++ b/Tools/fuzz-test.swift
@@ -1,8 +1,10 @@
-// Standalone test for the launcher matcher (run: swift Tools/fuzz-test.swift); keep in sync with FuzzyMatch in Tinycast/Core/AppIndex.swift.
+// Standalone test for the launcher matcher. FuzzyMatch below is a copy of the one in Tinycast/Core/AppIndex.swift — keep the two in sync; Pinyin is the real source, compiled in: swiftc -swift-version 6 Tinycast/Core/Pinyin.swift Tools/fuzz-test.swift -o /tmp/fuzz-test && /tmp/fuzz-test
 
 import Foundation
 
 enum FuzzyMatch {
+    static let romanizedPenalty = 5_000
+
     static func score(query: String, candidate: String) -> Int? {
         let q = normalized(query)
         let c = normalized(candidate)
@@ -60,69 +62,194 @@ enum FuzzyMatch {
     }
 }
 
-let apps = [
-    "Google Chrome", "Chess", "Time Machine", "Safari", "Bluetooth File Exchange",
-    "Screenshot", "Screen Sharing", "Visual Studio Code", "Photos", "App Store",
-    "System Settings", "Calendar", "Terminal", "WhatsApp", "Wick",
-]
+@main
+@MainActor
+struct FuzzTests {
+    static var failures = 0
 
-func rank(_ query: String, boosts: [String: Int] = [:]) -> [String] {
-    apps.compactMap { name -> (String, Int)? in
-        guard let s = FuzzyMatch.score(query: query, candidate: name) else { return nil }
-        return (name, s + boosts[name, default: 0])
+    static let apps = [
+        "Google Chrome", "Chess", "Time Machine", "Safari", "Bluetooth File Exchange",
+        "Screenshot", "Screen Sharing", "Visual Studio Code", "Photos", "App Store",
+        "System Settings", "Calendar", "Terminal", "WhatsApp", "Wick",
+        "微信", "网易云音乐", "高德地图", "钉钉", "QQ音乐", "迅雷",
+        // Literal names that collide with a reading, to pin the tier order.
+        "Xunlei", "WX Tool",
+    ]
+
+    /// Mirrors AppIndex.rank: the best score across the entry's name and every alias it carries.
+    static func rank(_ query: String, boosts: [String: Int] = [:]) -> [String] {
+        apps.compactMap { name -> (String, Int)? in
+            var best = FuzzyMatch.score(query: query, candidate: name)
+            // Readings land half a tier below the literal ladder, exactly as AppIndex.rank scores them.
+            for reading in Pinyin.aliases(for: name) {
+                guard let score = FuzzyMatch.score(query: query, candidate: reading) else { continue }
+                let demoted = score - FuzzyMatch.romanizedPenalty
+                best = max(best ?? demoted, demoted)
+            }
+            guard let score = best else { return nil }
+            return (name, score + boosts[name, default: 0])
+        }
+        .sorted { $0.1 != $1.1 ? $0.1 > $1.1 : $0.0.count < $1.0.count }
+        .map(\.0)
     }
-    .sorted { $0.1 != $1.1 ? $0.1 > $1.1 : $0.0.count < $1.0.count }
-    .map(\.0)
-}
 
-var failures = 0
-func check(_ desc: String, _ cond: Bool, _ detail: String = "") {
-    if cond {
-        print("PASS  \(desc)")
-    } else {
-        print("FAIL  \(desc)  \(detail)")
-        failures += 1
+    static func check(_ desc: String, _ cond: Bool, _ detail: String = "") {
+        if cond {
+            print("PASS  \(desc)")
+        } else {
+            print("FAIL  \(desc)  \(detail)")
+            failures += 1
+        }
+    }
+
+    static func main() {
+        let chrome = rank("chrome")
+        check("'chrome' top is Google Chrome", chrome.first == "Google Chrome", "got \(chrome)")
+        check("'chrome' does not include Chess", !chrome.contains("Chess"), "got \(chrome)")
+
+        let ch = rank("ch")
+        check("'ch' includes Google Chrome", ch.contains("Google Chrome"), "got \(ch)")
+        check("'ch' includes Chess", ch.contains("Chess"))
+        check(
+            "'ch' ranks Chess (prefix) above Chrome",
+            ch.firstIndex(of: "Chess")! < ch.firstIndex(of: "Google Chrome")!, "got \(ch)")
+
+        check("'saf' top is Safari", rank("saf").first == "Safari", "got \(rank("saf"))")
+        check("'tm' includes Time Machine", rank("tm").contains("Time Machine"), "got \(rank("tm"))")
+        check(
+            "'code' includes Visual Studio Code", rank("code").contains("Visual Studio Code"),
+            "got \(rank("code"))")
+        check("'terminal' exact top", rank("terminal").first == "Terminal")
+        check("'xyz' matches nothing", rank("xyz").isEmpty, "got \(rank("xyz"))")
+
+        let defaultW = rank("w")
+        check(
+            "shorter Wick wins the default prefix tie",
+            defaultW.firstIndex(of: "Wick")! < defaultW.firstIndex(of: "WhatsApp")!,
+            "got \(defaultW)")
+        let learnedW = rank("w", boosts: ["WhatsApp": 2_100])
+        check(
+            "learned boost promotes WhatsApp within the prefix tier",
+            learnedW.firstIndex(of: "WhatsApp")! < learnedW.firstIndex(of: "Wick")!,
+            "got \(learnedW)")
+        let markedWhatsApp = "\u{200E}WhatsApp"
+        check(
+            "invisible format mark does not demote WhatsApp's prefix match",
+            FuzzyMatch.score(query: "w", candidate: markedWhatsApp)
+                == FuzzyMatch.score(query: "w", candidate: "WhatsApp"))
+        check(
+            "learned marked WhatsApp can outrank Wick",
+            FuzzyMatch.score(query: "w", candidate: markedWhatsApp)! + 2_100
+                > FuzzyMatch.score(query: "w", candidate: "Wick")!)
+
+        // Pinyin aliases
+        check(
+            "full reading and initials, in that order",
+            Pinyin.aliases(for: "微信") == ["weixin", "wx"],
+            "got \(Pinyin.aliases(for: "微信"))")
+        check(
+            "a name in no Han script gets no alias",
+            Pinyin.aliases(for: "Visual Studio Code").isEmpty
+                && Pinyin.aliases(for: "ひらがな").isEmpty && Pinyin.aliases(for: "한글").isEmpty,
+            "got \(Pinyin.aliases(for: "ひらがな"))")
+        check(
+            "Latin inside a Han name carries through as typed",
+            Pinyin.aliases(for: "QQ音乐") == ["qqyinyue", "qqyy"],
+            "got \(Pinyin.aliases(for: "QQ音乐"))")
+        check(
+            "a one-letter initial is dropped rather than matching everything it leads",
+            Pinyin.aliases(for: "云") == ["yun"], "got \(Pinyin.aliases(for: "云"))")
+        check(
+            "digits carry through", Pinyin.aliases(for: "3D打印助手") == ["3ddayinzhushou", "3ddyzs"],
+            "got \(Pinyin.aliases(for: "3D打印助手"))")
+
+        // An alias only earns its keep if it can be typed, so nothing that isn't ASCII may reach one.
+        check(
+            "emoji, kana and hangul are dropped, not embedded",
+            Pinyin.aliases(for: "微信\u{1F600}音乐") == ["weixinyinyue", "wxyy"]
+                && Pinyin.aliases(for: "ひらがな漢字") == ["hanzi", "hz"]
+                && Pinyin.aliases(for: "한글漢字") == ["hanzi", "hz"],
+            "got \(Pinyin.aliases(for: "微信\u{1F600}音乐")) / \(Pinyin.aliases(for: "ひらがな漢字"))")
+        check(
+            "an accent folds rather than blocking the alias",
+            Pinyin.aliases(for: "café中文") == ["cafezhongwen", "cafezw"],
+            "got \(Pinyin.aliases(for: "café中文"))")
+        check(
+            "every alias is ASCII, whatever the name mixes in",
+            ["微信\u{1F600}音乐", "ひらがな漢字", "한글漢字", "café中文", "微信 · 测试", "QQ音乐", "3D打印助手"]
+                .flatMap(Pinyin.aliases(for:)).allSatisfy { $0.allSatisfy(\.isASCII) })
+        check(
+            "a name with no readable character gets no alias",
+            Pinyin.aliases(for: "\u{20000}\u{20001}").isEmpty && Pinyin.aliases(for: "!!!").isEmpty
+                && Pinyin.aliases(for: "   ").isEmpty)
+        // Left in, a BOM ends tokenization early and silently truncates the reading.
+        check(
+            "an invisible format scalar anywhere leaves the reading alone",
+            Pinyin.aliases(for: "\u{200E}微信") == ["weixin", "wx"]
+                && Pinyin.aliases(for: "微\u{200E}信") == ["weixin", "wx"]
+                && Pinyin.aliases(for: "汽水\u{FEFF}音乐") == ["qishuiyinyue", "qsyy"]
+                && Pinyin.aliases(for: "网易\u{200B}云音乐") == ["wangyiyunyinyue", "wyyyy"]
+                && Pinyin.aliases(for: "剪映\u{200D}专业版") == ["jianyingzhuanyeban", "jyzyb"],
+            "got \(Pinyin.aliases(for: "汽水\u{FEFF}音乐"))")
+        check(
+            "the ideographic zero is read, not treated as foreign",
+            Pinyin.aliases(for: "一〇〇") == ["yilingling", "yll"]
+                && Pinyin.aliases(for: "二〇二五") == ["erlingerwu", "elew"],
+            "got \(Pinyin.aliases(for: "二〇二五"))")
+
+        // Polyphones — these are the readings a character-at-a-time transliteration gets wrong.
+        for (name, reading) in [
+            ("音乐", "yinyue"), ("地图", "ditu"), ("银行", "yinhang"), ("长城", "changcheng"),
+            ("重庆", "chongqing"),
+        ] {
+            check(
+                "\(name) reads as \(reading)", Pinyin.aliases(for: name).first == reading,
+                "got \(Pinyin.aliases(for: name))")
+        }
+
+        // The character count is what makes an ambiguous syllable boundary decidable.
+        check("xian over two characters is xi + an", Pinyin.syllables(of: "xian", count: 2) == ["xi", "an"])
+        check("xian over one character stays whole", Pinyin.syllables(of: "xian", count: 1) == ["xian"])
+        check("pingan cuts longest-first, as 平安", Pinyin.syllables(of: "pingan", count: 2) == ["ping", "an"])
+        check("alibaba cuts into four", Pinyin.syllables(of: "alibaba", count: 4) == ["a", "li", "ba", "ba"])
+        check("an unreadable run does not cut", Pinyin.syllables(of: "zzz", count: 1) == nil)
+
+        // Ranking through the aliases
+        check("'weixin' top is 微信", rank("weixin").first == "微信", "got \(rank("weixin"))")
+        check("'wx' top is 微信", rank("wx").first == "微信", "got \(rank("wx"))")
+        check("'dd' top is 钉钉", rank("dd").first == "钉钉", "got \(rank("dd"))")
+        check(
+            "'wyyyy' top is 网易云音乐", rank("wyyyy").first == "网易云音乐", "got \(rank("wyyyy"))")
+        check(
+            "'ditu' top is 高德地图", rank("ditu").first == "高德地图", "got \(rank("ditu"))")
+        check(
+            "'yinyue' finds both 音乐 apps", rank("yinyue").contains("网易云音乐")
+                && rank("yinyue").contains("QQ音乐"), "got \(rank("yinyue"))")
+        check(
+            "a Han name still matches as typed", rank("微信").first == "微信",
+            "got \(rank("微信"))")
+        check(
+            "aliases do not disturb a Latin name's own ranking",
+            rank("saf").first == "Safari" && rank("chrome").first == "Google Chrome")
+
+        // Tier order between a literal name and a reading that spells the same thing.
+        check(
+            "a literal name beats a reading that spells it",
+            rank("xunlei").first == "Xunlei" && rank("xunlei").contains("迅雷"),
+            "got \(rank("xunlei"))")
+        check(
+            "a reading still beats a literal prefix of a longer name",
+            rank("wx").first == "微信" && rank("wx").contains("WX Tool"),
+            "got \(rank("wx"))")
+        check(
+            "a demoted exact reading sits between literal exact and literal prefix",
+            FuzzyMatch.score(query: "safari", candidate: "safari")! - FuzzyMatch.romanizedPenalty
+                < FuzzyMatch.score(query: "safari", candidate: "Safari")!
+                && FuzzyMatch.score(query: "safari", candidate: "safari")!
+                    - FuzzyMatch.romanizedPenalty
+                    > FuzzyMatch.score(query: "safari", candidate: "Safari Technology Preview")!)
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
     }
 }
-
-let chrome = rank("chrome")
-check("'chrome' top is Google Chrome", chrome.first == "Google Chrome", "got \(chrome)")
-check("'chrome' does not include Chess", !chrome.contains("Chess"), "got \(chrome)")
-
-let ch = rank("ch")
-check("'ch' includes Google Chrome", ch.contains("Google Chrome"), "got \(ch)")
-check("'ch' includes Chess", ch.contains("Chess"))
-check(
-    "'ch' ranks Chess (prefix) above Chrome",
-    ch.firstIndex(of: "Chess")! < ch.firstIndex(of: "Google Chrome")!, "got \(ch)")
-
-check("'saf' top is Safari", rank("saf").first == "Safari", "got \(rank("saf"))")
-check("'tm' includes Time Machine", rank("tm").contains("Time Machine"), "got \(rank("tm"))")
-check(
-    "'code' includes Visual Studio Code", rank("code").contains("Visual Studio Code"),
-    "got \(rank("code"))")
-check("'terminal' exact top", rank("terminal").first == "Terminal")
-check("'xyz' matches nothing", rank("xyz").isEmpty, "got \(rank("xyz"))")
-
-let defaultW = rank("w")
-check(
-    "shorter Wick wins the default prefix tie",
-    defaultW.firstIndex(of: "Wick")! < defaultW.firstIndex(of: "WhatsApp")!,
-    "got \(defaultW)")
-let learnedW = rank("w", boosts: ["WhatsApp": 2_100])
-check(
-    "learned boost promotes WhatsApp within the prefix tier",
-    learnedW.firstIndex(of: "WhatsApp")! < learnedW.firstIndex(of: "Wick")!,
-    "got \(learnedW)")
-let markedWhatsApp = "\u{200E}WhatsApp"
-check(
-    "invisible format mark does not demote WhatsApp's prefix match",
-    FuzzyMatch.score(query: "w", candidate: markedWhatsApp)
-        == FuzzyMatch.score(query: "w", candidate: "WhatsApp"))
-check(
-    "learned marked WhatsApp can outrank Wick",
-    FuzzyMatch.score(query: "w", candidate: markedWhatsApp)! + 2_100
-        > FuzzyMatch.score(query: "w", candidate: "Wick")!)
-
-print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
-exit(failures == 0 ? 0 : 1)

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,7 +75,8 @@ app; changes always apply (fixed build path — no need to delete `build/`).
 There's no XCTest target. Standalone harnesses:
 
 ```sh
-swift Tools/fuzz-test.swift                                        # launcher fuzzy matcher
+swiftc -swift-version 6 Tinycast/Core/Pinyin.swift Tools/fuzz-test.swift \
+    -o /tmp/fuzz-test && /tmp/fuzz-test                            # launcher fuzzy matcher + pinyin
 swiftc -swift-version 6 Tinycast/Core/LauncherRankingStore.swift Tools/ranking-test.swift \
     -o /tmp/ranking-test && /tmp/ranking-test                      # learned launcher ranking
 swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift \
@@ -98,8 +99,9 @@ swiftc -swift-version 6 Tinycast/Core/SystemCommand.swift Tools/system-command-t
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —
-change the scoring in one and mirror it in the other. The calc harness compiles the real engine
-sources, which is why `Tinycast/Core/Calculator/` must stay Foundation-only. The system-command harness
+change the scoring in one and mirror it in the other. It also compiles the real `Pinyin.swift`, which
+must therefore stay Foundation-only. The calc harness compiles the real engine sources, which is why
+`Tinycast/Core/Calculator/` must stay Foundation-only. The system-command harness
 similarly keeps `SystemCommand.swift` independent from AppKit and all command side effects.
 
 The clipboard harness likewise compiles the real `ClipboardStore.swift`, so that file must keep to

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -35,6 +35,36 @@ frecency boost (frequency plus decaying recency). The boost can reorder results 
 tier but cannot make a weaker match kind beat a stronger one. Matching strips invisible Unicode
 format scalars first, since app metadata can contain bidi/zero-width markers before the visible name.
 
+## Pinyin
+
+An entry whose name carries a Han character also matches on its Latin reading. `Pinyin.aliases`
+(`Core/Pinyin.swift`) returns the full reading and the per-character initials, and `AppEntry.init`
+attaches them to every entry it builds — so applications, System Settings panes, snippets, system
+commands and custom commands all get them from one place rather than each call site. 微信 answers to
+`weixin` and to `wx`, 网易云音乐 to `wangyiyunyinyue` and `wyyyy`. A name in no Han script costs one
+scalar range check and gets no alias.
+
+Readings come from `CFStringTokenizer`'s Latin transcription rather than
+`kCFStringTransformMandarinLatin`, because the tokenizer segments words before reading them and so
+resolves a polyphone in context where a character-at-a-time transform cannot: 音乐 is `yinyue`, not
+`yinle`, and 地图 is `ditu`, not `detu`.
+
+Initials need one syllable per character, but the transcription arrives word-grouped
+(`wangyi yun yinyue`), so `Pinyin.syllables` cuts it against the syllable inventory macOS itself
+transliterates to. Pinyin is ambiguous on its own — `xian` is 西安 or 险 — and it is the known
+character count that makes the boundaries decidable; the cut is longest-first, so `pingan` is 平安. A
+reading that won't cut still searches in full, it just contributes no initial-letter shortcut, and a
+one-letter initial is dropped rather than matching everything it leads.
+
+A reading is a weaker claim on the query than the name itself, so `AppEntry` keeps the two apart:
+`literalAliases` holds literal strings (a snippet's keyword) and scores in the name's own tiers,
+while `romanizedAliases` is scored `FuzzyMatch.romanizedPenalty` lower — half the gap between two
+tiers, and deliberately more than `LauncherRankingStore.maximumBoost`, so learned ranking cannot lift
+a reading back over the literal match it sits under. A reading therefore lands under the literal
+match of the same kind without falling past the kind below it: typing `safari` can never lose Safari
+to something whose pinyin spells it, but `wx` still reaches 微信 ahead of a longer name that merely
+starts with those letters. Names are read once per scan, off-main with the rest of `AppIndex.scan`.
+
 Selecting a launcher result records every prefix of the submitted query, so choosing WhatsApp for
 `wha` also teaches `w` and `wh`. Direct hotkeys and empty-query favorites do not affect learned
 ranking. Learned data stays on device in `launcher-ranking.json`; a result that has learned ranking
@@ -102,7 +132,7 @@ execution semantics.
 
 > **Invariant:** `Tools/fuzz-test.swift` contains a **copy** of `FuzzyMatch` from
 > `Tinycast/Core/AppIndex.swift`. If you change the scoring in one, mirror it in the other or the test
-> is meaningless.
+> is meaningless. It compiles the real `Core/Pinyin.swift`, which must therefore stay Foundation-only.
 
 The ranking harness covers prefix learning, frequency/recency scoring, persistence, and both reset
 paths; see the command in `development.md`.


### PR DESCRIPTION
## Related issue

Closes #119

## What changed

An entry whose displayed name carries a Han character now also matches on its Latin reading, so a
Chinese-named app is reachable from an ASCII keyboard: `xunlei` and `xl` both find 迅雷.

- **`Core/Pinyin.swift`** (new, Foundation-only). `Pinyin.aliases(for:)` returns the full reading and
  the per-character initials, or nothing when the name holds no Han character — that case costs one
  scalar range check and no allocation.
- **`AppEntry.init`** attaches them. Deriving there rather than at each call site means applications,
  System Settings panes, snippets, system commands and custom commands all get pinyin from one place,
  and no entry kind can be added without it. The existing `matchAliases` is renamed `literalAliases`,
  since beside `romanizedAliases` the old name reads like the umbrella rather than one of the two.
- **A reading is scored below the literal name.** `AppEntry` keeps two alias lists on purpose:
  `literalAliases` holds literal strings (a snippet's keyword) and scores in the name's own tiers,
  exactly as before, while `romanizedAliases` is scored `FuzzyMatch.romanizedPenalty` lower — 5,000,
  half the gap between two tiers — and deliberately more than `LauncherRankingStore.maximumBoost`
  (4,500), so learned ranking cannot lift a reading back over the literal match it sits under. A
  reading therefore lands under the literal match of the *same kind* without falling past the kind
  below it. Typing `safari` can never lose Safari to something whose
  pinyin happens to spell it, but `wx` still reaches 微信 ahead of a longer name that merely begins
  with those letters. Snippet keyword ranking is untouched.
- **Han detection goes through `Unicode.Scalar.Properties.isUnifiedIdeograph`**, plus 〇 and the
  compatibility ideographs, which the tokenizer reads but that property does not cover. Hand-written
  ranges missed both, and 〇 is not merely absent from the reading — it is dropped mid-name, so
  二〇二五 read as `ererwu` (二二五) rather than `erlingerwu`.
- **Invisible format scalars are stripped before tokenizing**, the same thing `FuzzyMatch.normalized`
  already does and for a sharper reason: a BOM sitting between two Han characters ends tokenization
  early and silently truncates the reading (`汽水\u{FEFF}音乐` read as `qishui`, losing 音乐 entirely),
  and any marker inside a token would inflate the character count the syllable cut is measured
  against.
- **Every alias is ASCII by construction.** An alias only earns its keep if it can be typed, so the
  non-Han parts of a name fold to ASCII rather than carrying through verbatim: `café中文` becomes
  `cafezhongwen` (typeable) instead of `cafézhongwen` (not), and emoji, kana and hangul are dropped
  rather than embedded in a string no ASCII keyboard can enter. Digits survive — `3D打印助手` is
  `3ddayinzhushou` / `3ddyzs`.

Two things in the diff worth calling out:

**Readings come from `CFStringTokenizer`'s Latin transcription, not `kCFStringTransformMandarinLatin`.**
The transform reads a character at a time and so gets polyphones wrong on exactly the words that
matter — 音乐 → `yinle`, 地图 → `detu`, 银行 → `yinxing`, 长城 → `zhangcheng`. The tokenizer segments
words before reading them and resolves all four. Measured over 58 real app names: tokenizer 58/58,
transform 50/58.

**The initials alias needs one syllable per character, but the transcription arrives word-grouped**
(`网易云音乐` → `wangyi yun yinyue`). `Pinyin.syllables` cuts it against the syllable inventory,
backtracking longest-first with the dead ends memoized, constrained to exactly the character count — which is what makes an otherwise ambiguous
boundary decidable, since `xian` is 西安 or 险 depending only on how many characters produced it. The
408-entry inventory is not hand-written: it is every syllable `kCFStringTransformMandarinLatin`
itself emits across the CJK ideograph blocks (27,166 characters), so a reading the system produces
can always be cut. Four of the 412 it emits are dropped on purpose — `m`, `n`, `ng` and `hm` are
interjection-only readings that never occur inside a word, and admitting them would let `xian` cut as
`xia` + `n`. No data file, no generator, no dependency, nothing hand-maintained to rot.

## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 19 MB  |
| Palette open            | 31 MB  |
| Feature in use (peak)   | 49 MB  |
| Palette closed, settled | 49 MB  |

Leak-tested: yes. `leaks` reports ~285 leaks / ~14 KB, every one of them inside AppIntents /
NSXPCConnection; no Tinycast frame appears in any leak root. Unmodified `main` reports ~287 / ~14 KB
on the same run, so the count is pre-existing and not something this adds.

Those absolute numbers mean little without a baseline, so I built unmodified `main` (79c07da) into a
separate DerivedData and drove both through the *same* workload — palette open, then walk 80 rows, so
each build renders and decodes the same icons. Note the peak row above is deliberately **not** the
comparison: the pinyin queries return results here and "No apps found" on `main`, so `main` never
decodes those rows and reads artificially low. Three runs of each, alternating:

| Step                   | `main` @79c07da | this branch |
| ---------------------- | --------------- | ----------- |
| Idle after launch      | 18–19 MB        | 19–20 MB    |
| Palette open           | 30–31 MB        | 30–31 MB    |
| After 80 rows rendered | 46–48 MB        | 47–49 MB    |
| Palette closed, settled| 48–50 MB        | 49–51 MB    |

The ranges overlap: `main`'s worst run (48 / 50 MB) is heavier than two of the three patched runs
(47 / 49 MB). Run-to-run spread is about ±2 MB either way, and the medians differ by at most 1 MB,
which is the resolution `footprint` reports in. I'd call that no measurable difference rather than
parity-by-luck — and it is what you'd expect, since the feature's own footprint is two short strings
per Han-named entry plus one static `Set<String>` (8 such entries on this machine).

The settled-above-idle figure is `IconCache` holding decoded icons; it is present on `main` too and
this change does not affect it.

Scan cost, measured over an index shaped like a real one (200 Latin names + 12 Han), 20 runs: **2.2 ms
per scan**, of which the 200 Latin names account for **0.006 ms** — the no-Han gate is a scalar range
check and effectively free, so a machine with no Chinese-named apps pays nothing. This runs inside the
existing `Task.detached` in `AppIndex.scan`, off the main actor.

## Demo

No UI, styling, layout or motion changed — the only visible difference is that queries which
previously returned "No apps found" now return results. Side-by-side anyway, same window, same
queries (`qsyy`, `xunlei`, `jyzyb`), left `main` @79c07da and right this branch:

https://github.com/user-attachments/assets/e4e47486-1f18-4204-84de-14f78aa74683

## Drawbacks

- **Readings are Mandarin.** A Japanese app name written in kanji gets a Mandarin reading rather than
  its on/kun reading — `ひらがな漢字` yields `hanzi`, not `kanji`. A name in kana or hangul alone is
  left untouched by the Han gate, and an alias is only ever added, never substituted for the name, so
  the failure mode is an alias nobody types rather than a wrong or missing result.
- **The syllable cut is longest-first**, which is right for `pingan` (平安, not 拼干) but wrong for the
  rarer shape where a syllable ends in `n`/`ng` before a vowel — 西南 cuts as `xin`+`an`, so its
  initials read `xa` instead of `xn`. The full-reading alias is unaffected, so the entry is still
  found; only the initials shortcut is off. Fixing it properly needs tone-mark positions, which
  neutral-tone syllables don't have, and it did not seem worth the complexity.
- **A reading can still outrank a literal *prefix*.** Same-kind collisions go to the literal name, but
  a complete reading beats a partial literal match: with both installed, `wx` puts 微信 above a
  hypothetical "WX Tool". I think that is right — the query is the whole of one and part of the other
  — but it is a genuine ordering change, not purely additive, so it is worth disagreeing with.
- A one-letter initials alias is dropped rather than emitted, because a single letter would match
  everything it leads; a single-character name is therefore reachable by its full reading only.

## Tests & validation

`Tools/fuzz-test.swift` now compiles the real `Core/Pinyin.swift` alongside its `FuzzyMatch` copy, so
the harness command changed and `docs/development.md`, `docs/launcher.md` and `AGENTS.md` are updated
to match. Cases added: full-reading and initials shape, no alias for Latin / kana / hangul, Latin
carried through inside a Han name (`QQ音乐` → `qqyinyue`), digits carried through, the
one-letter-initial drop, the five polyphones above, the syllable-cut unit cases (`xian` at one and two
characters, `pingan`, `alibaba`, an unreadable run), the tier order between a literal name and a
reading that spells it (a literal `Xunlei` outranks 迅雷 while 迅雷 stays in the results, `wx` still
puts 微信 over `WX Tool`, and a demoted exact reading provably sits between literal exact and literal
prefix), invisible format scalars in every position (leading, trailing, and — the one that actually
broke — between two Han characters, covering LRM, ZWSP, ZWNBSP and ZWJ), the ASCII invariant (emoji /
kana / hangul
dropped, accents folded, and a blanket assertion that no alias of any mixed-script name contains a
non-ASCII character), the ideographic zero (`一〇〇`, `二〇二五`), names with nothing readable in them (CJK Ext B with no reading, punctuation,
whitespace), and end-to-end ranking through the aliases including that a Latin name's ranking is
undisturbed.

All nine harnesses pass:

```
fuzz + pinyin   ALL PASSED       ranking         ALL PASSED
calc            486 passed       clipboard       23/23 passed
scopes          ALL PASSED       emoji           2054 records
system-command  72 passed        snippets        ALL PASSED
custom-command  ALL PASSED
```

`xcodebuild -configuration Debug` is clean, no new warnings.

By hand, against the real applications on my machine (results read back out of the accessibility
tree rather than eyeballed):

| Query                | Result |
| -------------------- | ------ |
| `xunlei`             | 迅雷 |
| `xl`                 | 迅雷, ranked above Expansion Slot Utility / Microsoft Excel / Pixelmator Pro |
| `jyzyb`              | 剪映专业版 |
| `qishuiyinyue`, `qsyy` | 汽水音乐 |
| `kuakewangpan`       | 夸克网盘 |
| `txsp`               | 腾讯视频 |
| `yinyue`             | QQ音乐, 汽水音乐 |
| `saf`, `chrome`, `terminal` | unchanged |

Also checked that `xcodegen generate` produces a 4-line project diff — XcodeGen older than 2.46
rewrites `objectVersion` 77 → 54 and unpacks the `tinycast.icon` bundle, which is worth knowing
before regenerating.
