### PR TITLE
Maintainer automation: CI, PR/issue-board sync workflows, devenv

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,13 @@ description: Report a bug running Tinycast
 title: "[Bug]: "
 labels: ["bug"]
 body:
+  - type: checkboxes
+    id: existing-search
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched open and closed issues and didn't find this already reported
+          required: false
   - type: textarea
     id: what-happened
     attributes:
@@ -12,11 +19,28 @@ body:
         A short recording beats a paragraph.
     validations:
       required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recording
+      description: Drag and drop images or a screen recording here. Optional but speeds up triage a lot.
+    validations:
+      required: false
   - type: input
     id: version
     attributes:
       label: Tinycast version + channel
-      placeholder: 0.1.0 · stable
+      placeholder: 0.1.0 stable
     validations:
       required: true
   - type: input

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+# Build + the Tools/ harnesses (docs/development.md) are required; SwiftLint is advisory only —
+# it never fails the job, it just annotates the PR. No XCTest target exists (AGENTS.md), so the
+# harnesses are the test suite.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode 26
+        run: |
+          XCODE_PATH="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -n1)"
+          if [ -z "$XCODE_PATH" ]; then
+            echo "::error::No Xcode 26.x found on this runner. Installed Xcodes:"
+            ls /Applications | grep -i xcode || true
+            exit 1
+          fi
+          echo "Using $XCODE_PATH"
+          echo "DEVELOPER_DIR=$XCODE_PATH/Contents/Developer" >> "$GITHUB_ENV"
+
+      - name: Build (Debug)
+        run: |
+          xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug build \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Run Tools/ harnesses
+        run: |
+          set -euo pipefail
+          swift Tools/fuzz-test.swift
+          swiftc -swift-version 6 Tinycast/Core/LauncherRankingStore.swift Tools/ranking-test.swift \
+            -o /tmp/ranking-test && /tmp/ranking-test
+          swiftc Tinycast/Core/Calculator/*.swift Tools/calc-test.swift \
+            -o /tmp/calc-test && /tmp/calc-test
+          swiftc -swift-version 6 Tinycast/Core/ClipboardStore.swift Tools/clipboard-test.swift \
+            -o /tmp/clipboard-test && /tmp/clipboard-test
+          swiftc -swift-version 6 Tinycast/Core/SearchScopes.swift Tools/scopes-test.swift \
+            -o /tmp/scopes-test && /tmp/scopes-test
+          swiftc Tinycast/Core/Emoji/EmojiCatalog.swift Tinycast/Core/Emoji/EmojiGridGeometry.swift \
+            Tinycast/Core/Emoji/EmojiData.generated.swift Tools/emoji-test.swift \
+            -o /tmp/emoji-test && /tmp/emoji-test
+          swiftc -swift-version 6 Tinycast/Core/CustomCommand.swift \
+            Tinycast/Core/ShellCommandRunner.swift Tools/custom-command-test.swift \
+            -o /tmp/custom-command-test && /tmp/custom-command-test
+          swiftc -swift-version 6 Tinycast/Core/NotificationToken.swift \
+            Tinycast/Core/Snippets/*.swift \
+            Tools/snippets-test.swift -o /tmp/snippets-test && /tmp/snippets-test
+          swiftc -swift-version 6 Tinycast/Core/SystemCommand.swift Tools/system-command-test.swift \
+            -o /tmp/system-command-test && /tmp/system-command-test
+          swiftc -swift-version 6 Tinycast/Core/WindowManagement/WindowCommand.swift \
+            Tinycast/Core/WindowManagement/WindowLayout.swift \
+            Tinycast/Core/WindowManagement/WindowActionMemory.swift Tools/window-command-test.swift \
+            -o /tmp/window-command-test && /tmp/window-command-test
+
+  lint:
+    runs-on: macos-26
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: SwiftLint (warning-only)
+        run: swiftlint lint --reporter github-actions-logging

--- a/.github/workflows/label-status-sync.yml
+++ b/.github/workflows/label-status-sync.yml
@@ -1,0 +1,86 @@
+name: Label Status Sync
+
+# Keeps the board column in step with two maintainer-applied labels: `needs info` moves the card to
+# "Needs Info", `approved` moves it to "Approved - Ready for PR". Listens on both issues and pull
+# requests for when PRs join this board too; today only issues are project items, so a PR label
+# event just no-ops (no matching project item found).
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  sync-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move card Status to match the applied label
+        uses: actions/github-script@v9
+        # Projects v2 needs a PAT with repo + project scope — the default GITHUB_TOKEN can't see it.
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const number = context.payload.issue?.number ?? context.payload.pull_request.number;
+            const appliedLabel = context.payload.label.name;
+
+            const NEEDS_INFO_LABEL = process.env.LABEL_NEEDS_INFO || "needs info";
+            const APPROVED_LABEL = process.env.LABEL_APPROVED || "approved";
+
+            const projectId = process.env.PROJECT_ID;
+            const statusFieldId = process.env.STATUS_FIELD_ID;
+
+            let optionId;
+            if (appliedLabel === NEEDS_INFO_LABEL) {
+              optionId = process.env.STATUS_OPTION_NEEDS_INFO;
+            } else if (appliedLabel === APPROVED_LABEL) {
+              optionId = process.env.STATUS_OPTION_APPROVED_READY_FOR_PR;
+            } else {
+              return;
+            }
+
+            if (!projectId || !statusFieldId || !optionId) {
+              core.warning("PROJECT_ID / PROJECT_STATUS_FIELD_ID / status option vars are not configured — skipping.");
+              return;
+            }
+
+            const { repository } = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issueOrPullRequest(number: $number) {
+                    ... on Issue {
+                      projectItems(first: 10) { nodes { id project { id } } }
+                    }
+                    ... on PullRequest {
+                      projectItems(first: 10) { nodes { id project { id } } }
+                    }
+                  }
+                }
+              }`,
+              { owner, repo, number }
+            );
+
+            const item = repository.issueOrPullRequest?.projectItems.nodes.find(
+              (n) => n.project.id === projectId
+            );
+            if (!item) return;
+
+            await github.graphql(
+              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: { projectId: $project, itemId: $item, fieldId: $field, value: { singleSelectOptionId: $option } }
+                ) { projectV2Item { id } }
+              }`,
+              { project: projectId, item: item.id, field: statusFieldId, option: optionId }
+            );
+        env:
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          STATUS_FIELD_ID: ${{ vars.PROJECT_STATUS_FIELD_ID }}
+          STATUS_OPTION_NEEDS_INFO: ${{ vars.PROJECT_STATUS_OPTION_NEEDS_INFO }}
+          STATUS_OPTION_APPROVED_READY_FOR_PR: ${{ vars.PROJECT_STATUS_OPTION_APPROVED_READY_FOR_PR }}
+          LABEL_NEEDS_INFO: ${{ vars.LABEL_NEEDS_INFO }}
+          LABEL_APPROVED: ${{ vars.LABEL_APPROVED }}

--- a/.github/workflows/needs-issue-link.yml
+++ b/.github/workflows/needs-issue-link.yml
@@ -1,0 +1,135 @@
+name: Needs Issue Link
+
+# Flags PRs that don't close an issue (CONTRIBUTING.md: no agreed issue, no merge). Toggles
+# `needs issue link` / `ready for review` and comments once via a hidden marker so it never spams.
+# Uses the PR's `closingIssuesReferences` (GitHub's own link detection: Closes/Fixes/Resolves #N,
+# including cross-repo) instead of hand-parsing the body, so this can never disagree with what
+# GitHub itself considers linked.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync labels, comment, and linked-issue Status
+        uses: actions/github-script@v9
+        # Projects v2 is invisible to the default GITHUB_TOKEN — reading `closingIssuesReferences`
+        # project items and writing the Status field both need a PAT with repo + project scope.
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const number = context.payload.pull_request.number;
+            const MARKER = "<!-- tinycast-bot:needs-issue-link -->";
+
+            const NEEDS_LABEL = process.env.LABEL_NEEDS_ISSUE_LINK || "needs issue link";
+            const READY_LABEL = process.env.LABEL_READY_FOR_REVIEW || "ready for review";
+            const TYPO_LABEL = process.env.LABEL_TYPO || "typo";
+            const DOCS_LABEL = process.env.LABEL_DOCS || "docs";
+
+            const { repository } = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    isDraft
+                    labels(first: 20) {
+                      nodes { name }
+                    }
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        projectItems(first: 10) {
+                          nodes { id project { id } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`,
+              { owner, repo, number }
+            );
+
+            const pr = repository.pullRequest;
+            const linkedIssues = pr.closingIssuesReferences.nodes;
+            const prLabels = pr.labels.nodes.map((l) => l.name);
+            // Only a maintainer can apply `typo`/`docs` — a contributor can't self-exempt by naming
+            // their own PR "typo fix", which is why this checks labels rather than the PR text.
+            const isExempt = prLabels.includes(TYPO_LABEL) || prLabels.includes(DOCS_LABEL);
+
+            async function addLabel(name) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [name] });
+            }
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+              }
+            }
+
+            if (linkedIssues.length === 0 && isExempt) {
+              await addLabel(READY_LABEL);
+              await removeLabel(NEEDS_LABEL);
+              return;
+            }
+
+            if (linkedIssues.length === 0) {
+              await addLabel(NEEDS_LABEL);
+              await removeLabel(READY_LABEL);
+
+              const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number });
+              const alreadyCommented = comments.data.some((c) => c.body?.includes(MARKER));
+              if (!alreadyCommented) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  body: [
+                    MARKER,
+                    "This PR doesn't close an issue yet.",
+                    "",
+                    "Add `Closes #<issue>` (or `Fixes`/`Resolves`) to the description, or open an issue first " +
+                      `if there isn't one — see [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md).`,
+                  ].join("\n"),
+                });
+              }
+              return;
+            }
+
+            await addLabel(READY_LABEL);
+            await removeLabel(NEEDS_LABEL);
+
+            if (pr.isDraft) return;
+
+            const projectId = process.env.PROJECT_ID;
+            const statusFieldId = process.env.STATUS_FIELD_ID;
+            const needsReviewOptionId = process.env.STATUS_OPTION_NEEDS_REVIEW;
+            if (!projectId || !statusFieldId || !needsReviewOptionId) return;
+
+            for (const issue of linkedIssues) {
+              const item = issue.projectItems.nodes.find((n) => n.project.id === projectId);
+              if (!item) continue;
+              await github.graphql(
+                `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: { projectId: $project, itemId: $item, fieldId: $field, value: { singleSelectOptionId: $option } }
+                  ) { projectV2Item { id } }
+                }`,
+                { project: projectId, item: item.id, field: statusFieldId, option: needsReviewOptionId }
+              );
+            }
+        env:
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          STATUS_FIELD_ID: ${{ vars.PROJECT_STATUS_FIELD_ID }}
+          STATUS_OPTION_NEEDS_REVIEW: ${{ vars.PROJECT_STATUS_OPTION_NEEDS_REVIEW }}
+          LABEL_NEEDS_ISSUE_LINK: ${{ vars.LABEL_NEEDS_ISSUE_LINK }}
+          LABEL_READY_FOR_REVIEW: ${{ vars.LABEL_READY_FOR_REVIEW }}
+          LABEL_TYPO: ${{ vars.LABEL_TYPO }}
+          LABEL_DOCS: ${{ vars.LABEL_DOCS }}

--- a/.github/workflows/pr-draft-status-sync.yml
+++ b/.github/workflows/pr-draft-status-sync.yml
@@ -1,0 +1,75 @@
+name: PR Draft Status Sync
+
+# Keeps a linked issue's board column honest across the draft <-> ready toggle: converting a PR to
+# draft means it isn't actually up for review yet, so its issue moves back to "Approved - Ready for
+# PR"; marking it ready moves the issue to "Needs Review". Only the linked issue's card moves — PRs
+# aren't tracked as their own project items on this board.
+on:
+  pull_request_target:
+    types: [converted_to_draft, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  sync-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issue's Status
+        uses: actions/github-script@v9
+        # Projects v2 needs a PAT with repo + project scope — the default GITHUB_TOKEN can't see it.
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const number = context.payload.pull_request.number;
+
+            const projectId = process.env.PROJECT_ID;
+            const statusFieldId = process.env.STATUS_FIELD_ID;
+            const optionId =
+              context.payload.action === "converted_to_draft"
+                ? process.env.STATUS_OPTION_APPROVED_READY_FOR_PR
+                : process.env.STATUS_OPTION_NEEDS_REVIEW;
+
+            if (!projectId || !statusFieldId || !optionId) {
+              core.warning("PROJECT_ID / PROJECT_STATUS_FIELD_ID / status option vars are not configured — skipping.");
+              return;
+            }
+
+            const { repository } = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        projectItems(first: 10) {
+                          nodes { id project { id } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`,
+              { owner, repo, number }
+            );
+
+            const linkedIssues = repository.pullRequest.closingIssuesReferences.nodes;
+
+            for (const issue of linkedIssues) {
+              const item = issue.projectItems.nodes.find((n) => n.project.id === projectId);
+              if (!item) continue;
+              await github.graphql(
+                `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: { projectId: $project, itemId: $item, fieldId: $field, value: { singleSelectOptionId: $option } }
+                  ) { projectV2Item { id } }
+                }`,
+                { project: projectId, item: item.id, field: statusFieldId, option: optionId }
+              );
+            }
+        env:
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          STATUS_FIELD_ID: ${{ vars.PROJECT_STATUS_FIELD_ID }}
+          STATUS_OPTION_NEEDS_REVIEW: ${{ vars.PROJECT_STATUS_OPTION_NEEDS_REVIEW }}
+          STATUS_OPTION_APPROVED_READY_FOR_PR: ${{ vars.PROJECT_STATUS_OPTION_APPROVED_READY_FOR_PR }}

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -41,7 +41,8 @@ jobs:
               "> **Open an issue before you write code — this is mandatory.** Get the bug or the feature agreed on",
               "> first; discussing it in the issue (or on [Discord](https://discord.gg/v2Eeb4QQy3)) is strongly",
               "> encouraged. A PR with no agreed issue behind it gets closed however good the patch is, and the",
-              "> work is wasted. Typo and docs-only fixes are the one exception.",
+              "> work is wasted. Typo and docs-only fixes are the one exception, a maintainer marks those",
+              "> `typo`/`docs` rather than asking for a linked issue.",
             ].join("\n");
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,3 +6,53 @@ excluded:
   - Tinycast/Core/Calculator/CurrencyData.generated.swift
 
 reporter: "github-actions-logging"
+
+# AGENTS.md mandates single-line `///` comments over wrapped multi-line blocks, so those
+# routinely run long; the rule still catches genuinely oversized *code* lines.
+line_length:
+  warning: 160
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+# Terse single/two-letter names are idiomatic here for loop indices, coordinate math
+# (CalcParser, WindowLayout) and parser/DSL tokens (CalcQuantity, ThinScrollbar) — the
+# default min length of 3 mostly just flags that convention rather than a real smell.
+identifier_name:
+  min_length:
+    warning: 1
+
+# `ID` mirrors `Identifiable.ID` — the standard Swift spelling, not a truncated name.
+type_name:
+  excluded:
+    - ID
+
+# AppCore (single-owner core) and RootPaletteView (the main content view) are
+# intentionally large per the architecture in AGENTS.md; SystemCommandRunner /
+# WindowCommand / CalcParser are one-case-per-line command dispatch or recursive-descent
+# parsing, where "complexity" just counts enum cases / token kinds, not real nesting.
+# These ceilings clear today's worst legitimate cases so a *new* runaway type/function
+# still gets flagged.
+cyclomatic_complexity:
+  warning: 45
+  error: 60
+
+function_body_length:
+  warning: 130
+  error: 200
+
+function_parameter_count:
+  warning: 9
+  error: 12
+
+type_body_length:
+  warning: 720
+  error: 900
+
+file_length:
+  warning: 950
+  error: 1200
+
+nesting:
+  type_level:
+    warning: 2

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,8 @@
+included:
+  - Tinycast
+
+excluded:
+  - Tinycast/Core/Emoji/EmojiData.generated.swift
+  - Tinycast/Core/Calculator/CurrencyData.generated.swift
+
+reporter: "github-actions-logging"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,13 @@ Check existing [issues](https://github.com/abue-ammar/tinycast/issues) and
 
 ## Before submitting
 
-- **A linked issue that got a green light.** No agreed issue, no merge — typos and docs-only fixes
-  aside.
+- **A linked issue that got a green light.** No agreed issue, no merge — unless a maintainer marks
+  the PR `typo` or `docs`.
 - Builds clean — no new warnings.
-- The `Tools/` harnesses pass; engine changes come with new cases.
+- The `Tools/` harnesses pass; engine changes come with new cases. CI runs the build and every
+  harness on your PR automatically — [`docs/development.md`](docs/development.md#tests) has the
+  commands to run them locally first. SwiftLint runs too (`swiftlint lint`,
+  [`docs/development.md`](docs/development.md#format--lint)) but is advisory, not a merge gate.
 - Leak-tested and memory-measured. Numbers in the PR.
 - You actually used the app, on your path and the ones next to it.
 - Rebased on `main`, squashed into logical commits.

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -177,7 +177,7 @@ final class AppCore: ObservableObject {
 
         // @Published emits synchronously before the property is written (as in `AppIndex.start`), so every re-projection defers to a task that reads the settled value.
         for publisher in [
-            settings.$windowManagementEnabled, settings.$windowManagementShowInLauncher,
+            settings.$windowManagementEnabled, settings.$windowManagementShowInLauncher
         ] {
             publisher.dropFirst()
                 .sink { [weak self] _ in
@@ -453,8 +453,7 @@ final class AppCore: ObservableObject {
                 title: Self.confirmationTitle(command),
                 message: Self.confirmationMessage(command),
                 confirmTitle: command.name, destructive: true,
-                kind: Self.confirmationKind(command))
-        {
+                kind: Self.confirmationKind(command)) {
             return
         }
         do {
@@ -483,7 +482,7 @@ final class AppCore: ObservableObject {
     /// Commands that change the output level or mute state; macOS only draws its own HUD for real media keys, so these get Tinycast's.
     private static let showsVolumeFeedback: Set<SystemCommand.ID> = [
         .setVolume, .volumeUp, .volumeDown, .toggleMute,
-        .volume0, .volume25, .volume50, .volume75, .volume100,
+        .volume0, .volume25, .volume50, .volume75, .volume100
     ]
 
     private static func confirmationTitle(_ command: SystemCommand) -> String {

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -150,8 +150,7 @@ enum IconCache {
         let config = NSImage.SymbolConfiguration(pointSize: 21, weight: .medium)
             .applying(.init(paletteColors: [tint]))
         if let symbol = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
-            .withSymbolConfiguration(config)
-        {
+            .withSymbolConfiguration(config) {
             return symbol
         }
         guard let asset = NSImage(named: name) else { return nil }
@@ -349,8 +348,7 @@ final class AppIndex: ObservableObject {
         let q = query.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return apps }
         if let matchCache, matchCache.query == q,
-            matchCache.rankingRevision == ranking.revision
-        {
+            matchCache.rankingRevision == ranking.revision {
             return matchCache.result
         }
         let result = rank(q, limit: limit)

--- a/Tinycast/Core/AppLauncher.swift
+++ b/Tinycast/Core/AppLauncher.swift
@@ -29,8 +29,7 @@ enum AppLauncher {
             return
         }
         if let url = running?.bundleURL
-            ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
-        {
+            ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
             // Dock-click semantics: activates, raises, unhides, and reopens a window — none of which a bare `activate()` reliably does under cooperative activation (macOS 14+).
             NSWorkspace.shared.openApplication(
                 at: url, configuration: NSWorkspace.OpenConfiguration())

--- a/Tinycast/Core/Backup/BackupActions.swift
+++ b/Tinycast/Core/Backup/BackupActions.swift
@@ -51,8 +51,7 @@ enum BackupActions {
     // MARK: - Raycast (the pane owns the passphrase field + inline status)
 
     static func importRaycast(file: URL, passphrase: String, options: RaycastImportOptions = .all)
-        async throws -> RaycastOutcome
-    {
+        async throws -> RaycastOutcome {
         // Decrypt (scrypt/AES/gunzip) AND parse off the main actor, inside an autoreleasepool so the large JSON tree drains at once instead of spiking the main-thread footprint. Only the value-type Result crosses back.
         let result = try await Task.detached(priority: .userInitiated) {
             try autoreleasepool {
@@ -96,8 +95,7 @@ enum BackupActions {
     static func quitRaycast() {
         for app in NSWorkspace.shared.runningApplications
         where app.bundleIdentifier.map(isRaycastBundleID) == true
-            && app.activationPolicy != .prohibited
-        {
+            && app.activationPolicy != .prohibited {
             app.terminate()
         }
     }

--- a/Tinycast/Core/Backup/RaycastImport.swift
+++ b/Tinycast/Core/Backup/RaycastImport.swift
@@ -30,7 +30,7 @@ struct RaycastImportOptions: OptionSet, Sendable {
     static let snippets = RaycastImportOptions(rawValue: 1 << 8)
     static let all: RaycastImportOptions = [
         .shortcuts, .favorites, .emojiSkinTone, .launchAtLogin, .menuBarVisibility, .clipboardHistory,
-        .popToRoot, .compactMode, .snippets,
+        .popToRoot, .compactMode, .snippets
     ]
 }
 
@@ -159,7 +159,7 @@ enum RaycastImport {
         "right_control": .rightControl,
         "right_shift": .rightShift,
         "right_option": .rightOption,
-        "right_command": .rightCommand,
+        "right_command": .rightCommand
     ]
 
     private static func mapSettings(_ json: [String: Any]) -> SettingsBackup.SettingsData? {
@@ -193,8 +193,7 @@ enum RaycastImport {
         }
         // Exact-match only: a Raycast timeout outside Tinycast's option set is skipped, not clamped.
         if let secs = general?["popToRootTimeout"] as? Int,
-            let timeout = PopToRootTimeout(rawValue: secs)
-        {
+            let timeout = PopToRootTimeout(rawValue: secs) {
             data.popToRootSeconds = timeout.rawValue
             mapped = true
         }
@@ -218,8 +217,7 @@ enum RaycastImport {
         var mapped = false
 
         if let general = settings?["general"] as? [String: Any],
-            let shortcut = keyShortcut(from: general["globalHotkey"])
-        {
+            let shortcut = keyShortcut(from: general["globalHotkey"]) {
             hotkeys.togglePalette = shortcut
             mapped = true
         }
@@ -235,8 +233,7 @@ enum RaycastImport {
                 mapped = true
             case "e:r:applications":
                 if let path = appPath(fromCommandID: command["id"] as? String),
-                    let bundleID = Bundle(url: URL(fileURLWithPath: path))?.bundleIdentifier
-                {
+                    let bundleID = Bundle(url: URL(fileURLWithPath: path))?.bundleIdentifier {
                     apps[bundleID] = shortcut
                     mapped = true
                 }
@@ -306,8 +303,7 @@ enum RaycastImport {
 
     // MARK: - Clipboard
 
-    private static func mapClipboard(_ json: [String: Any]) -> (items: [ClipboardItem], missing: Int)
-    {
+    private static func mapClipboard(_ json: [String: Any]) -> (items: [ClipboardItem], missing: Int) {
         guard
             let entries = (json["clipboardHistory"] as? [String: Any])?["clipboardEntries"]
                 as? [[String: Any]]

--- a/Tinycast/Core/Backup/Scrypt.swift
+++ b/Tinycast/Core/Backup/Scrypt.swift
@@ -30,7 +30,7 @@ enum Scrypt {
         for i in 1...blocks {
             let intBE: [UInt8] = [
                 UInt8((i >> 24) & 0xff), UInt8((i >> 16) & 0xff),
-                UInt8((i >> 8) & 0xff), UInt8(i & 0xff),
+                UInt8((i >> 8) & 0xff), UInt8(i & 0xff)
             ]
             var u = hmac(key: key, data: salt + intBE)
             var t = u

--- a/Tinycast/Core/Calculator/CalcCurrency.swift
+++ b/Tinycast/Core/Calculator/CalcCurrency.swift
@@ -127,7 +127,7 @@ enum CalcCurrency {
         "KRW": ["won"],  // 2
         "RON": ["leu", "lei"],  // 2
         "RUB": ["ruble", "rubles"],  // 2
-        "SAR": ["riyal", "riyals"],  // 2
+        "SAR": ["riyal", "riyals"]  // 2
     ]
 
     /// Lookup by lowercased ident. Codes, display names and uncontested nouns come from

--- a/Tinycast/Core/Calculator/CalcDateTime.swift
+++ b/Tinycast/Core/Calculator/CalcDateTime.swift
@@ -10,8 +10,7 @@ enum CalcDateTime {
     private enum MomentBias { case future, past }
 
     static func evaluate(_ raw: String, now: Date = Date(), calendar: Calendar = .current)
-        -> CalcResult?
-    {
+        -> CalcResult? {
         let echo = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         let query = echo.lowercased()
         guard !query.isEmpty else { return nil }
@@ -38,8 +37,7 @@ enum CalcDateTime {
     // MARK: - Grammar A: duration until a moment
 
     private static func parseUntil(_ query: String, echo: String, now: Date, calendar: Calendar)
-        -> CalcResult?
-    {
+        -> CalcResult? {
         guard let connector = [" until ", " till ", " til "].first(where: query.contains) else {
             return nil
         }
@@ -85,8 +83,7 @@ enum CalcDateTime {
     // MARK: - Grammar B: duration since a past moment
 
     private static func parseSince(_ query: String, echo: String, now: Date, calendar: Calendar)
-        -> CalcResult?
-    {
+        -> CalcResult? {
         let parts = query.components(separatedBy: " since ")
         guard parts.count == 2,
             let unit = durationUnit(parts[0]),
@@ -288,8 +285,7 @@ enum CalcDateTime {
                     month: month, day: day, now: now, calendar: calendar, bias: bias)
             }
             if parts.count == 3, let month = Int(parts[0]), let day = Int(parts[1]),
-                let year = Int(parts[2]), let date = makeDate(fullYear(year), month, day, calendar)
-            {
+                let year = Int(parts[2]), let date = makeDate(fullYear(year), month, day, calendar) {
                 return Moment(date: date, hasTime: false)
             }
         }
@@ -402,8 +398,7 @@ enum CalcDateTime {
     // MARK: - Formatting
 
     private static func momentString(_ date: Date, hasTime: Bool, now: Date, calendar: Calendar)
-        -> String
-    {
+        -> String {
         let day = dateString(date, now: now, calendar: calendar)
         return hasTime ? "\(day) at \(timeString(date, calendar: calendar))" : day
     }
@@ -479,8 +474,7 @@ enum CalcDateTime {
     }
 
     private static func makeDate(_ year: Int, _ month: Int, _ day: Int, _ calendar: Calendar)
-        -> Date?
-    {
+        -> Date? {
         guard (1...12).contains(month), (1...31).contains(day) else { return nil }
         var components = DateComponents()
         components.year = year
@@ -507,13 +501,13 @@ enum CalcDateTime {
         "january": 1, "jan": 1, "february": 2, "feb": 2, "march": 3, "mar": 3, "april": 4,
         "apr": 4, "may": 5, "june": 6, "jun": 6, "july": 7, "jul": 7, "august": 8, "aug": 8,
         "september": 9, "sep": 9, "sept": 9, "october": 10, "oct": 10, "november": 11, "nov": 11,
-        "december": 12, "dec": 12,
+        "december": 12, "dec": 12
     ]
 
     /// Gregorian weekday numbers (Sunday = 1).
     private static let weekdayByName: [String: Int] = [
         "sunday": 1, "sun": 1, "monday": 2, "mon": 2, "tuesday": 3, "tue": 3, "tues": 3,
         "wednesday": 4, "wed": 4, "thursday": 5, "thu": 5, "thurs": 5, "friday": 6, "fri": 6,
-        "saturday": 7, "sat": 7,
+        "saturday": 7, "sat": 7
     ]
 }

--- a/Tinycast/Core/Calculator/CalcEngine.swift
+++ b/Tinycast/Core/Calculator/CalcEngine.swift
@@ -51,8 +51,7 @@ enum CalcEngine {
         guard let tokens = CalcTokenizer.tokenize(query), !tokens.isEmpty else { return nil }
 
         if let partial = partialResult(
-            tokens, query: query, now: now, calendar: calendar, currency: currency)
-        {
+            tokens, query: query, now: now, calendar: calendar, currency: currency) {
             return partial
         }
 
@@ -182,16 +181,14 @@ enum CalcEngine {
 
         if let quantity = CalcQuantity.evaluate(
             prefixTokens, query: tokenQuery(prefixTokens), currency: currency,
-            preserveStandaloneUnit: true)
-        {
+            preserveStandaloneUnit: true) {
             return replacingExpression(
                 quantity, with: "\(quantity.expression) \(operatorText)")
         }
 
         // A conversion's own echo drops its target ("10 km" for `10km to mi`), so echo the typed text instead — the badges still name both units.
         if let complete = evaluate(
-            tokenQuery(prefixTokens), now: now, calendar: calendar, currency: currency)
-        {
+            tokenQuery(prefixTokens), now: now, calendar: calendar, currency: currency) {
             return replacingExpression(complete, with: prettyExpression(query))
         }
 
@@ -262,14 +259,12 @@ enum CalcEngine {
             sourceBadge = baseName(forRadix: radix)
             sourceText = literalText
         } else if valueTokens.count == 1, let value = decimalLiteral(valueTokens[0]),
-            value >= 0, value.rounded() == value, value <= 9_007_199_254_740_992
-        {
+            value >= 0, value.rounded() == value, value <= 9_007_199_254_740_992 {
             source = UInt64(value)
             sourceBadge = "Decimal"
             sourceText = literalText
         } else if let value = CalcParser.evaluate(valueTokens),
-            value >= 0, value.rounded() == value, value <= 9_007_199_254_740_992
-        {
+            value >= 0, value.rounded() == value, value <= 9_007_199_254_740_992 {
             source = UInt64(value)
             sourceBadge = "Decimal"
             sourceText = CalcFormatter.grouped(String(source))

--- a/Tinycast/Core/Calculator/CalcParser.swift
+++ b/Tinycast/Core/Calculator/CalcParser.swift
@@ -30,8 +30,7 @@ enum CalcTokenizer {
 
             // Radix literals: 0x… / 0b… / 0o… — needs ≥1 digit after the prefix, else fall through so "0" parses as a plain number.
             if ch == "0", i + 2 < chars.count,
-                let radix = ["x": 16, "b": 2, "o": 8][String(chars[i + 1]).lowercased()]
-            {
+                let radix = ["x": 16, "b": 2, "o": 8][String(chars[i + 1]).lowercased()] {
                 let start = i + 2
                 var end = start
                 while end < chars.count, chars[end].isHexDigit { end += 1 }
@@ -203,7 +202,7 @@ enum CalcParser {
     fileprivate static let functions: [String: @Sendable (Double) -> Double] = [
         "sqrt": { sqrt($0) }, "log": { log10($0) }, "ln": { log($0) }, "sin": { sin($0) },
         "cos": { cos($0) }, "tan": { tan($0) }, "abs": { abs($0) }, "floor": { floor($0) },
-        "ceil": { ceil($0) }, "round": { $0.rounded() },
+        "ceil": { ceil($0) }, "round": { $0.rounded() }
     ]
 
     fileprivate static let constants: [String: Double] = ["pi": .pi, "π": .pi, "e": M_E]

--- a/Tinycast/Core/Calculator/CalcQuantity.swift
+++ b/Tinycast/Core/Calculator/CalcQuantity.swift
@@ -56,8 +56,7 @@ enum CalcQuantity {
             // answer stays in the units the user wrote, so `2 * 5kg` is `10 kg`, not `22.05 lb`.
             if !preserveStandaloneUnit, parser.operationCount == 0, parser.dimensionCount == 1,
                 case .ident(let finalName)? = split.expressionTokens.last,
-                CalcUnits.byName[finalName] != nil
-            {
+                CalcUnits.byName[finalName] != nil {
                 return nil
             }
             guard parser.operationCount > 0 || preserveStandaloneUnit else { return nil }
@@ -213,8 +212,7 @@ enum CalcQuantity {
             // Money is written sign-first (`$10`), so echo the amount ahead of its code like every other quantity.
             if case .ident(let name) = tokens[index], CalcUnits.byName[name] == nil,
                 let definition = CalcCurrency.byName[name], index + 1 < tokens.count,
-                let amount = numberValue(tokens[index + 1])
-            {
+                let amount = numberValue(tokens[index + 1]) {
                 add(CalcFormatter.copyText(amount))
                 add(definition.code)
                 index += 2

--- a/Tinycast/Core/Calculator/CalcUnits.swift
+++ b/Tinycast/Core/Calculator/CalcUnits.swift
@@ -152,7 +152,7 @@ enum CalcUnits {
         "mmHg": ("psi", false), "Torr": ("psi", false),
         // Data transfer rate
         "Mbps": ("kbps", false), "Gbps": ("mbps", false), "Kbps": ("bps", false),
-        "bps": ("kbps", false), "Tbps": ("gbps", false),
+        "bps": ("kbps", false), "Tbps": ("gbps", false)
     ]
 
     /// Lookup by lowercased, `²`-folded name (the tokenizer's ident form).

--- a/Tinycast/Core/CalculatorHistoryStore.swift
+++ b/Tinycast/Core/CalculatorHistoryStore.swift
@@ -29,8 +29,7 @@ final class CalculatorHistoryStore: ObservableObject {
         fileURL = base.appendingPathComponent("calculator-history.json")
 
         if let data = try? Data(contentsOf: fileURL),
-            let decoded = try? JSONDecoder().decode([CalcHistoryEntry].self, from: data)
-        {
+            let decoded = try? JSONDecoder().decode([CalcHistoryEntry].self, from: data) {
             entries = decoded
         } else {
             entries = []

--- a/Tinycast/Core/ClipboardManager.swift
+++ b/Tinycast/Core/ClipboardManager.swift
@@ -12,7 +12,7 @@ final class ClipboardManager {
     static let sensitiveTypes: Set<NSPasteboard.PasteboardType> = [
         .init("org.nspasteboard.ConcealedType"),
         .init("org.nspasteboard.TransientType"),
-        .init("com.apple.is-sensitive"),
+        .init("com.apple.is-sensitive")
     ]
 
     private let store: ClipboardStore
@@ -65,8 +65,7 @@ final class ClipboardManager {
         if let sourceBundleID, settings.clipboardDisabledApps.contains(sourceBundleID) { return }
 
         if let text = pb.string(forType: .string),
-            !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
+            !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             guard text.count <= Self.maxTextLength else { return }
             store.addText(text, sourceBundleID: sourceBundleID)
             return

--- a/Tinycast/Core/ClipboardStore.swift
+++ b/Tinycast/Core/ClipboardStore.swift
@@ -547,7 +547,7 @@ final class ClipboardStore: ObservableObject {
     private func closeDatabase() {
         [
             insertStmt, loadStmt, windowFloorStmt, searchStmt, deleteByIDStmt, pinStmt,
-            staleImagesStmt, deleteStaleStmt,
+            staleImagesStmt, deleteStaleStmt
         ].forEach { sqlite3_finalize($0) }
         insertStmt = nil
         loadStmt = nil

--- a/Tinycast/Core/EdgeDissolve.swift
+++ b/Tinycast/Core/EdgeDissolve.swift
@@ -59,7 +59,7 @@ struct EdgeDissolveMask: ViewModifier {
             .init(color: .black, location: topFade / height),
             .init(color: .black, location: 1 - bottomFade / height),
             .init(color: .black.opacity(bottomAlpha), location: 1 - bottomFade / 2 / height),
-            .init(color: .black.opacity(0), location: 1),
+            .init(color: .black.opacity(0), location: 1)
         ]
     }
 }

--- a/Tinycast/Core/Emoji/EmojiIndex.swift
+++ b/Tinycast/Core/Emoji/EmojiIndex.swift
@@ -37,8 +37,7 @@ final class EmojiIndex: ObservableObject {
             let nameScore = FuzzyMatch.score(query: q, candidate: entry.name)
             var best = nameScore
             if !entry.keywords.isEmpty,
-                let keywordScore = FuzzyMatch.score(query: q, candidate: entry.keywords)
-            {
+                let keywordScore = FuzzyMatch.score(query: q, candidate: entry.keywords) {
                 best = max(best ?? Int.min, keywordScore - 500)
             }
             if let best { scored.append((entry, best, order)) }

--- a/Tinycast/Core/Emoji/FrequentEmojiStore.swift
+++ b/Tinycast/Core/Emoji/FrequentEmojiStore.swift
@@ -28,8 +28,7 @@ final class FrequentEmojiStore: ObservableObject {
         fileURL = base.appendingPathComponent("emoji-frequency.json")
 
         if let data = try? Data(contentsOf: fileURL),
-            let decoded = try? JSONDecoder().decode([FrequentEmoji].self, from: data)
-        {
+            let decoded = try? JSONDecoder().decode([FrequentEmoji].self, from: data) {
             records = decoded
         } else {
             records = []

--- a/Tinycast/Core/HotKey/HyperKeyTap.swift
+++ b/Tinycast/Core/HotKey/HyperKeyTap.swift
@@ -161,7 +161,7 @@ final class HyperKeyTap: ObservableObject {
                     queue: .main
                 ) { [weak self] _ in
                     MainActor.assumeIsolated { self?.sessionDidBecomeActive() }
-                }, center: center),
+                }, center: center)
         ]
     }
 

--- a/Tinycast/Core/HotKey/KeyShortcut.swift
+++ b/Tinycast/Core/HotKey/KeyShortcut.swift
@@ -87,14 +87,14 @@ struct KeyShortcut: Hashable, Sendable {
         kVK_Return: "↵", kVK_ANSI_KeypadEnter: "⌤", kVK_Tab: "⇥", kVK_Space: "Space",
         kVK_Delete: "⌫", kVK_ForwardDelete: "⌦", kVK_Escape: "⎋",
         kVK_LeftArrow: "←", kVK_RightArrow: "→", kVK_UpArrow: "↑", kVK_DownArrow: "↓",
-        kVK_Home: "↖", kVK_End: "↘", kVK_PageUp: "⇞", kVK_PageDown: "⇟", kVK_Help: "?⃝",
+        kVK_Home: "↖", kVK_End: "↘", kVK_PageUp: "⇞", kVK_PageDown: "⇟", kVK_Help: "?⃝"
     ]
 
     private static let functionKeyNames: [Int: String] = [
         kVK_F1: "F1", kVK_F2: "F2", kVK_F3: "F3", kVK_F4: "F4", kVK_F5: "F5",
         kVK_F6: "F6", kVK_F7: "F7", kVK_F8: "F8", kVK_F9: "F9", kVK_F10: "F10",
         kVK_F11: "F11", kVK_F12: "F12", kVK_F13: "F13", kVK_F14: "F14", kVK_F15: "F15",
-        kVK_F16: "F16", kVK_F17: "F17", kVK_F18: "F18", kVK_F19: "F19", kVK_F20: "F20",
+        kVK_F16: "F16", kVK_F17: "F17", kVK_F18: "F18", kVK_F19: "F19", kVK_F20: "F20"
     ]
 
     // `TISGetInputSourceProperty` is only safe on the main thread.

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -66,8 +66,7 @@ final class HotKeyManager: ObservableObject {
         objectWillChange.send()
         if let shortcut,
             let data = try? JSONEncoder().encode(shortcut),
-            let json = String(data: data, encoding: .utf8)
-        {
+            let json = String(data: data, encoding: .utf8) {
             UserDefaults.standard.set(json, forKey: action.defaultsKey)
             register(action)
         } else {

--- a/Tinycast/Core/ImageThumbnail.swift
+++ b/Tinycast/Core/ImageThumbnail.swift
@@ -63,7 +63,7 @@ enum ImageThumbnail {
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
             kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel
         ]
         guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
         else { return nil }

--- a/Tinycast/Core/LauncherRankingStore.swift
+++ b/Tinycast/Core/LauncherRankingStore.swift
@@ -29,8 +29,7 @@ final class LauncherRankingStore: ObservableObject {
         self.now = now
 
         if let data = try? Data(contentsOf: self.fileURL),
-            let decoded = try? JSONDecoder().decode([LauncherRankingRecord].self, from: data)
-        {
+            let decoded = try? JSONDecoder().decode([LauncherRankingRecord].self, from: data) {
             records = decoded.filter {
                 !$0.itemKey.isEmpty && !$0.query.isEmpty && $0.count > 0
             }

--- a/Tinycast/Core/ModalWindowController.swift
+++ b/Tinycast/Core/ModalWindowController.swift
@@ -51,7 +51,7 @@ struct ModalRequest {
     let title: String
     var message: String?
     /// Falls back to `kind.defaultSymbol` when unset; a `.custom` kind should always set this explicitly.
-    var symbol: String? = nil
+    var symbol: String?
     var kind: ModalKind = .warning
     var actions: [ModalAction]
     /// The button ↵ fires, normally the primary/confirm action.
@@ -154,15 +154,14 @@ final class ModalWindowController: NSObject, NSWindowDelegate {
             title: title, message: message, kind: kind ?? (destructive ? .warning : .info),
             actions: [
                 ModalAction(title: confirmTitle, role: destructive ? .destructive : .normal),
-                ModalAction(title: "Cancel", role: .cancel),
+                ModalAction(title: "Cancel", role: .cancel)
             ],
             defaultIndex: 0, cancelIndex: 1)
         return await present(request) == 0
     }
 
     func notice(title: String, message: String, symbol: String? = nil, kind: ModalKind = .info)
-        async
-    {
+        async {
         let request = ModalRequest(
             title: title, message: message, symbol: symbol, kind: kind,
             actions: [ModalAction(title: "OK", role: .cancel)], defaultIndex: 0, cancelIndex: 0)
@@ -188,7 +187,7 @@ final class ModalWindowController: NSObject, NSWindowDelegate {
             kind: .info,
             actions: [
                 ModalAction(title: "Set Volume"),
-                ModalAction(title: "Cancel", role: .cancel),
+                ModalAction(title: "Cancel", role: .cancel)
             ],
             defaultIndex: 0, cancelIndex: 1, showsVolumeSlider: true)
         guard await present(request) == 0 else { return nil }

--- a/Tinycast/Core/PalettePanel.swift
+++ b/Tinycast/Core/PalettePanel.swift
@@ -16,7 +16,7 @@ final class PalettePanel: NSPanel {
     /// Keys that drive an open menu (navigate/activate/dismiss); they must reach SwiftUI's `onKeyPress` even while the menu freezes text editing.
     private static let menuNavKeys: Set<Int> = [
         kVK_UpArrow, kVK_DownArrow, kVK_LeftArrow, kVK_RightArrow,
-        kVK_Return, kVK_ANSI_KeypadEnter, kVK_Escape, kVK_Tab,
+        kVK_Return, kVK_ANSI_KeypadEnter, kVK_Escape, kVK_Tab
     ]
 
     /// Hide/show the caret on SwiftUI's *own* live field editor (the current first responder) without replacing it — SwiftUI force-casts the field editor to a private subclass, so vending our own crashes; we can only tune the existing one. The field never resigns first responder, so its text/placeholder never reflows.
@@ -37,15 +37,13 @@ final class PalettePanel: NSPanel {
         if event.type == .keyDown,
             paletteViewModel?.menuOpen == true,
             event.modifierFlags.intersection([.command, .control]).isEmpty,
-            !Self.menuNavKeys.contains(Int(event.keyCode))
-        {
+            !Self.menuNavKeys.contains(Int(event.keyCode)) {
             return
         }
         if event.type == .keyDown,
             Int(event.keyCode) == kVK_Delete,
             event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty,
-            onBareBackspace?() == true
-        {
+            onBareBackspace?() == true {
             return
         }
         super.sendEvent(event)

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -61,8 +61,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             core.palette.prepare(mode: .launcher)
             return
         }
-        popToRootTimer = Timer.scheduledTimer(withTimeInterval: timeout.interval, repeats: false) {
-            [weak self] _ in
+        popToRootTimer = Timer.scheduledTimer(withTimeInterval: timeout.interval, repeats: false) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.popToRootTimer = nil
                 self?.core.palette.prepare(mode: .launcher)

--- a/Tinycast/Core/RunningApps.swift
+++ b/Tinycast/Core/RunningApps.swift
@@ -11,7 +11,7 @@ final class RunningAppsMonitor: ObservableObject {
         let center = NSWorkspace.shared.notificationCenter
         for name in [
             NSWorkspace.didLaunchApplicationNotification,
-            NSWorkspace.didTerminateApplicationNotification,
+            NSWorkspace.didTerminateApplicationNotification
         ] {
             let token = center.addObserver(forName: name, object: nil, queue: .main) {
                 [weak self] _ in

--- a/Tinycast/Core/SearchScopes.swift
+++ b/Tinycast/Core/SearchScopes.swift
@@ -13,7 +13,7 @@ enum SearchScopes {
         "/System/Volumes/Preboot/Cryptexes/App/System/Applications",
         // The one user-facing app in CoreServices — the other ~120 bundles there are background agents with no reliable way to tell them apart, so the directory itself is not a default.
         "/System/Library/CoreServices/Finder.app",
-        "~/Applications",
+        "~/Applications"
     ]
 
     /// Storage form: tilde-abbreviated and without a trailing slash, so the Settings list reads cleanly and a settings backup stays portable across machines.

--- a/Tinycast/Core/SettingsPaneScanner.swift
+++ b/Tinycast/Core/SettingsPaneScanner.swift
@@ -9,7 +9,7 @@ enum SettingsPaneScanner {
     /// Panes whose bundle carries a junk or missing display name; keyed by CFBundleIdentifier.
     private static let nameOverrides: [String: String] = [
         "com.apple.Battery-Settings.extension": "Battery",
-        "com.apple.HeadphoneSettings": "Headphones",
+        "com.apple.HeadphoneSettings": "Headphones"
     ]
 
     /// Panes that shouldn't appear in the launcher at all (contextual/one-shot panes).
@@ -71,8 +71,7 @@ enum SettingsPaneScanner {
         codes.append("en")
         for code in codes {
             if let entry = table[code] as? [String: Any],
-                let name = entry["CFBundleDisplayName"] as? String
-            {
+                let name = entry["CFBundleDisplayName"] as? String {
                 return name
             }
         }

--- a/Tinycast/Core/ShellCommandRunner.swift
+++ b/Tinycast/Core/ShellCommandRunner.swift
@@ -34,8 +34,8 @@ enum ShellCommandRunner {
         process.arguments = [loadingShellEnvironment ? "-ilc" : "-lc", command]
         process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
         // Lets a shell config skip slow or interactive sections when Tinycast is the caller: `[[ -n $TINYCAST ]] && return`.
-        process.environment = ProcessInfo.processInfo.environment.merging(["TINYCAST": "1"]) {
-            _, new in new
+        process.environment = ProcessInfo.processInfo.environment.merging(["TINYCAST": "1"]) { _, new in
+            new
         }
         // Load-bearing for the interactive shell: a config that prompts reads EOF and moves on instead of hanging forever.
         process.standardInput = FileHandle.nullDevice

--- a/Tinycast/Core/Snippets/SnippetKeywordListener.swift
+++ b/Tinycast/Core/Snippets/SnippetKeywordListener.swift
@@ -214,7 +214,7 @@ final class SnippetKeywordListener: ObservableObject {
                 ) { [weak self] _ in
                     MainActor.assumeIsolated { self?.sessionDidBecomeActive() }
                 },
-                center: center),
+                center: center)
         ]
     }
 
@@ -340,6 +340,6 @@ final class SnippetKeywordListener: ObservableObject {
         kVK_End,
         kVK_PageUp,
         kVK_PageDown,
-        kVK_ForwardDelete,
+        kVK_ForwardDelete
     ]
 }

--- a/Tinycast/Core/Snippets/SnippetMarkdownSerializer.swift
+++ b/Tinycast/Core/Snippets/SnippetMarkdownSerializer.swift
@@ -75,7 +75,7 @@ struct SnippetMarkdownSerializer {
     static func serialize(_ snippet: Snippet) -> String {
         var lines = [
             "---",
-            "name: \(encodeScalar(snippet.name))",
+            "name: \(encodeScalar(snippet.name))"
         ]
         if let keyword = snippet.keyword {
             lines.append("keyword: \(encodeScalar(keyword))")

--- a/Tinycast/Core/Snippets/SnippetRepository.swift
+++ b/Tinycast/Core/Snippets/SnippetRepository.swift
@@ -214,7 +214,7 @@ struct SnippetRepository: Sendable {
         fileURL: URL,
         expectedRevision: SnippetSourceRevision
     ) throws(RepositoryError) {
-        try coordinator.withLock { () throws(RepositoryError) -> Void in
+        try coordinator.withLock { () throws(RepositoryError) in
             try mappedError(at: fileURL) {
                 let fileURL = try validatedFileURL(fileURL)
                 try coordinatedMutation(at: fileURL, options: .forDeleting) {

--- a/Tinycast/Core/Snippets/SnippetTemplateEngine.swift
+++ b/Tinycast/Core/Snippets/SnippetTemplateEngine.swift
@@ -283,8 +283,7 @@ enum SnippetTemplateEngine {
         var position = source.startIndex
 
         while position < source.endIndex,
-            let opening = source[position...].firstIndex(of: "{")
-        {
+            let opening = source[position...].firstIndex(of: "{") {
             if position < opening {
                 segments.append(.literal(String(source[position..<opening])))
             }

--- a/Tinycast/Core/Snippets/SnippetTextInjector.swift
+++ b/Tinycast/Core/Snippets/SnippetTextInjector.swift
@@ -193,8 +193,7 @@ final class SnippetTextInjector {
                 postKey(code: CGKeyCode(kVK_LeftArrow), targetApp: targetApp)
             else { return }
             if index < offset - 1,
-                !(await wait(for: .milliseconds(8)))
-            {
+                !(await wait(for: .milliseconds(8))) {
                 return
             }
         }
@@ -296,8 +295,7 @@ final class SnippetTextInjector {
             else { return false }
             post(events[index], targetApp: targetApp)
             if index < events.count - 1,
-                !(await wait(for: .milliseconds(8)))
-            {
+                !(await wait(for: .milliseconds(8))) {
                 return false
             }
         }
@@ -388,15 +386,13 @@ final class SnippetTextInjector {
         for _ in 0..<50 {
             if targetApp.isActive,
                 NSWorkspace.shared.frontmostApplication?.processIdentifier
-                    == targetApp.processIdentifier
-            {
+                    == targetApp.processIdentifier {
                 return true
             }
             if let automaticGeneration,
                 !automaticExpansionIsAllowed(
                     generation: automaticGeneration,
-                    targetApp: targetApp)
-            {
+                    targetApp: targetApp) {
                 return false
             }
             guard await wait(for: .milliseconds(20)) else { return false }
@@ -471,16 +467,14 @@ final class SnippetTextInjector {
             else { return false }
 
             if let previousState,
-                let currentState = accessibilityTextState(in: targetApp)
-            {
+                let currentState = accessibilityTextState(in: targetApp) {
                 readStateAfterPaste = true
                 if currentState != previousState { return true }
             }
             if SnippetPasteConfirmationPolicy.acceptsUnconfirmedDelivery(
                 attempt: attempt,
                 hadPreviousState: previousState != nil,
-                readStateAfterPaste: readStateAfterPaste)
-            {
+                readStateAfterPaste: readStateAfterPaste) {
                 return true
             }
             guard await wait(for: .milliseconds(25)) else { return false }

--- a/Tinycast/Core/Snippets/SnippetsStore.swift
+++ b/Tinycast/Core/Snippets/SnippetsStore.swift
@@ -295,7 +295,7 @@ final class SnippetsStore: ObservableObject {
             let events = directoryWatcher?.data
         else { return }
 
-        if !events.intersection([.delete, .rename, .revoke]).isEmpty {
+        if !events.isDisjoint(with: [.delete, .rename, .revoke]) {
             stopWatchers()
         }
         noteFilesystemChange()
@@ -306,7 +306,7 @@ final class SnippetsStore: ObservableObject {
             let source = fileWatchers[path]
         else { return }
 
-        if !source.data.intersection([.delete, .rename, .revoke]).isEmpty {
+        if !source.data.isDisjoint(with: [.delete, .rename, .revoke]) {
             fileWatchers.removeValue(forKey: path)?.cancel()
         }
         noteFilesystemChange()

--- a/Tinycast/Core/SystemCommandRunner.swift
+++ b/Tinycast/Core/SystemCommandRunner.swift
@@ -45,8 +45,7 @@ enum SystemCommandRunner {
     /// What a command reports back once it succeeded. Only commands whose effect is otherwise invisible
     /// return one, since Show Desktop or Hide Others are their own confirmation.
     static func run(_ id: SystemCommand.ID, previousApp: NSRunningApplication?) async throws
-        -> SystemCommandFeedback?
-    {
+        -> SystemCommandFeedback? {
         switch id {
         case .lockScreen:
             try postKey(keyCode: CGKeyCode(kVK_ANSI_Q), flags: [.maskControl, .maskCommand])
@@ -249,8 +248,7 @@ enum SystemCommandRunner {
     }
 
     private static func volumeAddress(element: AudioObjectPropertyElement)
-        -> AudioObjectPropertyAddress
-    {
+        -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyVolumeScalar,
             mScope: kAudioDevicePropertyScopeOutput,
@@ -289,8 +287,7 @@ enum SystemCommandRunner {
         var muted: UInt32 = 0
         var size = UInt32(MemoryLayout<UInt32>.size)
         if AudioObjectHasProperty(device, &address),
-            AudioObjectGetPropertyData(device, &address, 0, nil, &size, &muted) == noErr
-        {
+            AudioObjectGetPropertyData(device, &address, 0, nil, &size, &muted) == noErr {
             try setMuted(muted == 0, on: device)
             return
         }
@@ -362,8 +359,7 @@ enum SystemCommandRunner {
         for app in NSWorkspace.shared.runningApplications
         where app.activationPolicy == .regular
             && app.processIdentifier != ownPID
-            && app.processIdentifier != keptPID
-        {
+            && app.processIdentifier != keptPID {
             app.hide()
         }
         previousApp?.unhide()
@@ -373,7 +369,7 @@ enum SystemCommandRunner {
     @discardableResult
     private static func ejectAllDisks() throws -> Int {
         let keys: Set<URLResourceKey> = [
-            .volumeIsEjectableKey, .volumeIsInternalKey, .volumeIsLocalKey,
+            .volumeIsEjectableKey, .volumeIsInternalKey, .volumeIsLocalKey
         ]
         let urls = FileManager.default.mountedVolumeURLs(
             includingResourceValuesForKeys: Array(keys), options: [.skipHiddenVolumes]) ?? []

--- a/Tinycast/Core/ThinScrollbar.swift
+++ b/Tinycast/Core/ThinScrollbar.swift
@@ -409,8 +409,7 @@ private struct ScrollbarInteraction: NSViewRepresentable {
             return nil
         }
 
-        private static func firstScrollView(under view: NSView, excluding: NSView?) -> NSScrollView?
-        {
+        private static func firstScrollView(under view: NSView, excluding: NSView?) -> NSScrollView? {
             for sub in view.subviews where sub !== excluding {
                 if let scroll = sub as? NSScrollView { return scroll }
                 if let scroll = firstScrollView(under: sub, excluding: nil) { return scroll }
@@ -428,7 +427,7 @@ private struct ScrollbarInteraction: NSViewRepresentable {
                 NSTrackingArea(
                     rect: .zero,
                     options: [
-                        .mouseMoved, .mouseEnteredAndExited, .activeAlways, .inVisibleRect,
+                        .mouseMoved, .mouseEnteredAndExited, .activeAlways, .inVisibleRect
                     ],
                     owner: self
                 ))

--- a/Tinycast/Core/WindowManagement/WindowCommand.swift
+++ b/Tinycast/Core/WindowManagement/WindowCommand.swift
@@ -101,7 +101,7 @@ enum WindowCommandCatalog {
     }
 
     static let cyclesOnRepeat: Set<WindowCommand.ID> = [
-        .leftHalf, .rightHalf, .topHalf, .bottomHalf,
+        .leftHalf, .rightHalf, .topHalf, .bottomHalf
     ]
 
     /// Nudges reposition without ever touching the size.

--- a/Tinycast/Core/WindowManagement/WindowLayout.swift
+++ b/Tinycast/Core/WindowManagement/WindowLayout.swift
@@ -14,12 +14,6 @@ enum WindowLayout {
         let id: Int
         let frame: CGRect
         let visibleFrame: CGRect
-
-        init(id: Int, frame: CGRect, visibleFrame: CGRect) {
-            self.id = id
-            self.frame = frame
-            self.visibleFrame = visibleFrame
-        }
     }
 
     /// Where a window that refused to shrink to its slot sits inside it — a left half stays left-aligned
@@ -37,8 +31,7 @@ enum WindowLayout {
         /// Places `size` inside `slot` per the anchor, used when an app clamped itself larger than the slot.
         func place(_ size: CGSize, in slot: CGRect) -> CGRect {
             func origin(_ axis: Axis, slotMin: CGFloat, slotLength: CGFloat, length: CGFloat)
-                -> CGFloat
-            {
+                -> CGFloat {
                 switch axis {
                 case .min: return slotMin
                 case .center: return slotMin + (slotLength - length) / 2
@@ -212,8 +205,7 @@ enum WindowLayout {
     }
 
     private static func displayPlacement(_ input: Input, from host: Screen, gap: CGFloat)
-        -> Placement?
-    {
+        -> Placement? {
         let ordered = ordered(input.screens)
         // A single display makes both commands a quiet no-op rather than a pointless re-place.
         guard ordered.count > 1, let index = ordered.firstIndex(where: { $0.id == host.id })
@@ -405,8 +397,7 @@ enum WindowLayout {
     }
 
     private static func nudged(_ frame: CGRect, in canvas: CGRect, command: WindowCommand.ID)
-        -> CGRect
-    {
+        -> CGRect {
         let dx = (canvas.width * stepFraction).rounded()
         let dy = (canvas.height * stepFraction).rounded()
         var moved = frame

--- a/Tinycast/Core/WindowManagement/WindowMover.swift
+++ b/Tinycast/Core/WindowManagement/WindowMover.swift
@@ -160,8 +160,7 @@ final class WindowMover {
 
         // The second resize can shift the origin — some apps anchor a resize on a different corner.
         if abs(actual.minX - placement.frame.minX) > Self.clampTolerance
-            || abs(actual.minY - placement.frame.minY) > Self.clampTolerance
-        {
+            || abs(actual.minY - placement.frame.minY) > Self.clampTolerance {
             _ = setPosition(placement.frame.origin, on: window)
             actual = frame(of: window) ?? actual
         }
@@ -171,8 +170,7 @@ final class WindowMover {
         // anchor, so a left half stays left-aligned instead of drifting centre. One correction, no loop:
         // iterating against an app that fights back just makes the window visibly jitter.
         if actual.width > placement.frame.width + Self.clampTolerance
-            || actual.height > placement.frame.height + Self.clampTolerance
-        {
+            || actual.height > placement.frame.height + Self.clampTolerance {
             var slot = placement.anchor.place(actual.size, in: placement.frame)
             if let canvas { slot = WindowLayout.clamped(slot, into: canvas) }
             _ = setPosition(WindowLayout.rounded(slot).origin, on: window)
@@ -223,8 +221,7 @@ final class WindowMover {
     private func toggleFullScreen(_ window: AXUIElement) -> Bool {
         let target: CFBoolean = isFullScreen(window) ? kCFBooleanFalse : kCFBooleanTrue
         if isSettable(Self.fullScreenAttribute as String, on: window),
-            AXUIElementSetAttributeValue(window, Self.fullScreenAttribute, target) == .success
-        {
+            AXUIElementSetAttributeValue(window, Self.fullScreenAttribute, target) == .success {
             return true
         }
         guard let button = element(window, Self.fullScreenButtonAttribute as String) else {
@@ -251,8 +248,7 @@ final class WindowMover {
 
     /// Cocoa screens converted into the AX space `WindowLayout` works in.
     private static func screens(_ screens: [NSScreen], geometry: AXGeometry)
-        -> [WindowLayout.Screen]
-    {
+        -> [WindowLayout.Screen] {
         screens.enumerated().map { index, screen in
             let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
                 as? NSNumber

--- a/Tinycast/Features/About/AboutView.swift
+++ b/Tinycast/Features/About/AboutView.swift
@@ -14,8 +14,7 @@ struct AboutView: View {
     @MainActor private static let appIcon: NSImage = {
         if let name = Bundle.main.infoDictionary?["CFBundleIconFile"] as? String,
             let url = Bundle.main.url(forResource: name, withExtension: "icns"),
-            let image = NSImage(contentsOf: url)
-        {
+            let image = NSImage(contentsOf: url) {
             return image
         }
         return NSApp.applicationIconImage
@@ -137,7 +136,7 @@ private struct AboutLink: Identifiable {
             url: URL(string: "https://x.com/abue_ammar")!),
         AboutLink(
             id: "email", glyph: .symbol("envelope"), title: "Email",
-            detail: "iabueammar@gmail.com", url: URL(string: "mailto:iabueammar@gmail.com")!),
+            detail: "iabueammar@gmail.com", url: URL(string: "mailto:iabueammar@gmail.com")!)
     ]
 }
 

--- a/Tinycast/Features/Calculator/CalculatorHistoryView.swift
+++ b/Tinycast/Features/Calculator/CalculatorHistoryView.swift
@@ -156,8 +156,7 @@ private struct CalcHistoryRow: View {
 @MainActor
 enum CalcHistoryActionsMenu {
     static func content(entry: CalcHistoryEntry, core: AppCore, calcHistory: CalculatorHistoryStore)
-        -> PopoverMenuContent
-    {
+        -> PopoverMenuContent {
         PopoverMenuContent(
             header: entry.expression,
             items: [
@@ -176,7 +175,7 @@ enum CalcHistoryActionsMenu {
                     title: "Delete All Entries", systemImage: "trash.fill", isDestructive: true
                 ) {
                     calcHistory.clearAll()
-                },
+                }
             ]
         )
     }

--- a/Tinycast/Features/Clipboard/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/ClipboardView.swift
@@ -143,7 +143,7 @@ enum ClipboardActionsMenu {
                 title: "Paste & Keep Window Open", icon: .paste(target, fallback: "macwindow")
             ) {
                 core.pasteKeepingWindowOpen(item)
-            },
+            }
         ]
         if item.isPinned {
             items.append(

--- a/Tinycast/Features/Emoji/EmojiGridView.swift
+++ b/Tinycast/Features/Emoji/EmojiGridView.swift
@@ -240,8 +240,7 @@ private struct EmojiCell: View {
 @MainActor
 enum EmojiActionsMenu {
     static func content(entry: EmojiEntry, core: AppCore, target: PasteTarget?)
-        -> PopoverMenuContent
-    {
+        -> PopoverMenuContent {
         PopoverMenuContent(
             header: entry.displayName,
             items: [
@@ -260,7 +259,7 @@ enum EmojiActionsMenu {
                     title: "Paste & Keep Window Open", icon: .paste(target, fallback: "macwindow")
                 ) {
                     core.pasteEmojiKeepingWindowOpen(entry)
-                },
+                }
             ]
         )
     }

--- a/Tinycast/Features/Launcher/CalculatorCardView.swift
+++ b/Tinycast/Features/Launcher/CalculatorCardView.swift
@@ -6,7 +6,14 @@ import SwiftUI
 /// without comparing the rate table itself.
 @MainActor
 enum CalcMemo {
-    private static var cache: (query: String, enabled: Bool, stamp: Date?, result: CalcResult?)?
+    private struct Cache {
+        let query: String
+        let enabled: Bool
+        let stamp: Date?
+        let result: CalcResult?
+    }
+
+    private static var cache: Cache?
 
     static func evaluate(_ query: String, currency: CurrencySource) -> CalcResult? {
         let enabled: Bool
@@ -23,7 +30,7 @@ enum CalcMemo {
             return cache.result
         }
         let result = CalcEngine.evaluate(query, currency: currency)
-        cache = (query, enabled, stamp, result)
+        cache = Cache(query: query, enabled: enabled, stamp: stamp, result: result)
         return result
     }
 }

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -63,7 +63,7 @@ struct LauncherList: View {
             ("Favorites", Array(favorites)), ("Applications", apps),
             ("System Settings", panes), ("Snippets", snippets),
             ("System Commands", systemCommands), ("Window Management", windowCommands),
-            ("Custom Commands", customCommands), ("Commands", commands),
+            ("Custom Commands", customCommands), ("Commands", commands)
         ]
         where !group.isEmpty {
             rows.append(.header(title))

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -340,8 +340,7 @@ struct OnboardingView: View {
     private static let appIcon: NSImage = {
         if let name = Bundle.main.infoDictionary?["CFBundleIconFile"] as? String,
             let url = Bundle.main.url(forResource: name, withExtension: "icns"),
-            let image = NSImage(contentsOf: url)
-        {
+            let image = NSImage(contentsOf: url) {
             return image
         }
         return NSApp.applicationIconImage

--- a/Tinycast/Features/PopoverMenu.swift
+++ b/Tinycast/Features/PopoverMenu.swift
@@ -16,7 +16,7 @@ enum PopoverMenuIcon: Equatable {
 struct PopoverMenuItem {
     let title: String
     let icon: PopoverMenuIcon
-    var shortcut: String? = nil
+    var shortcut: String?
     /// Destructive rows (delete) tint their icon + label red, matching the native menu convention.
     var isDestructive: Bool = false
     let action: () -> Void
@@ -44,13 +44,13 @@ struct PopoverMenuItem {
 
 /// A popover menu's header + rows, built once per feature and consumed by both the render path and `RootPaletteView`'s keyboard handlers.
 struct PopoverMenuContent {
-    var header: String? = nil
+    var header: String?
     let items: [PopoverMenuItem]
 }
 
 /// In-window overlay menu (not a system popover), anchored to a bottom corner so it stays clipped inside the palette, with a stock Liquid Glass surface. Data-driven so `selection` can highlight a row for keyboard navigation; `onActivate(index)` is the single path fired by both a click and Return.
 struct PopoverMenu: View {
-    var header: String? = nil
+    var header: String?
     let items: [PopoverMenuItem]
     @Binding var selection: Int
     let onActivate: (Int) -> Void

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -153,7 +153,7 @@ struct RootPaletteView: View {
             },
             PopoverMenuItem(title: "Settings", systemImage: "gearshape", shortcut: "⌘,") {
                 core.showSettings()
-            },
+            }
         ])
     }
 
@@ -280,8 +280,7 @@ struct RootPaletteView: View {
             // A nil `old.id` is the first load landing, not a row that moved.
             guard vm.mode == .clipboard, old.id != nil else { return }
             if isQueryEmpty, old.id != new.id, let id = new.id,
-                let index = clips.firstIndex(where: { $0.id == id })
-            {
+                let index = clips.firstIndex(where: { $0.id == id }) {
                 vm.selection = index
             }
             scroll = ScrollIntent(kind: .follow)

--- a/Tinycast/Features/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Settings/BackupSettingsView.swift
@@ -129,8 +129,7 @@ struct BackupSettingsView: View {
                 EmptyView()
             }
         case .failure(let message):
-            SettingsRow(title: message, systemImage: "exclamationmark.triangle.fill", tint: .orange)
-            {
+            SettingsRow(title: message, systemImage: "exclamationmark.triangle.fill", tint: .orange) {
                 EmptyView()
             }
         }

--- a/Tinycast/Features/Settings/CustomCommandsSettingsView.swift
+++ b/Tinycast/Features/Settings/CustomCommandsSettingsView.swift
@@ -32,8 +32,7 @@ struct CustomCommandsSettingsView: View {
                         EmptyView()
                     }
                 } else {
-                    ForEach(Array(sortedCommands.enumerated()), id: \.element.id) {
-                        index, command in
+                    ForEach(Array(sortedCommands.enumerated()), id: \.element.id) { index, command in
                         if index > 0 { SettingsDivider() }
                         CustomCommandSettingsRow(
                             command: command,

--- a/Tinycast/Features/Settings/RaycastImportSelection.swift
+++ b/Tinycast/Features/Settings/RaycastImportSelection.swift
@@ -20,7 +20,7 @@ struct RaycastImportSelection: View {
         .init(option: .clipboardHistory, symbol: "doc.on.clipboard", label: "Clipboard history"),
         .init(option: .snippets, symbol: "curlybraces", label: "Snippets"),
         .init(option: .popToRoot, symbol: "arrow.uturn.backward", label: "Pop to root"),
-        .init(option: .compactMode, symbol: "macwindow", label: "Compact mode"),
+        .init(option: .compactMode, symbol: "macwindow", label: "Compact mode")
     ]
 
     private static let columns = Array(

--- a/Tinycast/Features/Settings/SettingsComponents.swift
+++ b/Tinycast/Features/Settings/SettingsComponents.swift
@@ -46,7 +46,7 @@ struct SettingsHeader: View {
 
 /// A rounded, hairline-bordered container grouping related rows — the macOS System Settings "card" (rows split by inset dividers via `SettingsRow`/`SettingsDivider`).
 struct SettingsCard<Content: View>: View {
-    var header: String? = nil
+    var header: String?
     @ViewBuilder var content: Content
 
     var body: some View {
@@ -127,11 +127,11 @@ struct SettingsDivider: View {
 /// A single settings line (optional SF Symbol, title with optional subtitle, trailing control); fixed vertical rhythm keeps every card aligned regardless of the control.
 struct SettingsRow<Trailing: View>: View {
     let title: String
-    var subtitle: String? = nil
-    var systemImage: String? = nil
+    var subtitle: String?
+    var systemImage: String?
     var tint: Color = .secondary
     /// Optional state indicator rendered after the title (green = active, orange = attention).
-    var statusDot: Color? = nil
+    var statusDot: Color?
     @ViewBuilder var trailing: Trailing
 
     var body: some View {
@@ -172,7 +172,7 @@ struct SettingsRow<Trailing: View>: View {
 /// A tinted inset box for a notice or warning inside a `SettingsCard` — SF Symbol + title + optional message, with an optional trailing control (e.g. a fix-it button).
 struct SettingsCallout<Trailing: View>: View {
     let title: String
-    var message: String? = nil
+    var message: String?
     var systemImage: String = "info.circle"
     var tint: Color = .secondary
     @ViewBuilder var trailing: Trailing

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -137,8 +137,7 @@ private final class CaptureSession: ObservableObject {
                         keyCode: keyCode, flags: flags, action: action, hotKeys: hotKeys)
                 }
                 return nil  // always consume: no beeps, no leaking keys to the window
-            })
-        {
+            }) {
             monitors.append(monitor)
         }
 
@@ -149,8 +148,7 @@ private final class CaptureSession: ObservableObject {
                 let flags = event.modifierFlags.intersection([.command, .option, .control, .shift])
                 MainActor.assumeIsolated { self?.heldModifiers = flags }
                 return event
-            })
-        {
+            }) {
             monitors.append(monitor)
         }
 
@@ -160,8 +158,7 @@ private final class CaptureSession: ObservableObject {
             handler: { [weak hotKeys] event in
                 MainActor.assumeIsolated { hotKeys?.recordingAction = nil }
                 return event
-            })
-        {
+            }) {
             monitors.append(monitor)
         }
 

--- a/Tinycast/Features/Settings/SnippetsSettingsView.swift
+++ b/Tinycast/Features/Settings/SnippetsSettingsView.swift
@@ -365,8 +365,7 @@ private struct SnippetEditorSheet: View {
     /// Replaces the selection, or lands at the caret; appends when there is no usable one (the menu can be used before the editor is ever focused).
     private func insert(_ token: String) {
         if let selection, case .selection(let range) = selection.indices,
-            range.lowerBound >= text.startIndex, range.upperBound <= text.endIndex
-        {
+            range.lowerBound >= text.startIndex, range.upperBound <= text.endIndex {
             text.replaceSubrange(range, with: token)
         } else {
             text += token

--- a/Tinycast/Features/Settings/WindowManagementSettingsView.swift
+++ b/Tinycast/Features/Settings/WindowManagementSettingsView.swift
@@ -66,8 +66,7 @@ struct WindowManagementSettingsView: View {
 
     private var commandsCard: some View {
         SettingsCard(header: "Commands") {
-            ForEach(Array(WindowCommandCatalog.grouped().enumerated()), id: \.element.group) {
-                index, section in
+            ForEach(Array(WindowCommandCatalog.grouped().enumerated()), id: \.element.group) { index, section in
                 if index > 0 { SettingsDivider() }
                 WindowCommandGroupHeader(title: section.group.title)
                 ForEach(section.commands) { command in

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,22 @@ frame. All of it runs headless because the layer is pure: `WindowMover` owns eve
 and is deliberately not compiled in. The full contract is in
 [window-management.md](window-management.md).
 
+## Format & lint
+
+Formatting is whatever Xcode's own reindent does — there's no separate formatter. Linting is
+[SwiftLint](https://github.com/realm/SwiftLint), configured in [`.swiftlint.yml`](../.swiftlint.yml)
+(default ruleset, scoped to `Tinycast/`, the two `.generated.swift` files excluded):
+
+```sh
+brew install swiftlint   # once
+swiftlint lint           # report issues
+swiftlint lint --fix     # auto-fix what's fixable, then re-run lint to see what's left
+```
+
+Lint is advisory, not a merge gate — CI runs it as a non-blocking check (below). Warnings are still
+worth clearing before you open a PR; CONTRIBUTING.md's "builds clean" bar is about compiler warnings,
+which SwiftLint doesn't touch.
+
 ## Generated data
 
 Two Swift files are emitted by scripts and must never be hand-edited. Both download their source, so
@@ -169,6 +185,20 @@ Both local builds and CI releases sign with the same stable `Tinycast Self-Signe
 Apple Developer ID), so macOS quarantines a directly-downloaded DMG — the Homebrew cask strips that
 automatically, and direct downloaders run `xattr -dr com.apple.quarantine "…/Tinycast.app"` once.
 Full details in [signing.md](signing.md).
+
+## Continuous integration
+
+`.github/workflows/ci.yml` runs on every PR and every push to `main`, on a `macos-26` runner with
+Xcode 26 (same selection step as the release workflow):
+
+- **`build-and-test`** — required. `xcodebuild` Debug build, then every `Tools/*.swift` harness from
+  [Tests](#tests) above, in order. A merge is blocked if either the build or any harness fails.
+- **`lint`** — advisory. Runs `swiftlint lint --reporter github-actions-logging` so warnings show up
+  as inline PR annotations; `continue-on-error: true` means it never blocks a merge.
+
+Same commands locally: `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug
+build`, then the harness block from [Tests](#tests), then `swiftlint lint` from
+[Format & lint](#format--lint).
 
 ## CI releases
 


### PR DESCRIPTION
## Summary

Implements the maintainer-automation setup plan: three GitHub Actions workflows that keep PR labels
and the Project board's Status column in sync, a required CI workflow, SwiftLint, Dependabot for
SPM, and a devenv/direnv dev shell for the CLI tooling these docs reference.

## What's in this PR

- **`ci.yml`** — `macos-26` / Xcode 26. `xcodebuild` build + every `Tools/*.swift` harness is
  **required**. SwiftLint runs as a separate `continue-on-error` job — advisory only, never blocks a
  merge. Config in `.swiftlint.yml`.
- **`needs-issue-link.yml`** — flags PRs with no closing issue, using the PR's
  `closingIssuesReferences` (GitHub's own Closes/Fixes/Resolves detection, not a hand-rolled regex).
  Toggles `needs issue link` / `ready for review`, comments once via a hidden marker so it never
  spams. A PR labeled `typo` or `docs` by a maintainer is exempt from the check — a contributor can't
  self-exempt by just wording their PR "typo fix". When an issue gets linked on a non-draft PR, also
  pushes that issue's Project Status to **Needs Review**.
- **`pr-draft-status-sync.yml`** — PR converted to draft → linked issue's card moves to
  **Approved - Ready for PR**; PR marked ready for review → moves to **Needs Review**. Only the
  linked issue's card moves; PRs aren't tracked as their own items on this board (confirmed against
  the live project — see Decisions below).
- **`label-status-sync.yml`** — `needs info` label → **Needs Info** column; `approved` label →
  **Approved - Ready for PR** column. Listens on both issues and PRs so it's ready if PRs ever join
  the board; today a PR label event just no-ops since it isn't a project item.
- **`dependabot.yml`** — `swift` ecosystem, weekly. Inert today — the repo has zero SPM package
  dependencies right now — but ready for whenever one's added.
- **`devenv.yaml` / `devenv.nix` / `.envrc`** — Nix-pinned `xcodegen`, `swiftlint`, `node`, `gh` via
  devenv; `direnv allow` auto-activates per directory. Doesn't cover Xcode itself or
  `xcode-build-server` (not Nix-packaged) — both stay the existing manual steps.
- **Docs** — `docs/development.md` gained *Format & lint*, *Continuous integration*, and *CLI
  tooling (devenv)* sections; `CONTRIBUTING.md` and `welcome.yml`'s PR comment now state the
  typo/docs exemption the same way (maintainer-applied label), so they can't drift out of sync with
  what the bot actually enforces.

## Decisions made this pass (see commit messages for the "why" on each)

- **Typo/docs exemption → labels, not text-matching.** Explicit and can't be gamed by a contributor
  wording their own PR "typo fix"; costs a manual label from a maintainer.
- **`internal discussion needed` is being reused as-is** for "needs discussion" — no new label
  created. If that turns out to mean something narrower, a new label is a small follow-up.
- **Only the linked issue's card moves on draft/ready toggle**, not a PR's own card — confirmed via
  the Projects v2 API that PRs aren't currently items on this board at all, only issues.
- **No backfill of the ~100 pre-existing open issues/PRs.** This PR only wires the automation going
  forward; sweeping the backlog into the new labels/board is a separate, judgment-heavy pass.

## Manual setup required before any of this actually runs

None of this was done automatically — no labels, secrets, or repo variables were touched.

**1. Create 3 missing labels:**
```sh
gh label create "ready for review" --color "0E8A16" --repo abue-ammar/tinycast
gh label create "typo" --color "d4c5f9" --repo abue-ammar/tinycast
gh label create "docs" --color "0075ca" --repo abue-ammar/tinycast
```

**2. Add a `PROJECT_TOKEN` repo secret** — a classic PAT with `repo` + `project` scopes. The default
`GITHUB_TOKEN` can't read or write Projects v2 at all; without this secret the three
project-sync workflows log a warning and no-op on the board-sync part (labels/comments still work
where applicable).

**3. Set these repo variables** (values pulled live from the "Tinycast" project, #3):

| Variable | Value |
|---|---|
| `PROJECT_ID` | `PVT_kwHOANtKss4BfBSc` |
| `PROJECT_STATUS_FIELD_ID` | `PVTSSF_lAHOANtKss4BfBSczhZXQ1M` |
| `PROJECT_STATUS_OPTION_NEEDS_REVIEW` | `84f0f475` |
| `PROJECT_STATUS_OPTION_APPROVED_READY_FOR_PR` | `ea6d067f` |
| `PROJECT_STATUS_OPTION_NEEDS_INFO` | `47fc9ee4` |

```sh
gh variable set PROJECT_ID --body "PVT_kwHOANtKss4BfBSc" --repo abue-ammar/tinycast
gh variable set PROJECT_STATUS_FIELD_ID --body "PVTSSF_lAHOANtKss4BfBSczhZXQ1M" --repo abue-ammar/tinycast
gh variable set PROJECT_STATUS_OPTION_NEEDS_REVIEW --body "84f0f475" --repo abue-ammar/tinycast
gh variable set PROJECT_STATUS_OPTION_APPROVED_READY_FOR_PR --body "ea6d067f" --repo abue-ammar/tinycast
gh variable set PROJECT_STATUS_OPTION_NEEDS_INFO --body "47fc9ee4" --repo abue-ammar/tinycast
```

Optional label-name overrides, each defaults to the current name if unset: `LABEL_NEEDS_ISSUE_LINK`,
`LABEL_READY_FOR_REVIEW`, `LABEL_TYPO`, `LABEL_DOCS`, `LABEL_NEEDS_INFO`, `LABEL_APPROVED`.

## Still open — need your input, not decided here

- What happens to the ~100 existing open issues/PRs that predate this system.
- Stale-bot timeout duration (no stale-bot workflow drafted yet).
- Whether `internal discussion needed` truly covers everything "needs discussion" was meant to mean.

## Test plan

- [ ] `xcodegen generate` still produces a clean `Tinycast.xcodeproj` (no project.yml changes in this
      PR, so this should be a no-op — confirming anyway).
- [ ] Run the manual setup steps above on a test/fork repo (or this one, once merged) and:
  - [ ] Open a PR with no `Closes #` → confirm `needs issue link` label + one comment, no duplicate
        comments on subsequent pushes.
  - [ ] Add `Closes #<issue>` → confirm label flips to `ready for review` and the issue's card moves
        to Needs Review (once `PROJECT_TOKEN`/vars are set).
  - [ ] Label a PR `typo` with no linked issue → confirm it's exempted, no flag/comment.
  - [ ] Convert a ready PR to draft → confirm linked issue moves to Approved - Ready for PR.
  - [ ] Label an issue `needs info` / `approved` → confirm the board column moves.
- [ ] `ci.yml` runs on this PR itself once pushed — confirm build + harnesses pass and SwiftLint
      annotates without blocking.
- [ ] `direnv allow` in a fresh clone → confirm `xcodegen`/`swiftlint`/`node`/`gh` resolve (verified
      locally: `xcodegen 2.44.1`, `swiftlint 0.65.0`, `node v24.18.1`, `gh 2.96.0`).
