### PR TITLE
feat: Window management commands in the launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,8 @@ Full detail: [`docs/architecture.md`](docs/architecture.md).
   accessory apps).
 - **Subsystems:** [palette](docs/palette.md) · [launcher & fuzzy match](docs/launcher.md) ·
   [calculator](docs/calculator.md) · [clipboard](docs/clipboard.md) · [emoji](docs/emoji.md) ·
-  [snippets](docs/snippets.md) · [hotkeys](docs/hotkeys.md) · [UI & design system](docs/ui.md).
+  [snippets](docs/snippets.md) · [window management](docs/window-management.md) ·
+  [hotkeys](docs/hotkeys.md) · [UI & design system](docs/ui.md).
 
 ## Critical Invariants
 
@@ -78,7 +79,19 @@ Never break these without an explicit task to do so.
   template engine, repository and keyword policies stay Foundation-only, and the AppKit files there
   keep their dependencies to what the harness can stub. `Core/SystemCommand.swift` is also
   Foundation-only for `Tools/system-command-test.swift`; platform effects belong in
-  `SystemCommandRunner`, while confirmation and failure UI remain in `AppCore`.
+  `SystemCommandRunner`, while confirmation and failure UI remain in `AppCore`. `Core/WindowManagement/`
+  splits the same way for `Tools/window-command-test.swift`: `WindowCommand.swift`, `WindowLayout.swift`
+  and `WindowActionMemory.swift` stay Foundation + CoreGraphics and pure (no AX, no `NSScreen`, no
+  clock — `WindowActionMemory` takes `now` as a parameter), while every `AXUIElement` call and the
+  Cocoa↔AX coordinate flip live in `WindowMover.swift`.
+- **`WindowLayout` works exclusively in AX space** — global coordinates, top-left origin, +Y **down**.
+  `WindowMover.AXGeometry` is the only place that converts, and it anchors the flip on the **primary**
+  display's height, never the window's own screen: doing otherwise shears every rect on a
+  differently-sized display by the height difference, which is invisible on one monitor and wrong on
+  every mixed-size setup. The visible consequence is that "Top Half" has `minY == visibleFrame.minY`;
+  `Tools/window-command-test.swift` asserts it. Nothing in this feature ever touches
+  `backingScaleFactor` — all three of `NSScreen.frame`, `visibleFrame` and AX coordinates are in points,
+  so mixed-DPI correctness is automatic. See [window-management.md](docs/window-management.md).
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and
@@ -131,8 +144,8 @@ Never break these without an explicit task to do so.
 
 - `Tinycast/Core/` — managers, stores, windows, AppKit glue (no view bodies beyond hosting).
   `Core/Calculator/` and `Core/Emoji/` are Foundation-only engines; `Core/Snippets/` is a
-  standalone-harness input in full; `Core/Theme.swift` is the design-token source;
-  `Core/HotKey/` is the in-house hotkey stack.
+  standalone-harness input in full; `Core/WindowManagement/` is a pure geometry layer plus its one AX
+  file; `Core/Theme.swift` is the design-token source; `Core/HotKey/` is the in-house hotkey stack.
 - `Tinycast/Features/` — SwiftUI views: `RootPaletteView`, `Launcher/`, `Clipboard/`, `Calculator/`,
   `Emoji/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`.
 - `Tinycast/App/` — `@main` app + delegate.
@@ -145,7 +158,9 @@ Never break these without an explicit task to do so.
 - [`docs/palette.md`](docs/palette.md) — palette state flow, menu-open freeze, focus restoration.
 - [`docs/launcher.md`](docs/launcher.md) · [`docs/calculator.md`](docs/calculator.md) ·
   [`docs/clipboard.md`](docs/clipboard.md) · [`docs/emoji.md`](docs/emoji.md) ·
-  [`docs/snippets.md`](docs/snippets.md) · [`docs/hotkeys.md`](docs/hotkeys.md) — subsystem internals.
+  [`docs/snippets.md`](docs/snippets.md) ·
+  [`docs/window-management.md`](docs/window-management.md) ·
+  [`docs/hotkeys.md`](docs/hotkeys.md) — subsystem internals.
 - [`docs/ui.md`](docs/ui.md) — the full visual design system, tokens, scrollbars, section headers.
 - [`docs/development.md`](docs/development.md) — build, test, package, release.
 - [`docs/signing.md`](docs/signing.md) — signing model and Gatekeeper.

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -15,12 +15,14 @@
 		14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DC5A4706854493D23FD18A /* HyperKey.swift */; };
 		14A5A5ACD35A572EE906769F /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B976C84AFE60E357A346224 /* CalcEngine.swift */; };
 		1AF562E00FCB98B12076F01D /* SnippetKeywordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5051622CC6497E2151326CA /* SnippetKeywordListener.swift */; };
+		1B90AA42601E3AE7EEE3AD5D /* WindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388A58EDB35AB0CB30EE20DE /* WindowLayout.swift */; };
 		1D0C2F452B3801503B70EA9E /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */; };
 		1F39D145DBE2290532C93614 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */; };
 		1F555347D7CE8F37A2C37BAF /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C069647C67120EBAED14422 /* SnippetRepository.swift */; };
 		2085C9433B7534044E0A8A7D /* PermissionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C36D92A5018B9A7B33775DE /* PermissionsSettingsView.swift */; };
 		20C8E98F5BC0FDDB0F646F3D /* OverlayScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */; };
 		212B9B44D7EED18A0DEF47AF /* ShellCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286B7598B81017C746558C7C /* ShellCommandRunner.swift */; };
+		21736CC104E158BC194B1094 /* WindowMover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8859C0E99A2125D85B1233C /* WindowMover.swift */; };
 		24842144273FF92228540DBE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */; };
 		32697AB3853D043A12888B96 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */; };
 		344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */; };
@@ -48,6 +50,7 @@
 		6CDCE462405648998CDF1E77 /* CurrencyRateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */; };
 		6D3DBE00FCB757C67669CFBA /* CommandRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D57B0AE44D21035163BD422 /* CommandRegistry.swift */; };
 		6F08764D6CC09E9B3FD1E05A /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F50886DC766B9923C3875A5 /* RootPaletteView.swift */; };
+		701120BCA431BF00ABDEDBD4 /* WindowCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECE1FA4B89326C37DF12A8C /* WindowCommand.swift */; };
 		715F8A70F7A533D2EEEF6135 /* EdgeDissolve.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A13DB27EE627AC08051165 /* EdgeDissolve.swift */; };
 		72406E09AD9A33B56EA4923D /* CalcParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423CFE8AB90484D0309F24C0 /* CalcParser.swift */; };
 		72ACD144841BF1117CD4E705 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC2DEA0A052116A92F9A539 /* Theme.swift */; };
@@ -83,8 +86,10 @@
 		B9CED4B06F36998A67097FC5 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE084FDBE22B01204E7BEDA /* SnippetMarkdownSerializer.swift */; };
 		BA76E53A12248B3A9C42B4F9 /* Bundle+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */; };
 		C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37CCD024267EB21876C7E9 /* AppDelegate.swift */; };
+		C35864533DFB42DE63080ACB /* WindowManagementSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */; };
 		C3C45B2E5F0D05CD6E27D34C /* RaycastSnippetImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E4F8A2BCECFF0E11441BE /* RaycastSnippetImport.swift */; };
 		C526BEAA60A62E9BC78F309E /* CustomCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C105FED5D77A2392FDA3F0 /* CustomCommand.swift */; };
+		C7D8BB669C3DBC0D26EB6E32 /* WindowActionMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B940224413903867EF5A60E /* WindowActionMemory.swift */; };
 		C7DD1345A6BFB1D9EB22FCEE /* RunningApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B432D84D8F9C10521342199 /* RunningApps.swift */; };
 		C8F4555ECA895F63A34A327C /* EmojiGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */; };
 		CFB516312C4694DDFD99DBCA /* SettingsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68952539C0BD045BA175CBB6 /* SettingsRootView.swift */; };
@@ -130,6 +135,7 @@
 		309908BAB8C19B67F4608DA9 /* SnippetTextInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTextInjector.swift; sourceTree = "<group>"; };
 		32A53295959552ED28D34960 /* Gunzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gunzip.swift; sourceTree = "<group>"; };
 		33A13DB27EE627AC08051165 /* EdgeDissolve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeDissolve.swift; sourceTree = "<group>"; };
+		388A58EDB35AB0CB30EE20DE /* WindowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowLayout.swift; sourceTree = "<group>"; };
 		3A64EF5A07D459753998F78C /* AppCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCore.swift; sourceTree = "<group>"; };
 		3B976C84AFE60E357A346224 /* CalcEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcEngine.swift; sourceTree = "<group>"; };
 		3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayScroller.swift; sourceTree = "<group>"; };
@@ -138,6 +144,7 @@
 		46C3E740AA883770481A6A8C /* SnippetsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsStore.swift; sourceTree = "<group>"; };
 		4802942FF89B327A76432A9B /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		4B432D84D8F9C10521342199 /* RunningApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningApps.swift; sourceTree = "<group>"; };
+		4B940224413903867EF5A60E /* WindowActionMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowActionMemory.swift; sourceTree = "<group>"; };
 		4C27BF1320391CF684429FA6 /* TinycastModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinycastModalView.swift; sourceTree = "<group>"; };
 		4DA7B926405DAC632C056418 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
@@ -157,6 +164,7 @@
 		68952539C0BD045BA175CBB6 /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
 		68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
 		6BB7C545EFD9589A77AD7BE2 /* LauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherView.swift; sourceTree = "<group>"; };
+		6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagementSettingsView.swift; sourceTree = "<group>"; };
 		74F450E10D107C1E30EA2BC6 /* EmojiIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiIndex.swift; sourceTree = "<group>"; };
 		79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiData.generated.swift; sourceTree = "<group>"; };
 		7BC2DEA0A052116A92F9A539 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -179,10 +187,12 @@
 		9AA0E1FD530C764A021E6053 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
 		9B4C27209F650DAB6262F0D9 /* ModalWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalWindowController.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		9ECE1FA4B89326C37DF12A8C /* WindowCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommand.swift; sourceTree = "<group>"; };
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
 		A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
 		A76E4099082D59FA686C3485 /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
+		A8859C0E99A2125D85B1233C /* WindowMover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowMover.swift; sourceTree = "<group>"; };
 		AF5AE919A2699E6EB8BF7DC8 /* ShortcutsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsView.swift; sourceTree = "<group>"; };
 		AFE4F95DF8572910DFE602BA /* SystemCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCommandRunner.swift; sourceTree = "<group>"; };
 		B275099E59BD2531A838F7D8 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
@@ -230,6 +240,7 @@
 				E2E33C02FBE324BED2E84314 /* Emoji */,
 				CB742F7643800C43475DE213 /* HotKey */,
 				32B8FED93732983EAE729EB1 /* Snippets */,
+				36FA7A5040272D524D70EC0E /* WindowManagement */,
 				3A64EF5A07D459753998F78C /* AppCore.swift */,
 				BA7CE23482F7DF563A268806 /* AppIndex.swift */,
 				5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */,
@@ -318,6 +329,17 @@
 				68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */,
 			);
 			path = Calculator;
