### PR TITLE
feat: In-app updates with Sparkle, off by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: write
 
+# Pinned in one place so the appcast signer can never drift from the Sparkle SPM pin in project.yml.
+env:
+  SPARKLE_VERSION: "2.9.4"
+
 jobs:
   build:
     runs-on: macos-26
@@ -44,10 +48,12 @@ jobs:
           CHANNEL="${{ github.event.inputs.channel }}"
           BASE_VERSION="${{ github.event.inputs.version }}"
           # Each channel is a distinct, side-by-side app: its own display name + bundle id,
-          # and its own Homebrew cask in the abue-ammar/homebrew-tinycast tap.
+          # its own Homebrew cask in the abue-ammar/homebrew-tinycast tap, and its own Sparkle feed
+          # (two separate appcasts, never sparkle:channel — a beta host must never be offered the
+          # stable DMG). This is the single place channel identity is decided.
           case "$CHANNEL" in
-            beta)   SUFFIX="-beta.${GITHUB_RUN_NUMBER}";  DISPLAY="Tinycast Beta";  BUNDLE="com.tinycast.app.beta";  CASK="tinycast@beta";  PRERELEASE=true ;;
-            stable) SUFFIX="";                            DISPLAY="Tinycast";       BUNDLE="com.tinycast.app";       CASK="tinycast";       PRERELEASE=false ;;
+            beta)   SUFFIX="-beta.${GITHUB_RUN_NUMBER}";  DISPLAY="Tinycast Beta";  BUNDLE="com.tinycast.app.beta";  CASK="tinycast@beta";  APPCAST="appcast-beta.xml";  PRERELEASE=true ;;
+            stable) SUFFIX="";                            DISPLAY="Tinycast";       BUNDLE="com.tinycast.app";       CASK="tinycast";       APPCAST="appcast.xml";       PRERELEASE=false ;;
           esac
           FULL="${BASE_VERSION}${SUFFIX}"
           {
@@ -55,6 +61,7 @@ jobs:
             echo "display_name=${DISPLAY}"
             echo "bundle_id=${BUNDLE}"
             echo "cask_name=${CASK}"
+            echo "appcast_file=${APPCAST}"
             echo "dmg_file=Tinycast-${FULL}.dmg"
             echo "prerelease=${PRERELEASE}"
           } >> "$GITHUB_OUTPUT"
@@ -141,6 +148,56 @@ jobs:
           xattr -dr com.apple.quarantine \"/Applications/${{ steps.meta.outputs.display_name }}.app\"
           \`\`\`" \
             $PRERELEASE_FLAG
+
+      # Sign the DMG with the Sparkle EdDSA key and rewrite this channel's appcast. Runs after the
+      # release is published because the item's download URL must already resolve, and before the
+      # cask bump so a failure here can't leave the tap ahead of the feed.
+      - name: Sign DMG and update appcast
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          APPCAST: ${{ steps.meta.outputs.appcast_file }}
+          CASK: ${{ steps.meta.outputs.cask_name }}
+          VERSION: ${{ steps.meta.outputs.full_version }}
+        run: |
+          if [ -z "${SPARKLE_ED_PRIVATE_KEY}" ]; then
+            echo "::warning::SPARKLE_ED_PRIVATE_KEY secret not set — skipping appcast update. Add it to enable in-app updates."
+            exit 0
+          fi
+          curl -fsSL -o /tmp/sparkle.tar.xz \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+          mkdir -p /tmp/sparkle
+          tar -xJf /tmp/sparkle.tar.xz -C /tmp/sparkle
+          # --ed-key-file - reads the key from stdin, so it never lands in a Keychain, a file or the
+          # log. dist/ holds only the DMG just built, so the feed ends up with exactly that one item
+          # — which is all Sparkle needs — and deltas are off because there is no older archive here.
+          echo "${SPARKLE_ED_PRIVATE_KEY}" | /tmp/sparkle/bin/generate_appcast \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/abue-ammar/tinycast/releases/download/v${VERSION}/" \
+            --maximum-deltas 0 \
+            -o "website/public/${APPCAST}" \
+            dist/
+          # Land the appcast on main and nothing else: the workflow can be dispatched from any ref,
+          # so pushing HEAD would drop that ref's whole history onto main. Replay just this one file.
+          git fetch --depth=1 origin main
+          cp "website/public/${APPCAST}" "${RUNNER_TEMP}/${APPCAST}"
+          git checkout -B appcast-publish FETCH_HEAD
+          cp "${RUNNER_TEMP}/${APPCAST}" "website/public/${APPCAST}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "website/public/${APPCAST}"
+          if git diff --cached --quiet; then
+            echo "No appcast changes to commit."
+            exit 0
+          fi
+          git commit -m "appcast: ${CASK} ${VERSION}"
+          # The commit touches website/, which is exactly what .github/workflows/website.yml watches,
+          # so pushing it is what deploys the new feed to GitHub Pages.
+          if ! git push origin HEAD:main; then
+            # main moved while we were building — replay this one commit on top of it and retry once.
+            git fetch --depth=1 origin main
+            git rebase FETCH_HEAD || { echo "::error::Could not rebase the appcast commit onto main."; exit 1; }
+            git push origin HEAD:main || { echo "::error::Could not push the appcast commit to main."; exit 1; }
+          fi
 
       - name: Update Homebrew cask
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Full detail: [`docs/architecture.md`](docs/architecture.md).
 - **Subsystems:** [palette](docs/palette.md) · [launcher & fuzzy match](docs/launcher.md) ·
   [calculator](docs/calculator.md) · [clipboard](docs/clipboard.md) · [emoji](docs/emoji.md) ·
   [snippets](docs/snippets.md) · [window management](docs/window-management.md) ·
-  [hotkeys](docs/hotkeys.md) · [UI & design system](docs/ui.md).
+  [hotkeys](docs/hotkeys.md) · [updates](docs/updates.md) · [UI & design system](docs/ui.md).
 
 ## Critical Invariants
 
@@ -110,6 +110,20 @@ Never break these without an explicit task to do so.
   **cacheless** `URLSession` (`.ephemeral`, `urlCache = nil`), never `URLSession.shared` — a cacheable
   response would leave a second copy in the on-disk `URLCache` that opting out doesn't delete.
   `CurrencyRateStore` is the reference implementation — follow it rather than inventing a second shape.
+- **Updates use one feed per channel, never `sparkle:channel`.** Sparkle's default channel is always
+  allowed, so a channel attribute would offer a beta host the stable DMG, whose app name and bundle id
+  match neither — the install is then rejected. The feed comes from
+  `SPUUpdaterDelegate.feedURLStringForUpdater:` (there is no `SUFeedURL` in Info.plist) and is `nil`
+  on the dev channel, which is what makes dev provably un-updatable. Validation rests on two strands:
+  the stable self-signed cert (Sparkle checks the new bundle against the *old* one's designated
+  requirement — a leaf hash match, never Gatekeeper) **and** the EdDSA key; either alone recovers the
+  channel, losing both leaves every install unupdatable, and the Developer-ID rotation fallback never
+  fires for us because it hardcodes `anchor apple generic`. So never ship an unsigned build, and
+  **never add an `NSUpdateSecurityPolicy` dict** — it forces Sparkle off its atomic-swap path and
+  brings back the "wants to manage apps" prompt (Sparkle #2591). Background checks are networked, so
+  they ship off behind `SUEnableAutomaticChecks = NO` (which also zeroes startup network I/O and
+  suppresses Sparkle's own prompt), and the flag stays out of `AppSettings` so a `SettingsBackup`
+  import can't grant network access. See [updates.md](docs/updates.md).
 - **Snippets are channel-isolated and path-identified.** Persist them under
   `~/Library/Application Support/<bundle-id>/Snippets/`; `StoredSnippet.ID` is the standardized source
   path, and external rename is delete + create. The feature ships off and its enable switch doubles as
@@ -171,7 +185,7 @@ Never break these without an explicit task to do so.
   [`docs/clipboard.md`](docs/clipboard.md) · [`docs/emoji.md`](docs/emoji.md) ·
   [`docs/snippets.md`](docs/snippets.md) ·
   [`docs/window-management.md`](docs/window-management.md) ·
-  [`docs/hotkeys.md`](docs/hotkeys.md) — subsystem internals.
+  [`docs/hotkeys.md`](docs/hotkeys.md) · [`docs/updates.md`](docs/updates.md) — subsystem internals.
 - [`docs/ui.md`](docs/ui.md) — the full visual design system, tokens, scrollbars, section headers.
 - [`docs/development.md`](docs/development.md) — build, test, package, release.
 - [`docs/signing.md`](docs/signing.md) — signing model and Gatekeeper.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ A tiny, fully native macOS launcher — the essentials, without the bloat.
   <img src="docs/screenshot.png" alt="Tinycast command palette" width="720">
 </p>
 
-Around **3 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background
-CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there's nothing to it.
+Around **7 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background
+CPU churn. Just SwiftUI + AppKit, with [Sparkle](https://sparkle-project.org) for updates as the one
+dependency. It's fast because there's nothing to it.
 
 ## Features
 

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		8611F52FF00B8C43EC46F902 /* EmojiSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041AB49DDB9CA53148BB8A46 /* EmojiSettingsView.swift */; };
 		8631543D8E0E008E7C541345 /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC323070A08CD17DFFB2F8A /* BackupSettingsView.swift */; };
 		86D400D72735A8D0829029DE /* SettingsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */; };
+		86EC8065A0DE9A777214FE65 /* UpdateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64A0723AF1242FAC4214AC65 /* UpdateStore.swift */; };
 		8EF55652F19A1E0C5FF644B4 /* RaycastImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4049668745FD438D5792A2F /* RaycastImport.swift */; };
 		8F7431A1340D0A5783599087 /* MiscellaneousSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */; };
 		903E82F78D3FCEF3A1AF3752 /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */; };
@@ -80,6 +81,7 @@
 		ABBB2A811EB5C69D55A93B1C /* RaycastImportSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */; };
 		AD2141EBF98A246BDA3BAB8E /* Gunzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A53295959552ED28D34960 /* Gunzip.swift */; };
 		AE0D0C53004C65D65BE89B6F /* BackupActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8C2C59C2B578CFE61E004 /* BackupActions.swift */; };
+		AF04BEDD1792ACA87B06E32B /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4749B284382121680BDB690 /* Sparkle */; };
 		B1B3F5715BE7A092F0CEFA09 /* ClipboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76E4099082D59FA686C3485 /* ClipboardManager.swift */; };
 		B20599ED24698C1E1F82AA10 /* ScrollIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFD97FB49778B4358FA5189 /* ScrollIntent.swift */; };
 		B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */; };
@@ -109,6 +111,7 @@
 		F457EB595789DD3A25E888DF /* SnippetsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3E740AA883770481A6A8C /* SnippetsStore.swift */; };
 		F5F3381FF70997223F8888B0 /* KeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3EB07C07902C53BFD3B08B /* KeyShortcut.swift */; };
 		F6B79728FF2D37A60FED72AF /* HyperKeyTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */; };
+		F82C11A117C764DE34628525 /* UpdateUserDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6505B0CCDD8FE0F52F05208 /* UpdateUserDriver.swift */; };
 		FC934E5AE6A933F5BC7AC4DD /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D93A4CEA9FE857034D63EF7 /* CalcQuantity.swift */; };
 		FE6A9C75F87C3495F413E66E /* CalculatorHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */; };
 		FEA05585E8AA58506D378CAF /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B275099E59BD2531A838F7D8 /* AppSettings.swift */; };
@@ -162,6 +165,7 @@
 		5E08668A3C8418E2F0970300 /* CurrencyData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyData.generated.swift; sourceTree = "<group>"; };
 		6185011A02366B30B48B5B6C /* Paster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paster.swift; sourceTree = "<group>"; };
 		641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
+		64A0723AF1242FAC4214AC65 /* UpdateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateStore.swift; sourceTree = "<group>"; };
 		6621A88681E993D49EEF07A3 /* tinycast.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = tinycast.icon; sourceTree = "<group>"; };
 		68952539C0BD045BA175CBB6 /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
 		68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
@@ -214,6 +218,7 @@
 		D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppName.swift"; sourceTree = "<group>"; };
 		D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
+		D6505B0CCDD8FE0F52F05208 /* UpdateUserDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserDriver.swift; sourceTree = "<group>"; };
 		DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridGeometry.swift; sourceTree = "<group>"; };
 		DCBF70B1C646861FDF20ED2D /* CustomCommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandsSettingsView.swift; sourceTree = "<group>"; };
 		E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateTime.swift; sourceTree = "<group>"; };
@@ -225,6 +230,17 @@
 		F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFrameworksBuildPhase section */
+		5DD96C5B911AE4FC9AAD9EE8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF04BEDD1792ACA87B06E32B /* Sparkle in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
 /* Begin PBXGroup section */
 		005F026A8F7D5E209B1CE917 /* Clipboard */ = {
 			isa = PBXGroup;
@@ -232,6 +248,15 @@
 				52ADC36002F1A5B04D61B4D3 /* ClipboardView.swift */,
 			);
 			path = Clipboard;
+			sourceTree = "<group>";
+		};
+		073F84F3C21641A7E118DD9A /* Updates */ = {
+			isa = PBXGroup;
+			children = (
+				64A0723AF1242FAC4214AC65 /* UpdateStore.swift */,
+				D6505B0CCDD8FE0F52F05208 /* UpdateUserDriver.swift */,
+			);
+			path = Updates;
 			sourceTree = "<group>";
 		};
 		07DE9E76AC9C944A7EC3F253 /* Core */ = {
@@ -242,6 +267,7 @@
 				E2E33C02FBE324BED2E84314 /* Emoji */,
 				CB742F7643800C43475DE213 /* HotKey */,
 				32B8FED93732983EAE729EB1 /* Snippets */,
+				073F84F3C21641A7E118DD9A /* Updates */,
 				36FA7A5040272D524D70EC0E /* WindowManagement */,
 				3A64EF5A07D459753998F78C /* AppCore.swift */,
 				BA7CE23482F7DF563A268806 /* AppIndex.swift */,
@@ -509,6 +535,7 @@
 			buildPhases = (
 				6E13E657DC484EA7935E1C3A /* Sources */,
 				0E8F5C3C217EFF5576B2CB4F /* Resources */,
+				5DD96C5B911AE4FC9AAD9EE8 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -516,6 +543,7 @@
 			);
 			name = Tinycast;
 			packageProductDependencies = (
+				B4749B284382121680BDB690 /* Sparkle */,
 			);
 			productName = Tinycast;
 			productReference = 5392500F86E23C099D33561D /* Tinycast.app */;
@@ -545,6 +573,9 @@
 			);
 			mainGroup = FB9897CCA50570B3E7630145;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9FD7360AFB3ACA857F3E37B6 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 114270CAA80F01D311693B63 /* Products */;
 			projectDirPath = "";
@@ -668,6 +699,8 @@
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,
 				A7508663E4B5D80572E7BAAC /* TinycastModalView.swift in Sources */,
 				CAD10A49DBDEFD2A9C03A7BE /* Tooltip.swift in Sources */,
+				86EC8065A0DE9A777214FE65 /* UpdateStore.swift in Sources */,
+				F82C11A117C764DE34628525 /* UpdateUserDriver.swift in Sources */,
 				693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */,
 				A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */,
 				C7D8BB669C3DBC0D26EB6E32 /* WindowActionMemory.swift in Sources */,
@@ -873,6 +906,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9FD7360AFB3ACA857F3E37B6 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.9.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B4749B284382121680BDB690 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9FD7360AFB3ACA857F3E37B6 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = ADDC0DAB183B80B8B278C7BA /* Project object */;
 }

--- a/Tinycast.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tinycast.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -15,6 +15,11 @@ struct TinycastApp: App {
         ) {
             Button("Open \(appName)") { AppCore.shared.showPalette(mode: .launcher) }
             Button("Clipboard History") { AppCore.shared.showPalette(mode: .clipboard) }
+            // Absent on the dev channel, which has no update feed.
+            if AppCore.shared.updates.isSupported {
+                Divider()
+                Button("Check for Updates…") { AppCore.shared.checkForUpdates() }
+            }
             Divider()
             Button("Settings...") { AppCore.shared.showSettings() }
                 .keyboardShortcut(",")

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -107,6 +107,7 @@ final class AppCore: ObservableObject {
     let visibility = VisibilityStore()
     let calcHistory = CalculatorHistoryStore()
     let currencyRates = CurrencyRateStore()
+    let updates = UpdateStore()
     let emojiIndex = EmojiIndex()
     let frequentEmoji = FrequentEmojiStore()
     let runningApps = RunningAppsMonitor()
@@ -154,6 +155,7 @@ final class AppCore: ObservableObject {
         Task { await appIndex.refresh() }
         Task { await emojiIndex.load() }
         currencyRates.start()
+        updates.start()
 
         hotKeys.onTogglePalette = { [weak self] in self?.togglePalette() }
         hotKeys.onToggleClipboard = { [weak self] in self?.toggleClipboard() }
@@ -351,6 +353,11 @@ final class AppCore: ObservableObject {
 
     func showAbout() {
         showSettings(tab: .about)
+    }
+
+    /// The user-initiated check, from the menu bar or the palette. Background checks are the store's own business.
+    func checkForUpdates() {
+        updates.checkNow()
     }
 
     /// The first-run wizard: palette shortcut, Accessibility, Raycast import. Also re-runnable from Settings.
@@ -696,6 +703,9 @@ final class AppCore: ObservableObject {
         case .about:
             hidePalette(restoreFocus: false)
             showAbout()
+        case .checkForUpdates:
+            hidePalette(restoreFocus: false)
+            checkForUpdates()
         case .quit:
             NSApp.terminate(nil)
         case nil:

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -8,6 +8,7 @@ enum CommandID: String, CaseIterable, Sendable {
     case exportSettings = "command:export-settings"
     case importSettings = "command:import-settings"
     case importFromRaycast = "command:import-from-raycast"
+    case checkForUpdates = "command:check-for-updates"
     case settings = "command:settings"
     case about = "command:about"
     case quit = "command:quit"
@@ -20,6 +21,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .exportSettings: return "Export Settings"
         case .importSettings: return "Import Settings"
         case .importFromRaycast: return "Import from Raycast"
+        case .checkForUpdates: return "Check for Updates"
         case .settings: return "Settings"
         case .about: return "About Tinycast"
         case .quit: return "Quit Tinycast"
@@ -34,6 +36,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .exportSettings: return "square.and.arrow.up"
         case .importSettings: return "square.and.arrow.down"
         case .importFromRaycast: return "arrow.down.doc"
+        case .checkForUpdates: return "arrow.down.circle"
         case .settings: return "gearshape"
         case .about: return "info.circle"
         case .quit: return "power"
@@ -45,6 +48,11 @@ enum CommandRegistry {
     /// Sorted by name to keep the AppIndex sort invariant; the URL is a placeholder since commands are never launched from disk.
     nonisolated static let all: [AppEntry] =
         CommandID.allCases
+        // No feed for this bundle id means the channel is un-updatable, so it gets no command.
+        .filter {
+            $0 != .checkForUpdates
+                || UpdateStore.feedURL(for: Bundle.main.bundleIdentifier) != nil
+        }
         .map { id in
             AppEntry(
                 id: id.rawValue, name: id.name,

--- a/Tinycast/Core/Updates/UpdateStore.swift
+++ b/Tinycast/Core/Updates/UpdateStore.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Sparkle
+
+/// Owns the app's one `SPUUpdater` and republishes it as something SwiftUI can render. Sparkle's own
+/// windows never appear: `UpdateUserDriver` implements `SPUUserDriver` in full, so every confirmation
+/// is a Tinycast dialog.
+///
+/// Checking the feed reaches the network, so the *background* cadence is gated on explicit consent and
+/// ships off. The flag is Sparkle's own `SUEnableAutomaticChecks` user default rather than a second
+/// one of ours, and deliberately not part of `AppSettings`: `SettingsBackup` mirrors that type
+/// field-for-field, and an imported config must never be able to grant network access.
+@MainActor
+final class UpdateStore: NSObject, ObservableObject, SPUUpdaterDelegate {
+    enum State: Equatable {
+        case idle
+        case checking
+        /// Fraction complete, nil while the download's length is unknown or implausible.
+        case downloading(Double?)
+        case extracting
+        case readyToRelaunch
+        case failed(String)
+    }
+
+    /// Named in the consent sheet.
+    static let provider = "GitHub Pages"
+    static let providerURL = URL(string: "https://abue-ammar.github.io/tinycast/")!
+    static let releasesURL = URL(string: "https://github.com/abue-ammar/tinycast/releases")!
+
+    /// One feed per channel, never `sparkle:channel`: Sparkle always allows the default channel, so a
+    /// beta host would still be offered the stable DMG, whose app name and bundle id match neither and
+    /// whose install is then rejected. A bundle id absent from this table has no feed at all, which is
+    /// what makes the dev channel provably un-updatable rather than merely unconfigured.
+    private nonisolated static let feeds = [
+        "com.tinycast.app": URL(string: "https://abue-ammar.github.io/tinycast/appcast.xml")!,
+        "com.tinycast.app.beta": URL(string: "https://abue-ammar.github.io/tinycast/appcast-beta.xml")!
+    ]
+
+    /// Nonisolated so the launcher's `CommandRegistry`, which is built off the main actor, can drop
+    /// the update command on a channel that has no feed without reaching into main-actor state.
+    nonisolated static func feedURL(for bundleID: String?) -> URL? {
+        guard let bundleID else { return nil }
+        return feeds[bundleID]
+    }
+
+    /// Sparkle's own activity defaults, cleared when consent is withdrawn.
+    private static let activityKeys = ["SULastCheckTime", "SUSkippedVersion"]
+    /// Sparkle nests its downloads one level below the app's own cache directory. Removing the
+    /// *parent* would take `CurrencyRateStore`'s snapshot with it.
+    private static let cacheComponent = "org.sparkle-project.Sparkle"
+
+    /// Consent for background checks. Sparkle's default is the setting; this only republishes it.
+    /// Absent reads as false, which is the only safe default for a network feature.
+    @Published private(set) var isEnabled = false
+    @Published private(set) var state: State = .idle
+    @Published private(set) var lastCheckDate: Date?
+
+    private let defaults = UserDefaults.standard
+    private lazy var driver = UpdateUserDriver(store: self)
+    /// Lazy because `SPUUpdater` takes both its user driver and its delegate at init, and both are
+    /// rooted in `self`, which doesn't exist yet in a stored-property initializer.
+    private lazy var updater = SPUUpdater(
+        hostBundle: .main, applicationBundle: .main, userDriver: driver, delegate: self)
+
+    private var feed: URL? { Self.feedURL(for: Bundle.main.bundleIdentifier) }
+
+    /// False on the dev channel, which has no feed — hide or disable every update affordance.
+    var isSupported: Bool { feed != nil }
+
+    /// "0.7.5 (128)" — the same shape `AboutView` renders.
+    var currentVersion: String {
+        let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+        return "\(short) (\(build))"
+    }
+
+    /// From `AppCore.start()`. Guard 1 — an unsupported channel never even builds an updater, so
+    /// `start()` can be called unconditionally. With `SUEnableAutomaticChecks = NO` this performs zero
+    /// network I/O: Sparkle early-returns before arming its timer.
+    func start() {
+        guard isSupported else { return }
+        do {
+            try updater.start()
+        } catch {
+            state = .failed(error.localizedDescription)
+            return
+        }
+        isEnabled = updater.automaticallyChecksForUpdates
+        lastCheckDate = updater.lastUpdateCheckDate
+    }
+
+    /// The Settings toggle's only entry point, called after the user accepts the consent dialog.
+    /// Disabling must leave nothing behind: Sparkle's activity defaults and its download cache go too.
+    /// Guard 2 — a channel with no feed has nothing to consent to.
+    func setEnabled(_ enabled: Bool) {
+        guard isSupported, enabled != isEnabled else { return }
+        updater.automaticallyChecksForUpdates = enabled
+        // Sparkle owns the flag, so read it back rather than assume the write took.
+        isEnabled = updater.automaticallyChecksForUpdates
+        guard !enabled else { return }
+        state = .idle
+        lastCheckDate = nil
+        for key in Self.activityKeys { defaults.removeObject(forKey: key) }
+        try? FileManager.default.removeItem(at: cacheDirectory)
+    }
+
+    /// The explicit gesture, from the menu bar or the palette. Always allowed — consent gates the
+    /// unattended cadence, not a check the user just asked for. Guard 3 — no feed, no check;
+    /// `canCheckForUpdates` additionally covers a failed `start()` and a session already in flight.
+    func checkNow() {
+        guard isSupported, updater.canCheckForUpdates else { return }
+        driver.isUserInitiated = true
+        state = .checking
+        updater.checkForUpdates()
+    }
+
+    /// `UpdateUserDriver`'s only channel back, so the store stays the single thing SwiftUI observes.
+    func publish(_ state: State) {
+        self.state = state
+        lastCheckDate = updater.lastUpdateCheckDate
+    }
+
+    private var cacheDirectory: URL {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
+        return FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(bundleID, isDirectory: true)
+            .appendingPathComponent(Self.cacheComponent, isDirectory: true)
+    }
+
+    // MARK: - SPUUpdaterDelegate
+
+    /// The feed is supplied here rather than by `SUFeedURL`, which is absent from `Info.plist` on
+    /// purpose: the delegate wins over the plist, and returning nil leaves no URL to fall back to.
+    func feedURLString(for _: SPUUpdater) -> String? { feed?.absoluteString }
+
+    /// Belt and braces. `SUEnableAutomaticChecks` in `Info.plist` already suppresses Sparkle's own
+    /// permission prompt permanently; Tinycast's consent sheet is the only thing allowed to ask.
+    func updaterShouldPromptForPermissionToCheck(forUpdates _: SPUUpdater) -> Bool { false }
+}

--- a/Tinycast/Core/Updates/UpdateUserDriver.swift
+++ b/Tinycast/Core/Updates/UpdateUserDriver.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Sparkle
+
+/// Tinycast's `SPUUserDriver`. Sparkle drives all update UI through this protocol, so implementing it
+/// in full is what keeps Sparkle's own AppKit windows off screen: a confirmation goes through
+/// `AppCore.askConfirmation`, a report through `AppCore.showNotice`, like the rest of the app.
+///
+/// Everything else is *published*, not shown. The app is an accessory: a background check that found
+/// an update must not steal focus from whatever the user is actually doing, so progress reaches the
+/// Settings row through `UpdateStore` and nothing appears until there is a question to ask.
+@MainActor
+final class UpdateUserDriver: NSObject, SPUUserDriver {
+    /// Set by `UpdateStore.checkNow()`. Sparkle reports "no update found" and errors identically for
+    /// scheduled and explicit checks; only the explicit one has earned the right to put a dialog up.
+    var isUserInitiated = false
+
+    private weak var store: UpdateStore?
+    private var expectedLength: UInt64 = 0
+    private var receivedLength: UInt64 = 0
+
+    init(store: UpdateStore) {
+        self.store = store
+        super.init()
+    }
+
+    /// Never reached — `SUEnableAutomaticChecks` in `Info.plist` suppresses this prompt for good — but
+    /// the answer still has to be the safe one rather than a default-constructed yes.
+    func show(_: SPUUpdatePermissionRequest) async -> SUUpdatePermissionResponse {
+        SUUpdatePermissionResponse(automaticUpdateChecks: false, sendSystemProfile: false)
+    }
+
+    /// Cancellation is deliberately dropped: nothing in Tinycast's UI can cancel a check in flight,
+    /// and holding a block no one calls is dead weight. Same for the download's cancellation below.
+    func showUserInitiatedUpdateCheck(cancellation _: @escaping () -> Void) {
+        store?.publish(.checking)
+    }
+
+    func showUpdateFound(with appcastItem: SUAppcastItem, state _: SPUUserUpdateState) async
+        -> SPUUserUpdateChoice {
+        let version = appcastItem.displayVersionString
+        // An information-only update has no archive to install; replying `.install` is explicitly
+        // unsupported, so say where the release lives and leave the installation alone.
+        guard !appcastItem.isInformationOnlyUpdate else {
+            await AppCore.shared.showNotice(
+                title: "Tinycast \(version) Is Available",
+                message: "This release has to be installed by hand, from "
+                    + "\(UpdateStore.releasesURL.absoluteString).",
+                kind: .info)
+            return .dismiss
+        }
+
+        var message = "You're on \(store?.currentVersion ?? "an older version")."
+        if let date = appcastItem.date {
+            message += " \(version) was released \(date.formatted(date: .abbreviated, time: .omitted))."
+        }
+        let confirmed = await AppCore.shared.askConfirmation(
+            title: "Update to Tinycast \(version)", message: message, confirmTitle: "Update",
+            destructive: false)
+        // A refused dialog — one is already on screen — comes back false, which is a dismissal and
+        // never a hang: Sparkle gets its reply either way.
+        return confirmed ? .install : .dismiss
+    }
+
+    /// Release notes are not rendered anywhere in Tinycast, so both hooks are deliberately inert.
+    func showUpdateReleaseNotes(with _: SPUDownloadData) {}
+
+    func showUpdateReleaseNotesFailedToDownloadWithError(_: any Error) {}
+
+    func showUpdateNotFoundWithError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        store?.publish(.idle)
+        // A scheduled check that found nothing is a non-event; only the explicit gesture gets an answer.
+        guard isUserInitiated else {
+            acknowledgement()
+            return
+        }
+        let message = (error as NSError).localizedRecoverySuggestion
+            ?? "Tinycast \(store?.currentVersion ?? "") is the latest version."
+        Task {
+            await AppCore.shared.showNotice(
+                title: "You're Up to Date", message: message, kind: .info)
+            acknowledgement()
+        }
+    }
+
+    func showUpdaterError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        // Sparkle routes "no update found" through this method too when the cycle aborts. That is an
+        // outcome, not a failure, and reporting it as one would contradict the notice just shown.
+        guard !Self.isNoUpdate(error) else {
+            store?.publish(.idle)
+            acknowledgement()
+            return
+        }
+        store?.publish(.failed(error.localizedDescription))
+        guard isUserInitiated else {
+            NSLog("Tinycast: background update check failed: %@", error.localizedDescription)
+            acknowledgement()
+            return
+        }
+        Task {
+            await AppCore.shared.showNotice(
+                title: "Update Failed", message: error.localizedDescription, kind: .error)
+            acknowledgement()
+        }
+    }
+
+    func showDownloadInitiated(cancellation _: @escaping () -> Void) {
+        expectedLength = 0
+        receivedLength = 0
+        store?.publish(.downloading(nil))
+    }
+
+    func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
+        expectedLength = expectedContentLength
+    }
+
+    func showDownloadDidReceiveData(ofLength length: UInt64) {
+        receivedLength += length
+        // The feed's length is allowed to be absent or simply wrong, so an implausible one falls back
+        // to indeterminate rather than driving a bar past its own end.
+        let known = expectedLength > 0 && receivedLength <= expectedLength
+        let fraction = known ? Double(receivedLength) / Double(expectedLength) : nil
+        store?.publish(.downloading(fraction))
+    }
+
+    func showDownloadDidStartExtractingUpdate() {
+        store?.publish(.extracting)
+    }
+
+    func showExtractionReceivedProgress(_: Double) {
+        store?.publish(.extracting)
+    }
+
+    func showReadyToInstallAndRelaunch() async -> SPUUserUpdateChoice {
+        store?.publish(.readyToRelaunch)
+        let confirmed = await AppCore.shared.askConfirmation(
+            title: "Update Ready",
+            message: "Tinycast will relaunch to finish installing. Decline and it installs the next "
+                + "time you quit.",
+            confirmTitle: "Relaunch Now", destructive: false)
+        return confirmed ? .install : .dismiss
+    }
+
+    /// `retryTerminatingApplication` is intentionally unused: Tinycast never delays or cancels its own
+    /// termination, and the hook is only for a driver that has to ask again.
+    func showInstallingUpdate(
+        withApplicationTerminated _: Bool, retryTerminatingApplication _: @escaping () -> Void
+    ) {
+        // `State` has no installing case, and needs none — the app is already on its way out.
+        store?.publish(.readyToRelaunch)
+    }
+
+    func showUpdateInstalledAndRelaunched(_: Bool, acknowledgement: @escaping () -> Void) {
+        store?.publish(.idle)
+        acknowledgement()
+    }
+
+    /// Nothing to raise: Tinycast's dialogs are `.modalPanel` level and ordered front regardless, so
+    /// whatever is on screen is already above everything the palette itself puts up.
+    func showUpdateInFocus() {}
+
+    func dismissUpdateInstallation() {
+        expectedLength = 0
+        receivedLength = 0
+        isUserInitiated = false
+        // A failure survives the teardown: Sparkle dismisses immediately after reporting one, and
+        // clearing it here would wipe the only thing the Settings row has left to show.
+        if let state = store?.state, case .failed = state { return }
+        store?.publish(.idle)
+    }
+
+    private static func isNoUpdate(_ error: any Error) -> Bool {
+        let error = error as NSError
+        return error.domain == SUSparkleErrorDomain
+            && error.code == Int(SUError.noUpdateError.rawValue)
+    }
+}

--- a/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
+++ b/Tinycast/Features/Settings/MiscellaneousSettingsView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
-/// The catch-all pane. Home to currency conversion — the one feature in Tinycast that reaches the
-/// network, which is why it ships off and needs an explicit yes before it can be switched on.
+/// The catch-all pane, and the app's network pane: software update and currency conversion both reach
+/// out, which is why each ships off and needs an explicit yes before it can be switched on.
 struct MiscellaneousSettingsView: View {
     @ObservedObject private var currencyRates = AppCore.shared.currencyRates
+    @ObservedObject private var updates = AppCore.shared.updates
     @State private var askingConsent = false
+    @State private var askingUpdateConsent = false
     @State private var refreshing = false
     @State private var refreshFailed = false
 
@@ -13,6 +15,56 @@ struct MiscellaneousSettingsView: View {
             title: "Miscellaneous",
             subtitle: "Options that don't belong to a single feature."
         ) {
+            // The dev channel has no feed, so it gets no update affordance at all rather than a dead switch.
+            if updates.isSupported {
+                SettingsCard(header: "Software Update") {
+                    SettingsRow(
+                        title: "Check for updates automatically",
+                        subtitle: automaticChecksStatus,
+                        systemImage: "arrow.down.circle",
+                        tint: .blue,
+                        statusDot: updates.isEnabled ? .green : nil
+                    ) {
+                        // Same springs-back shape as the currency switch: on only opens the consent sheet.
+                        Toggle(
+                            "",
+                            isOn: Binding(
+                                get: { updates.isEnabled },
+                                set: { wantsOn in
+                                    if wantsOn {
+                                        askingUpdateConsent = true
+                                    } else {
+                                        updates.setEnabled(false)
+                                    }
+                                })
+                        )
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                    }
+
+                    SettingsDivider()
+                    SettingsRow(
+                        title: "Version \(updates.currentVersion)",
+                        subtitle: updateStatus,
+                        systemImage: "sparkles",
+                        tint: .gray
+                    ) {
+                        Button("Check Now") { updates.checkNow() }
+                            .disabled(isUpdateBusy)
+                    }
+                }
+                // Attached here, not to the pane, so it never contends with the currency sheet.
+                .sheet(isPresented: $askingUpdateConsent) {
+                    UpdateConsentSheet(
+                        onCancel: { askingUpdateConsent = false },
+                        onAccept: {
+                            askingUpdateConsent = false
+                            updates.setEnabled(true)
+                        })
+                }
+            }
+
             SettingsCard(header: "Calculator") {
                 SettingsRow(
                     title: "Currency Conversion",
@@ -71,6 +123,43 @@ struct MiscellaneousSettingsView: View {
         }
     }
 
+    private var automaticChecksStatus: String {
+        let cadence = "Looks for a new version once a day, in the background."
+        return updates.isEnabled ? cadence : "\(cadence) Off — nothing is contacted."
+    }
+
+    /// Mirrors `ratesStatus`, including the off-state promise: with the switch off only this row's
+    /// button reaches the network, and only when pressed.
+    private var updateStatus: String {
+        switch updates.state {
+        case .checking:
+            return "Checking…"
+        case .downloading(let fraction):
+            guard let fraction else { return "Downloading…" }
+            return "Downloading… \(Int((fraction * 100).rounded()))%"
+        case .extracting:
+            return "Extracting…"
+        case .readyToRelaunch:
+            return "Update ready to install."
+        case .failed(let reason):
+            return reason.isEmpty ? "Couldn't reach \(UpdateStore.provider). Try again." : reason
+        case .idle:
+            guard updates.isEnabled else { return "Off — nothing is contacted." }
+            guard let checked = updates.lastCheckDate else {
+                return "\(UpdateStore.provider) · not checked yet."
+            }
+            let stamp = checked.formatted(date: .abbreviated, time: .shortened)
+            return "Up to date · checked \(stamp)."
+        }
+    }
+
+    private var isUpdateBusy: Bool {
+        switch updates.state {
+        case .idle, .failed: return false
+        default: return true
+        }
+    }
+
     /// Carries the off-state promise that used to need its own callout: nothing is contacted until
     /// the switch is on.
     private var conversionStatus: String {
@@ -86,6 +175,52 @@ struct MiscellaneousSettingsView: View {
         }
         let stamp = fetched.formatted(date: .abbreviated, time: .shortened)
         return "\(CurrencyRateStore.provider) · updated \(stamp). Refreshes daily."
+    }
+}
+
+/// The update consent step, same three deciding facts as `CurrencyConsentSheet` — who is contacted, how
+/// often, and that nothing about the machine goes with it — plus the provider link so it's checkable.
+private struct UpdateConsentSheet: View {
+    let onCancel: () -> Void
+    let onAccept: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+            HStack(spacing: Theme.Spacing.lg) {
+                Image(systemName: "arrow.down.circle")
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(.blue)
+                Text("Check for updates automatically?")
+                    .font(.headline)
+            }
+
+            Text(
+                "Once a day, Tinycast asks \(UpdateStore.provider) for a small static XML file listing "
+                + "the latest version. That HTTPS request is all that leaves your Mac — no account, no "
+                + "identifiers, nothing about this machine or how you use it. You can turn it off at "
+                + "any time."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: Theme.Spacing.lg) {
+                Link(destination: UpdateStore.providerURL) {
+                    HStack(spacing: Theme.Spacing.xs) {
+                        Text(UpdateStore.providerURL.host() ?? "Provider")
+                        Image(systemName: "arrow.up.right.square")
+                    }
+                    .font(.callout)
+                }
+                Spacer()
+                Button("Not Now", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Enable", action: onAccept)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(Theme.Spacing.xxl)
+        .frame(width: 420)
     }
 }
 

--- a/Tinycast/Info.plist
+++ b/Tinycast/Info.plist
@@ -32,5 +32,18 @@
 	<string>Tinycast uses Bluetooth access only when you run the Toggle Bluetooth command.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Tinycast</string>
+	<key>SUPublicEDKey</key>
+	<string>OsIfXjEIsBSnebzgkLBB4ChJlKe32Kw2KW+EHtmc/Sw=</string>
+	<!-- Present and NO: the key merely being present is what permanently suppresses Sparkle's own permission prompt, and it keeps startUpdater() from arming a timer or touching the network. The Settings toggle writes the matching user default, which SUHost prefers over this. -->
+	<key>SUEnableAutomaticChecks</key>
+	<false/>
+	<!-- Nothing about this machine is ever appended to the feed request. -->
+	<key>SUEnableSystemProfiling</key>
+	<false/>
+	<key>SUAutomaticallyUpdate</key>
+	<false/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
+	<!-- No SUFeedURL on purpose: the feed comes from SPUUpdaterDelegate, which returns nil on the dev channel so a local build can never update itself. -->
 </dict>
 </plist>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,9 +13,9 @@ System-command catalog, launcher integration and permission behavior are documen
 manager — `AppIndex`, `ClipboardStore`, `ClipboardManager`, `SnippetsStore`,
 `SnippetKeywordListener`, `SnippetTextInjector`, `HotKeyManager`, `AppSettings`, `FavoritesStore`,
 `VisibilityStore`, `LauncherRankingStore`, `CustomCommandStore`, `CalculatorHistoryStore`,
-`CurrencyRateStore`, `RunningAppsMonitor`, `PaletteViewModel` — plus the window controllers, including
-`ModalWindowController` (dialogs are reached from elsewhere via `AppCore.showNotice` /
-`askConfirmation`, so the controller stays single-owned).
+`CurrencyRateStore`, `UpdateStore`, `RunningAppsMonitor`, `PaletteViewModel` — plus the window
+controllers, including `ModalWindowController` (dialogs are reached from elsewhere via
+`AppCore.showNotice` / `askConfirmation`, so the controller stays single-owned).
 `AppDelegate.applicationDidFinishLaunching` calls
 `AppCore.shared.start()` and nothing else; that is the single wiring point. All palette / paste /
 launch actions are methods on `AppCore` that the SwiftUI views call.

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,10 @@ frame. All of it runs headless because the layer is pure: `WindowMover` owns eve
 and is deliberately not compiled in. The full contract is in
 [window-management.md](window-management.md).
 
+Updates have no harness on purpose: Sparkle is a binary framework and both `UpdateStore` and
+`UpdateUserDriver` are AppKit-bound, so there is no pure layer to compile standalone (see
+[updates.md](updates.md#no-standalone-harness)).
+
 ## Format & lint
 
 Formatting is whatever Xcode's own reindent does — there's no separate formatter. Linting is
@@ -219,6 +223,17 @@ It builds on a `macos-26` runner with Xcode 26 and publishes a GitHub Release ta
 `v<full-version>` with a versioned DMG asset (`Tinycast-<full-version>.dmg`), marked prerelease
 for beta. On success it also bumps the matching cask in the tap (below).
 
+### Appcast signing
+
+The same DMG is the Sparkle update archive, so the job runs `generate_appcast` over it — which
+EdDSA-signs the archive and rewrites the
+channel's appcast — `website/public/appcast.xml` for stable, `website/public/appcast-beta.xml` for
+beta — with the new `<item>`, then commits it. That commit touches `website/`, which is exactly what
+the website workflow (below) triggers on, so the appcast reaches GitHub Pages through the existing
+site deploy. Signing needs a `SPARKLE_ED_PRIVATE_KEY` repo secret — the Ed25519 private key exported
+from the login keychain, set up once per **[signing.md](signing.md) §3**. The full update contract,
+including the two-feed channel model, is in [updates.md](updates.md).
+
 ### Homebrew tap automation
 
 The release job's final step rewrites the `version` + `sha256` of the channel's cask (`tinycast`
@@ -226,6 +241,10 @@ or `tinycast@beta`) in the
 [`homebrew-tinycast`](https://github.com/abue-ammar/homebrew-tinycast) tap and pushes. It needs a
 `HOMEBREW_TAP_TOKEN` repo secret — a fine-grained PAT with **Contents: read/write** on the tap
 repo. Without the secret the step logs a warning and skips (the release still publishes).
+
+Each cask must also declare `auto_updates true` so `brew upgrade` compares against the installed
+app's `Info.plist` instead of clobbering a self-updated install. That's a one-line manual edit in the
+tap, not something CI writes — see [updates.md](updates.md#homebrew-coexistence).
 
 ## Website
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -70,13 +70,68 @@ rm -f /tmp/signing.p12.base64   # holds your private key — delete it
 ```
 
 If you ever lose the secrets, just re-run this section — as long as the `Tinycast Self-Signed`