+			sourceTree = "<group>";
+		};
+		36FA7A5040272D524D70EC0E /* WindowManagement */ = {
+			isa = PBXGroup;
+			children = (
+				4B940224413903867EF5A60E /* WindowActionMemory.swift */,
+				9ECE1FA4B89326C37DF12A8C /* WindowCommand.swift */,
+				388A58EDB35AB0CB30EE20DE /* WindowLayout.swift */,
+				A8859C0E99A2125D85B1233C /* WindowMover.swift */,
+			);
+			path = WindowManagement;
 			sourceTree = "<group>";
 		};
 		4667598F175BCBB55CA88BEE /* About */ = {
@@ -446,6 +468,7 @@
 				596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */,
 				AF5AE919A2699E6EB8BF7DC8 /* ShortcutsSettingsView.swift */,
 				CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */,
+				6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -643,6 +666,11 @@
 				A7508663E4B5D80572E7BAAC /* TinycastModalView.swift in Sources */,
 				693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */,
 				A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */,
+				C7D8BB669C3DBC0D26EB6E32 /* WindowActionMemory.swift in Sources */,
+				701120BCA431BF00ABDEDBD4 /* WindowCommand.swift in Sources */,
+				1B90AA42601E3AE7EEE3AD5D /* WindowLayout.swift in Sources */,
+				C35864533DFB42DE63080ACB /* WindowManagementSettingsView.swift in Sources */,
+				21736CC104E158BC194B1094 /* WindowMover.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -101,6 +101,7 @@ final class AppCore: ObservableObject {
     let snippetTextInjector: SnippetTextInjector
     let hotKeys = HotKeyManager()
     let hyperKeyTap = HyperKeyTap()
+    let windowMover = WindowMover()
     let settings: AppSettings
     let favorites = FavoritesStore()
     let visibility = VisibilityStore()
@@ -149,6 +150,7 @@ final class AppCore: ObservableObject {
             self?.applyCustomCommandsPresence()
         }
         applyCustomCommandsPresence()
+        applyWindowCommandsPresence()
         Task { await appIndex.refresh() }
         Task { await emojiIndex.load() }
         currencyRates.start()
@@ -157,6 +159,7 @@ final class AppCore: ObservableObject {
         hotKeys.onToggleClipboard = { [weak self] in self?.toggleClipboard() }
         hotKeys.onToggleEmoji = { [weak self] in self?.toggleEmoji() }
         hotKeys.onRunCustomCommand = { [weak self] id in self?.runCustomCommand(id: id) }
+        hotKeys.onRunWindowCommand = { [weak self] id in self?.runWindowCommand(id: id) }
         hotKeys.start(customCommandIDs: Set(customCommands.commands.map(\.id)))
         // Deliberately keeps running while `hotKeys.recordingAction` pauses Carbon: the recorder relies on the tap's rewritten flags to capture Hyper shortcuts.
         hyperKeyTap.start(settings: settings)
@@ -173,6 +176,18 @@ final class AppCore: ObservableObject {
         }
 
         // @Published emits synchronously before the property is written (as in `AppIndex.start`), so every re-projection defers to a task that reads the settled value.
+        for publisher in [
+            settings.$windowManagementEnabled, settings.$windowManagementShowInLauncher,
+        ] {
+            publisher.dropFirst()
+                .sink { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        guard let self else { return }
+                        Task { self.applyWindowCommandsPresence() }
+                    }
+                }
+                .store(in: &cancellables)
+        }
         for publisher in [settings.$customCommandsEnabled, settings.$customCommandsShowInLauncher] {
             publisher.dropFirst()
                 .sink { [weak self] _ in
@@ -220,6 +235,11 @@ final class AppCore: ObservableObject {
     private func applyCustomCommandsPresence() {
         let visible = settings.customCommandsEnabled && settings.customCommandsShowInLauncher
         appIndex.setCustomCommands(visible ? customCommands.commands : [])
+    }
+
+    private func applyWindowCommandsPresence() {
+        let visible = settings.windowManagementEnabled && settings.windowManagementShowInLauncher
+        appIndex.setWindowCommandsVisible(visible)
     }
 
     private func applySnippetsLauncherPresence() {
@@ -368,6 +388,11 @@ final class AppCore: ObservableObject {
             runSystemCommand(app)
             return
         }
+        if app.kind == .windowCommand {
+            guard let command = WindowCommandCatalog.command(forEntryID: app.id) else { return }
+            runWindowCommand(id: command.id)
+            return
+        }
         let previous = windowController.previousApp
         hidePalette(restoreFocus: false)
         switch app.kind {
@@ -379,13 +404,33 @@ final class AppCore: ObservableObject {
         case .snippet:
             let snippetID = String(app.id.dropFirst("snippet:".count))
             expandSnippet(id: snippetID, targetApp: previous)
-        case .command, .systemCommand:
+        case .command, .systemCommand, .windowCommand:
             break  // handled above
         }
     }
 
     func resetRanking(for app: AppEntry) {
         launcherRanking.reset(itemKey: app.preferenceKey)
+    }
+
+    // MARK: - Window commands
+
+    /// The one funnel for both palette activation and a command's global hotkey, so the feature switch
+    /// can't be bypassed by either — a shortcut stays registered while the feature is off and must move
+    /// nothing.
+    ///
+    /// The command acts on the app the user was in, so the palette hands focus back before dispatching,
+    /// the same dance the paste path does. Focus is restored rather than dropped: the window being moved
+    /// is the one they want to keep working in.
+    func runWindowCommand(id: WindowCommand.ID) {
+        guard settings.windowManagementEnabled else { return }
+        let target =
+            windowController.isVisible
+            ? windowController.previousApp : NSWorkspace.shared.frontmostApplication
+        if windowController.isVisible { hidePalette(restoreFocus: true) }
+        windowMover.perform(
+            id, target: target, gap: CGFloat(settings.windowGap),
+            cycleOnRepeat: settings.windowCycleOnRepeat)
     }
 
     // MARK: - System commands

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -8,6 +8,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case command
         case snippet
         case systemCommand
+        case windowCommand
     }
 
     let id: String  // file path (or "command:…" id) — always unique
@@ -31,6 +32,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case .command: return isCustomCommand ? "Custom Command" : "Command"
         case .snippet: return "Snippet"
         case .systemCommand: return "System Command"
+        case .windowCommand: return "Window Command"
         }
     }
 
@@ -43,6 +45,8 @@ struct AppEntry: Identifiable, Hashable, Sendable {
             return bundleID.map { .settingsPane(bundleID: $0) }
         case .command:
             return CustomCommand.id(fromEntryID: id).map { .customCommand(id: $0) }
+        case .windowCommand:
+            return WindowCommandCatalog.command(forEntryID: id).map { .windowCommand(id: $0.id) }
         case .snippet, .systemCommand:
             return nil
         }
@@ -51,10 +55,13 @@ struct AppEntry: Identifiable, Hashable, Sendable {
     /// Synthetic command entries have no file behind them to reveal.
     var canRevealInFinder: Bool { kind == .application || kind == .systemSettings || kind == .snippet }
 
-    /// Command, snippet and system-command entries draw an SF Symbol tile; everything else uses its file icon.
-    var isSymbolIcon: Bool { kind == .command || kind == .snippet || kind == .systemCommand }
+    /// Synthetic entries draw an SF Symbol tile; everything else uses its file icon.
+    var isSymbolIcon: Bool {
+        kind == .command || kind == .snippet || kind == .systemCommand || kind == .windowCommand
+    }
     var symbolIconName: String {
         if kind == .snippet { return "text.quote" }
+        if let window = WindowCommandCatalog.command(forEntryID: id) { return window.sfSymbol }
         if let system = SystemCommandCatalog.command(forEntryID: id) { return system.sfSymbol }
         if let builtIn = CommandRegistry.command(for: self) { return builtIn.sfSymbol }
         return isCustomCommand ? "terminal" : "questionmark"
@@ -188,8 +195,18 @@ final class AppIndex: ObservableObject {
         }
         .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
 
+    private static let allWindowCommandEntries: [AppEntry] = WindowCommandCatalog.all
+        .map { command in
+            AppEntry(
+                id: command.entryID, name: command.name,
+                url: URL(string: "tinycast://window-command/" + command.id.rawValue)!,
+                bundleID: nil, kind: .windowCommand)
+        }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
     private var discoveredEntries: [AppEntry] = []
     private var customCommandEntries: [AppEntry] = []
+    private var windowCommandEntries: [AppEntry] = []
     private var isRefreshing = false
     /// Set when a refresh is requested mid-scan, so a scope edit landing during an in-flight scan isn't silently dropped.
     private var refreshPending = false
@@ -212,6 +229,15 @@ final class AppIndex: ObservableObject {
         .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         guard entries != customCommandEntries else { return }
         customCommandEntries = entries
+        publishEntries()
+    }
+
+    /// Shows or hides the whole window-command slice; the catalog is static, so this is the on/off switch
+    /// rather than a content update.
+    func setWindowCommandsVisible(_ visible: Bool) {
+        let entries = visible ? Self.allWindowCommandEntries : []
+        guard entries != windowCommandEntries else { return }
+        windowCommandEntries = entries
         publishEntries()
     }
 
@@ -295,7 +321,7 @@ final class AppIndex: ObservableObject {
     private func publishEntries() {
         // Each slice is already alphabetical; the slice order is the launcher's section order (LauncherList mirrors it), so custom commands sit in their own section ahead of the built-ins.
         let updated =
-            discoveredEntries + snippetEntries + Self.systemCommandEntries
+            discoveredEntries + snippetEntries + Self.systemCommandEntries + windowCommandEntries
             + customCommandEntries + CommandRegistry.all
         guard updated != apps else { return }
         apps = updated

--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -44,6 +44,10 @@ final class AppSettings: ObservableObject {
         static let customCommandsShowInLauncher = "customCommandsShowInLauncher"
         static let snippetsEnabled = "snippetsEnabled"
         static let snippetsShowInLauncher = "snippetsShowInLauncher"
+        static let windowManagementEnabled = "windowManagementEnabled"
+        static let windowManagementShowInLauncher = "windowManagementShowInLauncher"
+        static let windowGap = "windowManagementGap"
+        static let windowCycleOnRepeat = "windowManagementCycleOnRepeat"
     }
 
     /// Folders (and individual `.app` bundles) `AppIndex` scans, in scan order. Editing this re-indexes — `AppIndex.start(settings:)` observes it.
@@ -129,6 +133,27 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(snippetsShowInLauncher, forKey: Key.snippetsShowInLauncher) }
     }
 
+    /// Off means fully off: no launcher entries, and a still-registered shortcut moves nothing.
+    @Published var windowManagementEnabled: Bool {
+        didSet { defaults.set(windowManagementEnabled, forKey: Key.windowManagementEnabled) }
+    }
+
+    @Published var windowManagementShowInLauncher: Bool {
+        didSet {
+            defaults.set(windowManagementShowInLauncher, forKey: Key.windowManagementShowInLauncher)
+        }
+    }
+
+    /// Points left between tiled windows and around the screen edge. `WindowLayout` caps anything absurd.
+    @Published var windowGap: Int {
+        didSet { defaults.set(windowGap, forKey: Key.windowGap) }
+    }
+
+    /// Re-triggering a half steps it through ⅓ and ⅔ instead of re-applying the same frame.
+    @Published var windowCycleOnRepeat: Bool {
+        didSet { defaults.set(windowCycleOnRepeat, forKey: Key.windowCycleOnRepeat) }
+    }
+
     init() {
         // integer(forKey:) returns 0 when unset, which no case matches — falls through to 3 Months.
         clipboardRetention =
@@ -175,5 +200,12 @@ final class AppSettings: ObservableObject {
         snippetsShowInLauncher =
             defaults.object(forKey: Key.snippetsShowInLauncher) == nil
             || defaults.bool(forKey: Key.snippetsShowInLauncher)
+        windowManagementEnabled = defaults.bool(forKey: Key.windowManagementEnabled)
+        windowManagementShowInLauncher =
+            defaults.object(forKey: Key.windowManagementShowInLauncher) == nil
+            || defaults.bool(forKey: Key.windowManagementShowInLauncher)
+        // Unset reads as 0, which is the intended default anyway — no gap.
+        windowGap = defaults.integer(forKey: Key.windowGap)
+        windowCycleOnRepeat = defaults.bool(forKey: Key.windowCycleOnRepeat)
     }
 }

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -30,6 +30,12 @@ struct SettingsBackup: Codable {
         var customCommandsEnabled: Bool?
         var customCommandsShowInLauncher: Bool?
         var snippetsShowInLauncher: Bool?
+        // Safe to carry, unlike `snippetsEnabled`: this grants no permission class of its own — window
+        // commands reuse the Accessibility grant paste already prompts for.
+        var windowManagementEnabled: Bool?
+        var windowManagementShowInLauncher: Bool?
+        var windowGap: Int?
+        var windowCycleOnRepeat: Bool?
     }
 
     struct HotkeyBackup: Codable {
@@ -39,6 +45,7 @@ struct SettingsBackup: Codable {
         var apps: [String: KeyShortcut]?
         var panes: [String: KeyShortcut]?
         var customCommands: [String: KeyShortcut]?
+        var windowCommands: [String: KeyShortcut]?
     }
 
     /// A tally of what an import touched, for user-facing confirmation.
@@ -76,7 +83,11 @@ extension SettingsBackup {
             openOnCursorScreen: s.openOnCursorScreen,
             customCommandsEnabled: s.customCommandsEnabled,
             customCommandsShowInLauncher: s.customCommandsShowInLauncher,
-            snippetsShowInLauncher: s.snippetsShowInLauncher)
+            snippetsShowInLauncher: s.snippetsShowInLauncher,
+            windowManagementEnabled: s.windowManagementEnabled,
+            windowManagementShowInLauncher: s.windowManagementShowInLauncher,
+            windowGap: s.windowGap,
+            windowCycleOnRepeat: s.windowCycleOnRepeat)
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
@@ -94,6 +105,10 @@ extension SettingsBackup {
         hotkeys.customCommands = Dictionary(
             uniqueKeysWithValues: hk.boundCustomCommandIDs.compactMap { id in
                 hk.shortcut(for: .customCommand(id: id)).map { (id.uuidString.lowercased(), $0) }
+            })
+        hotkeys.windowCommands = Dictionary(
+            uniqueKeysWithValues: WindowCommand.ID.allCases.compactMap { id in
+                hk.shortcut(for: .windowCommand(id: id)).map { (id.rawValue, $0) }
             })
         backup.hotkeys = hotkeys
 
@@ -199,6 +214,22 @@ extension SettingsBackup {
             settings.snippetsShowInLauncher = flag
             count += 1
         }
+        if let flag = s.windowManagementEnabled {
+            settings.windowManagementEnabled = flag
+            count += 1
+        }
+        if let flag = s.windowManagementShowInLauncher {
+            settings.windowManagementShowInLauncher = flag
+            count += 1
+        }
+        if let gap = s.windowGap {
+            settings.windowGap = gap
+            count += 1
+        }
+        if let flag = s.windowCycleOnRepeat {
+            settings.windowCycleOnRepeat = flag
+            count += 1
+        }
         return count
     }
 
@@ -221,6 +252,10 @@ extension SettingsBackup {
                 continue
             }
             apply(s, .customCommand(id: id))
+        }
+        for (rawID, s) in hotkeys.windowCommands ?? [:] {
+            guard let id = WindowCommand.ID(rawValue: rawID) else { continue }
+            apply(s, .windowCommand(id: id))
         }
         return count
     }

--- a/Tinycast/Core/HotKey/KeyShortcut.swift
+++ b/Tinycast/Core/HotKey/KeyShortcut.swift
@@ -153,6 +153,7 @@ enum HotKeyAction: Hashable, Sendable {
     case app(bundleID: String)
     case settingsPane(bundleID: String)
     case customCommand(id: UUID)
+    case windowCommand(id: WindowCommand.ID)
 
     /// UserDefaults key holding the shortcut JSON; the `KeyboardShortcuts_` prefix is a fossil of the replaced package, kept verbatim so existing bindings need no migration.
     var defaultsKey: String {
@@ -164,6 +165,7 @@ enum HotKeyAction: Hashable, Sendable {
         case .settingsPane(let bundleID): "KeyboardShortcuts_paneHotkey." + bundleID
         case .customCommand(let id):
             "KeyboardShortcuts_customCommandHotkey." + id.uuidString.lowercased()
+        case .windowCommand(let id): "KeyboardShortcuts_windowCommandHotkey." + id.rawValue
         }
     }
 }

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -7,6 +7,7 @@ final class HotKeyManager: ObservableObject {
     var onToggleClipboard: (() -> Void)?
     var onToggleEmoji: (() -> Void)?
     var onRunCustomCommand: ((UUID) -> Void)?
+    var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
 
     /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses Carbon so the typed combo can't fire a hotkey.
     @Published var recordingAction: HotKeyAction? {
@@ -31,6 +32,8 @@ final class HotKeyManager: ObservableObject {
         let live = Set(boundCustomCommandIDs).intersection(customCommandIDs)
         persistBoundCustomCommandIDs(live)
         for id in live { register(.customCommand(id: id)) }
+        // A fixed catalog, so there's no index to maintain — `register` no-ops on an unbound command.
+        for id in WindowCommand.ID.allCases { register(.windowCommand(id: id)) }
     }
 
     /// Bundle IDs that currently have a per-app hotkey — lets `start()` know which records to load and lets launcher rows show keycaps.
@@ -84,7 +87,7 @@ final class HotKeyManager: ObservableObject {
             var set = Set(boundCustomCommandIDs)
             if shortcut == nil { set.remove(id) } else { set.insert(id) }
             persistBoundCustomCommandIDs(set)
-        case .togglePalette, .toggleClipboard, .toggleEmoji:
+        case .togglePalette, .toggleClipboard, .toggleEmoji, .windowCommand:
             break
         }
     }
@@ -95,6 +98,7 @@ final class HotKeyManager: ObservableObject {
         candidates += boundBundleIDs.map { .app(bundleID: $0) }
         candidates += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
         candidates += boundCustomCommandIDs.map { .customCommand(id: $0) }
+        candidates += WindowCommand.ID.allCases.map { .windowCommand(id: $0) }
         for candidate in candidates
         where candidate != action && self.shortcut(for: candidate) == shortcut {
             return displayName(of: candidate)
@@ -120,6 +124,8 @@ final class HotKeyManager: ObservableObject {
                 ?? bundleID
         case .customCommand(let id):
             return AppCore.shared.customCommands.command(id: id)?.name ?? "Custom Command"
+        case .windowCommand(let id):
+            return WindowCommandCatalog.command(id: id)?.name ?? "Window Command"
         }
     }
 
@@ -138,6 +144,7 @@ final class HotKeyManager: ObservableObject {
         case .app(let bundleID): AppLauncher.toggle(bundleID: bundleID)
         case .settingsPane(let bundleID): AppLauncher.openSettingsPane(bundleID: bundleID)
         case .customCommand(let id): onRunCustomCommand?(id)
+        case .windowCommand(let id): onRunWindowCommand?(id)
         }
     }
 

--- a/Tinycast/Core/WindowManagement/WindowActionMemory.swift
+++ b/Tinycast/Core/WindowManagement/WindowActionMemory.swift
@@ -1,0 +1,135 @@
+import CoreGraphics
+import Foundation
+
+/// What Tinycast remembers about each window it has moved: the frame to restore, the frame it was left
+/// at, and where it sits in a size cycle.
+///
+/// Cycling and Restore both reduce to one question — *has the user moved this window themselves since
+/// our last action?* — so both are answered here. Generic over the key so this stays Foundation-only:
+/// the app keys by `AXUIElement`, `Tools/window-command-test.swift` keys by `Int`.
+struct WindowActionMemory<Key: Hashable> {
+    struct Record: Equatable, Sendable {
+        /// Where the window was before Tinycast first touched it.
+        var restoreFrame: CGRect
+        /// Where we *observed* it after our last write — not what we asked for. See `decide`.
+        var appliedFrame: CGRect
+        var command: WindowCommand.ID
+        var step: Int
+        var screenID: Int
+        var at: Date
+    }
+
+    struct Decision: Equatable, Sendable {
+        /// Cycle position for this press, fed straight into `WindowLayout.Input.step`.
+        var step: Int
+        /// The frame `commit` should persist as this window's restore point.
+        var restoreFrame: CGRect
+        /// False the first time we see a window: there is nothing to go back to yet, so a Restore press
+        /// must do nothing rather than "restore" it to where it already is.
+        var canRestore: Bool
+        /// Set only when the window still sits exactly where a tile command left it.
+        var lastTileCommand: WindowCommand.ID?
+    }
+
+    /// Point tolerance for "is this still the frame we left it at" — loose enough for subpixel drift,
+    /// tight enough that a deliberate drag always registers.
+    static var tolerance: CGFloat { 2 }
+
+    /// Bounded so a long session over many windows can't grow this without limit.
+    var capacity: Int
+    /// When set, a cycle that has gone cold restarts from the half instead of continuing mid-sequence.
+    var cycleTimeout: TimeInterval?
+
+    private var records: [Key: Record] = [:]
+    /// Least-recently-used first, so eviction is a `removeFirst`.
+    private var order: [Key] = []
+
+    init(capacity: Int = 64, cycleTimeout: TimeInterval? = nil) {
+        self.capacity = capacity
+        self.cycleTimeout = cycleTimeout
+    }
+
+    var count: Int { records.count }
+
+    func record(for key: Key) -> Record? { records[key] }
+
+    /// Resolves the cycle step and restore point for a press. Pure — `commit` performs the write, once
+    /// the mover knows what actually landed.
+    func decide(
+        key: Key, command: WindowCommand.ID, currentFrame: CGRect, currentScreenID: Int,
+        cycleEnabled: Bool, now: Date
+    ) -> Decision {
+        // First time we've seen this window: capture where it was, so Restore works even for windows
+        // Tinycast has never moved.
+        guard let record = records[key] else {
+            return Decision(
+                step: 0, restoreFrame: currentFrame, canRestore: false, lastTileCommand: nil)
+        }
+
+        // Compare against the frame we *observed*, never the one we asked for: Terminal resizes in whole
+        // character cells and never lands exactly on target, so comparing against the target would read
+        // as "the user moved it" on every single press and break cycling and Restore for such apps.
+        guard approximatelyEqual(currentFrame, record.appliedFrame) else {
+            return Decision(
+                step: 0, restoreFrame: currentFrame, canRestore: true, lastTileCommand: nil)
+        }
+
+        let lastTileCommand =
+            WindowLayout.isTileCommand(record.command) ? record.command : nil
+        let cycles = WindowCommandCatalog.command(id: command)?.cyclesOnRepeat ?? false
+        let expired = cycleTimeout.map { now.timeIntervalSince(record.at) > $0 } ?? false
+        let continues =
+            cycleEnabled && cycles && command == record.command
+            && currentScreenID == record.screenID && !expired
+        return Decision(
+            step: continues ? (record.step + 1) % 3 : 0, restoreFrame: record.restoreFrame,
+            canRestore: true, lastTileCommand: lastTileCommand)
+    }
+
+    /// Records what actually landed. `appliedFrame` must be read back from the window, not assumed.
+    mutating func commit(
+        key: Key, command: WindowCommand.ID, decision: Decision, appliedFrame: CGRect,
+        screenID: Int, now: Date
+    ) {
+        records[key] = Record(
+            restoreFrame: decision.restoreFrame, appliedFrame: appliedFrame, command: command,
+            step: decision.step, screenID: screenID, at: now)
+        touch(key)
+    }
+
+    /// Breaks the size-cycle chain while keeping the restore point — what a fullscreen toggle needs,
+    /// since macOS restores the pre-fullscreen frame itself but the user's original frame is still the
+    /// right Restore target.
+    mutating func forgetCycle(key: Key) {
+        guard var record = records[key] else { return }
+        record.step = 0
+        records[key] = record
+    }
+
+    mutating func forget(where predicate: (Key) -> Bool) {
+        let doomed = records.keys.filter(predicate)
+        guard !doomed.isEmpty else { return }
+        for key in doomed { records.removeValue(forKey: key) }
+        order.removeAll { doomed.contains($0) }
+    }
+
+    mutating func forget(key: Key) {
+        guard records.removeValue(forKey: key) != nil else { return }
+        order.removeAll { $0 == key }
+    }
+
+    private mutating func touch(_ key: Key) {
+        order.removeAll { $0 == key }
+        order.append(key)
+        while order.count > capacity, let oldest = order.first {
+            order.removeFirst()
+            records.removeValue(forKey: oldest)
+        }
+    }
+
+    private func approximatelyEqual(_ a: CGRect, _ b: CGRect) -> Bool {
+        let tolerance = Self.tolerance
+        return abs(a.minX - b.minX) <= tolerance && abs(a.minY - b.minY) <= tolerance
+            && abs(a.width - b.width) <= tolerance && abs(a.height - b.height) <= tolerance
+    }
+}

--- a/Tinycast/Core/WindowManagement/WindowCommand.swift
+++ b/Tinycast/Core/WindowManagement/WindowCommand.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+struct WindowCommand: Identifiable, Hashable, Sendable {
+    enum ID: String, CaseIterable, Sendable {
+        case leftHalf = "left-half"
+        case rightHalf = "right-half"
+        case topHalf = "top-half"
+        case bottomHalf = "bottom-half"
+        case topLeftQuarter = "top-left-quarter"
+        case topRightQuarter = "top-right-quarter"
+        case bottomLeftQuarter = "bottom-left-quarter"
+        case bottomRightQuarter = "bottom-right-quarter"
+        case firstThird = "first-third"
+        case centerThird = "center-third"
+        case lastThird = "last-third"
+        case firstTwoThirds = "first-two-thirds"
+        case lastTwoThirds = "last-two-thirds"
+        case maximize
+        case almostMaximize = "almost-maximize"
+        case maximizeHeight = "maximize-height"
+        case maximizeWidth = "maximize-width"
+        case center
+        case centerHalf = "center-half"
+        case makeLarger = "make-larger"
+        case makeSmaller = "make-smaller"
+        case restore
+        case moveLeft = "move-left"
+        case moveRight = "move-right"
+        case moveUp = "move-up"
+        case moveDown = "move-down"
+        case nextDisplay = "next-display"
+        case previousDisplay = "previous-display"
+        case toggleFullscreen = "toggle-fullscreen"
+    }
+
+    /// What the mover has to do, so its dispatch stays exhaustive and the catalog remains the one source of truth.
+    enum Kind: String, Sendable {
+        /// Resolve a target frame from the screen and write it.
+        case geometry
+        /// Geometry too, but sourced from the recorded pre-action frame rather than computed.
+        case restore
+        /// No geometry at all — the native `AXFullScreen` toggle.
+        case fullscreen
+    }
+
+    /// The launcher section a command belongs to, and the order the Settings panel lists them in.
+    enum Group: String, CaseIterable, Sendable {
+        case halves
+        case quarters
+        case thirds
+        case sizing
+        case moving
+        case fullscreen
+
+        var title: String {
+            switch self {
+            case .halves: return "Halves"
+            case .quarters: return "Quarters"
+            case .thirds: return "Thirds"
+            case .sizing: return "Sizing"
+            case .moving: return "Moving"
+            case .fullscreen: return "Fullscreen"
+            }
+        }
+    }
+
+    let id: ID
+    let name: String
+    let sfSymbol: String
+    let kind: Kind
+    let group: Group
+    /// Only the four halves cycle ½ → ⅓ → ⅔; every other command ignores the step it is handed.
+    let cyclesOnRepeat: Bool
+    /// False for the nudges, so the mover never writes `kAXSizeAttribute` for them.
+    let resizes: Bool
+
+    var entryID: String { "window-command:" + id.rawValue }
+}
+
+enum WindowCommandCatalog {
+    static let all: [WindowCommand] = WindowCommand.ID.allCases.map { id in
+        WindowCommand(
+            id: id, name: name(for: id), sfSymbol: symbol(for: id), kind: kind(for: id),
+            group: group(for: id), cyclesOnRepeat: cyclesOnRepeat.contains(id),
+            resizes: !movesOnly.contains(id))
+    }
+
+    private static let byID = Dictionary(uniqueKeysWithValues: all.map { ($0.id, $0) })
+    private static let byEntryID = Dictionary(uniqueKeysWithValues: all.map { ($0.entryID, $0) })
+
+    static func command(id: WindowCommand.ID) -> WindowCommand? { byID[id] }
+
+    static func command(forEntryID entryID: String) -> WindowCommand? { byEntryID[entryID] }
+
+    /// Catalog order grouped for the Settings list; `ID.allCases` is already in group order, so this only partitions it.
+    static func grouped() -> [(group: WindowCommand.Group, commands: [WindowCommand])] {
+        WindowCommand.Group.allCases.compactMap { group in
+            let commands = all.filter { $0.group == group }
+            return commands.isEmpty ? nil : (group, commands)
+        }
+    }
+
+    static let cyclesOnRepeat: Set<WindowCommand.ID> = [
+        .leftHalf, .rightHalf, .topHalf, .bottomHalf,
+    ]
+
+    /// Nudges reposition without ever touching the size.
+    static let movesOnly: Set<WindowCommand.ID> = [.moveLeft, .moveRight, .moveUp, .moveDown]
+
+    private static func name(for id: WindowCommand.ID) -> String {
+        switch id {
+        case .leftHalf: return "Left Half"
+        case .rightHalf: return "Right Half"
+        case .topHalf: return "Top Half"
+        case .bottomHalf: return "Bottom Half"
+        case .topLeftQuarter: return "Top Left Quarter"
+        case .topRightQuarter: return "Top Right Quarter"
+        case .bottomLeftQuarter: return "Bottom Left Quarter"
+        case .bottomRightQuarter: return "Bottom Right Quarter"
+        case .firstThird: return "First Third"
+        case .centerThird: return "Center Third"
+        case .lastThird: return "Last Third"
+        case .firstTwoThirds: return "First Two Thirds"
+        case .lastTwoThirds: return "Last Two Thirds"
+        case .maximize: return "Maximize"
+        case .almostMaximize: return "Almost Maximize"
+        case .maximizeHeight: return "Maximize Height"
+        case .maximizeWidth: return "Maximize Width"
+        case .center: return "Center"
+        case .centerHalf: return "Center Half"
+        case .makeLarger: return "Make Larger"
+        case .makeSmaller: return "Make Smaller"
+        case .restore: return "Restore Window"
+        case .moveLeft: return "Move Left"
+        case .moveRight: return "Move Right"
+        case .moveUp: return "Move Up"
+        case .moveDown: return "Move Down"
+        case .nextDisplay: return "Move to Next Display"
+        case .previousDisplay: return "Move to Previous Display"
+        case .toggleFullscreen: return "Toggle Fullscreen"
+        }
+    }
+
+    private static func symbol(for id: WindowCommand.ID) -> String {
+        switch id {
+        case .leftHalf: return "rectangle.lefthalf.filled"
+        case .rightHalf: return "rectangle.righthalf.filled"
+        case .topHalf: return "rectangle.tophalf.filled"
+        case .bottomHalf: return "rectangle.bottomhalf.filled"
+        case .topLeftQuarter: return "rectangle.inset.topleading.filled"
+        case .topRightQuarter: return "rectangle.inset.toptrailing.filled"
+        case .bottomLeftQuarter: return "rectangle.inset.bottomleading.filled"
+        case .bottomRightQuarter: return "rectangle.inset.bottomtrailing.filled"
+        case .firstThird, .firstTwoThirds: return "rectangle.leadingthird.inset.filled"
+        case .centerThird: return "rectangle.center.inset.filled"
+        case .lastThird, .lastTwoThirds: return "rectangle.trailingthird.inset.filled"
+        case .maximize: return "arrow.up.left.and.arrow.down.right"
+        case .almostMaximize: return "rectangle.inset.filled"
+        case .maximizeHeight: return "arrow.up.and.down"
+        case .maximizeWidth: return "arrow.left.and.right"
+        case .center: return "rectangle.center.inset.filled"
+        case .centerHalf: return "rectangle.split.3x1"
+        case .makeLarger: return "plus.magnifyingglass"
+        case .makeSmaller: return "minus.magnifyingglass"
+        case .restore: return "arrow.uturn.backward"
+        case .moveLeft: return "arrow.left"
+        case .moveRight: return "arrow.right"
+        case .moveUp: return "arrow.up"
+        case .moveDown: return "arrow.down"
+        case .nextDisplay: return "rectangle.on.rectangle.angled"
+        case .previousDisplay: return "rectangle.on.rectangle.angled"
+        case .toggleFullscreen: return "arrow.up.left.and.arrow.down.right.square"
+        }
+    }
+
+    private static func kind(for id: WindowCommand.ID) -> WindowCommand.Kind {
+        switch id {
+        case .restore: return .restore
+        case .toggleFullscreen: return .fullscreen
+        default: return .geometry
+        }
+    }
+
+    private static func group(for id: WindowCommand.ID) -> WindowCommand.Group {
+        switch id {
+        case .leftHalf, .rightHalf, .topHalf, .bottomHalf:
+            return .halves
+        case .topLeftQuarter, .topRightQuarter, .bottomLeftQuarter, .bottomRightQuarter:
+            return .quarters
+        case .firstThird, .centerThird, .lastThird, .firstTwoThirds, .lastTwoThirds:
+            return .thirds
+        case .maximize, .almostMaximize, .maximizeHeight, .maximizeWidth, .center, .centerHalf,
+            .makeLarger, .makeSmaller, .restore:
+            return .sizing
+        case .moveLeft, .moveRight, .moveUp, .moveDown, .nextDisplay, .previousDisplay:
+            return .moving
+        case .toggleFullscreen:
+            return .fullscreen
+        }
+    }
+}

--- a/Tinycast/Core/WindowManagement/WindowLayout.swift
+++ b/Tinycast/Core/WindowManagement/WindowLayout.swift
@@ -1,0 +1,450 @@
+import CoreGraphics
+import Foundation
+
+/// Pure window geometry: every frame the window commands produce, with no Accessibility, no `NSScreen`
+/// and no clock — so `Tools/window-command-test.swift` can compile and exercise it standalone.
+///
+/// Everything here works in **AX space**: global coordinates, top-left origin, +Y pointing *down*.
+/// `WindowMover` is the only place that converts to and from Cocoa's bottom-left space. The visible
+/// consequence is that "Top Half" has `minY == visibleFrame.minY`.
+enum WindowLayout {
+    /// A display, already converted to AX space by the caller.
+    struct Screen: Equatable, Sendable {
+        /// `CGDirectDisplayID` in the app; any stable value in tests.
+        let id: Int
+        let frame: CGRect
+        let visibleFrame: CGRect
+
+        init(id: Int, frame: CGRect, visibleFrame: CGRect) {
+            self.id = id
+            self.frame = frame
+            self.visibleFrame = visibleFrame
+        }
+    }
+
+    /// Where a window that refused to shrink to its slot sits inside it — a left half stays left-aligned
+    /// rather than centred.
+    struct Anchor: Equatable, Sendable {
+        /// `min` is left / top, since +Y points down here.
+        enum Axis: Equatable, Sendable { case min, center, max }
+
+        var horizontal: Axis
+        var vertical: Axis
+
+        static let topLeading = Anchor(horizontal: .min, vertical: .min)
+        static let centered = Anchor(horizontal: .center, vertical: .center)
+
+        /// Places `size` inside `slot` per the anchor, used when an app clamped itself larger than the slot.
+        func place(_ size: CGSize, in slot: CGRect) -> CGRect {
+            func origin(_ axis: Axis, slotMin: CGFloat, slotLength: CGFloat, length: CGFloat)
+                -> CGFloat
+            {
+                switch axis {
+                case .min: return slotMin
+                case .center: return slotMin + (slotLength - length) / 2
+                case .max: return slotMin + slotLength - length
+                }
+            }
+            return CGRect(
+                x: origin(
+                    horizontal, slotMin: slot.minX, slotLength: slot.width, length: size.width),
+                y: origin(vertical, slotMin: slot.minY, slotLength: slot.height, length: size.height),
+                width: size.width, height: size.height)
+        }
+    }
+
+    struct Input: Equatable, Sendable {
+        var command: WindowCommand.ID
+        var windowFrame: CGRect
+        var screens: [Screen]
+        var gap: CGFloat
+        /// Cycle position, supplied by `WindowActionMemory` so the geometry itself stays stateless.
+        var step: Int
+        /// Read only by `.restore`.
+        var restoreFrame: CGRect?
+        /// The tile command that last placed this window, when it hasn't been touched since. Lets the
+        /// display moves re-derive that tile exactly on the destination instead of scaling it.
+        var lastTileCommand: WindowCommand.ID?
+
+        init(
+            command: WindowCommand.ID, windowFrame: CGRect, screens: [Screen], gap: CGFloat = 0,
+            step: Int = 0, restoreFrame: CGRect? = nil, lastTileCommand: WindowCommand.ID? = nil
+        ) {
+            self.command = command
+            self.windowFrame = windowFrame
+            self.screens = screens
+            self.gap = gap
+            self.step = step
+            self.restoreFrame = restoreFrame
+            self.lastTileCommand = lastTileCommand
+        }
+    }
+
+    struct Placement: Equatable, Sendable {
+        var frame: CGRect
+        var screenID: Int
+        var anchor: Anchor
+        var resizes: Bool
+    }
+
+    // MARK: - Tuning
+
+    /// Make Larger / Make Smaller and the four nudges all step by this fraction of the screen.
+    private static let stepFraction: CGFloat = 0.05
+    private static let almostMaximizeFraction: CGFloat = 0.9
+
+    // MARK: - Entry point
+
+    /// The target placement, or `nil` when there is nothing to apply — an unknown restore point, a
+    /// display move with only one display, a fullscreen command, or degenerate input. `nil` means the
+    /// mover writes nothing at all rather than writing something harmless.
+    static func placement(for input: Input) -> Placement? {
+        guard let command = WindowCommandCatalog.command(id: input.command),
+            command.kind != .fullscreen,
+            !input.screens.isEmpty
+        else { return nil }
+
+        if command.kind == .restore { return restorePlacement(input) }
+
+        guard let host = screen(containing: input.windowFrame, in: input.screens),
+            host.visibleFrame.width > 0, host.visibleFrame.height > 0
+        else { return nil }
+
+        let gap = sanitizedGap(input.gap, in: host.visibleFrame)
+
+        switch input.command {
+        case .nextDisplay, .previousDisplay:
+            return displayPlacement(input, from: host, gap: gap)
+        default:
+            break
+        }
+
+        // Non-cycling commands ignore the step entirely, so a stale cycle position can never leak in.
+        let step = command.cyclesOnRepeat ? normalizedStep(input.step) : 0
+
+        if let fractions = tileFractions(input.command, step: step) {
+            let frame = tile(
+                host.visibleFrame, x0: fractions.x0, x1: fractions.x1, y0: fractions.y0,
+                y1: fractions.y1, gap: gap)
+            return Placement(
+                frame: frame, screenID: host.id, anchor: fractions.anchor, resizes: true)
+        }
+
+        let canvas = canvas(host.visibleFrame, gap: gap)
+        guard canvas.width > 0, canvas.height > 0 else { return nil }
+        let current = input.windowFrame
+
+        switch input.command {
+        case .maximize:
+            return Placement(
+                frame: canvas, screenID: host.id, anchor: .topLeading, resizes: true)
+
+        case .almostMaximize:
+            let size = CGSize(
+                width: canvas.width * almostMaximizeFraction,
+                height: canvas.height * almostMaximizeFraction)
+            return Placement(
+                frame: rounded(Anchor.centered.place(size, in: canvas)), screenID: host.id,
+                anchor: .centered, resizes: true)
+
+        // Both keep the untouched axis's position, but clamp it: a window sitting off the display would
+        // otherwise come back full-height and still entirely off-screen.
+        case .maximizeHeight:
+            let frame = CGRect(
+                x: current.minX, y: canvas.minY, width: current.width, height: canvas.height)
+            return Placement(
+                frame: rounded(clamped(frame, into: canvas)), screenID: host.id,
+                anchor: .topLeading, resizes: true)
+
+        case .maximizeWidth:
+            let frame = CGRect(
+                x: canvas.minX, y: current.minY, width: canvas.width, height: current.height)
+            return Placement(
+                frame: rounded(clamped(frame, into: canvas)), screenID: host.id,
+                anchor: .topLeading, resizes: true)
+
+        case .center:
+            let size = CGSize(
+                width: min(current.width, canvas.width), height: min(current.height, canvas.height))
+            return Placement(
+                frame: rounded(Anchor.centered.place(size, in: canvas)), screenID: host.id,
+                anchor: .centered, resizes: true)
+
+        case .makeLarger, .makeSmaller:
+            return Placement(
+                frame: resized(current, in: canvas, larger: input.command == .makeLarger),
+                screenID: host.id, anchor: .centered, resizes: true)
+
+        case .moveLeft, .moveRight, .moveUp, .moveDown:
+            return Placement(
+                frame: nudged(current, in: canvas, command: input.command), screenID: host.id,
+                anchor: .topLeading, resizes: false)
+
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Screens
+
+    /// The display a window lives on: most overlapping area wins, so a window straddling two displays
+    /// belongs to whichever shows more of it. Falls back to the display holding its centre.
+    static func screen(containing frame: CGRect, in screens: [Screen]) -> Screen? {
+        guard !screens.isEmpty else { return nil }
+        var best: (screen: Screen, area: CGFloat)?
+        for screen in screens {
+            let overlap = screen.frame.intersection(frame)
+            let area = overlap.isNull ? 0 : overlap.width * overlap.height
+            if area > (best?.area ?? 0) { best = (screen, area) }
+        }
+        if let best, best.area > 0 { return best.screen }
+        let centre = CGPoint(x: frame.midX, y: frame.midY)
+        return screens.first { $0.frame.contains(centre) } ?? screens.first
+    }
+
+    /// Left-to-right, then top-to-bottom — a stable order independent of however `NSScreen.screens`
+    /// happens to be sorted.
+    static func ordered(_ screens: [Screen]) -> [Screen] {
+        screens.sorted {
+            $0.frame.minX != $1.frame.minX
+                ? $0.frame.minX < $1.frame.minX : $0.frame.minY < $1.frame.minY
+        }
+    }
+
+    private static func displayPlacement(_ input: Input, from host: Screen, gap: CGFloat)
+        -> Placement?
+    {
+        let ordered = ordered(input.screens)
+        // A single display makes both commands a quiet no-op rather than a pointless re-place.
+        guard ordered.count > 1, let index = ordered.firstIndex(where: { $0.id == host.id })
+        else { return nil }
+        let offset = input.command == .nextDisplay ? 1 : -1
+        let destination = ordered[(index + offset + ordered.count) % ordered.count]
+        let frame = moved(
+            input.windowFrame, from: host, to: destination, gap: gap,
+            lastTile: input.lastTileCommand)
+        return Placement(
+            frame: frame, screenID: destination.id, anchor: .centered, resizes: true)
+    }
+
+    private static func moved(
+        _ frame: CGRect, from: Screen, to: Screen, gap: CGFloat, lastTile: WindowCommand.ID?
+    ) -> CGRect {
+        // Exactness beats proportion: a window still sitting where a tile command put it re-derives that
+        // same tile on the destination, so thirds and gaps land on the point instead of being scaled.
+        if let lastTile, let fractions = tileFractions(lastTile, step: 0) {
+            return tile(
+                to.visibleFrame, x0: fractions.x0, x1: fractions.x1, y0: fractions.y0,
+                y1: fractions.y1, gap: sanitizedGap(gap, in: to.visibleFrame))
+        }
+        let source = from.visibleFrame
+        let target = to.visibleFrame
+        guard source.width > 0, source.height > 0 else { return frame }
+        // Relative to `visibleFrame`, not `frame`: a window tucked against the Dock should land tucked
+        // against the destination's Dock, whatever each display reserves.
+        let relativeX = (frame.minX - source.minX) / source.width
+        let relativeY = (frame.minY - source.minY) / source.height
+        let scaled = CGRect(
+            x: target.minX + relativeX * target.width,
+            y: target.minY + relativeY * target.height,
+            width: min(target.width, frame.width / source.width * target.width),
+            height: min(target.height, frame.height / source.height * target.height))
+        return rounded(clamped(scaled, into: target))
+    }
+
+    // MARK: - Restore
+
+    private static func restorePlacement(_ input: Input) -> Placement? {
+        guard let restoreFrame = input.restoreFrame,
+            let host = screen(containing: restoreFrame, in: input.screens)
+        else { return nil }
+        let overlap = host.visibleFrame.intersection(restoreFrame)
+        // A restore point stranded off every current display (a monitor was unplugged meanwhile) comes
+        // back centred at its old size rather than off-screen where it can't be reached.
+        let stranded = overlap.isNull || overlap.width < 40 || overlap.height < 40
+        let frame =
+            stranded
+            ? rounded(
+                clamped(
+                    Anchor.centered.place(restoreFrame.size, in: host.visibleFrame),
+                    into: host.visibleFrame))
+            : restoreFrame
+        return Placement(frame: frame, screenID: host.id, anchor: .centered, resizes: true)
+    }
+
+    // MARK: - Tiles
+
+    private struct Fractions {
+        var x0: CGFloat
+        var x1: CGFloat
+        var y0: CGFloat
+        var y1: CGFloat
+        var anchor: Anchor
+    }
+
+    private static let oneThird: CGFloat = 1.0 / 3.0
+    private static let twoThirds: CGFloat = 2.0 / 3.0
+
+    /// The fractional bounds of a tile command, or `nil` if the command isn't a tile. `step` only ever
+    /// matters for the four halves, which cycle ½ → ⅓ → ⅔. The vertical cycle has no commands of its
+    /// own — Thirds are horizontal — so it is expressed here as fractions rather than other command IDs.
+    private static func tileFractions(_ command: WindowCommand.ID, step: Int) -> Fractions? {
+        let cycle: [CGFloat] = [0.5, oneThird, twoThirds]
+        let position = cycle[normalizedStep(step)]
+        switch command {
+        case .leftHalf:
+            return Fractions(x0: 0, x1: position, y0: 0, y1: 1, anchor: .topLeading)
+        case .rightHalf:
+            return Fractions(
+                x0: 1 - position, x1: 1, y0: 0, y1: 1,
+                anchor: Anchor(horizontal: .max, vertical: .min))
+        case .topHalf:
+            return Fractions(x0: 0, x1: 1, y0: 0, y1: position, anchor: .topLeading)
+        case .bottomHalf:
+            return Fractions(
+                x0: 0, x1: 1, y0: 1 - position, y1: 1,
+                anchor: Anchor(horizontal: .min, vertical: .max))
+
+        case .topLeftQuarter:
+            return Fractions(x0: 0, x1: 0.5, y0: 0, y1: 0.5, anchor: .topLeading)
+        case .topRightQuarter:
+            return Fractions(
+                x0: 0.5, x1: 1, y0: 0, y1: 0.5, anchor: Anchor(horizontal: .max, vertical: .min))
+        case .bottomLeftQuarter:
+            return Fractions(
+                x0: 0, x1: 0.5, y0: 0.5, y1: 1, anchor: Anchor(horizontal: .min, vertical: .max))
+        case .bottomRightQuarter:
+            return Fractions(
+                x0: 0.5, x1: 1, y0: 0.5, y1: 1, anchor: Anchor(horizontal: .max, vertical: .max))
+
+        case .firstThird:
+            return Fractions(x0: 0, x1: oneThird, y0: 0, y1: 1, anchor: .topLeading)
+        case .centerThird:
+            return Fractions(
+                x0: oneThird, x1: twoThirds, y0: 0, y1: 1,
+                anchor: Anchor(horizontal: .center, vertical: .min))
+        case .lastThird:
+            return Fractions(
+                x0: twoThirds, x1: 1, y0: 0, y1: 1,
+                anchor: Anchor(horizontal: .max, vertical: .min))
+        case .firstTwoThirds:
+            return Fractions(x0: 0, x1: twoThirds, y0: 0, y1: 1, anchor: .topLeading)
+        case .lastTwoThirds:
+            return Fractions(
+                x0: oneThird, x1: 1, y0: 0, y1: 1,
+                anchor: Anchor(horizontal: .max, vertical: .min))
+
+        // Half the screen's area — half its width, full height — so it reads as the family sibling of
+        // Center Third.
+        case .centerHalf:
+            return Fractions(
+                x0: 0.25, x1: 0.75, y0: 0, y1: 1,
+                anchor: Anchor(horizontal: .center, vertical: .min))
+
+        default:
+            return nil
+        }
+    }
+
+    /// Whether the command places the window on the fractional grid — the ones a display move can
+    /// re-derive exactly on the destination rather than scaling proportionally.
+    static func isTileCommand(_ command: WindowCommand.ID) -> Bool {
+        tileFractions(command, step: 0) != nil
+    }
+
+    /// A tile from fractional bounds of `visible`. An edge sitting on the screen boundary takes the full
+    /// gap, an interior edge takes half — so two adjacent tiles leave exactly `gap` between them and
+    /// every screen edge is inset by `gap`, with no per-family special cases.
+    static func tile(
+        _ visible: CGRect, x0: CGFloat, x1: CGFloat, y0: CGFloat, y1: CGFloat, gap: CGFloat
+    ) -> CGRect {
+        let left = visible.minX + x0 * visible.width + (x0 == 0 ? gap : gap / 2)
+        let right = visible.minX + x1 * visible.width - (x1 == 1 ? gap : gap / 2)
+        let top = visible.minY + y0 * visible.height + (y0 == 0 ? gap : gap / 2)
+        let bottom = visible.minY + y1 * visible.height - (y1 == 1 ? gap : gap / 2)
+        return rounded(
+            CGRect(
+                x: left, y: top, width: max(1, right - left), height: max(1, bottom - top)))
+    }
+
+    /// The box free-floating commands work in. A centred window has no neighbour to gutter against, so it
+    /// takes the full gap on every side rather than the tile grid's half-gaps.
+    static func canvas(_ visible: CGRect, gap: CGFloat) -> CGRect {
+        rounded(visible.insetBy(dx: gap, dy: gap))
+    }
+
+    // MARK: - Sizing
+
+    /// Never let repeated shrinking collapse a window to nothing.
+    private static func minimumSize(in canvas: CGRect) -> CGSize {
+        CGSize(
+            width: min(canvas.width, max(200, canvas.width * 0.15)),
+            height: min(canvas.height, max(150, canvas.height * 0.15)))
+    }
+
+    /// Even so that growing and shrinking move each edge by a whole point, which is what makes the two
+    /// commands exactly invertible instead of drifting by a point per round trip.
+    private static func evenStep(_ dimension: CGFloat) -> CGFloat {
+        max(2, (dimension * stepFraction / 2).rounded() * 2)
+    }
+
+    /// Grows or shrinks about the centre by a fixed fraction of the *screen*, not of the window. A
+    /// screen-relative step is exactly invertible — `size × 0.95 × 1.05 ≠ size`, so a size-relative one
+    /// would shrink a little on every round trip — and it feels the same at any window size.
+    private static func resized(_ frame: CGRect, in canvas: CGRect, larger: Bool) -> CGRect {
+        let direction: CGFloat = larger ? 1 : -1
+        let floorSize = minimumSize(in: canvas)
+        let width = min(
+            canvas.width, max(floorSize.width, frame.width + direction * evenStep(canvas.width)))
+        let height = min(
+            canvas.height, max(floorSize.height, frame.height + direction * evenStep(canvas.height)))
+        let centred = CGRect(
+            x: frame.minX - (width - frame.width) / 2, y: frame.minY - (height - frame.height) / 2,
+            width: width, height: height)
+        return rounded(clamped(centred, into: canvas))
+    }
+
+    private static func nudged(_ frame: CGRect, in canvas: CGRect, command: WindowCommand.ID)
+        -> CGRect
+    {
+        let dx = (canvas.width * stepFraction).rounded()
+        let dy = (canvas.height * stepFraction).rounded()
+        var moved = frame
+        switch command {
+        case .moveLeft: moved.origin.x -= dx
+        case .moveRight: moved.origin.x += dx
+        case .moveUp: moved.origin.y -= dy
+        case .moveDown: moved.origin.y += dy
+        default: break
+        }
+        return rounded(clamped(moved, into: canvas))
+    }
+
+    // MARK: - Primitives
+
+    /// Rounds the four *edges* rather than origin and size: two tiles sharing a fractional boundary
+    /// (480.333 for thirds of 1441) round it identically, so tiles never overlap and never leave a seam.
+    static func rounded(_ rect: CGRect) -> CGRect {
+        let minX = rect.minX.rounded()
+        let minY = rect.minY.rounded()
+        let maxX = rect.maxX.rounded()
+        let maxY = rect.maxY.rounded()
+        return CGRect(x: minX, y: minY, width: max(0, maxX - minX), height: max(0, maxY - minY))
+    }
+
+    /// Keeps `frame` inside `box` without resizing it. An oversized window pins its leading edge rather
+    /// than being shoved off the far side.
+    static func clamped(_ frame: CGRect, into box: CGRect) -> CGRect {
+        let x = min(max(frame.minX, box.minX), max(box.minX, box.maxX - frame.width))
+        let y = min(max(frame.minY, box.minY), max(box.minY, box.maxY - frame.height))
+        return CGRect(x: x, y: y, width: frame.width, height: frame.height)
+    }
+
+    /// A gap wider than the screen can carry would produce zero-width tiles, so cap it before any math.
+    static func sanitizedGap(_ gap: CGFloat, in visible: CGRect) -> CGFloat {
+        guard gap.isFinite, gap > 0, visible.width > 0, visible.height > 0 else { return 0 }
+        return min(gap, min(visible.width, visible.height) / 10)
+    }
+
+    private static func normalizedStep(_ step: Int) -> Int { ((step % 3) + 3) % 3 }
+}

--- a/Tinycast/Core/WindowManagement/WindowMover.swift
+++ b/Tinycast/Core/WindowManagement/WindowMover.swift
@@ -1,0 +1,371 @@
+import AppKit
+// `@preconcurrency` downgrades AX concurrency diagnostics, as in `Permissions`: the `kAX…` constants are
+// mutable C globals but process-constant.
+@preconcurrency import ApplicationServices
+
+/// Applies window commands to the focused window of another app over Accessibility.
+///
+/// All geometry decisions live in `WindowLayout`; this type only reads the current frame, converts
+/// between coordinate spaces, writes the result, and remembers what landed. Every failure path is
+/// silent by design — a window that refuses to move is left exactly as it was, never half-moved.
+@MainActor
+final class WindowMover {
+    /// `AXUIElement` is a CF type, so `CFEqual`/`CFHash` are the supported identity; the pid keeps two
+    /// processes' elements from colliding in the same bucket.
+    private struct WindowKey: Hashable {
+        let pid: pid_t
+        let element: AXUIElement
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.pid == rhs.pid && CFEqual(lhs.element, rhs.element)
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(pid)
+            hasher.combine(CFHash(element))
+        }
+    }
+
+    /// A hung target must not stall the main actor for the AX default (6s). Per element, never inherited.
+    private static let messagingTimeout: Float = 1
+    /// Slack when checking whether the app honoured the size we asked for.
+    private static let clampTolerance: CGFloat = 2
+
+    private static let fullScreenAttribute = "AXFullScreen" as CFString
+    private static let fullScreenButtonAttribute = "AXFullScreenButton" as CFString
+
+    private var memory = WindowActionMemory<WindowKey>()
+    private var terminationToken: NotificationToken?
+
+    init() {
+        // Drop a quit app's windows rather than waiting for LRU eviction to reclaim them.
+        let token = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification, object: nil, queue: .main
+        ) { [weak self] note in
+            guard
+                let app = note.userInfo?[NSWorkspace.applicationUserInfoKey]
+                    as? NSRunningApplication
+            else { return }
+            let pid = app.processIdentifier
+            MainActor.assumeIsolated {
+                self?.memory.forget { $0.pid == pid }
+            }
+        }
+        terminationToken = NotificationToken(token, center: NSWorkspace.shared.notificationCenter)
+    }
+
+    /// Runs `command` against `target`'s focused window. `target` is explicit because the palette is
+    /// frontmost when a command dispatches from it — `AppCore` passes the app it recorded before hiding.
+    ///
+    /// Returns whether anything actually changed, so a caller can stay quiet when nothing did.
+    @discardableResult
+    func perform(
+        _ command: WindowCommand.ID, target: NSRunningApplication?, gap: CGFloat,
+        cycleOnRepeat: Bool
+    ) -> Bool {
+        // Invoked from an explicit user gesture, so prompting for the grant is appropriate here.
+        guard Permissions.ensureAccessibility() else { return false }
+        guard let target, !target.isTerminated,
+            target.processIdentifier != ProcessInfo.processInfo.processIdentifier
+        else { return false }
+        guard let catalogued = WindowCommandCatalog.command(id: command) else { return false }
+
+        let application = AXUIElementCreateApplication(target.processIdentifier)
+        AXUIElementSetMessagingTimeout(application, Self.messagingTimeout)
+        guard let window = targetWindow(in: application) else { return false }
+        AXUIElementSetMessagingTimeout(window, Self.messagingTimeout)
+
+        let key = WindowKey(pid: target.processIdentifier, element: window)
+
+        if catalogued.kind == .fullscreen {
+            guard toggleFullScreen(window) else { return false }
+            // The size chain is meaningless now, but the pre-Tinycast frame is still the right Restore
+            // target — macOS restores the pre-fullscreen frame itself on the way out.
+            memory.forgetCycle(key: key)
+            return true
+        }
+        // Tiling a natively fullscreen window fights the window server; leave it alone.
+        guard !isFullScreen(window), let current = frame(of: window) else { return false }
+
+        let geometry = AXGeometry(screens: NSScreen.screens)
+        let screens = Self.screens(NSScreen.screens, geometry: geometry)
+        guard let host = WindowLayout.screen(containing: current, in: screens) else { return false }
+
+        // One timestamp for the whole command, so the cycle timeout can't straddle two readings.
+        let now = Date()
+        let decision = memory.decide(
+            key: key, command: command, currentFrame: current, currentScreenID: host.id,
+            cycleEnabled: cycleOnRepeat, now: now)
+
+        let input = WindowLayout.Input(
+            command: command, windowFrame: current, screens: screens, gap: gap, step: decision.step,
+            restoreFrame: decision.canRestore ? decision.restoreFrame : nil,
+            lastTileCommand: decision.lastTileCommand)
+        guard let placement = WindowLayout.placement(for: input) else { return false }
+
+        // Checked before a single write, so a window that can't be positioned is left untouched rather
+        // than resized in place.
+        guard isSettable(kAXPositionAttribute, on: window) else { return false }
+        let canResize =
+            placement.resizes && isSettable(kAXSizeAttribute, on: window)
+
+        guard
+            let applied = apply(
+                placement, to: window, application: application, current: current,
+                canResize: canResize, screens: screens, gap: gap)
+        else { return false }
+
+        let landedOn =
+            WindowLayout.screen(containing: applied, in: screens)?.id ?? placement.screenID
+        memory.commit(
+            key: key, command: command, decision: decision, appliedFrame: applied,
+            screenID: landedOn, now: now)
+        return !applied.equalTo(current)
+    }
+
+    // MARK: - Applying a placement
+
+    private func apply(
+        _ placement: WindowLayout.Placement, to window: AXUIElement, application: AXUIElement,
+        current: CGRect, canResize: Bool, screens: [WindowLayout.Screen], gap: CGFloat
+    ) -> CGRect? {
+        let destination = screens.first { $0.id == placement.screenID }
+        let canvas = destination.map {
+            WindowLayout.canvas($0.visibleFrame, gap: WindowLayout.sanitizedGap(gap, in: $0.visibleFrame))
+        }
+
+        guard canResize else {
+            // The window refuses to resize: place the size it already has inside the slot and stop, so
+            // the result is one coherent move rather than a half-applied one.
+            var slot = placement.anchor.place(current.size, in: placement.frame)
+            if let canvas { slot = WindowLayout.clamped(slot, into: canvas) }
+            guard setPosition(WindowLayout.rounded(slot).origin, on: window) else { return nil }
+            return frame(of: window) ?? current
+        }
+
+        let restoreEnhancedUI = suppressEnhancedUserInterface(on: application)
+        defer { restoreEnhancedUI() }
+
+        // size → position → size. The first write shrinks the window so the move isn't clamped by the
+        // display it is leaving; the second applies the real size now that it is on the destination, the
+        // only display that can validate a larger frame. Whichever direction this is, one is a no-op.
+        _ = setSize(placement.frame.size, on: window)
+        guard setPosition(placement.frame.origin, on: window) else {
+            _ = setSize(current.size, on: window)  // Roll the shrink back; nothing visibly moved.
+            return nil
+        }
+        _ = setSize(placement.frame.size, on: window)
+
+        guard var actual = frame(of: window) else { return placement.frame }
+
+        // The second resize can shift the origin — some apps anchor a resize on a different corner.
+        if abs(actual.minX - placement.frame.minX) > Self.clampTolerance
+            || abs(actual.minY - placement.frame.minY) > Self.clampTolerance
+        {
+            _ = setPosition(placement.frame.origin, on: window)
+            actual = frame(of: window) ?? actual
+        }
+
+        // The app refused to shrink to the slot (a minimum size, which AX exposes no attribute for — the
+        // read-back is the only way to learn it). Re-place the size it insisted on per the placement's
+        // anchor, so a left half stays left-aligned instead of drifting centre. One correction, no loop:
+        // iterating against an app that fights back just makes the window visibly jitter.
+        if actual.width > placement.frame.width + Self.clampTolerance
+            || actual.height > placement.frame.height + Self.clampTolerance
+        {
+            var slot = placement.anchor.place(actual.size, in: placement.frame)
+            if let canvas { slot = WindowLayout.clamped(slot, into: canvas) }
+            _ = setPosition(WindowLayout.rounded(slot).origin, on: window)
+            actual = frame(of: window) ?? actual
+        }
+        return actual
+    }
+
+    // MARK: - Finding the window
+
+    private func targetWindow(in application: AXUIElement) -> AXUIElement? {
+        for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
+            if let window = element(application, attribute), isEligible(window) { return window }
+        }
+        // Last resort for apps that report neither: the first window that isn't a sheet or a panel.
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(application, kAXWindowsAttribute as CFString, &value)
+                == .success,
+            let windows = value as? [AXUIElement]
+        else { return nil }
+        return windows.first(where: isEligible)
+    }
+
+    /// A real, restorable window — not a sheet, popover or minimized one, and one that reports geometry.
+    private func isEligible(_ window: AXUIElement) -> Bool {
+        guard string(window, kAXRoleAttribute) == (kAXWindowRole as String) else { return false }
+        if bool(window, kAXMinimizedAttribute) == true { return false }
+        return frame(of: window) != nil
+    }
+
+    // MARK: - Fullscreen
+
+    private func isFullScreen(_ window: AXUIElement) -> Bool {
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(window, Self.fullScreenAttribute, &value) == .success
+        else { return false }
+        return (value as? Bool) ?? false
+    }
+
+    /// `AXFullScreen` is undocumented but universally implemented; the green button is the fallback for
+    /// windows that expose it yet refuse the attribute write. No synthetic ⌃⌘F third attempt — it is
+    /// app-rebindable and could fire an unrelated menu command.
+    ///
+    /// Deliberately does not read geometry back: the transition is animated and asynchronous, so any
+    /// frame read here would be a mid-animation value.
+    private func toggleFullScreen(_ window: AXUIElement) -> Bool {
+        let target: CFBoolean = isFullScreen(window) ? kCFBooleanFalse : kCFBooleanTrue
+        if isSettable(Self.fullScreenAttribute as String, on: window),
+            AXUIElementSetAttributeValue(window, Self.fullScreenAttribute, target) == .success
+        {
+            return true
+        }
+        guard let button = element(window, Self.fullScreenButtonAttribute as String) else {
+            return false
+        }
+        return AXUIElementPerformAction(button, kAXPressAction as CFString) == .success
+    }
+
+    /// Some apps (VoiceOver clients, a few Electron shells) reinterpret frame writes while
+    /// `AXEnhancedUserInterface` is on, landing windows in the wrong place. Clear it for the duration and
+    /// restore it immediately — but never while VoiceOver is actually running, which would break it.
+    private func suppressEnhancedUserInterface(on application: AXUIElement) -> () -> Void {
+        let attribute = "AXEnhancedUserInterface" as CFString
+        guard !NSWorkspace.shared.isVoiceOverEnabled else { return {} }
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(application, attribute, &value) == .success,
+            (value as? Bool) == true
+        else { return {} }
+        AXUIElementSetAttributeValue(application, attribute, kCFBooleanFalse)
+        return { AXUIElementSetAttributeValue(application, attribute, kCFBooleanTrue) }
+    }
+
+    // MARK: - Screens
+
+    /// Cocoa screens converted into the AX space `WindowLayout` works in.
+    private static func screens(_ screens: [NSScreen], geometry: AXGeometry)
+        -> [WindowLayout.Screen]
+    {
+        screens.enumerated().map { index, screen in
+            let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
+                as? NSNumber
+            // A display with no number still needs a stable, collision-free id for this call.
+            return WindowLayout.Screen(
+                id: number.map { Int($0.uint32Value) } ?? -(index + 1),
+                frame: geometry.flip(screen.frame),
+                visibleFrame: geometry.flip(screen.visibleFrame))
+        }
+    }
+
+    // MARK: - Accessibility primitives
+
+    private func frame(of window: AXUIElement) -> CGRect? {
+        guard let origin = point(window, kAXPositionAttribute),
+            let size = size(window, kAXSizeAttribute)
+        else { return nil }
+        return CGRect(origin: origin, size: size)
+    }
+
+    private func setPosition(_ origin: CGPoint, on window: AXUIElement) -> Bool {
+        var origin = origin
+        guard let value = AXValueCreate(.cgPoint, &origin) else { return false }
+        return AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, value)
+            == .success
+    }
+
+    private func setSize(_ size: CGSize, on window: AXUIElement) -> Bool {
+        var size = size
+        guard let value = AXValueCreate(.cgSize, &size) else { return false }
+        return AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, value) == .success
+    }
+
+    private func point(_ element: AXUIElement, _ attribute: String) -> CGPoint? {
+        guard let value = axValue(element, attribute, type: .cgPoint) else { return nil }
+        var point = CGPoint.zero
+        guard AXValueGetValue(value, .cgPoint, &point) else { return nil }
+        return point
+    }
+
+    private func size(_ element: AXUIElement, _ attribute: String) -> CGSize? {
+        guard let value = axValue(element, attribute, type: .cgSize) else { return nil }
+        var size = CGSize.zero
+        guard AXValueGetValue(value, .cgSize, &size) else { return nil }
+        return size
+    }
+
+    private func axValue(_ element: AXUIElement, _ attribute: String, type: AXValueType) -> AXValue? {
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
+            let value, CFGetTypeID(value) == AXValueGetTypeID()
+        else { return nil }
+        let axValue = value as! AXValue
+        return AXValueGetType(axValue) == type ? axValue : nil
+    }
+
+    private func element(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
+            let value, CFGetTypeID(value) == AXUIElementGetTypeID()
+        else { return nil }
+        return (value as! AXUIElement)
+    }
+
+    private func string(_ element: AXUIElement, _ attribute: String) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success
+        else { return nil }
+        return value as? String
+    }
+
+    private func bool(_ element: AXUIElement, _ attribute: String) -> Bool? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success
+        else { return nil }
+        return value as? Bool
+    }
+
+    private func isSettable(_ attribute: String, on element: AXUIElement) -> Bool {
+        var settable = DarwinBoolean(false)
+        guard
+            AXUIElementIsAttributeSettable(element, attribute as CFString, &settable) == .success
+        else { return false }
+        return settable.boolValue
+    }
+}
+
+/// Converts between Cocoa's bottom-left, +Y-up global space and the top-left, +Y-down space AX and
+/// Quartz use.
+///
+/// Both are anchored on the **primary** display — the one whose Cocoa frame origin is `(0, 0)` — not on
+/// whichever display a window happens to be on. Flipping through the window's own screen height shears
+/// every rect on a differently-sized display by the height difference, which is invisible on a single
+/// monitor and wrong on every mixed-size multi-monitor setup.
+struct AXGeometry {
+    let anchorHeight: CGFloat
+
+    /// Snapshot the anchor once per command: `NSScreen.screens` can change between calls (hotplug, wake,
+    /// resolution change), and mixing two anchors inside one command corrupts the result.
+    @MainActor
+    init(screens: [NSScreen]) {
+        let primary = screens.first { $0.frame.origin == .zero } ?? screens.first
+        anchorHeight = primary?.frame.height ?? 0
+    }
+
+    /// An involution — `flip(flip(rect)) == rect`. Through `maxY`, not `minY`: the two spaces anchor a
+    /// rect on opposite edges, since one hangs up from its origin and the other hangs down.
+    ///
+    /// No scaling is involved at any point. `NSScreen.frame`, `visibleFrame` and AX coordinates are all
+    /// in points, so `backingScaleFactor` must never appear here — mixed-DPI correctness is automatic.
+    func flip(_ rect: CGRect) -> CGRect {
+        CGRect(x: rect.origin.x, y: anchorHeight - rect.maxY, width: rect.width, height: rect.height)
+    }
+}

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -49,17 +49,20 @@ struct LauncherList: View {
         var rows: [Row] = calcRows
         let favorites = results.prefix(favoriteCount)
         let rest = results.dropFirst(favoriteCount)
-        // `rest` is apps, panes, snippets, system commands, custom commands, then built-in commands by the AppIndex sort invariant, so filtering by kind keeps row order identical and the flat selection index valid.
+        // `rest` is apps, panes, snippets, system commands, window commands, custom commands, then
+        // built-in commands by the AppIndex sort invariant, so filtering by kind keeps row order
+        // identical and the flat selection index valid.
         let apps = rest.filter { $0.kind == .application }
         let panes = rest.filter { $0.kind == .systemSettings }
         let snippets = rest.filter { $0.kind == .snippet }
         let systemCommands = rest.filter { $0.kind == .systemCommand }
+        let windowCommands = rest.filter { $0.kind == .windowCommand }
         let customCommands = rest.filter(\.isCustomCommand)
         let commands = rest.filter { $0.kind == .command && !$0.isCustomCommand }
         for (title, group) in [
             ("Favorites", Array(favorites)), ("Applications", apps),
             ("System Settings", panes), ("Snippets", snippets),
-            ("System Commands", systemCommands),
+            ("System Commands", systemCommands), ("Window Management", windowCommands),
             ("Custom Commands", customCommands), ("Commands", commands),
         ]
         where !group.isEmpty {
@@ -293,6 +296,7 @@ enum AppActionsMenu {
         case .command: return "Run Command"
         case .snippet: return "Paste Snippet"
         case .systemCommand: return "Run System Command"
+        case .windowCommand: return "Move Window"
         }
     }
 }

--- a/Tinycast/Features/Settings/SettingsRootView.swift
+++ b/Tinycast/Features/Settings/SettingsRootView.swift
@@ -6,8 +6,8 @@ extension Notification.Name {
 }
 
 enum SettingsTab: Int, CaseIterable, Identifiable {
-    case general, clipboard, emoji, snippets, permissions, shortcuts, customCommands, backup,
-        miscellaneous, about
+    case general, clipboard, emoji, snippets, windowManagement, permissions, shortcuts,
+        customCommands, backup, miscellaneous, about
     var id: Int { rawValue }
 
     var title: String {
@@ -16,6 +16,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .clipboard: return "Clipboard"
         case .emoji: return "Emoji & Symbols"
         case .snippets: return "Snippets"
+        case .windowManagement: return "Window Management"
         case .permissions: return "Permissions"
         case .shortcuts: return "Shortcuts"
         case .customCommands: return "Custom Commands"
@@ -31,6 +32,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .clipboard: return "doc.on.clipboard"
         case .emoji: return "face.smiling"
         case .snippets: return "curlybraces"
+        case .windowManagement: return "macwindow"
         case .permissions: return "lock.shield"
         case .shortcuts: return "keyboard"
         case .customCommands: return "terminal"
@@ -47,6 +49,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .clipboard: return .orange
         case .emoji: return .yellow
         case .snippets: return .green
+        case .windowManagement: return .blue
         case .permissions: return .blue
         case .shortcuts: return .indigo
         case .customCommands: return .green
@@ -75,6 +78,7 @@ struct SettingsRootView: View {
                 case .clipboard: ClipboardSettingsView()
                 case .emoji: EmojiSettingsView()
                 case .snippets: SnippetsSettingsView()
+                case .windowManagement: WindowManagementSettingsView()
                 case .permissions: PermissionsSettingsView()
                 case .shortcuts: ShortcutsSettingsView()
                 case .customCommands: CustomCommandsSettingsView()

--- a/Tinycast/Features/Settings/ShortcutsSettingsView.swift
+++ b/Tinycast/Features/Settings/ShortcutsSettingsView.swift
@@ -43,8 +43,8 @@ struct ShortcutsSettingsView: View {
         case .application: return "Search applications…"
         case .systemSettings: return "Search System Settings…"
         case .command: return "Search commands…"
-        // Unreachable — snippets have no tab here; they're managed in Settings › Snippets.
-        case .snippet: return ""
+        // Unreachable — snippets and window commands have no tab here; they're managed in their own panes.
+        case .snippet, .windowCommand: return ""
         case .systemCommand: return "Search system commands…"
         }
     }

--- a/Tinycast/Features/Settings/WindowManagementSettingsView.swift
+++ b/Tinycast/Features/Settings/WindowManagementSettingsView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+struct WindowManagementSettingsView: View {
+    @ObservedObject private var settings = AppCore.shared.settings
+
+    var body: some View {
+        SettingsPane(
+            title: "Window Management",
+            subtitle:
+                "Snap, resize and move the frontmost window from the launcher or a global shortcut."
+        ) {
+            FeatureSwitchCard(
+                header: "Window Management",
+                enableTitle: "Enable window management",
+                enableSubtitle:
+                    "Moves the window you were last in, using the Accessibility permission Tinycast already uses to paste.",
+                systemImage: "macwindow",
+                launcherSubtitle: "Find the window commands in launcher search.",
+                isEnabled: $settings.windowManagementEnabled,
+                showsInLauncher: $settings.windowManagementShowInLauncher)
+
+            Group {
+                optionsCard
+                commandsCard
+            }
+            // Same dim as ShortcutsSettingsView's hidden-category card; the switch above stays live.
+            .opacity(settings.windowManagementEnabled ? 1 : 0.45)
+            .disabled(!settings.windowManagementEnabled)
+        }
+    }
+
+    private var optionsCard: some View {
+        SettingsCard(header: "Options") {
+            SettingsRow(
+                title: "Cycle sizes on repeat",
+                subtitle:
+                    "Triggering a half again steps it through a third and two thirds before returning.",
+                systemImage: "arrow.triangle.2.circlepath",
+                tint: .blue
+            ) {
+                Toggle("Cycle sizes on repeat", isOn: $settings.windowCycleOnRepeat)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .accessibilityLabel("Cycle sizes on repeat")
+            }
+
+            SettingsDivider()
+
+            SettingsRow(
+                title: "Gap between windows",
+                subtitle: "Points left between tiled windows and around the screen edge.",
+                systemImage: "square.split.2x1",
+                tint: .blue
+            ) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Text("\(settings.windowGap) pt")
+                        .font(.body.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Stepper(
+                        "Gap between windows", value: $settings.windowGap, in: 0...64, step: 2)
+                        .labelsHidden()
+                }
+            }
+        }
+    }
+
+    private var commandsCard: some View {
+        SettingsCard(header: "Commands") {
+            ForEach(Array(WindowCommandCatalog.grouped().enumerated()), id: \.element.group) {
+                index, section in
+                if index > 0 { SettingsDivider() }
+                WindowCommandGroupHeader(title: section.group.title)
+                ForEach(section.commands) { command in
+                    WindowCommandSettingsRow(command: command)
+                }
+            }
+        }
+    }
+}
+
+private struct WindowCommandGroupHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(Theme.Typography.sectionHeader)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.top, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.xs)
+    }
+}
+
+/// One command: its shortcut recorder and the launcher-visibility checkbox, mirroring
+/// `ShortcutsSettingsView`'s row so both lists behave identically.
+private struct WindowCommandSettingsRow: View {
+    let command: WindowCommand
+    @EnvironmentObject private var visibility: VisibilityStore
+    // Hover lives on the row so a mouse sweep repaints only the rows entering and leaving.
+    @State private var hovered = false
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: command.sfSymbol)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.blue)
+                .frame(width: Theme.Size.settingsRowIcon)
+
+            Text(command.name)
+                .font(.body)
+                .lineLimit(1)
+
+            Spacer(minLength: Theme.Spacing.lg)
+
+            ShortcutRecorder(action: .windowCommand(id: command.id))
+
+            Toggle("", isOn: visibilityBinding)
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .help("Show in launcher")
+                .accessibilityLabel("Show \(command.name) in launcher")
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .fill(hovered ? Theme.Colors.rowHover : .clear)
+                .padding(.horizontal, Theme.Spacing.sm)
+        )
+        .onHover { hovered = $0 }
+    }
+
+    /// `VisibilityStore` keys on the entry, so this builds the same entry `AppIndex` publishes.
+    private var entry: AppEntry {
+        AppEntry(
+            id: command.entryID, name: command.name,
+            url: URL(string: "tinycast://window-command/" + command.id.rawValue)!, bundleID: nil,
+            kind: .windowCommand)
+    }
+
+    private var visibilityBinding: Binding<Bool> {
+        Binding(
+            get: { visibility.isItemVisible(entry) },
+            set: { visibility.setItemVisible($0, for: entry) })
+    }
+}

--- a/Tools/window-command-test.swift
+++ b/Tools/window-command-test.swift
@@ -1,0 +1,853 @@
+// Standalone contract tests for the pure window-management geometry and action memory.
+// Run: swiftc -swift-version 6 Tinycast/Core/WindowManagement/WindowCommand.swift \
+//     Tinycast/Core/WindowManagement/WindowLayout.swift \
+//     Tinycast/Core/WindowManagement/WindowActionMemory.swift Tools/window-command-test.swift \
+//     -o /tmp/window-command-test && /tmp/window-command-test
+
+import CoreGraphics
+import Foundation
+
+@main
+@MainActor
+struct WindowCommandTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func expectRect(_ actual: CGRect, _ expected: CGRect, _ message: String) {
+        if actual == expected {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message) — got \(actual), expected \(expected)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// The reference display: origin at the AX origin, evenly divisible by halves and thirds.
+    static let mainScreen = WindowLayout.Screen(
+        id: 1, frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+        visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 900))
+
+    static func screens(_ list: WindowLayout.Screen...) -> [WindowLayout.Screen] { list }
+
+    static func frame(
+        _ command: WindowCommand.ID, on screen: WindowLayout.Screen = mainScreen,
+        window: CGRect = CGRect(x: 100, y: 100, width: 600, height: 400), gap: CGFloat = 0,
+        step: Int = 0, restore: CGRect? = nil, lastTile: WindowCommand.ID? = nil,
+        allScreens: [WindowLayout.Screen]? = nil
+    ) -> CGRect? {
+        WindowLayout.placement(
+            for: WindowLayout.Input(
+                command: command, windowFrame: window, screens: allScreens ?? [screen], gap: gap,
+                step: step, restoreFrame: restore, lastTileCommand: lastTile)
+        )?.frame
+    }
+
+    static func main() {
+        testCatalog()
+        testConventionLock()
+        testTiling()
+        testNonDivisible()
+        testOffOriginScreens()
+        testGaps()
+        testSizing()
+        testLargerSmaller()
+        testNudges()
+        testDisplays()
+        testRestore()
+        testMemory()
+        testFuzz()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Catalog
+
+    static func testCatalog() {
+        let commands = WindowCommandCatalog.all
+        expect(commands.count == 29, "catalog contains all 29 agreed commands")
+        expect(commands.map(\.id) == WindowCommand.ID.allCases, "catalog covers every ID once")
+        expect(Set(commands.map(\.id)).count == commands.count, "IDs are unique")
+        expect(Set(commands.map(\.entryID)).count == commands.count, "entry IDs are unique")
+        expect(
+            Set(commands.map { $0.name.lowercased() }).count == commands.count, "names are unique")
+        expect(commands.allSatisfy { !$0.name.isEmpty }, "names are non-empty")
+        expect(commands.allSatisfy { !$0.sfSymbol.isEmpty }, "symbols are non-empty")
+
+        for command in commands {
+            expect(
+                WindowCommandCatalog.command(forEntryID: command.entryID) == command,
+                "\(command.id.rawValue) round-trips through its entry ID")
+            expect(
+                WindowCommandCatalog.command(id: command.id) == command,
+                "\(command.id.rawValue) round-trips through its ID")
+            expect(
+                command.entryID.hasPrefix("window-command:"),
+                "\(command.id.rawValue) is namespaced")
+        }
+        expect(
+            WindowCommandCatalog.command(forEntryID: "window-command:unknown") == nil,
+            "unknown entry IDs are rejected")
+        expect(
+            WindowCommandCatalog.command(forEntryID: "system-command:sleep") == nil,
+            "system-command entry IDs are not claimed")
+
+        let cycling = Set(commands.filter(\.cyclesOnRepeat).map(\.id))
+        expect(
+            cycling == [.leftHalf, .rightHalf, .topHalf, .bottomHalf],
+            "only the four halves cycle on repeat")
+        let moveOnly = Set(commands.filter { !$0.resizes }.map(\.id))
+        expect(
+            moveOnly == [.moveLeft, .moveRight, .moveUp, .moveDown],
+            "only the four nudges leave the size alone")
+        expect(
+            Set(commands.filter { $0.kind == .fullscreen }.map(\.id)) == [.toggleFullscreen],
+            "only Toggle Fullscreen is a fullscreen command")
+        expect(
+            Set(commands.filter { $0.kind == .restore }.map(\.id)) == [.restore],
+            "only Restore is a restore command")
+
+        // Grouping drives the Settings list; every command must land in exactly one group.
+        let grouped = WindowCommandCatalog.grouped()
+        expect(
+            grouped.flatMap(\.commands).count == commands.count, "grouping loses no command")
+        expect(
+            grouped.map(\.group) == WindowCommand.Group.allCases,
+            "every group is represented, in declaration order")
+        expect(grouped.first { $0.group == .halves }?.commands.count == 4, "four halves")
+        expect(grouped.first { $0.group == .quarters }?.commands.count == 4, "four quarters")
+        expect(grouped.first { $0.group == .thirds }?.commands.count == 5, "five thirds")
+        expect(grouped.first { $0.group == .sizing }?.commands.count == 9, "nine sizing commands")
+        expect(grouped.first { $0.group == .moving }?.commands.count == 6, "six moving commands")
+
+        expect(
+            WindowLayout.isTileCommand(.leftHalf) && WindowLayout.isTileCommand(.centerHalf),
+            "halves and center half are tiles")
+        expect(
+            !WindowLayout.isTileCommand(.maximize) && !WindowLayout.isTileCommand(.moveLeft),
+            "free-floating commands are not tiles")
+
+        // Fullscreen has no geometry at all — the mover branches before ever asking for a placement.
+        expect(frame(.toggleFullscreen) == nil, "Toggle Fullscreen produces no placement")
+    }
+
+    // MARK: - Convention lock
+
+    static func testConventionLock() {
+        // AX space: +Y points down, so the top half starts at the visible frame's minY. This single
+        // assertion is what stops a bottom-left convention being reintroduced by accident.
+        expect(
+            frame(.topHalf)?.minY == mainScreen.visibleFrame.minY,
+            "top half is anchored at visibleFrame.minY (AX space, +Y down)")
+        expect(
+            frame(.bottomHalf)?.maxY == mainScreen.visibleFrame.maxY,
+            "bottom half is anchored at visibleFrame.maxY")
+        expect(
+            frame(.topLeftQuarter)?.minY == mainScreen.visibleFrame.minY,
+            "top left quarter sits at the top")
+    }
+
+    // MARK: - Tiling
+
+    static func testTiling() {
+        expectRect(frame(.leftHalf)!, CGRect(x: 0, y: 0, width: 720, height: 900), "left half")
+        expectRect(frame(.rightHalf)!, CGRect(x: 720, y: 0, width: 720, height: 900), "right half")
+        expectRect(frame(.topHalf)!, CGRect(x: 0, y: 0, width: 1440, height: 450), "top half")
+        expectRect(
+            frame(.bottomHalf)!, CGRect(x: 0, y: 450, width: 1440, height: 450), "bottom half")
+
+        expectRect(
+            frame(.topLeftQuarter)!, CGRect(x: 0, y: 0, width: 720, height: 450), "top left quarter")
+        expectRect(
+            frame(.topRightQuarter)!, CGRect(x: 720, y: 0, width: 720, height: 450),
+            "top right quarter")
+        expectRect(
+            frame(.bottomLeftQuarter)!, CGRect(x: 0, y: 450, width: 720, height: 450),
+            "bottom left quarter")
+        expectRect(
+            frame(.bottomRightQuarter)!, CGRect(x: 720, y: 450, width: 720, height: 450),
+            "bottom right quarter")
+
+        let quarters = [
+            frame(.topLeftQuarter)!, frame(.topRightQuarter)!, frame(.bottomLeftQuarter)!,
+            frame(.bottomRightQuarter)!,
+        ]
+        expect(
+            quarters.reduce(CGRect.null) { $0.union($1) } == mainScreen.visibleFrame,
+            "the four quarters union to the visible frame")
+        var overlapping = false
+        for i in quarters.indices {
+            for j in quarters.indices where j > i {
+                if !quarters[i].intersection(quarters[j]).isEmpty { overlapping = true }
+            }
+        }
+        expect(!overlapping, "quarters never overlap")
+
+        expectRect(frame(.firstThird)!, CGRect(x: 0, y: 0, width: 480, height: 900), "first third")
+        expectRect(
+            frame(.centerThird)!, CGRect(x: 480, y: 0, width: 480, height: 900), "center third")
+        expectRect(frame(.lastThird)!, CGRect(x: 960, y: 0, width: 480, height: 900), "last third")
+        expectRect(
+            frame(.firstTwoThirds)!, CGRect(x: 0, y: 0, width: 960, height: 900), "first two thirds")
+        expectRect(
+            frame(.lastTwoThirds)!, CGRect(x: 480, y: 0, width: 960, height: 900), "last two thirds")
+
+        expect(
+            frame(.firstThird)!.union(frame(.lastTwoThirds)!) == mainScreen.visibleFrame,
+            "first third and last two thirds partition the screen")
+        expect(
+            frame(.firstTwoThirds)!.union(frame(.lastThird)!) == mainScreen.visibleFrame,
+            "first two thirds and last third partition the screen")
+
+        // Half the screen's area: half width, full height, horizontally centred.
+        expectRect(
+            frame(.centerHalf)!, CGRect(x: 360, y: 0, width: 720, height: 900), "center half")
+
+        // Cycling: halves only, ½ → ⅓ → ⅔, wrapping.
+        expectRect(frame(.leftHalf, step: 1)!, frame(.firstThird)!, "left half step 1 is a third")
+        expectRect(
+            frame(.leftHalf, step: 2)!, frame(.firstTwoThirds)!, "left half step 2 is two thirds")
+        expectRect(frame(.leftHalf, step: 3)!, frame(.leftHalf)!, "left half step 3 wraps to the half")
+        expectRect(frame(.rightHalf, step: 1)!, frame(.lastThird)!, "right half step 1 is a third")
+        expectRect(
+            frame(.rightHalf, step: 2)!, frame(.lastTwoThirds)!, "right half step 2 is two thirds")
+        expectRect(
+            frame(.topHalf, step: 1)!, CGRect(x: 0, y: 0, width: 1440, height: 300),
+            "top half step 1 is a vertical third")
+        expectRect(
+            frame(.topHalf, step: 2)!, CGRect(x: 0, y: 0, width: 1440, height: 600),
+            "top half step 2 is vertical two thirds")
+        expectRect(
+            frame(.bottomHalf, step: 1)!, CGRect(x: 0, y: 600, width: 1440, height: 300),
+            "bottom half step 1 is a vertical third")
+        expectRect(
+            frame(.bottomHalf, step: 2)!, CGRect(x: 0, y: 300, width: 1440, height: 600),
+            "bottom half step 2 is vertical two thirds")
+
+        // A step handed to a command that doesn't cycle must be ignored outright.
+        for step in 0...5 {
+            expectRect(
+                frame(.firstThird, step: step)!, frame(.firstThird)!,
+                "non-cycling commands ignore step \(step)")
+            expectRect(
+                frame(.maximize, step: step)!, frame(.maximize)!,
+                "maximize ignores step \(step)")
+        }
+        // Negative steps can't crash or escape the cycle.
+        expectRect(frame(.leftHalf, step: -1)!, frame(.firstTwoThirds)!, "negative steps normalize")
+    }
+
+    // MARK: - Non-divisible widths
+
+    static func testNonDivisible() {
+        for width in [1441, 1000, 1367] as [CGFloat] {
+            let screen = WindowLayout.Screen(
+                id: 9, frame: CGRect(x: 0, y: 0, width: width, height: 901),
+                visibleFrame: CGRect(x: 0, y: 0, width: width, height: 901))
+            let first = frame(.firstThird, on: screen)!
+            let center = frame(.centerThird, on: screen)!
+            let last = frame(.lastThird, on: screen)!
+            expect(first.maxX == center.minX, "\(width): first/center thirds share an edge exactly")
+            expect(center.maxX == last.minX, "\(width): center/last thirds share an edge exactly")
+            expect(
+                first.union(center).union(last) == screen.visibleFrame,
+                "\(width): thirds still cover the whole screen")
+
+            let left = frame(.leftHalf, on: screen)!
+            let right = frame(.rightHalf, on: screen)!
+            expect(left.maxX == right.minX, "\(width): halves share an edge exactly")
+            expect(left.union(right) == screen.visibleFrame, "\(width): halves cover the screen")
+            expect(abs(left.width - right.width) <= 1, "\(width): halves differ by at most a point")
+
+            let top = frame(.topHalf, on: screen)!
+            let bottom = frame(.bottomHalf, on: screen)!
+            expect(top.maxY == bottom.minY, "\(width): vertical halves share an edge exactly")
+        }
+    }
+
+    // MARK: - Off-origin displays
+
+    static func testOffOriginScreens() {
+        // A display up and to the right of the primary — negative Y in AX space.
+        let high = WindowLayout.Screen(
+            id: 2, frame: CGRect(x: 1920, y: -300, width: 2560, height: 1440),
+            visibleFrame: CGRect(x: 1920, y: -300, width: 2560, height: 1440))
+        expectRect(
+            frame(.leftHalf, on: high, window: CGRect(x: 2000, y: 0, width: 400, height: 300))!,
+            CGRect(x: 1920, y: -300, width: 1280, height: 1440), "left half on an off-origin display")
+        expect(
+            frame(.topHalf, on: high, window: CGRect(x: 2000, y: 0, width: 400, height: 300))!.minY
+                == -300, "top half honours a negative minY")
+
+        // A display left of and below the primary.
+        let low = WindowLayout.Screen(
+            id: 3, frame: CGRect(x: -1440, y: 200, width: 1440, height: 900),
+            visibleFrame: CGRect(x: -1440, y: 200, width: 1440, height: 900))
+        expectRect(
+            frame(.rightHalf, on: low, window: CGRect(x: -1000, y: 300, width: 400, height: 300))!,
+            CGRect(x: -720, y: 200, width: 720, height: 900), "right half on a negative-X display")
+        expectRect(
+            frame(.maximize, on: low, window: CGRect(x: -1000, y: 300, width: 400, height: 300))!,
+            low.visibleFrame, "maximize on a negative-X display")
+
+        // A visible frame smaller than the full frame (menu bar and Dock reserved).
+        let reserved = WindowLayout.Screen(
+            id: 4, frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 25, width: 1440, height: 800))
+        expectRect(
+            frame(.topHalf, on: reserved)!, CGRect(x: 0, y: 25, width: 1440, height: 400),
+            "tiles respect a reserved visible frame")
+        expectRect(frame(.maximize, on: reserved)!, reserved.visibleFrame, "maximize never covers the menu bar")
+    }
+
+    // MARK: - Gaps
+
+    static func testGaps() {
+        expectRect(
+            frame(.leftHalf, gap: 10)!, CGRect(x: 10, y: 10, width: 705, height: 880),
+            "left half with a 10pt gap")
+        expectRect(
+            frame(.rightHalf, gap: 10)!, CGRect(x: 725, y: 10, width: 705, height: 880),
+            "right half with a 10pt gap")
+        expect(
+            frame(.leftHalf, gap: 10)!.maxX + 10 == frame(.rightHalf, gap: 10)!.minX,
+            "the gutter between halves is exactly the gap")
+        expect(
+            frame(.topHalf, gap: 10)!.maxY + 10 == frame(.bottomHalf, gap: 10)!.minY,
+            "the gutter between vertical halves is exactly the gap")
+
+        // Every outer edge is inset by the full gap, every gutter is exactly one gap.
+        let quarters = [
+            frame(.topLeftQuarter, gap: 10)!, frame(.topRightQuarter, gap: 10)!,
+            frame(.bottomLeftQuarter, gap: 10)!, frame(.bottomRightQuarter, gap: 10)!,
+        ]
+        expect(quarters[0].maxX + 10 == quarters[1].minX, "quarters: vertical gutter is the gap")
+        expect(quarters[0].maxY + 10 == quarters[2].minY, "quarters: horizontal gutter is the gap")
+        expect(
+            quarters.allSatisfy {
+                $0.minX >= 10 && $0.minY >= 10 && $0.maxX <= 1430 && $0.maxY <= 890
+            }, "quarters stay inset from every screen edge")
+
+        // Thirds: two gutters, both exact.
+        expect(
+            frame(.firstThird, gap: 10)!.maxX + 10 == frame(.centerThird, gap: 10)!.minX,
+            "thirds: first/center gutter is the gap")
+        expect(
+            frame(.centerThird, gap: 10)!.maxX + 10 == frame(.lastThird, gap: 10)!.minX,
+            "thirds: center/last gutter is the gap")
+
+        // An odd gap must not drift when halved and rounded.
+        expect(
+            frame(.leftHalf, gap: 9)!.maxX + 9 == frame(.rightHalf, gap: 9)!.minX,
+            "an odd gap still produces an exact gutter")
+
+        expectRect(frame(.maximize, gap: 12)!, CGRect(x: 12, y: 12, width: 1416, height: 876),
+            "maximize honours the gap")
+
+        // Degenerate gaps must never produce an unusable window.
+        for gap in [-5, 0, 10_000] as [CGFloat] {
+            let rect = frame(.leftHalf, gap: gap)!
+            expect(rect.width > 0 && rect.height > 0, "gap \(gap) still yields a positive tile")
+            expect(
+                mainScreen.visibleFrame.contains(rect), "gap \(gap) keeps the tile on screen")
+        }
+        expectRect(frame(.leftHalf, gap: -5)!, frame(.leftHalf)!, "a negative gap reads as zero")
+        // Every non-finite value reads as zero — one rule, so NaN and infinity can't behave differently.
+        expectRect(frame(.leftHalf, gap: .nan)!, frame(.leftHalf)!, "a NaN gap reads as zero")
+        expectRect(
+            frame(.leftHalf, gap: .infinity)!, frame(.leftHalf)!, "an infinite gap reads as zero")
+        // A merely oversized (but finite) gap is capped rather than zeroed.
+        expectRect(
+            frame(.leftHalf, gap: 10_000)!, frame(.leftHalf, gap: 90)!,
+            "an oversized finite gap is capped to a tenth of the smaller dimension")
+    }
+
+    // MARK: - Sizing
+
+    static func testSizing() {
+        expectRect(frame(.maximize)!, mainScreen.visibleFrame, "maximize fills the visible frame")
+
+        let almost = frame(.almostMaximize)!
+        expectRect(almost, CGRect(x: 72, y: 45, width: 1296, height: 810), "almost maximize")
+        expectRect(
+            frame(.almostMaximize, window: almost)!, almost, "almost maximize is idempotent")
+        expect(
+            almost.midX == mainScreen.visibleFrame.midX
+                && almost.midY == mainScreen.visibleFrame.midY,
+            "almost maximize stays centred")
+
+        let window = CGRect(x: 100, y: 200, width: 300, height: 400)
+        let tall = frame(.maximizeHeight, window: window)!
+        expect(
+            tall.minX == 100 && tall.width == 300, "maximize height preserves minX and width exactly")
+        expect(tall.minY == 0 && tall.height == 900, "maximize height fills the canvas vertically")
+
+        let wide = frame(.maximizeWidth, window: window)!
+        expect(
+            wide.minY == 200 && wide.height == 400, "maximize width preserves minY and height exactly")
+        expect(wide.minX == 0 && wide.width == 1440, "maximize width fills the canvas horizontally")
+
+        // An off-screen window must not come back full-height and still off-screen.
+        let stray = CGRect(x: -900, y: -900, width: 200, height: 150)
+        let strayTall = frame(.maximizeHeight, window: stray)!
+        expect(strayTall.minX == 0 && strayTall.width == 200, "maximize height clamps a stray x")
+        expect(
+            !strayTall.intersection(mainScreen.visibleFrame).isNull,
+            "maximize height brings a stray window back on screen")
+        let strayWide = frame(.maximizeWidth, window: stray)!
+        expect(strayWide.minY == 0 && strayWide.height == 150, "maximize width clamps a stray y")
+        expect(
+            !strayWide.intersection(mainScreen.visibleFrame).isNull,
+            "maximize width brings a stray window back on screen")
+
+        expectRect(
+            frame(.center, window: window)!, CGRect(x: 570, y: 250, width: 300, height: 400),
+            "center preserves the size and centres it")
+        expectRect(
+            frame(.center, window: frame(.center, window: window)!)!,
+            frame(.center, window: window)!, "center is idempotent")
+
+        // A window larger than the screen must be clamped down, not centred off-screen.
+        let huge = CGRect(x: -500, y: -500, width: 3000, height: 2000)
+        let centred = frame(.center, window: huge)!
+        expect(
+            centred.width <= 1440 && centred.height <= 900, "center clamps an oversized window")
+        expect(mainScreen.visibleFrame.contains(centred), "a clamped center stays on screen")
+
+        expectRect(
+            frame(.centerHalf)!, CGRect(x: 360, y: 0, width: 720, height: 900),
+            "center half is half the screen's area")
+    }
+
+    // MARK: - Make Larger / Make Smaller
+
+    static func testLargerSmaller() {
+        let start = CGRect(x: 100, y: 100, width: 600, height: 400)
+        let larger = frame(.makeLarger, window: start)!
+        expect(larger.width > start.width && larger.height > start.height, "make larger grows")
+        // The assertion that justifies screen-relative steps: size-relative ones cannot round-trip.
+        expectRect(
+            frame(.makeSmaller, window: larger)!, start,
+            "larger then smaller returns the exact original rect")
+        let smaller = frame(.makeSmaller, window: start)!
+        expectRect(
+            frame(.makeLarger, window: smaller)!, start,
+            "smaller then larger returns the exact original rect")
+        expect(larger.midX == start.midX && larger.midY == start.midY, "growing keeps the centre")
+        expect(smaller.midX == start.midX && smaller.midY == start.midY, "shrinking keeps the centre")
+
+        // Repeated shrinking saturates at the floor instead of collapsing.
+        var shrinking = start
+        for _ in 0..<40 { shrinking = frame(.makeSmaller, window: shrinking)! }
+        expect(shrinking.width > 0 && shrinking.height > 0, "40 shrinks never collapse the window")
+        expectRect(
+            frame(.makeSmaller, window: shrinking)!, shrinking, "shrinking saturates into a no-op")
+
+        // Repeated growing converges on the canvas.
+        var growing = start
+        for _ in 0..<40 { growing = frame(.makeLarger, window: growing)! }
+        expectRect(growing, mainScreen.visibleFrame, "40 grows converge on the maximized frame")
+        expectRect(frame(.makeLarger, window: growing)!, growing, "growing saturates into a no-op")
+
+        // With a gap, growing converges on the gapped canvas rather than the raw visible frame.
+        var gapped = start
+        for _ in 0..<40 { gapped = frame(.makeLarger, window: gapped, gap: 12)! }
+        expectRect(gapped, frame(.maximize, gap: 12)!, "growing respects the gap")
+    }
+
+    // MARK: - Nudges
+
+    static func testNudges() {
+        let start = CGRect(x: 300, y: 300, width: 600, height: 400)
+        for command in [WindowCommand.ID.moveLeft, .moveRight, .moveUp, .moveDown] {
+            let moved = frame(command, window: start)!
+            expect(moved.size == start.size, "\(command.rawValue) leaves the size untouched")
+        }
+        expectRect(
+            frame(.moveLeft, window: start)!, CGRect(x: 228, y: 300, width: 600, height: 400),
+            "move left nudges by 5% of the screen width")
+        expectRect(
+            frame(.moveUp, window: start)!, CGRect(x: 300, y: 255, width: 600, height: 400),
+            "move up nudges by 5% of the screen height")
+        expectRect(
+            frame(.moveRight, window: frame(.moveLeft, window: start)!)!, start,
+            "left then right returns the original position")
+        expectRect(
+            frame(.moveDown, window: frame(.moveUp, window: start)!)!, start,
+            "up then down returns the original position")
+
+        var sliding = start
+        for _ in 0..<30 { sliding = frame(.moveLeft, window: sliding)! }
+        expect(sliding.minX == 0, "30 nudges left end flush against the canvas edge")
+        expect(sliding.size == start.size, "nudging to the edge never resizes")
+        expectRect(frame(.moveLeft, window: sliding)!, sliding, "a flush window nudges no further")
+
+        // A window wider than the canvas pins its leading edge rather than being shoved off the far side.
+        let overWide = CGRect(x: 100, y: 100, width: 2000, height: 400)
+        let pinned = frame(.moveLeft, window: overWide)!
+        expect(pinned.minX == 0, "an oversized window pins to the canvas edge")
+        expect(pinned.size == overWide.size, "an oversized nudge never resizes")
+    }
+
+    // MARK: - Displays
+
+    static func testDisplays() {
+        expect(frame(.nextDisplay) == nil, "a single display makes Next Display a no-op")
+        expect(frame(.previousDisplay) == nil, "a single display makes Previous Display a no-op")
+
+        let left = mainScreen
+        let right = WindowLayout.Screen(
+            id: 2, frame: CGRect(x: 1440, y: 0, width: 2560, height: 1440),
+            visibleFrame: CGRect(x: 1440, y: 0, width: 2560, height: 1440))
+        // Deliberately out of order, to prove the ordering is derived and not inherited.
+        let both = screens(right, left)
+        expect(WindowLayout.ordered(both).map(\.id) == [1, 2], "displays order left-to-right")
+
+        let leftHalfOnLeft = frame(.leftHalf, on: left)!
+        let onRight = frame(
+            .nextDisplay, window: leftHalfOnLeft, allScreens: both)!
+        expectRect(
+            onRight, CGRect(x: 1440, y: 0, width: 1280, height: 1440),
+            "a left half maps proportionally onto the larger display")
+        expect(right.visibleFrame.contains(onRight), "the moved window stays inside the destination")
+
+        expectRect(
+            frame(.previousDisplay, window: onRight, allScreens: both)!, leftHalfOnLeft,
+            "next then previous round-trips to the original frame")
+
+        // Wrapping in both directions.
+        expect(
+            WindowLayout.placement(
+                for: WindowLayout.Input(
+                    command: .previousDisplay, windowFrame: leftHalfOnLeft, screens: both)
+            )?.screenID == 2, "previous from the first display wraps to the last")
+        expect(
+            WindowLayout.placement(
+                for: WindowLayout.Input(command: .nextDisplay, windowFrame: onRight, screens: both)
+            )?.screenID == 1, "next from the last display wraps to the first")
+
+        // A remembered tile is re-derived exactly on the destination, gaps included.
+        expectRect(
+            frame(.nextDisplay, window: leftHalfOnLeft, gap: 10, lastTile: .leftHalf, allScreens: both)!,
+            frame(.leftHalf, on: right, gap: 10)!,
+            "a remembered tile is re-derived exactly on the destination")
+        expectRect(
+            frame(.nextDisplay, window: frame(.firstThird, on: left)!, lastTile: .firstThird,
+                allScreens: both)!,
+            frame(.firstThird, on: right)!,
+            "a remembered third is re-derived exactly on the destination")
+
+        // Screen resolution by overlap.
+        expect(
+            WindowLayout.screen(
+                containing: CGRect(x: 1150, y: 0, width: 500, height: 100), in: both)?.id == 1,
+            "a straddling window belongs to the display showing more of it")
+        expect(
+            WindowLayout.screen(
+                containing: CGRect(x: 1300, y: 0, width: 500, height: 100), in: both)?.id == 2,
+            "the overlap majority flips with the window")
+        expect(
+            WindowLayout.screen(
+                containing: CGRect(x: -5000, y: -5000, width: 100, height: 100), in: both) != nil,
+            "a window off every display still resolves to one")
+    }
+
+    // MARK: - Restore
+
+    static func testRestore() {
+        expect(frame(.restore) == nil, "restore with no recorded frame does nothing")
+
+        let recorded = CGRect(x: 123, y: 234, width: 456, height: 321)
+        expectRect(
+            frame(.restore, restore: recorded)!, recorded, "a valid restore frame comes back untouched")
+
+        // A restore point stranded off every current display (a monitor was unplugged) is recovered.
+        let stranded = CGRect(x: 9000, y: 9000, width: 400, height: 300)
+        let recovered = frame(.restore, restore: stranded)!
+        expect(recovered.size == stranded.size, "a stranded restore keeps its size")
+        expect(
+            mainScreen.visibleFrame.contains(recovered), "a stranded restore lands back on screen")
+        expect(
+            recovered.midX == mainScreen.visibleFrame.midX,
+            "a stranded restore is re-centred horizontally")
+    }
+
+    // MARK: - Action memory
+
+    static func testMemory() {
+        let clock = Date(timeIntervalSince1970: 1_000_000)
+        let half = CGRect(x: 0, y: 0, width: 720, height: 900)
+        let original = CGRect(x: 100, y: 100, width: 600, height: 400)
+
+        // A fresh window: step 0, nothing to restore to yet, and the current frame becomes the anchor.
+        var memory = WindowActionMemory<Int>()
+        var decision = memory.decide(
+            key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        expect(decision.step == 0, "a first press starts at step 0")
+        expect(!decision.canRestore, "a never-seen window has nothing to restore to")
+        expectRect(decision.restoreFrame, original, "the first press captures the original frame")
+        memory.commit(
+            key: 1, command: .leftHalf, decision: decision, appliedFrame: half, screenID: 1,
+            now: clock)
+
+        // Repeats advance the cycle and never disturb the restore point.
+        for expected in [1, 2, 0, 1] {
+            let applied = frame(.leftHalf, step: expected)!
+            decision = memory.decide(
+                key: 1, command: .leftHalf, currentFrame: memory.record(for: 1)!.appliedFrame,
+                currentScreenID: 1, cycleEnabled: true, now: clock)
+            expect(decision.step == expected, "the cycle advances to step \(expected)")
+            expectRect(decision.restoreFrame, original, "the restore point survives step \(expected)")
+            expect(decision.canRestore, "a seen window can be restored")
+            memory.commit(
+                key: 1, command: .leftHalf, decision: decision, appliedFrame: applied, screenID: 1,
+                now: clock)
+        }
+
+        // A different command, screen, or window resets the cycle.
+        decision = memory.decide(
+            key: 1, command: .rightHalf, currentFrame: memory.record(for: 1)!.appliedFrame,
+            currentScreenID: 1, cycleEnabled: true, now: clock)
+        expect(decision.step == 0, "a different command restarts the cycle")
+        expectRect(decision.restoreFrame, original, "a different command keeps the restore point")
+        decision = memory.decide(
+            key: 1, command: .leftHalf, currentFrame: memory.record(for: 1)!.appliedFrame,
+            currentScreenID: 2, cycleEnabled: true, now: clock)
+        expect(decision.step == 0, "a different display restarts the cycle")
+        decision = memory.decide(
+            key: 99, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        expect(decision.step == 0 && !decision.canRestore, "another window has its own chain")
+
+        // A user drag resets the cycle and re-anchors the restore point.
+        var dragged = WindowActionMemory<Int>()
+        let seed = dragged.decide(
+            key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        dragged.commit(
+            key: 1, command: .leftHalf, decision: seed, appliedFrame: half, screenID: 1, now: clock)
+        let movedByUser = CGRect(x: 400, y: 400, width: 500, height: 300)
+        decision = dragged.decide(
+            key: 1, command: .leftHalf, currentFrame: movedByUser, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        expect(decision.step == 0, "a user drag restarts the cycle")
+        expectRect(decision.restoreFrame, movedByUser, "a user drag re-anchors the restore point")
+        expect(decision.lastTileCommand == nil, "a user drag forgets the remembered tile")
+
+        // A quantising app that lands a point off its target must NOT read as a user drag.
+        let quantised = CGRect(x: half.minX + 1, y: half.minY, width: half.width - 1, height: half.height)
+        decision = dragged.decide(
+            key: 1, command: .leftHalf, currentFrame: quantised, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        expect(decision.step == 1, "a sub-tolerance difference keeps the cycle running")
+        expect(decision.lastTileCommand == .leftHalf, "an untouched tile is remembered")
+
+        // The cycle switch pins everything to step 0.
+        var pinned = WindowActionMemory<Int>()
+        var pinnedDecision = pinned.decide(
+            key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: false, now: clock)
+        for _ in 0..<5 {
+            pinned.commit(
+                key: 1, command: .leftHalf, decision: pinnedDecision, appliedFrame: half,
+                screenID: 1, now: clock)
+            pinnedDecision = pinned.decide(
+                key: 1, command: .leftHalf, currentFrame: half, currentScreenID: 1,
+                cycleEnabled: false, now: clock)
+            expect(pinnedDecision.step == 0, "cycling off pins every repeat to step 0")
+        }
+
+        // A non-cycling command never advances even with cycling on.
+        var nonCycling = WindowActionMemory<Int>()
+        let maximized = mainScreen.visibleFrame
+        var nonDecision = nonCycling.decide(
+            key: 1, command: .maximize, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        for _ in 0..<5 {
+            nonCycling.commit(
+                key: 1, command: .maximize, decision: nonDecision, appliedFrame: maximized,
+                screenID: 1, now: clock)
+            nonDecision = nonCycling.decide(
+                key: 1, command: .maximize, currentFrame: maximized, currentScreenID: 1,
+                cycleEnabled: true, now: clock)
+            expect(nonDecision.step == 0, "a non-cycling command never advances")
+        }
+
+        // Cycle timeout.
+        var timed = WindowActionMemory<Int>(cycleTimeout: 60)
+        let timedSeed = timed.decide(
+            key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        timed.commit(
+            key: 1, command: .leftHalf, decision: timedSeed, appliedFrame: half, screenID: 1,
+            now: clock)
+        expect(
+            timed.decide(
+                key: 1, command: .leftHalf, currentFrame: half, currentScreenID: 1,
+                cycleEnabled: true, now: clock.addingTimeInterval(30)
+            ).step == 1, "a cycle inside the timeout continues")
+        expect(
+            timed.decide(
+                key: 1, command: .leftHalf, currentFrame: half, currentScreenID: 1,
+                cycleEnabled: true, now: clock.addingTimeInterval(120)
+            ).step == 0, "a cycle past the timeout restarts")
+
+        // The restore point survives a run of different commands, then Restore is idempotent.
+        var run = WindowActionMemory<Int>()
+        var runDecision = run.decide(
+            key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        run.commit(
+            key: 1, command: .leftHalf, decision: runDecision, appliedFrame: half, screenID: 1,
+            now: clock)
+        var applied = half
+        for command in [WindowCommand.ID.maximize, .topRightQuarter, .centerThird] {
+            runDecision = run.decide(
+                key: 1, command: command, currentFrame: applied, currentScreenID: 1,
+                cycleEnabled: true, now: clock)
+            applied = frame(command)!
+            run.commit(
+                key: 1, command: command, decision: runDecision, appliedFrame: applied, screenID: 1,
+                now: clock)
+        }
+        runDecision = run.decide(
+            key: 1, command: .restore, currentFrame: applied, currentScreenID: 1, cycleEnabled: true,
+            now: clock)
+        expectRect(
+            runDecision.restoreFrame, original, "the restore point survives three other commands")
+        expect(runDecision.canRestore, "the window can be restored after a run of commands")
+        let restored = frame(.restore, restore: runDecision.restoreFrame)!
+        expectRect(restored, original, "restore returns the true original frame")
+        run.commit(
+            key: 1, command: .restore, decision: runDecision, appliedFrame: restored, screenID: 1,
+            now: clock)
+        let second = run.decide(
+            key: 1, command: .restore, currentFrame: restored, currentScreenID: 1,
+            cycleEnabled: true, now: clock)
+        expectRect(
+            frame(.restore, restore: second.restoreFrame)!, original, "a second restore is idempotent")
+
+        // Fullscreen breaks the cycle chain but keeps the restore point.
+        run.forgetCycle(key: 1)
+        expect(run.record(for: 1)?.step == 0, "forgetCycle resets the step")
+        expectRect(
+            run.record(for: 1)!.restoreFrame, original, "forgetCycle keeps the restore point")
+
+        // Bounded growth, most-recently-used retained.
+        var bounded = WindowActionMemory<Int>(capacity: 64)
+        for key in 0..<100 {
+            let boundedDecision = bounded.decide(
+                key: key, command: .leftHalf, currentFrame: original, currentScreenID: 1,
+                cycleEnabled: true, now: clock)
+            bounded.commit(
+                key: key, command: .leftHalf, decision: boundedDecision, appliedFrame: half,
+                screenID: 1, now: clock)
+        }
+        expect(bounded.count == 64, "the memory is bounded at its capacity")
+        expect(bounded.record(for: 99) != nil, "the most recent key survives eviction")
+        expect(bounded.record(for: 0) == nil, "the oldest key is evicted")
+        expect(bounded.record(for: 36) != nil, "the 64 most recent keys survive")
+
+        // Forgetting.
+        bounded.forget { $0 % 2 == 0 }
+        expect(bounded.record(for: 99) != nil, "forget(where:) keeps non-matching keys")
+        expect(bounded.record(for: 98) == nil, "forget(where:) drops matching keys")
+        bounded.forget(key: 99)
+        expect(bounded.record(for: 99) == nil, "forget(key:) drops that key")
+    }
+
+    // MARK: - Fuzz
+
+    static func testFuzz() {
+        let displays: [[WindowLayout.Screen]] = [
+            [mainScreen],
+            [
+                mainScreen,
+                WindowLayout.Screen(
+                    id: 2, frame: CGRect(x: 1440, y: -200, width: 2560, height: 1440),
+                    visibleFrame: CGRect(x: 1440, y: -175, width: 2560, height: 1390)),
+            ],
+            [
+                WindowLayout.Screen(
+                    id: 5, frame: CGRect(x: 0, y: 0, width: 1024, height: 640),
+                    visibleFrame: CGRect(x: 0, y: 25, width: 1024, height: 590)),
+                WindowLayout.Screen(
+                    id: 6, frame: CGRect(x: -3840, y: 0, width: 3840, height: 2160),
+                    visibleFrame: CGRect(x: -3840, y: 25, width: 3840, height: 2060)),
+            ],
+        ]
+        let windows: [CGRect] = [
+            CGRect(x: 100, y: 100, width: 600, height: 400),
+            CGRect(x: 0, y: 0, width: 0, height: 0),
+            CGRect(x: -900, y: -900, width: 200, height: 150),
+            CGRect(x: 200, y: 200, width: 5000, height: 4000),
+            CGRect(x: 1439, y: 899, width: 1, height: 1),
+        ]
+        let gaps: [CGFloat] = [0, 1, 8, 25, 200]
+
+        var checked = 0
+        var problems: [String] = []
+        for screens in displays {
+            for window in windows {
+                for gap in gaps {
+                    for command in WindowCommand.ID.allCases {
+                        let input = WindowLayout.Input(
+                            command: command, windowFrame: window, screens: screens, gap: gap,
+                            step: 0, restoreFrame: window, lastTileCommand: nil)
+                        // A nil placement is a legitimate quiet no-op, not a failure.
+                        guard let placement = WindowLayout.placement(for: input) else { continue }
+                        checked += 1
+                        let rect = placement.frame
+                        let label = "\(command.rawValue) gap \(gap) window \(window)"
+
+                        if !(rect.minX.isFinite && rect.minY.isFinite && rect.width.isFinite
+                            && rect.height.isFinite)
+                        {
+                            problems.append("non-finite frame: \(label)")
+                        }
+                        if rect.width < 0 || rect.height < 0 {
+                            problems.append("negative size: \(label)")
+                        }
+                        guard let host = screens.first(where: { $0.id == placement.screenID })
+                        else {
+                            problems.append("unknown screen id: \(label)")
+                            continue
+                        }
+                        if rect.intersection(host.visibleFrame).isNull {
+                            problems.append("off-screen frame: \(label)")
+                        }
+                        // Determinism, and no drift when the same command is applied twice at step 0.
+                        if WindowLayout.placement(for: input)?.frame != rect {
+                            problems.append("non-deterministic: \(label)")
+                        }
+                        var repeated = input
+                        repeated.windowFrame = rect
+                        if let again = WindowLayout.placement(for: repeated)?.frame,
+                            command != .makeLarger, command != .makeSmaller, command != .moveLeft,
+                            command != .moveRight, command != .moveUp, command != .moveDown,
+                            command != .nextDisplay, command != .previousDisplay,
+                            again != rect
+                        {
+                            problems.append("drifts on repeat: \(label) — \(rect) then \(again)")
+                        }
+                    }
+                }
+            }
+        }
+        expect(checked > 1000, "the fuzz sweep exercised a meaningful number of placements")
+        expect(problems.isEmpty, "fuzz sweep found no violations")
+        for problem in problems.prefix(10) { print("      \(problem)") }
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,6 +95,10 @@ swiftc -swift-version 6 Tinycast/Core/NotificationToken.swift \
     Tools/snippets-test.swift -o /tmp/snippets-test && /tmp/snippets-test  # snippets
 swiftc -swift-version 6 Tinycast/Core/SystemCommand.swift Tools/system-command-test.swift \
     -o /tmp/system-command-test && /tmp/system-command-test        # system command metadata + safety
+swiftc -swift-version 6 Tinycast/Core/WindowManagement/WindowCommand.swift \
+    Tinycast/Core/WindowManagement/WindowLayout.swift \
+    Tinycast/Core/WindowManagement/WindowActionMemory.swift Tools/window-command-test.swift \
+    -o /tmp/window-command-test && /tmp/window-command-test        # window geometry + action memory
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —
@@ -116,6 +120,14 @@ keyword/event/lifecycle policies, AppKit delivery primitives and main-actor stor
 roots and named pasteboards cover identity, per-channel isolation, malformed files, revision
 conflicts, watcher rearming, template determinism, delivery serialization and pasteboard restoration without touching a real snippets library or clipboard. The
 complete subsystem contract is in [snippets.md](snippets.md).
+
+The window-command harness compiles the real catalog, geometry and action memory (Foundation +
+CoreGraphics — `CGRect`'s `Equatable` conformance lives in the CoreGraphics overlay, not Foundation).
+It covers tiling, gaps, cycling, restore, display moves and the memory's reset rules against synthetic
+`WindowLayout.Screen` values, plus a fuzz sweep over every command × gap × screen × degenerate window
+frame. All of it runs headless because the layer is pure: `WindowMover` owns every `AXUIElement` call
+and is deliberately not compiled in. The full contract is in
+[window-management.md](window-management.md).
 
 ## Generated data
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -14,6 +14,12 @@ format** from the removed KeyboardShortcuts package, kept so old bindings surviv
 bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch. System Settings panes use
 `boundPaneBundleIDs`; custom commands use their stable UUIDs in `boundCustomCommandIDs`.
 
+Window commands persist under `KeyboardShortcuts_windowCommandHotkey.<raw-id>` but need **no** bound-ID
+index: the catalog is fixed, so `start()` and `conflictOwner` iterate `WindowCommand.ID.allCases` and
+`register` no-ops on an unbound command. A registered window-command shortcut still runs nothing while
+the feature switch is off — `AppCore.runWindowCommand` re-checks it. See
+[window-management.md](window-management.md).
+
 ## Recorder
 
 The settings recorder (`Features/Settings/ShortcutRecorder.swift`) is deliberately **not** a focusable

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -54,8 +54,9 @@ stable entry IDs, labels, symbols and confirmation policy are covered by
 confirmation or value dialog and surfacing permission-aware failures.
 
 System commands occupy their own launcher and Shortcuts Settings category. The empty-query publication
-order is applications, System Settings, system commands, then built-in/custom commands; the sectioned
-view filters in that same order so the visible rows remain identical to the flat selection index.
+order is applications, System Settings, snippets, system commands, window commands, custom commands,
+then built-in commands; the sectioned view filters in that same order so the visible rows remain
+identical to the flat selection index.
 Search, favorites, visibility and learned ranking work through the normal `AppEntry` path. Dedicated
 global hotkeys are deliberately out of scope.
 
@@ -88,6 +89,16 @@ control at all. Multi-disk ejection excludes internal and network volumes, treat
 that the same physical eject already unmounted as done, and reports remaining failures together.
 Preference-backed toggles refuse to write when the current value can't be read, and notification
 dismissal matches Accessibility subroles rather than English labels.
+
+## Window commands
+
+`WindowCommandCatalog` supplies the 29 window actions as a static slice, published as a whole by
+`AppIndex.setWindowCommandsVisible(_:)` and shown under a "Window Management" section. Unlike system
+commands they **do** carry dedicated global hotkeys (`AppEntry.hotKeyAction` returns
+`.windowCommand(id:)`), so launcher rows render keycaps for them. Their per-command shortcut and
+visibility controls live only in Settings › Window Management, not in Settings › Shortcuts — the same
+call already made for snippets. The feature ships off. See
+[window-management.md](window-management.md).
 
 ## Custom commands
 

--- a/docs/window-management.md
+++ b/docs/window-management.md
@@ -1,0 +1,192 @@
+# Window Management
+
+Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves and native
+fullscreen — searchable in the palette and bindable to global shortcuts. 29 commands, no new
+dependencies and no new permission: they reuse the Accessibility grant clipboard paste already needs.
+
+Ships **off**. Settings › Window Management is the switch, and while it is off there are no launcher
+entries and a still-registered shortcut moves nothing.
+
+## Layout
+
+| File | Imports | Role |
+|---|---|---|
+| `Core/WindowManagement/WindowCommand.swift` | Foundation | Catalog: id, name, symbol, kind, group, `cyclesOnRepeat`, `resizes` |
+| `Core/WindowManagement/WindowLayout.swift` | Foundation + CoreGraphics | **Pure.** Every frame the commands produce |
+| `Core/WindowManagement/WindowActionMemory.swift` | Foundation + CoreGraphics | **Pure.** Per-window cycle position and restore point |
+| `Core/WindowManagement/WindowMover.swift` | AppKit + ApplicationServices | `@MainActor`. Every `AXUIElement` call and the coordinate flip |
+
+The first three compile into `Tools/window-command-test.swift`, so they must not gain an AppKit,
+SwiftUI or `NSScreen` dependency, and must stay pure — `WindowActionMemory` takes `now` as a parameter
+rather than reading a clock. CoreGraphics is needed only because `CGRect`'s `Equatable` conformance
+lives in that overlay rather than in Foundation.
+
+Adding a command is four edits in `WindowCommand.swift` (a case in `ID`, plus `name`, `symbol` and
+`group` arms), an arm in `WindowLayout.placement` or `tileFractions`, and bumping
+`commands.count == 29` in the harness.
+
+## Coordinate space
+
+**`WindowLayout` works exclusively in AX space**: global coordinates, top-left origin, +Y pointing
+*down*. `WindowMover.AXGeometry` is the only place that converts to and from Cocoa's bottom-left space.
+The visible consequence is that Top Half has `minY == visibleFrame.minY`, which the harness asserts
+specifically to stop a bottom-left convention creeping back in.
+
+The flip is anchored on the **primary** display's height — the display whose Cocoa frame origin is
+`(0, 0)` — never on the window's own screen. Both global spaces are anchored on the primary; flipping
+through the window's own screen height shears every rect on a differently-sized display by the height
+difference. That bug is invisible on a single monitor and wrong on every mixed-size multi-monitor
+setup, so it is worth stating twice.
+
+`AXGeometry` is snapshotted once per command: `NSScreen.screens` can change between calls on hotplug,
+wake or a resolution change, and mixing two anchors inside one command corrupts the result.
+
+Nothing here touches `backingScaleFactor`. `NSScreen.frame`, `NSScreen.visibleFrame` and AX
+coordinates are all in points, so mixed-DPI correctness is automatic; a scale factor appearing anywhere
+in this feature is a bug. `visibleFrame` already excludes the menu bar, the Dock and the notch.
+
+## Geometry
+
+**Tiles** come from fractional bounds of `visibleFrame`. Gaps use one rule that composes across every
+family: an edge sitting on the screen boundary takes the full gap, an interior edge takes half. Two
+adjacent tiles therefore leave exactly `gap` between them and every screen edge is inset by `gap`, with
+no per-family special cases. Rects are rounded on their four **edges**, not origin + size, so two tiles
+sharing a fractional boundary (480.333 for thirds of 1441) round it identically — no overlaps, no
+one-point seams.
+
+**Free-floating commands** (Maximize, Almost Maximize, Center, Make Larger/Smaller, the nudges) work in
+`canvas = visibleFrame.insetBy(gap)` instead: a centred window has no neighbour to gutter against.
+
+**Make Larger / Make Smaller** step by 5% of the *screen*, not of the window, and the step is forced
+even so each edge moves a whole point. That makes the two commands exactly invertible — `size × 0.95 ×
+1.05 ≠ size`, so a size-relative step would shrink a little on every round trip — and it feels the same
+at any window size. Both directions saturate into exact no-ops: the ceiling is the canvas, the floor is
+`max(200×150, 15% of canvas)`.
+
+**Center Half** is half the screen's *area*: half width, full height, horizontally centred — the family
+sibling of Center Third.
+
+An oversized or off-screen window is always clamped back onto the display; `clamped` pins the leading
+edge rather than shoving the window off the far side. Maximize Height and Maximize Width keep the
+untouched axis's position but clamp it, so a window sitting off the display doesn't come back
+full-height and still off-screen.
+
+## Cycling and Restore
+
+Both reduce to one question — *has the user moved this window themselves since our last action?* — so
+`WindowActionMemory` answers it once. It is generic over the key so it stays Foundation-only: the app
+keys by `AXUIElement` (via `CFEqual`/`CFHash` plus the pid), the harness keys by `Int`.
+
+`decide` is a pure query returning the cycle step, which is then fed into `WindowLayout.Input.step` —
+cycle state is never hidden inside the geometry. Its rules, in order:
+
+1. No record → step 0, capture the current frame as the restore point, `canRestore: false`.
+2. The frame drifted from `appliedFrame` by more than 2 pt → step 0, **and refresh** the restore point.
+3. A different command, a different display, cycling disabled, a non-cycling command, or a lapsed
+   `cycleTimeout` → step 0.
+4. Otherwise → `(step + 1) % 3`.
+
+Two details carry their weight:
+
+- **Rule 2 compares against the frame we observed, never the one we asked for.** Terminal resizes in
+  whole character cells and never lands exactly on target; comparing against the target would read as
+  "the user moved it" on every press and break both cycling and Restore for such apps.
+- **Restore is single-level, not a stack.** Left Half → Maximize → Top Right → Restore lands on the
+  original frame, because rule 1 captures once and the intermediate actions never overwrite it. A stack
+  has no defensible answer for what a *second* Restore press should do.
+
+Rule 1 also delivers the "works for windows Tinycast never moved" requirement: the capture happens in
+`WindowMover.perform` before a single write.
+
+**Cycling covers the four halves only** (½ → ⅓ → ⅔), and is off by default. Top and Bottom Half cycle
+through *vertical* thirds, which have no commands of their own — the Thirds group is horizontal — so
+they are expressed as fractions rather than other command IDs.
+
+Growth is bounded three ways: an LRU cap of 64, an `NSWorkspace.didTerminateApplicationNotification`
+observer (the house `NotificationToken` RAII idiom) dropping a quit app's keys, and lazy invalidation
+when a read fails. Nothing is persisted.
+
+## Applying a placement
+
+`WindowMover.perform(_:target:gap:cycleOnRepeat:)` is the only entry point. `target` is **explicit**
+because the palette is frontmost when a command dispatches from it — `AppCore.runWindowCommand` passes
+`windowController.previousApp`, the same recorded app the paste path targets, and restores focus to it
+rather than dropping it. It is synchronous: every AX call is a bounded mach round trip capped by a 1s
+messaging timeout, and `await` would only add reentrancy between a held hotkey's repeats. The timeout
+is set on the application element *and again* on the window element — it is per-element and never
+inherited.
+
+The write sequence is **size → position → size**. Whichever single order you pick is wrong in one
+direction: growing first fails when the source display is smaller than the target size, shrinking first
+leaves the window shrunken after a cross-display move. Writing the size on both sides of the position
+write costs one extra round trip and makes both directions correct with no branching; one of the two is
+always a no-op.
+
+**Failing quietly** is a requirement, not a nicety, and has three distinct paths:
+
+- Position not settable → return with **zero** writes; the window is untouched.
+- Size not settable → the move-only branch: one position write placing the size it already has inside
+  the slot per the placement's anchor. One coherent move, never a half-applied one.
+- The position write fails after the shrink → roll the size back. Net visible effect: nothing.
+
+The frame is read back **once** afterwards, for three reasons: to detect an app-imposed minimum size
+(AX exposes no attribute for it, so the read-back is the only way to learn it), to record a truthful
+`appliedFrame`, and to report whether anything actually changed. When the app refused to shrink, the
+window is re-placed per the placement's `anchor` so a left half stays left-aligned instead of drifting
+centre. **One correction, no loop** — iterating against an app that fights back just makes the window
+visibly jitter.
+
+**Toggle Fullscreen** uses the undocumented `AXFullScreen` attribute, falling back to pressing
+`AXFullScreenButton`, then a quiet no-op. There is deliberately no synthetic ⌃⌘F third attempt: it is
+app-rebindable and could fire an unrelated menu command. It does not read geometry back — the
+transition is animated and asynchronous, so any frame read there is a mid-animation value — and it
+clears the cycle chain while keeping the restore point, since macOS restores the pre-fullscreen frame
+itself but the user's original frame is still the right Restore target.
+
+Windows that are minimized, not `AXWindow`-roled (sheets, popovers), already natively fullscreen, or
+that report no position or size are rejected before any work happens.
+
+`AXEnhancedUserInterface` is cleared for the duration of the writes and restored immediately, because
+some apps reinterpret frame writes while it is on — but never while VoiceOver is running, which would
+break the screen reader. **This mitigation is inherited convention and unverified on macOS 26**; if a
+stock Electron app tiles correctly without it, delete the helper rather than keep it.
+
+## Wiring
+
+- **`AppEntry.Kind.windowCommand`** — entries are `window-command:<id>`, published by
+  `AppIndex.setWindowCommandsVisible(_:)` between the system-command and custom-command slices.
+  `LauncherView.rows` mirrors that position with a "Window Management" section; the slice order is the
+  flat-selection invariant, so the two must move together.
+- **`HotKeyAction.windowCommand(id:)`** — persisted under
+  `KeyboardShortcuts_windowCommandHotkey.<raw-id>`, matching the legacy prefix convention. Unlike
+  custom commands there is no bound-ID index to maintain: the catalog is fixed, so `HotKeyManager.start`
+  and `conflictOwner` iterate `WindowCommand.ID.allCases` and `register` no-ops on an unbound command.
+- **`AppCore.runWindowCommand(id:)`** is the one funnel for both palette activation and the global
+  hotkey, so the feature switch cannot be bypassed by either.
+- **Settings** — `windowManagementEnabled` (off), `windowManagementShowInLauncher` (on), `windowGap`
+  (0) and `windowCycleOnRepeat` (off). All four ride in settings backups: unlike `snippetsEnabled` they
+  grant no permission class of their own.
+- **Per-command visibility** reuses `VisibilityStore` as-is; clearing a recorded shortcut is how a
+  hotkey is disabled, so there is no separate per-command enabled flag. Window commands deliberately
+  get **no** tab in Settings › Shortcuts — they are managed only in their own pane, the same call
+  already made for snippets.
+
+## Testing
+
+`Tools/window-command-test.swift` (310 assertions) covers the catalog, the AX-space convention lock,
+tiling on divisible and non-divisible screens, off-origin and negative-coordinate displays, gap
+arithmetic including degenerate values, sizing, the Make Larger/Smaller round trip, nudges, display
+moves and wrapping, restore recovery, every `WindowActionMemory` rule, and a fuzz sweep over every
+command × gap × screen × degenerate window frame checking for non-finite output, negative dimensions,
+off-screen results, non-determinism and drift on repeat.
+
+Everything runs headless because the layer is pure. `WindowMover` is not compiled into the harness and
+has no automated coverage — the AX paths need manual verification, particularly:
+
+1. A non-resizable window (System Information) must fail silently, left untouched rather than
+   half-moved.
+2. **A mixed-resolution multi-monitor setup** — the coordinate-flip bug appears nowhere else. Tile on
+   the secondary display, then round-trip Next/Previous Display.
+3. Toggle Fullscreen on a window that accepts it and one that refuses it.
+4. Cycling: three presses of Left Half, then drag the window and confirm the next press restarts at ½.
+5. Restore on a window Tinycast has never moved.


### PR DESCRIPTION
Adds 29 Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves and native fullscreen — searchable in the palette (`left half` ↵) and bindable to global shortcuts. No new dependencies and no new permission: they reuse the Accessibility grant clipboard paste already needs.

Ships **off**, behind its own Settings pane.

## Related Issues
closes #39

## Layout

Split along the project's existing pure/platform seam, so the geometry is testable headlessly:

| File | Imports | Role |
|---|---|---|
| `Core/WindowManagement/WindowCommand.swift` | Foundation | Catalog of the 29 commands |
| `Core/WindowManagement/WindowLayout.swift` | Foundation + CoreGraphics | **Pure.** Every frame the commands produce |
| `Core/WindowManagement/WindowActionMemory.swift` | Foundation + CoreGraphics | **Pure.** Cycle position + restore point |
| `Core/WindowManagement/WindowMover.swift` | AppKit + ApplicationServices | The only `AXUIElement` / `NSScreen` code |

`import CoreGraphics` is needed because `CGRect`'s `Equatable` conformance lives in that overlay rather than Foundation. Still standalone-compilable with no AppKit/SwiftUI, so the harness invariant holds; the nuance is recorded in `AGENTS.md` and `docs/development.md`.

## Decisions that carry weight

- **The coordinate flip anchors on the primary display's height**, never the window's own screen. Anchoring on the window's screen shears every rect on a mixed-size setup — invisible on one monitor, wrong on every multi-monitor one.
- **The drift check compares against the frame we observed, not the one we requested.** Terminal resizes in whole character cells and never lands exactly on target; comparing against the target would read as "the user moved it" on every press and break both cycling and Restore for such apps.
- **Make Larger/Smaller step by a forced-even fraction of the *screen*.** `size × 0.95 × 1.05 ≠ size`, so a size-relative step drifts smaller on every round trip; screen-relative is exactly invertible and the harness asserts it.
- **Restore is single-level, not a stack** — a stack has no defensible answer for what a second Restore press should do.
- **The write sequence is size → position → size.** Either single order is wrong in one direction; writing size on both sides costs one round trip and needs no branching.
- **Failing quietly** has three distinct paths, all before or around the writes, so a window that refuses to move is left exactly as it was rather than half-moved.

Full rationale in [`docs/window-management.md`](docs/window-management.md).

## Testing

`Tools/window-command-test.swift` — **310 assertions, green**: catalog, the AX-space convention lock, tiling on divisible and non-divisible screens, off-origin and negative-coordinate displays, gap arithmetic including degenerate values, sizing, the Make Larger/Smaller round trip, nudges, display moves and wrapping, restore recovery, every `WindowActionMemory` rule, and a fuzz sweep over every command × gap × screen × degenerate window frame.

The fuzz sweep's off-screen check **caught a real bug**: `Maximize Height`/`Maximize Width` preserve the untouched axis's position, so an off-screen window came back full-height and still entirely off-screen. Both now clamp that axis.

Every pre-existing harness re-run green. Clean `xcodebuild`, no new warnings. App launches with the new wiring and the feature correctly ships off (no defaults written).

## Not verified — needs review on real hardware

**`WindowMover` has no automated coverage** — AX can't be exercised from a harness. Draft because these need hands-on checking:

1. **A mixed-resolution multi-monitor setup** — the coordinate-flip bug appears nowhere else. Tile on the secondary display, then round-trip Next/Previous Display.
2. A non-resizable window (System Information) → must fail silently, not half-moved.
3. Toggle Fullscreen on a window that accepts it and one that refuses it.
4. Cycling: three presses of Left Half, then drag the window and confirm the next press restarts at ½.
5. Restore on a window Tinycast has never moved.

One inherited convention I kept but could not confirm: the `AXEnhancedUserInterface` suppression in `WindowMover`. It's invasive and may be obsolete on macOS 26 — if a stock Electron app tiles correctly without it, that helper should be deleted rather than kept.

`AXFullScreen` / `AXFullScreenButton` are undocumented attribute strings. Universally implemented and used by every window manager, but not contractual — hence the fallback chain ending in a quiet no-op.

## Demo

https://github.com/user-attachments/assets/df713b1e-921a-4e9f-973a-2fcfca38f42e