-identity is still in your keychain, the exported identity is the same, so users are unaffected. If you
-lose the identity entirely, recreate it (step 1) and re-do this; existing users will re-grant
-Accessibility once on their next update, then it's stable again.
+identity is still in your keychain, the exported identity is the same, so users are unaffected.
+
+## 3. Generate the Sparkle EdDSA key (once)
+
+[In-app updates](updates.md) are signed with an Ed25519 key separate from the code-signing
+identity. It lives in the login keychain the same way the identity does — service
+`https://sparkle-project.org`, account `ed25519` — and, like the identity, you create it once and
+never rotate it.
+
+The matching public key is already in `Tinycast/Info.plist` as
+`SUPublicEDKey` = `OsIfXjEIsBSnebzgkLBB4ChJlKe32Kw2KW+EHtmc/Sw=`, so the key below is not a new one to
+invent: it is the private half of that, exported out of the keychain and handed to CI.
+
+`generate_keys` ships in Sparkle's release tarball, which unpacks **flat** (no top-level directory),
+so give it a directory of its own:
+
+```sh
+curl -fsSL -o /tmp/sparkle.tar.xz \
+  https://github.com/sparkle-project/Sparkle/releases/download/2.9.4/Sparkle-2.9.4.tar.xz
+mkdir -p /tmp/sparkle && tar -xJf /tmp/sparkle.tar.xz -C /tmp/sparkle
+
+# Export the existing private key from the login keychain (approve the dialog if asked).
+# Run it with no arguments first if the key doesn't exist yet — that generates and stores it,
+# and prints the public key to put in Info.plist.
+/tmp/sparkle/bin/generate_keys -x /tmp/sparkle-ed.key
+
+gh secret set SPARKLE_ED_PRIVATE_KEY --repo abue-ammar/tinycast < /tmp/sparkle-ed.key
+
+rm -rf /tmp/sparkle /tmp/sparkle.tar.xz
+rm -f /tmp/sparkle-ed.key   # holds your private key — delete it
+```
+
+The release workflow uses that secret to sign each DMG and stamp the signature into the channel's
+appcast. Without it, releases still publish but no client will accept them.
+
+## What losing a key actually costs
+
+Sparkle validates an update if **either** the EdDSA signature checks out **or** the new bundle matches
+the old bundle's code-signing designated requirement, so the `.p12` and the EdDSA key are *both*
+load-bearing and **either one alone can recover the update channel**. Losing one is survivable; losing
+both leaves every existing install with no in-app path forward.
+
+That matters more here than it would elsewhere, because Sparkle's usual escape hatch doesn't exist for
+us. Its key-rotation fallback — accepting an update signed by a new key when the bundle still
+validates against a Developer ID — hardcodes `anchor apple generic`, which a self-signed certificate
+can never satisfy. So there is no "sign with the new key and let the old code signature vouch for it"
+recovery here.
+
+Practically:
+
+- **Lost the CI secrets, still have the keychain** — re-run §2 and §3. Nothing changes for users.
+- **Lost the code-signing identity, still have the EdDSA key** — recreate the identity (§1), re-do §2.
+  Updates keep flowing on the EdDSA signature; existing users re-grant Accessibility once on that
+  update, then it's stable again.
+- **Lost the EdDSA key, still have the identity** — generate a new one (§3, no arguments) and update
+  `SUPublicEDKey`. Updates keep flowing on the code-signature match.
+- **Lost both** — existing installs can no longer be updated in place. Back up the login keychain.
 
 ## Quarantine (separate from signing)
 
 macOS quarantines anything downloaded from the internet, and Gatekeeper blocks even a correctly
 self-signed app with an "unverified developer" warning. The Homebrew cask runs
 `xattr -dr com.apple.quarantine` in `postflight`, so **brew users never touch it**. People who
-download the DMG directly clear it once by hand.
+download the DMG directly clear it once by hand. In-app updates need neither: Sparkle strips the
+attribute from the bundle it installs (see [updates.md](updates.md)).

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,135 @@
+# Updates
+
+Tinycast updates itself with [Sparkle](https://sparkle-project.org) 2.9.4, pulled in as an SPM binary
+target. The `.dmg` the release workflow already publishes *is* the update archive — Sparkle unarchives
+`.dmg` natively — so there is no second artifact to build, sign or keep in sync.
+
+Every dialog belongs to Tinycast. `UpdateUserDriver` implements `SPUUserDriver` in full, so Sparkle's
+own AppKit windows never appear; a confirmation goes through `AppCore.askConfirmation` and a report
+through `AppCore.showNotice`, exactly like the rest of the app (see [ui.md](ui.md#modals--hud)).
+Progress is not a dialog at all: the app is an accessory, so a background check that found something
+must not steal focus. `AppCore` owns the store as `updates`; `UpdateStore` is `@MainActor` and
+publishes one `State` (`idle` / `checking` / `downloading` / `extracting` / `readyToRelaunch` /
+`failed`) that the Settings row renders, and nothing appears on screen until there is a question to
+ask.
+
+Sparkle 2.9.4 is a floor, not a preference: 2.9.3 opened the update window behind every other window
+for dockless apps, which for an `LSUIElement` app means the update UI is simply invisible.
+
+## Why this works for a self-signed app
+
+Tinycast is signed with a stable self-signed identity and is not notarized (see
+[signing.md](signing.md)). That would break most update mechanisms, and does not break this one,
+because Sparkle never consults Gatekeeper.
+
+`SUCodeSigningVerifier` lifts the **old** bundle's code-signing *designated requirement* —
+`identifier "…" and certificate leaf = H"…"` — and checks the downloaded bundle against it. That is a
+leaf-certificate hash match against the app that is already installed, not a trust decision about a
+certificate chain, so a self-signed identity satisfies it as long as it stays the same identity.
+`spctl` is never invoked.
+
+`SUUpdateValidator` accepts an update when **either** the EdDSA signature validates **or** the code
+signature matches. Both hold here, which is why either the `.p12` or the EdDSA key alone can keep the
+channel alive — and why losing both is unrecoverable. Sparkle refuses the *removal* of a code-signing
+identity, so a future build must never ship unsigned.
+
+Quarantine is handled inside Sparkle: `SUPlainInstaller` strips `com.apple.quarantine` from the
+installed bundle, so an in-app update needs none of the manual `xattr` step a directly-downloaded DMG
+does.
+
+macOS App Management (TCC) does not engage. That protection keys off the Team ID of the app being
+modified; Tinycast's bundle carries none, so there is nothing to protect and no "wants to manage
+apps" prompt. Nor is there an admin prompt when the app is user-owned in `/Applications`, which is
+what a Homebrew install produces.
+
+## Two feeds, not one channel
+
+Each channel gets its own appcast. `sparkle:channel` is the wrong tool here, and not by a small
+margin: Sparkle's *default* channel is always allowed, so a beta host subscribed to a beta channel is
+still offered the stable DMG. That DMG contains `Tinycast.app` with bundle id `com.tinycast.app`,
+which matches neither the beta host's filename nor its bundle id, and the install fails with "No
+suitable install is found". Separate feeds make the mismatch impossible rather than merely unlikely.
+
+| bundle id | app | feed |
+| --- | --- | --- |
+| `com.tinycast.app` | `Tinycast.app` | `https://abue-ammar.github.io/tinycast/appcast.xml` |
+| `com.tinycast.app.beta` | `Tinycast Beta.app` | `https://abue-ammar.github.io/tinycast/appcast-beta.xml` |
+| `com.tinycast.app.dev` | `Tinycast Dev.app` | none — updates disabled entirely |
+
+`SUFeedURL` is deliberately **absent** from `Info.plist`. The feed is supplied at runtime by
+`SPUUpdaterDelegate.feedURLStringForUpdater:`, which wins over `Info.plist`, and which returns `nil`
+for any bundle id it does not recognise. That is what makes the dev channel provably un-updatable
+instead of merely unconfigured: there is no URL to fall back to. `UpdateStore.isSupported` is false
+there, and every update affordance hides.
+
+Both appcasts live in `website/public/` and are served by GitHub Pages. Vite's `base: "/tinycast/"`
+copies `public/` to the site root, so `website/public/appcast.xml` becomes
+`https://abue-ammar.github.io/tinycast/appcast.xml`.
+
+## Consent
+
+Update checking is a networked feature, so it ships off and is consent-gated like every other one.
+
+`SUEnableAutomaticChecks = NO` in `Info.plist` is what makes "off" mean off: with it, `startUpdater()`
+performs **zero** network I/O — `scheduleNextUpdateCheckFiringImmediately:` early-returns before
+arming a timer — and the same value permanently suppresses Sparkle's own update-permission prompt, so
+the only thing that ever asks is Tinycast's consent sheet. That sheet names the provider (GitHub
+Pages), the cadence (daily) and what leaves the machine: an HTTPS GET of a static XML file, and
+nothing about the machine, which is what `SUEnableSystemProfiling = NO` guarantees.
+
+`SUHost` prefers the **user default** over `Info.plist`, so writing the `SUEnableAutomaticChecks` user
+default at runtime turns background checks on live — no relaunch, and no second flag to keep in sync
+with Sparkle's own idea of the setting. Sparkle's default *is* the setting; `UpdateStore.isEnabled`
+only republishes it.
+
+That flag deliberately does not live in `AppSettings`: `SettingsBackup` mirrors that type
+field-for-field, and importing a backup must not be able to grant network access. Opting out leaves
+nothing behind — Sparkle's activity defaults (`SULastCheckTime`, `SUSkippedVersion`) are cleared and
+its cache directory under `~/Library/Caches/<bundle-id>/` is deleted.
+
+A user-initiated check is a separate path and always allowed; it is the explicit gesture, so it may
+present a dialog immediately. A background check must never steal focus — the app is an accessory,
+and an update found while the user is working somewhere else is not an emergency.
+
+## Homebrew coexistence
+
+The cask **must** declare `auto_updates true`. Since Homebrew 6.0.0 that no longer means "brew never
+touches this app". `brew upgrade` reads the **installed** app's `Info.plist` and upgrades only when
+the installed bundle looks older than the cask's version, so a Tinycast that already updated itself is
+never downgraded, while a user who never opens the app is still pulled forward by `brew upgrade`. The
+two mechanisms compose instead of fighting.
+
+One constraint follows from that comparison: `CFBundleVersion` must never be `"0"` or `"0.0"`.
+Homebrew treats those as unset and silently disables the version comparison, which puts the cask back
+to clobbering a self-updated install.
+
+This is a one-line change in each cask, and it lives in the separate
+[`homebrew-tinycast`](https://github.com/abue-ammar/homebrew-tinycast) tap — `Casks/tinycast.rb` and
+`Casks/tinycast@beta.rb`. The release workflow rewrites only `version` and `sha256`, so adding
+`auto_updates true` is a **required manual maintainer step**, not something CI will do for you.
+
+## Two rules with teeth
+
+**Never add an `NSUpdateSecurityPolicy` dict to `Info.plist`.** It forces Sparkle off its atomic-swap
+installation path, and the fallback path is exactly the one that reintroduces the "wants to manage
+apps" prompt (Sparkle issue #2591). The key looks like hardening and is a regression here.
+
+**Never ship an unsigned build.** Sparkle refuses the removal of a code-signing identity, so the
+first unsigned release would not merely be unverifiable — it would strand every install that is
+already out there, with no in-app path forward.
+
+## Release mechanics
+
+The release workflow runs Sparkle's `generate_appcast` over the finished DMG, which both EdDSA-signs
+it (the key comes from the `SPARKLE_ED_PRIVATE_KEY` secret on stdin, so it never touches a keychain
+or a file) and rewrites the channel's appcast — `website/public/appcast.xml` for
+stable, `website/public/appcast-beta.xml` for beta — with the new `<item>`, then commits it. That
+commit touches `website/`, which is what `.github/workflows/website.yml` triggers on, so the appcast
+reaches GitHub Pages through the existing site deploy rather than a second publishing mechanism. Full
+pipeline in [development.md](development.md#ci-releases).
+
+## No standalone harness
+
+This subsystem has none, deliberately. Sparkle is a binary framework and both `UpdateStore` and
+`UpdateUserDriver` are AppKit- and Sparkle-bound, so there is nothing a Foundation-only `Tools/`
+harness could compile — unlike the pure engines listed in [development.md](development.md#tests).

--- a/project.yml
+++ b/project.yml
@@ -26,12 +26,21 @@ settings:
       STRIP_SWIFT_SYMBOLS: YES
       DEAD_CODE_STRIPPING: YES
 
+# Sparkle ships as a prebuilt xcframework binary target, so this resolves to a download, not a
+# source build. Pin >= 2.9.4: 2.9.3 opened the update window behind everything for dockless apps.
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: 2.9.4
+
 targets:
   Tinycast:
     type: application
     platform: macOS
     sources:
       - path: Tinycast
+    dependencies:
+      - package: Sparkle
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tinycast.app

--- a/website/public/appcast-beta.xml
+++ b/website/public/appcast-beta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Sparkle feed for the beta channel (com.tinycast.app.beta / Tinycast Beta.app). A separate feed,
+     never sparkle:channel — a beta host must never be offered the stable DMG. Regenerated in full by
+     the "Sign DMG and update appcast" step of .github/workflows/release.yml — do not edit by hand.
+     No <item> means "no update available", which is the correct answer until the first Sparkle-era
+     release exists and keeps the very first update check from 404ing. -->
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Tinycast Beta</title>
+    <link>https://abue-ammar.github.io/tinycast/appcast-beta.xml</link>
+    <description>Update feed for the Tinycast beta channel.</description>
+  </channel>
+</rss>

--- a/website/public/appcast.xml
+++ b/website/public/appcast.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Sparkle feed for the stable channel (com.tinycast.app / Tinycast.app). Regenerated in full by
+     the "Sign DMG and update appcast" step of .github/workflows/release.yml — do not edit by hand.
+     No <item> means "no update available", which is the correct answer until the first Sparkle-era
+     release exists and keeps the very first update check from 404ing. -->
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Tinycast</title>
+    <link>https://abue-ammar.github.io/tinycast/appcast.xml</link>
+    <description>Update feed for the Tinycast stable channel.</description>
+  </channel>
+</rss>


### PR DESCRIPTION
## Related issue

Closes #136

## What changed

In-app updates via [Sparkle](https://sparkle-project.org) 2.9.4, pulled in as an SPM binary target and driven by a **custom `SPUUserDriver`**, so none of Sparkle's own AppKit windows ever appear — confirmations go through `AppCore.askConfirmation`, reports through `showNotice`, like everything else in the app.

- **`Core/Updates/UpdateStore.swift`** — `@MainActor`, owned by `AppCore` as `updates`, started from `start()`. Publishes one `State` that the Settings row renders.
- **`Core/Updates/UpdateUserDriver.swift`** — all 16 required `SPUUserDriver` methods. Progress is *published*, never shown: the app is an accessory, so a background check that finds something must not steal focus.
- **Settings → Miscellaneous** gains a Software Update card (auto-check toggle + consent sheet, version + Check Now), plus a menu-bar item and a launcher command. All three hidden when the channel has no feed.
- **`release.yml`** runs `generate_appcast` over the DMG it already builds and commits the channel's appcast under `website/public/`.
- **Docs** — new `docs/updates.md`; `signing.md`, `development.md`, `architecture.md`, `AGENTS.md` and `README.md` updated.

Three things in the diff are deliberate and won't be obvious:

1. **No `SUFeedURL` in `Info.plist`.** The feed comes from `SPUUpdaterDelegate.feedURLStringForUpdater:`, which wins over the plist and returns `nil` for `com.tinycast.app.dev`. There is no URL to fall back to, which makes the dev channel *provably* un-updatable rather than merely unconfigured.
2. **Two feeds, not `sparkle:channel`.** Sparkle's default channel is always allowed, so a beta host subscribed to a beta channel would still be offered the stable DMG — whose `Tinycast.app` / `com.tinycast.app` matches neither the beta host's filename nor its bundle id, and the install fails with "No suitable install is found". Separate feeds make the mismatch impossible.
3. **`SUEnableAutomaticChecks = NO` is load-bearing twice.** Its *presence* permanently suppresses Sparkle's own permission prompt, so only Tinycast's consent sheet ever asks; and it makes `startUpdater()` early-return before arming a timer. `SUHost` prefers the user default over the plist, so the toggle flips it live — one flag, not two, which is also why it stays out of `AppSettings` where a `SettingsBackup` import could have granted network access.

Why this works at all for a self-signed, non-notarized app — checked against Sparkle's source, not assumed — is written up in `docs/updates.md`: validation is a leaf-hash match against the **old** bundle's designated requirement, Gatekeeper is never consulted, Sparkle strips quarantine itself, and App Management (TCC) doesn't engage because there's no Team ID to protect.

## Memory footprint

Release build, same machine, identical key sequence on both branches, onboarding already completed on both.

| Step                    | Memory | `main` |
| ----------------------- | ------ | ------ |
| Idle after launch       | 20 MB  | 20 MB  |
| Palette open            | 34 MB  | 33 MB  |
| Feature in use (peak)   | 43 MB  | 39 MB  |
| Palette closed, settled | 38 MB  | 38 MB  |

Sparkle costs **nothing resident** while idle — `startUpdater()` early-returns and the framework's pages are file-backed. The 4 MB at peak is the check itself (URLSession + XML parse) and it releases. Settled sits above idle-at-launch on *both* branches; that's the app index and its cached icons, unchanged here.

Leak-tested: `leaks <pid>` after a full check cycle → **0 leaks for 0 total leaked bytes** (169075 nodes / 34940 KB malloced, 42.2 MB footprint).

## Demo

**Outstanding — this is why the PR is a draft.** Three before/after clips still to record, same window size:

1. Settings → Miscellaneous: the Software Update card, toggling it on to show the consent sheet.
2. Palette: typing "check for updates" and pressing ↵.
3. The resulting dialog — verified on screen already (Tinycast's own dark `.error` modal, one OK button, no `NSAlert`), just not captured as video.

## Drawbacks

- **+2.9 MB on disk** (4.2 → 7.1 MB). Real, and the largest single cost here; zero resident cost, per the table. Stripping the XPC services would recover 0.4 MB but needs a re-sign script — not worth the moving part. `README.md`'s "around 3 MB" and "zero dependencies" are corrected in this branch rather than left false.
- **Two keys are now load-bearing, not one.** Sparkle's Developer-ID key-rotation fallback hardcodes `anchor apple generic` and can never fire for us, so the `.p12` and the EdDSA key each independently keep the channel alive — and losing *both* strands every existing install. `signing.md` documents the four recovery cases; back up the login keychain.
- **The release workflow now pushes to `main`.** It replays only the one appcast file onto `origin/main` rather than pushing `HEAD` (the workflow can be dispatched from any ref), but it is still CI writing to the default branch. The alternative was a second publishing mechanism just for the feed.
- **No `Tools/` harness.** Sparkle is a binary framework and both new types are AppKit-bound, so there's nothing a Foundation-only harness could compile. Called out in `docs/updates.md` so the omission reads as deliberate rather than forgotten.
- **The install leg is unexercised.** Everything up to the HTTP response is verified end-to-end; download → verify → swap → relaunch can't run until an appcast is actually live on Pages. The first **beta** release is the real test, and it's the safe one to fail on.

## Tests & validation

Builds clean, Debug and Release, no new warnings. In the Release bundle `Sparkle.framework` is embedded and **re-signed with `Tinycast Self-Signed`** — the identity match the whole scheme rests on — and `codesign --verify --deep --strict` passes.

All ten harnesses from `docs/development.md § Tests` pass: fuzz, ranking, calc, clipboard, scopes, emoji, custom-command, snippets, system-command, window-command. No cases added — see the no-harness note above. SwiftLint isn't installed on this machine, so lint is unrun.

By hand, against the real feed URL, with prefs backed up and restored afterwards:

- **Off means off.** Launched with consent off: `SUHasLaunchedBefore=1` (the updater *did* start), `SULastCheckTime` absent, **zero open sockets**, no Sparkle cache directory.
- **Consent flips live.** Wrote the user default, relaunched: `SULastCheckTime` stamped within a second, and the log shows the request going to exactly `https://abue-ammar.github.io/tinycast/appcast.xml` — the delegate-supplied URL. It 404s (feed not deployed yet) and the background failure produced **no dialog**, which is the correct accessory-app behaviour.
- **User-initiated path renders our UI.** Drove the palette (⌘Space → "check for upd" → ↵) and got Tinycast's own dark error modal, "Update Failed", one OK button.
- **The publishing half works.** Ran the exact CI command against a real DMG: `generate_appcast` emitted a correctly signed item (`sparkle:version=200`, `shortVersionString=0.7.6`, `edSignature`, correct enclosure URL) and preserved the channel metadata.

## Before this can leave draft

Three of these are maintainer-only — I don't have write access to the tap or the secrets:

1. **Record the demo clips** (above).
2. **`gh secret set SPARKLE_ED_PRIVATE_KEY`** — the key currently exists only in my login keychain; `docs/signing.md §3` has the exact commands. Without it the appcast step warns and skips: releases still publish, nothing updates.
3. **Add `auto_updates true`** to `Casks/tinycast.rb` and `Casks/tinycast@beta.rb` in the tap. CI only rewrites `version`/`sha256`, so this is manual — and without it `brew upgrade` will clobber a self-updated app.
4. **Cut a beta first.** The install leg has never run against a live feed; beta is where to find out.
