### PR TITLE
Support double-tap modifier shortcuts (⌘⌘, ⌃⌃, ⌥⌥, ⇧⇧)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
           swiftc -swift-version 6 Tinycast/Core/NotificationToken.swift \
             Tinycast/Core/Snippets/*.swift \
             Tools/snippets-test.swift -o /tmp/snippets-test && /tmp/snippets-test
+          swiftc -swift-version 6 Tinycast/Core/HotKey/DoubleTapModifier.swift \
+            Tinycast/Core/HotKey/DoubleTapDetector.swift Tools/hotkey-test.swift \
+            -o /tmp/hotkey-test && /tmp/hotkey-test
           swiftc -swift-version 6 Tinycast/Core/SystemAction.swift Tools/system-action-test.swift \
             -o /tmp/system-action-test && /tmp/system-action-test
           swiftc -swift-version 6 Tinycast/Core/WindowManagement/WindowCommand.swift \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
           swiftc -swift-version 6 Tinycast/Core/HotKey/DoubleTapModifier.swift \
             Tinycast/Core/HotKey/DoubleTapDetector.swift Tools/hotkey-test.swift \
             -o /tmp/hotkey-test && /tmp/hotkey-test
+          swiftc -swift-version 6 Tinycast/Core/Theme.swift \
+            Tinycast/Core/CalloutPlacement.swift Tools/callout-test.swift \
+            -o /tmp/callout-test && /tmp/callout-test
           swiftc -swift-version 6 Tinycast/Core/SystemAction.swift Tools/system-action-test.swift \
             -o /tmp/system-action-test && /tmp/system-action-test
           swiftc -swift-version 6 Tinycast/Core/WindowManagement/WindowCommand.swift \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,16 @@ Never break these without an explicit task to do so.
   pointers to plain values before crossing into actor code.
 - **Clipboard writes stamp a private `internalType` marker** so the poller skips Tinycast's own writes.
 - **Hotkeys persist under legacy `KeyboardShortcuts_<name>` UserDefaults keys** (from the removed
-  KeyboardShortcuts package) so old bindings survive. See [hotkeys.md](docs/hotkeys.md).
+  KeyboardShortcuts package) so old bindings survive. `HotKeyBinding` is the one thing an action is
+  bound to and it has two cases with two engines: a `.combo` is a Carbon registration, a `.doubleTap`
+  is recognized by `DoubleTapMonitor` (Carbon cannot see a lone modifier at all). Its `Codable`
+  conformance is the compatibility seam — a `.combo` must keep encoding as the bare
+  `{"carbonKeyCode":N,"carbonModifiers":N}` record and decoding must keep trying that shape first, or
+  every existing binding and backup breaks. `Core/HotKey/DoubleTapModifier.swift` and
+  `DoubleTapDetector.swift` stay Foundation-only and pure with the clock injected as a parameter, for
+  `Tools/hotkey-test.swift`; every `CGEvent` call lives in `DoubleTapMonitor.swift`, which is
+  listen-only, installs *only* while something is bound to a double-tap, and never prompts for
+  Accessibility. See [hotkeys.md](docs/hotkeys.md).
 - **Tinycast presents its own dialogs, never `NSAlert` / `NSSlider` / system popovers.** Every
   confirmation, failure report and value prompt goes through `DialogController` (`Core/Dialog/`,
   owned by `AppCore`; reachable elsewhere via `AppCore.showNotice` / `confirm`). Presentation is

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */ = {isa = PBXBuildFile; fileRef = 6621A88681E993D49EEF07A3 /* tinycast.icon */; };
 		374235D358A127741447551E /* SettingsBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5043CD44B4B40C49BE79852A /* SettingsBackup.swift */; };
 		3FEBE1C993C5BD92F1C3D95B /* LauncherRankingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B6E442944C99B4D1FE1C74 /* LauncherRankingStore.swift */; };
+		4006B894BE909BD067ED1E3A /* ShortcutRecorderPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA7727C7F5F511E7F1EF1 /* ShortcutRecorderPopover.swift */; };
 		40EC75A7BC165783128CA9E2 /* MessageHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F62D88E5BAC5F095E060B8 /* MessageHUDView.swift */; };
 		41164F539DD16E9FFEF44F8E /* DialogPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0379921C89CA45189533B9 /* DialogPanel.swift */; };
 		42828BD1C5E4E6E7AA1BF103 /* CalculatorHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */; };
@@ -42,6 +43,7 @@
 		48AB20B04EB50F9F4A68BD66 /* SnippetTemplateEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A002AC0DE601E1F65D20C4A /* SnippetTemplateEngine.swift */; };
 		4F3D96E59E117459153336F4 /* SettingsPaneScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */; };
 		4F740AF85545CF4133C89B82 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4802942FF89B327A76432A9B /* AboutView.swift */; };
+		4F8C9F202EE37D39C1AC13EF /* CalloutShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24AD5CFE167900DF8B2705C /* CalloutShape.swift */; };
 		5568D02AE095293A15A7F30D /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9ACD504E016DFF6FE6C1B /* RightClick.swift */; };
 		57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */; };
 		5B0EFBA180AAFFBC08CC395A /* HotKeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5C3FDF5037F730E23E53D /* HotKeyBinding.swift */; };
@@ -124,6 +126,7 @@
 		E5072CA7D34BA877D97DF392 /* ImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */; };
 		E5CA6385C7A7EE754A506815 /* DoubleTapDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E24E9328F01F2EE12120C38 /* DoubleTapDetector.swift */; };
 		E768AC4C8A6D6A1BA6218279 /* HUDPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D4192BC6F5A78012027488 /* HUDPresenter.swift */; };
+		E8B6ADBCECD7CA81BC67EE78 /* CalloutPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1D759B8FC5A4573E401B8 /* CalloutPlacement.swift */; };
 		E952B659AEB905A3B233F78B /* EmojiGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94F0767AE0A5855FB22BF6 /* EmojiGridView.swift */; };
 		EDCEE2DDCF97C354AAC72BF2 /* RaycastImportV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6999B617ECF28C9021027B9 /* RaycastImportV2.swift */; };
 		F25D58ED6EF3308D38D01732 /* PaletteWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */; };
@@ -133,6 +136,7 @@
 		F69CB40ABBBAAB91322732AE /* RaycastFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E312F99D07F01172202478C6 /* RaycastFormat.swift */; };
 		F6B79728FF2D37A60FED72AF /* HyperKeyTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */; };
 		F7D26DE09844A5A38787CDD2 /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0818D48887156CA562EF20B8 /* VolumeLevel.swift */; };
+		F9C1192D849B94E783D05568 /* ShortcutCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC35D5134516ECB65AABDC51 /* ShortcutCaptureSession.swift */; };
 		FBA8548636E1F1EABCC3A8CA /* LauncherItemsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F221037C057C8085CE51C /* LauncherItemsCard.swift */; };
 		FC934E5AE6A933F5BC7AC4DD /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D93A4CEA9FE857034D63EF7 /* CalcQuantity.swift */; };
 		FE6A9C75F87C3495F413E66E /* CalculatorHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */; };
@@ -191,6 +195,7 @@
 		5D3E4F8A2BCECFF0E11441BE /* RaycastSnippetImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastSnippetImport.swift; sourceTree = "<group>"; };
 		5D57B0AE44D21035163BD422 /* CommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRegistry.swift; sourceTree = "<group>"; };
 		5E08668A3C8418E2F0970300 /* CurrencyData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyData.generated.swift; sourceTree = "<group>"; };
+		5F3AA7727C7F5F511E7F1EF1 /* ShortcutRecorderPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderPopover.swift; sourceTree = "<group>"; };
 		6185011A02366B30B48B5B6C /* Paster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paster.swift; sourceTree = "<group>"; };
 		6256CC7C3F15BA05A216E820 /* VolumeHUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDController.swift; sourceTree = "<group>"; };
 		641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
@@ -247,6 +252,7 @@
 		BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardStore.swift; sourceTree = "<group>"; };
 		C01FB6EBC716BBFD38471D95 /* PanelTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelTransition.swift; sourceTree = "<group>"; };
 		C1DE4D8B82F1D4AFB025FB24 /* SystemSettingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsSettingsView.swift; sourceTree = "<group>"; };
+		C24AD5CFE167900DF8B2705C /* CalloutShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutShape.swift; sourceTree = "<group>"; };
 		C45190564C9D9F1722E83943 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C64C87569634E26E1BE99A91 /* CalculatorCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCardView.swift; sourceTree = "<group>"; };
 		C6DC5A4706854493D23FD18A /* HyperKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKey.swift; sourceTree = "<group>"; };
@@ -255,9 +261,11 @@
 		C8B33C0EA6D52B365B82752D /* RaycastV1Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastV1Decoder.swift; sourceTree = "<group>"; };
 		C9D8C2C59C2B578CFE61E004 /* BackupActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupActions.swift; sourceTree = "<group>"; };
 		CAE385AAF41C4CB276025211 /* RaycastImportV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV1.swift; sourceTree = "<group>"; };
+		CC35D5134516ECB65AABDC51 /* ShortcutCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureSession.swift; sourceTree = "<group>"; };
 		CC6173CA658DA56245031FE6 /* VolumeHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDView.swift; sourceTree = "<group>"; };
 		CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsSettingsView.swift; sourceTree = "<group>"; };
 		CD3764D91B2F3170690A473A /* SnippetKeywordPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordPolicy.swift; sourceTree = "<group>"; };
+		D2A1D759B8FC5A4573E401B8 /* CalloutPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutPlacement.swift; sourceTree = "<group>"; };
 		D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppName.swift"; sourceTree = "<group>"; };
 		D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
@@ -301,6 +309,8 @@
 				B275099E59BD2531A838F7D8 /* AppSettings.swift */,
 				D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */,
 				F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */,
+				D2A1D759B8FC5A4573E401B8 /* CalloutPlacement.swift */,
+				C24AD5CFE167900DF8B2705C /* CalloutShape.swift */,
 				A76E4099082D59FA686C3485 /* ClipboardManager.swift */,
 				BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */,
 				5D57B0AE44D21035163BD422 /* CommandRegistry.swift */,
@@ -533,6 +543,7 @@
 				C6DC5A4706854493D23FD18A /* HyperKey.swift */,
 				919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */,
 				2C3EB07C07902C53BFD3B08B /* KeyShortcut.swift */,
+				CC35D5134516ECB65AABDC51 /* ShortcutCaptureSession.swift */,
 			);
 			path = HotKey;
 			sourceTree = "<group>";
@@ -567,6 +578,7 @@
 				D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */,
 				68952539C0BD045BA175CBB6 /* SettingsRootView.swift */,
 				596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */,
+				5F3AA7727C7F5F511E7F1EF1 /* ShortcutRecorderPopover.swift */,
 				CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */,
 				29B90AEA968DD7B91A553E07 /* SystemActionsSettingsView.swift */,
 				C1DE4D8B82F1D4AFB025FB24 /* SystemSettingsSettingsView.swift */,
@@ -692,6 +704,8 @@
 				DB04CC2AFEDD69D0676CA1D1 /* CalculatorCardView.swift in Sources */,
 				42828BD1C5E4E6E7AA1BF103 /* CalculatorHistoryStore.swift in Sources */,
 				FE6A9C75F87C3495F413E66E /* CalculatorHistoryView.swift in Sources */,
+				E8B6ADBCECD7CA81BC67EE78 /* CalloutPlacement.swift in Sources */,
+				4F8C9F202EE37D39C1AC13EF /* CalloutShape.swift in Sources */,
 				B1B3F5715BE7A092F0CEFA09 /* ClipboardManager.swift in Sources */,
 				1F39D145DBE2290532C93614 /* ClipboardSettingsView.swift in Sources */,
 				441CF705AE1D03F6E236A61E /* ClipboardStore.swift in Sources */,
@@ -767,7 +781,9 @@
 				4F3D96E59E117459153336F4 /* SettingsPaneScanner.swift in Sources */,
 				CFB516312C4694DDFD99DBCA /* SettingsRootView.swift in Sources */,
 				212B9B44D7EED18A0DEF47AF /* ShellCommandRunner.swift in Sources */,
+				F9C1192D849B94E783D05568 /* ShortcutCaptureSession.swift in Sources */,
 				57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */,
+				4006B894BE909BD067ED1E3A /* ShortcutRecorderPopover.swift in Sources */,
 				85A9ACCB19D9502A79F1A508 /* Snippet.swift in Sources */,
 				0674D8E1567253879EF50150 /* SnippetArgumentsPrompt.swift in Sources */,
 				1AF562E00FCB98B12076F01D /* SnippetKeywordListener.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		4F740AF85545CF4133C89B82 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4802942FF89B327A76432A9B /* AboutView.swift */; };
 		5568D02AE095293A15A7F30D /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9ACD504E016DFF6FE6C1B /* RightClick.swift */; };
 		57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */; };
+		5B0EFBA180AAFFBC08CC395A /* HotKeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5C3FDF5037F730E23E53D /* HotKeyBinding.swift */; };
 		5DD58D999A421873EF3F2204 /* MessageHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE6E09755C1AF3AFBA6107E /* MessageHUDController.swift */; };
 		5E49E070BDBB91A2829F5321 /* SnippetTextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309908BAB8C19B67F4608DA9 /* SnippetTextInjector.swift */; };
 		5F107A05A7EB05204465E89D /* VolumeHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6256CC7C3F15BA05A216E820 /* VolumeHUDController.swift */; };
@@ -93,6 +94,7 @@
 		B20599ED24698C1E1F82AA10 /* ScrollIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFD97FB49778B4358FA5189 /* ScrollIntent.swift */; };
 		B3A213551CD73CC364476E9F /* VolumeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFAB36FFE7E7108FB50E9134 /* VolumeSlider.swift */; };
 		B545BD845189EE893D8D8DE7 /* RaycastV1Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B33C0EA6D52B365B82752D /* RaycastV1Decoder.swift */; };
+		B7274961ABF4E8F82B2D3BB7 /* DoubleTapMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75F40AED77119558D5FB4E4 /* DoubleTapMonitor.swift */; };
 		B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */; };
 		B9CED4B06F36998A67097FC5 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE084FDBE22B01204E7BEDA /* SnippetMarkdownSerializer.swift */; };
 		BA76E53A12248B3A9C42B4F9 /* Bundle+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */; };
@@ -113,12 +115,14 @@
 		D322804853973E1C19F2A408 /* AppIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CE23482F7DF563A268806 /* AppIndex.swift */; };
 		D3CA50C1CFABC31E6BC7B73C /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A65B4EC5AE7E22594BFC5E /* CalcPercent.swift */; };
 		D3D2ACD2D94588786C2185AE /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299122624B5E1BA2C5400478 /* CalcCurrency.swift */; };
+		D8704A9F0BC1A55B7BE4D717 /* DoubleTapModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4B045F847659544FA182D4 /* DoubleTapModifier.swift */; };
 		DA2EBB18F026BD055E0270CD /* AppLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */; };
 		DA5BCA13045FF91B3FC8EB35 /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9B4E6E477C30372C85F86 /* OnboardingState.swift */; };
 		DB04CC2AFEDD69D0676CA1D1 /* CalculatorCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64C87569634E26E1BE99A91 /* CalculatorCardView.swift */; };
 		DCC36924E538C11136CEC060 /* LauncherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7C545EFD9589A77AD7BE2 /* LauncherView.swift */; };
 		DEC660F280699E43AA028E8A /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */; };
 		E5072CA7D34BA877D97DF392 /* ImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99945F0952ADADBBEB9B8388 /* ImageThumbnail.swift */; };
+		E5CA6385C7A7EE754A506815 /* DoubleTapDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E24E9328F01F2EE12120C38 /* DoubleTapDetector.swift */; };
 		E768AC4C8A6D6A1BA6218279 /* HUDPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D4192BC6F5A78012027488 /* HUDPresenter.swift */; };
 		E952B659AEB905A3B233F78B /* EmojiGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94F0767AE0A5855FB22BF6 /* EmojiGridView.swift */; };
 		EDCEE2DDCF97C354AAC72BF2 /* RaycastImportV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6999B617ECF28C9021027B9 /* RaycastImportV2.swift */; };
@@ -144,6 +148,7 @@
 		0D045D032498C2294A99890E /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
 		0D16E927986D415F5386CDCF /* SystemAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAction.swift; sourceTree = "<group>"; };
 		0F50886DC766B9923C3875A5 /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
+		1A4B045F847659544FA182D4 /* DoubleTapModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapModifier.swift; sourceTree = "<group>"; };
 		1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportSelection.swift; sourceTree = "<group>"; };
 		1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -200,6 +205,7 @@
 		74F450E10D107C1E30EA2BC6 /* EmojiIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiIndex.swift; sourceTree = "<group>"; };
 		79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiData.generated.swift; sourceTree = "<group>"; };
 		7BC2DEA0A052116A92F9A539 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		7E24E9328F01F2EE12120C38 /* DoubleTapDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapDetector.swift; sourceTree = "<group>"; };
 		7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		8214A6789CF8E3B5E16BB4C2 /* CursorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorScreen.swift; sourceTree = "<group>"; };
 		825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityStore.swift; sourceTree = "<group>"; };
@@ -225,6 +231,7 @@
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
 		A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
+		A75F40AED77119558D5FB4E4 /* DoubleTapMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapMonitor.swift; sourceTree = "<group>"; };
 		A76E4099082D59FA686C3485 /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
 		A8859C0E99A2125D85B1233C /* WindowMover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowMover.swift; sourceTree = "<group>"; };
 		AD0A151A3B8AC682395E621D /* DialogController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogController.swift; sourceTree = "<group>"; };
@@ -236,6 +243,7 @@
 		B8A9B4E6E477C30372C85F86 /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
 		BA7CE23482F7DF563A268806 /* AppIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIndex.swift; sourceTree = "<group>"; };
 		BB94F0767AE0A5855FB22BF6 /* EmojiGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridView.swift; sourceTree = "<group>"; };
+		BBB5C3FDF5037F730E23E53D /* HotKeyBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyBinding.swift; sourceTree = "<group>"; };
 		BDC43CFF6777C11BB880F398 /* ClipboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardStore.swift; sourceTree = "<group>"; };
 		C01FB6EBC716BBFD38471D95 /* PanelTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelTransition.swift; sourceTree = "<group>"; };
 		C1DE4D8B82F1D4AFB025FB24 /* SystemSettingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsSettingsView.swift; sourceTree = "<group>"; };
@@ -517,6 +525,10 @@
 		CB742F7643800C43475DE213 /* HotKey */ = {
 			isa = PBXGroup;
 			children = (
+				7E24E9328F01F2EE12120C38 /* DoubleTapDetector.swift */,
+				1A4B045F847659544FA182D4 /* DoubleTapModifier.swift */,
+				A75F40AED77119558D5FB4E4 /* DoubleTapMonitor.swift */,
+				BBB5C3FDF5037F730E23E53D /* HotKeyBinding.swift */,
 				1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */,
 				C6DC5A4706854493D23FD18A /* HyperKey.swift */,
 				919AC64DE9C9DC3A973A0B4E /* HyperKeyTap.swift */,
@@ -695,6 +707,9 @@
 				41164F539DD16E9FFEF44F8E /* DialogPanel.swift in Sources */,
 				7A2C6032E0DE0346DD10A747 /* DialogRequest.swift in Sources */,
 				CC911DB8A6FB9EDA3BBA1AAC /* DialogView.swift in Sources */,
+				E5CA6385C7A7EE754A506815 /* DoubleTapDetector.swift in Sources */,
+				D8704A9F0BC1A55B7BE4D717 /* DoubleTapModifier.swift in Sources */,
+				B7274961ABF4E8F82B2D3BB7 /* DoubleTapMonitor.swift in Sources */,
 				715F8A70F7A533D2EEEF6135 /* EdgeDissolve.swift in Sources */,
 				344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */,
 				B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */,
@@ -708,6 +723,7 @@
 				AD2141EBF98A246BDA3BAB8E /* Gunzip.swift in Sources */,
 				CC97C121823B1DC61886BAFC /* HUDPanel.swift in Sources */,
 				E768AC4C8A6D6A1BA6218279 /* HUDPresenter.swift in Sources */,
+				5B0EFBA180AAFFBC08CC395A /* HotKeyBinding.swift in Sources */,
 				DEC660F280699E43AA028E8A /* HotKeyCenter.swift in Sources */,
 				903E82F78D3FCEF3A1AF3752 /* HotKeyManager.swift in Sources */,
 				14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -603,7 +603,7 @@ final class AppCore: ObservableObject {
         for id in ids {
             let action = HotKeyAction.customCommand(id: id)
             if hotKeys.recordingAction == action { hotKeys.recordingAction = nil }
-            hotKeys.setShortcut(nil, for: action)
+            hotKeys.setBinding(nil, for: action)
         }
         favorites.remove(keys: entryIDs)
         visibility.removeItemKeys(entryIDs)

--- a/Tinycast/Core/Backup/RaycastImportV1.swift
+++ b/Tinycast/Core/Backup/RaycastImportV1.swift
@@ -84,23 +84,25 @@ enum RaycastImportV1 {
         var mapped = false
 
         if let clipboard = payload.toggleClipboard {
-            hotkeys.toggleClipboard = shortcut(clipboard)
+            hotkeys.toggleClipboard = binding(clipboard)
             mapped = true
         }
         if let emoji = payload.toggleEmoji {
-            hotkeys.toggleEmoji = shortcut(emoji)
+            hotkeys.toggleEmoji = binding(emoji)
             mapped = true
         }
         if !payload.appHotkeys.isEmpty {
-            hotkeys.apps = payload.appHotkeys.mapValues(shortcut)
+            hotkeys.apps = payload.appHotkeys.mapValues(binding)
             mapped = true
         }
         return mapped ? hotkeys : nil
     }
 
-    private static func shortcut(_ hotkey: RaycastV1Payload.Hotkey) -> KeyShortcut {
-        KeyShortcut(
-            carbonKeyCode: hotkey.carbonKeyCode, carbonModifiers: hotkey.carbonModifiers)
+    /// Always a `.combo`: Raycast has no double-tap binding to import.
+    private static func binding(_ hotkey: RaycastV1Payload.Hotkey) -> HotKeyBinding {
+        .combo(
+            KeyShortcut(
+                carbonKeyCode: hotkey.carbonKeyCode, carbonModifiers: hotkey.carbonModifiers))
     }
 
     /// Enum raw values line up (`light`…`dark`); Raycast's `default` maps to none.

--- a/Tinycast/Core/Backup/RaycastImportV2.swift
+++ b/Tinycast/Core/Backup/RaycastImportV2.swift
@@ -124,28 +124,28 @@ enum RaycastImportV2 {
     private static func mapHotkeys(_ json: [String: Any]) -> SettingsBackup.HotkeyBackup? {
         let settings = json["settings"] as? [String: Any]
         var hotkeys = SettingsBackup.HotkeyBackup()
-        var apps: [String: KeyShortcut] = [:]
+        var apps: [String: HotKeyBinding] = [:]
         var mapped = false
 
         if let general = settings?["general"] as? [String: Any],
-            let shortcut = keyShortcut(from: general["globalHotkey"]) {
-            hotkeys.togglePalette = shortcut
+            let binding = binding(from: general["globalHotkey"]) {
+            hotkeys.togglePalette = binding
             mapped = true
         }
 
         for command in settings?["commands"] as? [[String: Any]] ?? [] {
-            guard let shortcut = keyShortcut(from: command["macosHotkey"]) else { continue }
+            guard let binding = binding(from: command["macosHotkey"]) else { continue }
             switch command["extensionId"] as? String {
             case "e:r:clipboard-history":
-                hotkeys.toggleClipboard = shortcut
+                hotkeys.toggleClipboard = binding
                 mapped = true
             case "e:r:emoji-picker":
-                hotkeys.toggleEmoji = shortcut
+                hotkeys.toggleEmoji = binding
                 mapped = true
             case "e:r:applications":
                 if let path = appPath(fromCommandID: command["id"] as? String),
                     let bundleID = Bundle(url: URL(fileURLWithPath: path))?.bundleIdentifier {
-                    apps[bundleID] = shortcut
+                    apps[bundleID] = binding
                     mapped = true
                 }
             default:
@@ -156,8 +156,8 @@ enum RaycastImportV2 {
         return mapped ? hotkeys : nil
     }
 
-    /// Build a `KeyShortcut` from a Raycast hotkey object (`{ kind: { shortcut: { modifiers, key } } }`).
-    private static func keyShortcut(from hotkey: Any?) -> KeyShortcut? {
+    /// Build a binding from a Raycast hotkey object (`{ kind: { shortcut: { modifiers, key } } }`). Always a `.combo`: Raycast has no double-tap binding to import.
+    private static func binding(from hotkey: Any?) -> HotKeyBinding? {
         guard let dict = hotkey as? [String: Any],
             let shortcut = (dict["kind"] as? [String: Any])?["shortcut"] as? [String: Any],
             let key = shortcut["key"] as? [String: Any],
@@ -175,8 +175,9 @@ enum RaycastImportV2 {
             default: break
             }
         }
-        return KeyShortcut(
-            carbonKeyCode: code, carbonModifiers: KeyShortcut.carbonModifiers(from: flags))
+        return .combo(
+            KeyShortcut(
+                carbonKeyCode: code, carbonModifiers: KeyShortcut.carbonModifiers(from: flags)))
     }
 
     /// Raycast marks favorited items with `favoriteOrder` (0-based). Only app favorites map to Tinycast, keyed by bundle ID (the same key `FavoritesStore` uses), preserving Raycast's order.

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A passwordless, human-readable snapshot of Tinycast's configuration. Every field is optional so an import applies only the keys actually present (non-destructive merge): a partial file — or one from Raycast — leaves everything it omits untouched.
 struct SettingsBackup: Codable {
-    var version = 2
+    var version = 3
     var settings: SettingsData?
     var hotkeys: HotkeyBackup?
     var customCommands: [CustomCommand]?
@@ -38,15 +38,16 @@ struct SettingsBackup: Codable {
         var windowCycleOnRepeat: Bool?
     }
 
+    /// `HotKeyBinding` encodes a combo in the legacy `KeyShortcut` shape, so files written before double-tap bindings existed import unchanged. The reverse doesn't hold: a file containing a double-tap can't be read by a pre-double-tap build, which is what the `version` bump records.
     struct HotkeyBackup: Codable {
-        var togglePalette: KeyShortcut?
-        var toggleClipboard: KeyShortcut?
-        var toggleEmoji: KeyShortcut?
-        var apps: [String: KeyShortcut]?
-        var panes: [String: KeyShortcut]?
-        var customCommands: [String: KeyShortcut]?
-        var systemActions: [String: KeyShortcut]?
-        var windowCommands: [String: KeyShortcut]?
+        var togglePalette: HotKeyBinding?
+        var toggleClipboard: HotKeyBinding?
+        var toggleEmoji: HotKeyBinding?
+        var apps: [String: HotKeyBinding]?
+        var panes: [String: HotKeyBinding]?
+        var customCommands: [String: HotKeyBinding]?
+        var systemActions: [String: HotKeyBinding]?
+        var windowCommands: [String: HotKeyBinding]?
     }
 
     /// A tally of what an import touched, for user-facing confirmation.
@@ -92,28 +93,28 @@ extension SettingsBackup {
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
-        hotkeys.togglePalette = hk.shortcut(for: .togglePalette)
-        hotkeys.toggleClipboard = hk.shortcut(for: .toggleClipboard)
-        hotkeys.toggleEmoji = hk.shortcut(for: .toggleEmoji)
+        hotkeys.togglePalette = hk.binding(for: .togglePalette)
+        hotkeys.toggleClipboard = hk.binding(for: .toggleClipboard)
+        hotkeys.toggleEmoji = hk.binding(for: .toggleEmoji)
         hotkeys.apps = Dictionary(
             uniqueKeysWithValues: hk.boundBundleIDs.compactMap { id in
-                hk.shortcut(for: .app(bundleID: id)).map { (id, $0) }
+                hk.binding(for: .app(bundleID: id)).map { (id, $0) }
             })
         hotkeys.panes = Dictionary(
             uniqueKeysWithValues: hk.boundPaneBundleIDs.compactMap { id in
-                hk.shortcut(for: .settingsPane(bundleID: id)).map { (id, $0) }
+                hk.binding(for: .settingsPane(bundleID: id)).map { (id, $0) }
             })
         hotkeys.customCommands = Dictionary(
             uniqueKeysWithValues: hk.boundCustomCommandIDs.compactMap { id in
-                hk.shortcut(for: .customCommand(id: id)).map { (id.uuidString.lowercased(), $0) }
+                hk.binding(for: .customCommand(id: id)).map { (id.uuidString.lowercased(), $0) }
             })
         hotkeys.systemActions = Dictionary(
             uniqueKeysWithValues: SystemAction.ID.allCases.compactMap { id in
-                hk.shortcut(for: .systemAction(id: id)).map { (id.rawValue, $0) }
+                hk.binding(for: .systemAction(id: id)).map { (id.rawValue, $0) }
             })
         hotkeys.windowCommands = Dictionary(
             uniqueKeysWithValues: WindowCommand.ID.allCases.compactMap { id in
-                hk.shortcut(for: .windowCommand(id: id)).map { (id.rawValue, $0) }
+                hk.binding(for: .windowCommand(id: id)).map { (id.rawValue, $0) }
             })
         backup.hotkeys = hotkeys
 
@@ -241,30 +242,30 @@ extension SettingsBackup {
     private func applyHotkeys(_ hotkeys: HotkeyBackup, to core: AppCore) -> Int {
         let hk = core.hotKeys
         var count = 0
-        // Skip a binding whose combo is already claimed by an earlier-applied (or existing) action: two actions on the same key would make Carbon's second RegisterEventHotKey fail with eventHotKeyExistsErr, silently killing that shortcut. The recorder does this check interactively; imports must too.
-        func apply(_ s: KeyShortcut, _ action: HotKeyAction) {
-            guard hk.conflictOwner(of: s, excluding: action) == nil else { return }
-            hk.setShortcut(s, for: action)
+        // Skip a binding already claimed by an earlier-applied (or existing) action: two actions on the same combo would make Carbon's second RegisterEventHotKey fail with eventHotKeyExistsErr, silently killing that shortcut, and two on the same double-tap modifier would leave the winner arbitrary. The recorder does this check interactively; imports must too.
+        func apply(_ binding: HotKeyBinding, _ action: HotKeyAction) {
+            guard hk.conflictOwner(of: binding, excluding: action) == nil else { return }
+            hk.setBinding(binding, for: action)
             count += 1
         }
-        if let s = hotkeys.togglePalette { apply(s, .togglePalette) }
-        if let s = hotkeys.toggleClipboard { apply(s, .toggleClipboard) }
-        if let s = hotkeys.toggleEmoji { apply(s, .toggleEmoji) }
-        for (id, s) in hotkeys.apps ?? [:] { apply(s, .app(bundleID: id)) }
-        for (id, s) in hotkeys.panes ?? [:] { apply(s, .settingsPane(bundleID: id)) }
-        for (rawID, s) in hotkeys.customCommands ?? [:] {
+        if let b = hotkeys.togglePalette { apply(b, .togglePalette) }
+        if let b = hotkeys.toggleClipboard { apply(b, .toggleClipboard) }
+        if let b = hotkeys.toggleEmoji { apply(b, .toggleEmoji) }
+        for (id, b) in hotkeys.apps ?? [:] { apply(b, .app(bundleID: id)) }
+        for (id, b) in hotkeys.panes ?? [:] { apply(b, .settingsPane(bundleID: id)) }
+        for (rawID, b) in hotkeys.customCommands ?? [:] {
             guard let id = UUID(uuidString: rawID), core.customCommands.command(id: id) != nil else {
                 continue
             }
-            apply(s, .customCommand(id: id))
+            apply(b, .customCommand(id: id))
         }
-        for (rawID, s) in hotkeys.systemActions ?? [:] {
+        for (rawID, b) in hotkeys.systemActions ?? [:] {
             guard let id = SystemAction.ID(rawValue: rawID) else { continue }
-            apply(s, .systemAction(id: id))
+            apply(b, .systemAction(id: id))
         }
-        for (rawID, s) in hotkeys.windowCommands ?? [:] {
+        for (rawID, b) in hotkeys.windowCommands ?? [:] {
             guard let id = WindowCommand.ID(rawValue: rawID) else { continue }
-            apply(s, .windowCommand(id: id))
+            apply(b, .windowCommand(id: id))
         }
         return count
     }

--- a/Tinycast/Core/CalloutPlacement.swift
+++ b/Tinycast/Core/CalloutPlacement.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+
+/// Where a callout sits and where its pointer lands. Pure, metrics injected, so `Tools/callout-test.swift` drives it without a window.
+struct CalloutPlacement: Equatable {
+    enum CaretEdge: Equatable {
+        case top
+        case bottom
+    }
+
+    /// Callout centre in container coordinates, ready for `.position`.
+    let center: CGPoint
+    let caretEdge: CaretEdge
+    /// Tip in the callout's own x, already clear of the corner arcs.
+    let caretX: CGFloat
+
+    /// Above the field when it fits, else below; clamped inside the container either way.
+    static func resolve(
+        field: CGRect, container: CGSize, size: CGSize, gap: CGFloat, inset: CGFloat,
+        cornerRadius: CGFloat, caretWidth: CGFloat
+    ) -> CalloutPlacement {
+        let above = field.minY >= size.height + gap
+        let half = size.width / 2
+
+        // `max` guards a container narrower than the callout, where the two bounds cross.
+        let lower = half + inset
+        let centerX = min(max(field.midX, lower), max(container.width - half - inset, lower))
+        let centerY =
+            above
+            ? field.minY - gap - size.height / 2
+            : field.maxY + gap + size.height / 2
+
+        // Once clamped, the tip walks so it still aims at the field.
+        let limit = cornerRadius + caretWidth / 2
+        let tip = field.midX - (centerX - half)
+
+        return CalloutPlacement(
+            center: CGPoint(x: centerX, y: centerY),
+            caretEdge: above ? .bottom : .top,
+            caretX: min(max(tip, limit), max(size.width - limit, limit))
+        )
+    }
+}

--- a/Tinycast/Core/CalloutShape.swift
+++ b/Tinycast/Core/CalloutShape.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Rounded rect plus a rounded-tip triangle pointer, as one path so the glass lenses them together.
+struct CalloutShape: Shape {
+    let caretEdge: CalloutPlacement.CaretEdge
+    let caretX: CGFloat
+    var cornerRadius: CGFloat = Theme.Radius.menuPanel
+    var caretWidth: CGFloat = Theme.Size.calloutCaretWidth
+    var caretHeight: CGFloat = Theme.Size.calloutCaretHeight
+    var tipRadius: CGFloat = Theme.Size.calloutCaretTip
+
+    func path(in rect: CGRect) -> Path {
+        let up = caretEdge == .top
+        let body = CGRect(
+            x: rect.minX, y: up ? rect.minY + caretHeight : rect.minY,
+            width: rect.width, height: rect.height - caretHeight)
+        var path = Path(roundedRect: body, cornerRadius: cornerRadius, style: .continuous)
+
+        let half = caretWidth / 2
+        let baseY = up ? body.minY : body.maxY
+        let tipY = up ? rect.minY : rect.maxY
+        // Two straight edges meeting at an arc: a triangle whose tip is rounded, not a dome.
+        path.move(to: CGPoint(x: caretX - half, y: baseY))
+        path.addArc(
+            tangent1End: CGPoint(x: caretX, y: tipY),
+            tangent2End: CGPoint(x: caretX + half, y: baseY),
+            radius: tipRadius)
+        path.addLine(to: CGPoint(x: caretX + half, y: baseY))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/Tinycast/Core/HotKey/DoubleTapDetector.swift
+++ b/Tinycast/Core/HotKey/DoubleTapDetector.swift
@@ -8,7 +8,7 @@ struct DoubleTapDetector {
     static let maxGap: TimeInterval = 0.30
 
     enum Input: Sendable {
-        /// A modifier transition: which of the four eligible modifiers are now held, and whether anything else (fn, Caps Lock) is down alongside.
+        /// A modifier transition: which of the four eligible modifiers are now held, and whether `fn` is down alongside.
         case modifiers(Set<DoubleTapModifier>, hasOtherModifiers: Bool)
         /// A key press or mouse click, which turns the press in flight into a chord.
         case otherInput

--- a/Tinycast/Core/HotKey/DoubleTapDetector.swift
+++ b/Tinycast/Core/HotKey/DoubleTapDetector.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Recognizes "tap a lone modifier twice" out of a stream of modifier snapshots. Pure and clock-injected (`now` is a caller-supplied monotonic timestamp) so `Tools/hotkey-test.swift` can drive it without an event tap.
+struct DoubleTapDetector {
+    /// Longest a press may last and still count as a tap — matches `HyperKeyTap.quickPressWindow`, so a "tap" means the same thing in both features.
+    static let maxHold: TimeInterval = 0.25
+    /// Longest gap between the first tap's release and the second tap's press.
+    static let maxGap: TimeInterval = 0.30
+
+    enum Input: Sendable {
+        /// A modifier transition: which of the four eligible modifiers are now held, and whether anything else (fn, Caps Lock) is down alongside.
+        case modifiers(Set<DoubleTapModifier>, hasOtherModifiers: Bool)
+        /// A key press or mouse click, which turns the press in flight into a chord.
+        case otherInput
+    }
+
+    private var held: Set<DoubleTapModifier> = []
+    private var press: (modifier: DoubleTapModifier, startedAt: TimeInterval)?
+    private var pendingTap: (modifier: DoubleTapModifier, releasedAt: TimeInterval)?
+
+    /// Returns the modifier whose double-tap just completed. Firing happens on the *second release*, so the modifier is already up when the caller runs the action — the palette never opens with a phantom ⌘ held, and "double-tap and hold" is a deliberate non-event.
+    mutating func handle(_ input: Input, at now: TimeInterval) -> DoubleTapModifier? {
+        switch input {
+        case .otherInput:
+            invalidate()
+            return nil
+        case .modifiers(let modifiers, let hasOtherModifiers):
+            return handle(modifiers, hasOtherModifiers: hasOtherModifiers, at: now)
+        }
+    }
+
+    mutating func reset() {
+        held = []
+        invalidate()
+    }
+
+    private mutating func handle(
+        _ modifiers: Set<DoubleTapModifier>, hasOtherModifiers: Bool, at now: TimeInterval
+    ) -> DoubleTapModifier? {
+        let previous = held
+        held = modifiers
+
+        guard !hasOtherModifiers else {
+            invalidate()
+            return nil
+        }
+        if modifiers.isEmpty { return completeTap(at: now) }
+
+        // A tap can only begin from nothing held: a second modifier joining, or a chord unwinding back to one, must not read as a fresh press.
+        guard previous.isEmpty, modifiers.count == 1, let modifier = modifiers.first else {
+            invalidate()
+            return nil
+        }
+        press = (modifier, now)
+        return nil
+    }
+
+    private mutating func completeTap(at now: TimeInterval) -> DoubleTapModifier? {
+        guard let press, now - press.startedAt <= Self.maxHold else {
+            invalidate()
+            return nil
+        }
+        self.press = nil
+
+        guard let pending = pendingTap, pending.modifier == press.modifier,
+            press.startedAt - pending.releasedAt <= Self.maxGap
+        else {
+            pendingTap = (press.modifier, now)
+            return nil
+        }
+        pendingTap = nil
+        return press.modifier
+    }
+
+    private mutating func invalidate() {
+        press = nil
+        pendingTap = nil
+    }
+}

--- a/Tinycast/Core/HotKey/DoubleTapModifier.swift
+++ b/Tinycast/Core/HotKey/DoubleTapModifier.swift
@@ -16,15 +16,5 @@ enum DoubleTapModifier: String, CaseIterable, Codable, Sendable {
         }
     }
 
-    var title: String {
-        switch self {
-        case .control: "Control"
-        case .option: "Option"
-        case .shift: "Shift"
-        case .command: "Command"
-        }
-    }
-
-    /// The bound shortcut rendered as keycaps — the same glyph twice, which is what a double-tap reads as everywhere it's shown.
     var keycaps: [String] { [glyph, glyph] }
 }

--- a/Tinycast/Core/HotKey/DoubleTapModifier.swift
+++ b/Tinycast/Core/HotKey/DoubleTapModifier.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A modifier whose double-tap can carry a global binding. Deliberately just these four: Caps Lock belongs to the Hyper Key, and `fn` isn't a real modifier on every keyboard.
+enum DoubleTapModifier: String, CaseIterable, Codable, Sendable {
+    case control
+    case option
+    case shift
+    case command
+
+    var glyph: String {
+        switch self {
+        case .control: "⌃"
+        case .option: "⌥"
+        case .shift: "⇧"
+        case .command: "⌘"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .control: "Control"
+        case .option: "Option"
+        case .shift: "Shift"
+        case .command: "Command"
+        }
+    }
+
+    /// The bound shortcut rendered as keycaps — the same glyph twice, which is what a double-tap reads as everywhere it's shown.
+    var keycaps: [String] { [glyph, glyph] }
+}

--- a/Tinycast/Core/HotKey/DoubleTapMonitor.swift
+++ b/Tinycast/Core/HotKey/DoubleTapMonitor.swift
@@ -48,7 +48,7 @@ final class DoubleTapMonitor: ObservableObject {
     private var sessionActive = true
     private var loggedTapFailure = false
 
-    // Isolated so teardown runs on main; the tap holds an unretained pointer to `self`, so it must not outlive it. This is an AppCore-owned singleton today, so it only matters if one is ever recreated.
+    // The tap holds an unretained `self`, so it must not outlive it.
     isolated deinit {
         tearDownTap()
         stopHealthTimer()
@@ -95,7 +95,7 @@ final class DoubleTapMonitor: ObservableObject {
         return held
     }
 
-    // Only `fn`, never `maskAlphaShift`: that bit tracks the Caps Lock *latch*, not a press, so testing it would disqualify every tap for as long as Caps Lock happens to be on.
+    // Never `maskAlphaShift`: it tracks the Caps Lock latch, so it would kill every tap while Caps Lock is on.
     private static func hasOtherModifiers(in flags: CGEventFlags) -> Bool {
         flags.contains(.maskSecondaryFn)
     }

--- a/Tinycast/Core/HotKey/DoubleTapMonitor.swift
+++ b/Tinycast/Core/HotKey/DoubleTapMonitor.swift
@@ -1,0 +1,220 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// C entry point for the tap (always on the main thread): reduce the `CGEvent` to Sendable scalars, then cross into the actor. Listen-only, so the event is always returned untouched.
+private func doubleTapEventTapCallback(
+    proxy: CGEventTapProxy, type: CGEventType, event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard let userInfo else { return Unmanaged.passUnretained(event) }
+    let monitor = Unmanaged<DoubleTapMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+
+    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        MainActor.assumeIsolated { monitor.tapWasDisabled() }
+        return Unmanaged.passUnretained(event)
+    }
+
+    let isFlagsChanged = type == .flagsChanged
+    let flagsRaw = event.flags.rawValue
+    MainActor.assumeIsolated {
+        monitor.process(isFlagsChanged: isFlagsChanged, flagsRaw: flagsRaw)
+    }
+    return Unmanaged.passUnretained(event)
+}
+
+/// Watches for a double-tapped lone modifier system-wide and reports the matching action. A third tap is unavoidable: Carbon can't register a modifier-only shortcut, `HyperKeyTap` only exists while a Hyper Key is configured, and the snippet listener must stay compilable by its own harness. This one is listen-only and installs *only* while something is bound to a double-tap.
+@MainActor
+final class DoubleTapMonitor: ObservableObject {
+    enum Status: Equatable {
+        case off
+        case active
+        case needsAccessibility
+    }
+
+    @Published private(set) var status: Status = .off
+
+    /// Fired on the second release of a bound modifier; the owner turns it into an action.
+    var onDoubleTap: ((DoubleTapModifier) -> Void)?
+
+    /// Set while a recorder is capturing, so editing a binding can't trigger it (mirrors `HotKeyCenter.isPaused`).
+    var isPaused = false {
+        didSet {
+            guard isPaused != oldValue else { return }
+            detector.reset()
+        }
+    }
+
+    private var bound: Set<DoubleTapModifier> = []
+    private var detector = DoubleTapDetector()
+    private var tapPort: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var healthTimer: Timer?
+    private var sessionTokens: [NotificationToken] = []
+    private var sessionActive = true
+    private var loggedTapFailure = false
+
+    func start() {
+        installObserversIfNeeded()
+        syncTapPresence()
+    }
+
+    /// The set of modifiers currently carrying a binding; an empty set tears the tap down, so users who never bind a double-tap pay nothing.
+    func update(bound: Set<DoubleTapModifier>) {
+        guard bound != self.bound else { return }
+        self.bound = bound
+        detector.reset()
+        syncTapPresence()
+    }
+
+    // MARK: - Detection
+
+    fileprivate func process(isFlagsChanged: Bool, flagsRaw: UInt64) {
+        guard !isPaused, !bound.isEmpty else { return }
+        let input: DoubleTapDetector.Input
+        if isFlagsChanged {
+            let flags = CGEventFlags(rawValue: flagsRaw)
+            input = .modifiers(
+                Self.modifiers(in: flags), hasOtherModifiers: Self.hasOtherModifiers(in: flags))
+        } else {
+            input = .otherInput
+        }
+        // `systemUptime` is monotonic, so a wall-clock adjustment can't turn a tap into a hold.
+        guard let modifier = detector.handle(input, at: ProcessInfo.processInfo.systemUptime),
+            bound.contains(modifier)
+        else { return }
+        onDoubleTap?(modifier)
+    }
+
+    private static func modifiers(in flags: CGEventFlags) -> Set<DoubleTapModifier> {
+        var held: Set<DoubleTapModifier> = []
+        if flags.contains(.maskControl) { held.insert(.control) }
+        if flags.contains(.maskAlternate) { held.insert(.option) }
+        if flags.contains(.maskShift) { held.insert(.shift) }
+        if flags.contains(.maskCommand) { held.insert(.command) }
+        return held
+    }
+
+    private static func hasOtherModifiers(in flags: CGEventFlags) -> Bool {
+        flags.contains(.maskSecondaryFn) || flags.contains(.maskAlphaShift)
+    }
+
+    // MARK: - Tap lifecycle
+
+    private func installObserversIfNeeded() {
+        guard sessionTokens.isEmpty else { return }
+        // Fast user switching: another session owns the keyboard, so drop half-held state until this one is back.
+        let center = NSWorkspace.shared.notificationCenter
+        sessionTokens = [
+            NotificationToken(
+                center.addObserver(
+                    forName: NSWorkspace.sessionDidResignActiveNotification, object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.sessionDidChange(active: false) }
+                }, center: center),
+            NotificationToken(
+                center.addObserver(
+                    forName: NSWorkspace.sessionDidBecomeActiveNotification, object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.sessionDidChange(active: true) }
+                }, center: center)
+        ]
+    }
+
+    private func sessionDidChange(active: Bool) {
+        sessionActive = active
+        detector.reset()
+        syncTapPresence()
+    }
+
+    private func syncTapPresence() {
+        guard !bound.isEmpty, sessionActive else {
+            tearDownTap()
+            stopHealthTimer()
+            status = .off
+            return
+        }
+        startHealthTimer()
+        installTapIfNeeded()
+    }
+
+    private func installTapIfNeeded() {
+        guard tapPort == nil else { return }
+        let mask: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.leftMouseDown.rawValue)
+            | (1 << CGEventType.rightMouseDown.rawValue)
+            | (1 << CGEventType.otherMouseDown.rawValue)
+        guard
+            let port = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                // Appended rather than head-inserted so `HyperKeyTap`'s rewrite lands first: a Hyper-remapped modifier arrives as the full ⌃⌥⇧⌘ chord and correctly reads as "not a lone modifier".
+                place: .tailAppendEventTap,
+                options: .listenOnly,
+                eventsOfInterest: mask,
+                callback: doubleTapEventTapCallback,
+                userInfo: Unmanaged.passUnretained(self).toOpaque())
+        else {
+            // Even a listen-only keyboard tap needs the Accessibility grant; the health timer retries so a binding starts working the moment the user grants it.
+            if !loggedTapFailure {
+                NSLog("Tinycast: Failed to create double-tap event tap")
+                loggedTapFailure = true
+            }
+            status = .needsAccessibility
+            return
+        }
+        loggedTapFailure = false
+        tapPort = port
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0)
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: port, enable: true)
+        status = .active
+    }
+
+    private func tearDownTap() {
+        detector.reset()
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+            self.runLoopSource = nil
+        }
+        if let tapPort {
+            CGEvent.tapEnable(tap: tapPort, enable: false)
+            CFMachPortInvalidate(tapPort)
+            self.tapPort = nil
+        }
+    }
+
+    /// Called from the callback when the system disables the tap (timeout / user input); any half-tracked press is stale by then.
+    fileprivate func tapWasDisabled() {
+        detector.reset()
+        if let tapPort { CGEvent.tapEnable(tap: tapPort, enable: true) }
+    }
+
+    private func startHealthTimer() {
+        guard healthTimer == nil else { return }
+        healthTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.healthCheck() }
+        }
+    }
+
+    private func stopHealthTimer() {
+        healthTimer?.invalidate()
+        healthTimer = nil
+    }
+
+    /// One-second watchdog while something is bound: retries installation until Accessibility is granted, notices revocation, and revives a system-disabled tap.
+    private func healthCheck() {
+        guard !bound.isEmpty, sessionActive else { return }
+        if tapPort == nil {
+            installTapIfNeeded()
+        } else if !Permissions.isAccessibilityTrusted() {
+            tearDownTap()
+            status = .needsAccessibility
+        } else if let tapPort, !CGEvent.tapIsEnabled(tap: tapPort) {
+            CGEvent.tapEnable(tap: tapPort, enable: true)
+        }
+    }
+}

--- a/Tinycast/Core/HotKey/DoubleTapMonitor.swift
+++ b/Tinycast/Core/HotKey/DoubleTapMonitor.swift
@@ -25,13 +25,8 @@ private func doubleTapEventTapCallback(
 /// Watches for a double-tapped lone modifier system-wide and reports the matching action. A third tap is unavoidable: Carbon can't register a modifier-only shortcut, `HyperKeyTap` only exists while a Hyper Key is configured, and the snippet listener must stay compilable by its own harness. This one is listen-only and installs *only* while something is bound to a double-tap.
 @MainActor
 final class DoubleTapMonitor: ObservableObject {
-    enum Status: Equatable {
-        case off
-        case active
-        case needsAccessibility
-    }
-
-    @Published private(set) var status: Status = .off
+    /// True only while something is bound and the tap can't be created; the recorder surfaces it next to the binding.
+    @Published private(set) var needsAccessibility = false
 
     /// Fired on the second release of a bound modifier; the owner turns it into an action.
     var onDoubleTap: ((DoubleTapModifier) -> Void)?
@@ -102,7 +97,7 @@ final class DoubleTapMonitor: ObservableObject {
 
     private func installObserversIfNeeded() {
         guard sessionTokens.isEmpty else { return }
-        // Fast user switching: another session owns the keyboard, so drop half-held state until this one is back.
+        // Fast user switching: another session owns the keyboard, so stop watching until this one is back.
         let center = NSWorkspace.shared.notificationCenter
         sessionTokens = [
             NotificationToken(
@@ -132,7 +127,7 @@ final class DoubleTapMonitor: ObservableObject {
         guard !bound.isEmpty, sessionActive else {
             tearDownTap()
             stopHealthTimer()
-            status = .off
+            needsAccessibility = false
             return
         }
         startHealthTimer()
@@ -162,7 +157,7 @@ final class DoubleTapMonitor: ObservableObject {
                 NSLog("Tinycast: Failed to create double-tap event tap")
                 loggedTapFailure = true
             }
-            status = .needsAccessibility
+            needsAccessibility = true
             return
         }
         loggedTapFailure = false
@@ -171,7 +166,7 @@ final class DoubleTapMonitor: ObservableObject {
         runLoopSource = source
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: port, enable: true)
-        status = .active
+        needsAccessibility = false
     }
 
     private func tearDownTap() {
@@ -212,7 +207,7 @@ final class DoubleTapMonitor: ObservableObject {
             installTapIfNeeded()
         } else if !Permissions.isAccessibilityTrusted() {
             tearDownTap()
-            status = .needsAccessibility
+            needsAccessibility = true
         } else if let tapPort, !CGEvent.tapIsEnabled(tap: tapPort) {
             CGEvent.tapEnable(tap: tapPort, enable: true)
         }

--- a/Tinycast/Core/HotKey/DoubleTapMonitor.swift
+++ b/Tinycast/Core/HotKey/DoubleTapMonitor.swift
@@ -28,7 +28,7 @@ final class DoubleTapMonitor: ObservableObject {
     /// True only while something is bound and the tap can't be created; the recorder surfaces it next to the binding.
     @Published private(set) var needsAccessibility = false
 
-    /// Fired on the second release of a bound modifier; the owner turns it into an action.
+    /// Fired on the second *release* of a bound modifier, so it is already up by the time the action runs.
     var onDoubleTap: ((DoubleTapModifier) -> Void)?
 
     /// Set while a recorder is capturing, so editing a binding can't trigger it (mirrors `HotKeyCenter.isPaused`).
@@ -47,6 +47,12 @@ final class DoubleTapMonitor: ObservableObject {
     private var sessionTokens: [NotificationToken] = []
     private var sessionActive = true
     private var loggedTapFailure = false
+
+    // Isolated so teardown runs on main; the tap holds an unretained pointer to `self`, so it must not outlive it. This is an AppCore-owned singleton today, so it only matters if one is ever recreated.
+    isolated deinit {
+        tearDownTap()
+        stopHealthTimer()
+    }
 
     func start() {
         installObserversIfNeeded()
@@ -89,8 +95,9 @@ final class DoubleTapMonitor: ObservableObject {
         return held
     }
 
+    // Only `fn`, never `maskAlphaShift`: that bit tracks the Caps Lock *latch*, not a press, so testing it would disqualify every tap for as long as Caps Lock happens to be on.
     private static func hasOtherModifiers(in flags: CGEventFlags) -> Bool {
-        flags.contains(.maskSecondaryFn) || flags.contains(.maskAlphaShift)
+        flags.contains(.maskSecondaryFn)
     }
 
     // MARK: - Tap lifecycle

--- a/Tinycast/Core/HotKey/HotKeyBinding.swift
+++ b/Tinycast/Core/HotKey/HotKeyBinding.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// What a `HotKeyAction` is bound to. Two kinds, two engines: a `.combo` is a Carbon registration, a `.doubleTap` is recognized by `DoubleTapMonitor` (Carbon can't see lone modifiers at all).
+enum HotKeyBinding: Hashable, Sendable {
+    case combo(KeyShortcut)
+    case doubleTap(DoubleTapModifier)
+
+    /// One string per keycap, so every display site renders both kinds through the same path.
+    @MainActor var keycaps: [String] {
+        switch self {
+        case .combo(let shortcut): shortcut.keycaps
+        case .doubleTap(let modifier): modifier.keycaps
+        }
+    }
+
+    var shortcut: KeyShortcut? {
+        if case .combo(let shortcut) = self { return shortcut }
+        return nil
+    }
+
+    var doubleTapModifier: DoubleTapModifier? {
+        if case .doubleTap(let modifier) = self { return modifier }
+        return nil
+    }
+}
+
+// A `.combo` encodes as the bare legacy `{"carbonKeyCode":N,"carbonModifiers":N}` record, so existing `KeyboardShortcuts_*` values and old backups load and re-save unchanged; `.doubleTap` gets its own shape, which an older build fails to decode and therefore reads as unbound — the right way to degrade.
+extension HotKeyBinding: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case doubleTapModifier
+    }
+
+    init(from decoder: Decoder) throws {
+        if let shortcut = try? KeyShortcut(from: decoder) {
+            self = .combo(shortcut)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self = .doubleTap(try container.decode(DoubleTapModifier.self, forKey: .doubleTapModifier))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .combo(let shortcut):
+            try shortcut.encode(to: encoder)
+        case .doubleTap(let modifier):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(modifier, forKey: .doubleTapModifier)
+        }
+    }
+}

--- a/Tinycast/Core/HotKey/HotKeyBinding.swift
+++ b/Tinycast/Core/HotKey/HotKeyBinding.swift
@@ -13,6 +13,14 @@ enum HotKeyBinding: Hashable, Sendable {
         }
     }
 
+    /// Modifiers collapsed into one cap, so the narrow field shows any binding in two chips.
+    @MainActor var compactKeycaps: [String] {
+        guard case .combo(let shortcut) = self else { return keycaps }
+        let caps = shortcut.keycaps
+        guard caps.count > 2, let key = caps.last else { return caps }
+        return [caps.dropLast().joined(), key]
+    }
+
     var shortcut: KeyShortcut? {
         if case .combo(let shortcut) = self { return shortcut }
         return nil

--- a/Tinycast/Core/HotKey/HotKeyBinding.swift
+++ b/Tinycast/Core/HotKey/HotKeyBinding.swift
@@ -13,14 +13,6 @@ enum HotKeyBinding: Hashable, Sendable {
         }
     }
 
-    /// Modifiers collapsed into one cap, so the narrow field shows any binding in two chips.
-    @MainActor var compactKeycaps: [String] {
-        guard case .combo(let shortcut) = self else { return keycaps }
-        let caps = shortcut.keycaps
-        guard caps.count > 2, let key = caps.last else { return caps }
-        return [caps.dropLast().joined(), key]
-    }
-
     var shortcut: KeyShortcut? {
         if case .combo(let shortcut) = self { return shortcut }
         return nil

--- a/Tinycast/Core/HotKey/ShortcutCaptureSession.swift
+++ b/Tinycast/Core/HotKey/ShortcutCaptureSession.swift
@@ -1,0 +1,164 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// Local event monitors for the one active recording. `HotKeyManager.recordingAction` starts and stops it, so one session serves the app and the callout can read it from outside the row.
+@MainActor
+final class ShortcutCaptureSession: ObservableObject {
+    /// A rejected binding and whoever already holds it.
+    struct Conflict: Equatable {
+        let binding: HotKeyBinding
+        let owner: String
+    }
+
+    @Published private(set) var heldModifiers: NSEvent.ModifierFlags = []
+    @Published private(set) var conflict: Conflict?
+
+    private static let conflictDwell: Duration = .seconds(1.5)
+
+    private var monitors: [Any] = []
+    private var resignObserver: NSObjectProtocol?
+    private var conflictReset: Task<Void, Never>?
+    /// The same recognizer the global monitor uses, driven here by local monitors — recording a double-tap therefore needs no event tap and no permission.
+    private var detector = DoubleTapDetector()
+
+    func start(action: HotKeyAction, hotKeys: HotKeyManager) {
+        stop()
+        heldModifiers = NSEvent.modifierFlags.intersection([.command, .option, .control, .shift])
+
+        // The handlers run on the main thread but AppKit predates actor annotations, hence assumeIsolated; only Sendable event pieces (key code, flags, timestamp) cross in.
+        if let monitor = NSEvent.addLocalMonitorForEvents(
+            matching: .keyDown,
+            handler: { [weak self, weak hotKeys] event in
+                let keyCode = Int(event.keyCode)
+                let flags = event.modifierFlags
+                let timestamp = event.timestamp
+                MainActor.assumeIsolated {
+                    guard let self, let hotKeys else { return }
+                    self.handleKeyDown(
+                        keyCode: keyCode, flags: flags, at: timestamp, action: action,
+                        hotKeys: hotKeys)
+                }
+                return nil  // always consume: no beeps, no leaking keys to the window
+            }) {
+            monitors.append(monitor)
+        }
+
+        if let monitor = NSEvent.addLocalMonitorForEvents(
+            matching: .flagsChanged,
+            handler: { [weak self, weak hotKeys] event in
+                let all = event.modifierFlags
+                let flags = all.intersection([.command, .option, .control, .shift])
+                // `.function` only: `.capsLock` is the latch state, and testing it would make a recorder refuse every double-tap while Caps Lock is on.
+                let hasOthers = all.contains(.function)
+                let timestamp = event.timestamp
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.heldModifiers = flags
+                    guard let hotKeys else { return }
+                    self.handleModifiers(
+                        flags, hasOtherModifiers: hasOthers, at: timestamp, action: action,
+                        hotKeys: hotKeys)
+                }
+                return event
+            }) {
+            monitors.append(monitor)
+        }
+
+        // A click anywhere ends the recording, then travels on — so a click on another recorder cancels this one and starts that one in a single click.
+        if let monitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown],
+            handler: { [weak hotKeys] event in
+                MainActor.assumeIsolated { hotKeys?.recordingAction = nil }
+                return event
+            }) {
+            monitors.append(monitor)
+        }
+
+        // Local monitors go quiet when the settings window resigns key — treat it as a cancel so the paused global hotkeys come back.
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification, object: nil, queue: .main
+        ) { [weak hotKeys] _ in
+            MainActor.assumeIsolated { hotKeys?.recordingAction = nil }
+        }
+    }
+
+    func stop() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors = []
+        if let resignObserver {
+            NotificationCenter.default.removeObserver(resignObserver)
+            self.resignObserver = nil
+        }
+        conflictReset?.cancel()
+        conflictReset = nil
+        conflict = nil
+        heldModifiers = []
+        detector.reset()
+    }
+
+    private func handleKeyDown(
+        keyCode: Int, flags: NSEvent.ModifierFlags, at timestamp: TimeInterval,
+        action: HotKeyAction, hotKeys: HotKeyManager
+    ) {
+        // A key press makes any modifier held at the moment part of a combo, not a tap.
+        _ = detector.handle(.otherInput, at: timestamp)
+
+        let bareKey = flags.isDisjoint(with: [.command, .option, .control, .shift])
+
+        if bareKey, keyCode == kVK_Escape {
+            hotKeys.recordingAction = nil
+            return
+        }
+        // Plain Delete clears the existing binding.
+        if bareKey, keyCode == kVK_Delete || keyCode == kVK_ForwardDelete {
+            hotKeys.setBinding(nil, for: action)
+            hotKeys.recordingAction = nil
+            return
+        }
+        // Not a bindable combo (e.g. a bare letter): swallow it and keep recording.
+        guard let shortcut = KeyShortcut(keyCode: keyCode, modifierFlags: flags) else { return }
+        commit(.combo(shortcut), action: action, hotKeys: hotKeys)
+    }
+
+    private func handleModifiers(
+        _ flags: NSEvent.ModifierFlags, hasOtherModifiers: Bool, at timestamp: TimeInterval,
+        action: HotKeyAction, hotKeys: HotKeyManager
+    ) {
+        // `NSEvent.timestamp` is seconds since boot — the same monotonic basis `DoubleTapMonitor` feeds the detector.
+        guard
+            let modifier = detector.handle(
+                .modifiers(Self.doubleTapModifiers(in: flags), hasOtherModifiers: hasOtherModifiers),
+                at: timestamp)
+        else { return }
+        commit(.doubleTap(modifier), action: action, hotKeys: hotKeys)
+    }
+
+    private static func doubleTapModifiers(in flags: NSEvent.ModifierFlags)
+        -> Set<DoubleTapModifier> {
+        var held: Set<DoubleTapModifier> = []
+        if flags.contains(.control) { held.insert(.control) }
+        if flags.contains(.option) { held.insert(.option) }
+        if flags.contains(.shift) { held.insert(.shift) }
+        if flags.contains(.command) { held.insert(.command) }
+        return held
+    }
+
+    private func commit(_ binding: HotKeyBinding, action: HotKeyAction, hotKeys: HotKeyManager) {
+        if let owner = hotKeys.conflictOwner(of: binding, excluding: action) {
+            flashConflict(Conflict(binding: binding, owner: owner))
+            return
+        }
+        hotKeys.setBinding(binding, for: action)
+        hotKeys.recordingAction = nil
+    }
+
+    private func flashConflict(_ rejected: Conflict) {
+        conflict = rejected
+        conflictReset?.cancel()
+        conflictReset = Task { [weak self] in
+            try? await Task.sleep(for: Self.conflictDwell)
+            guard !Task.isCancelled else { return }
+            self?.conflict = nil
+        }
+    }
+}

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -10,20 +10,28 @@ final class HotKeyManager: ObservableObject {
     var onRunSystemAction: ((SystemAction.ID) -> Void)?
     var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
 
-    /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses both engines so the shortcut being typed can't fire the binding it's replacing.
+    /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses both engines so the shortcut being typed can't fire the binding it's replacing. Setting it also starts/stops `capture`.
     @Published var recordingAction: HotKeyAction? {
         didSet {
+            guard recordingAction != oldValue else { return }
             let recording = recordingAction != nil
             center.isPaused = recording
             doubleTapMonitor.isPaused = recording
+            if let recordingAction {
+                capture.start(action: recordingAction, hotKeys: self)
+            } else {
+                capture.stop()
+            }
         }
     }
 
     let doubleTapMonitor = DoubleTapMonitor()
+    /// Live state of the open recorder, read by its callout.
+    let capture = ShortcutCaptureSession()
 
     private let center = HotKeyCenter()
     private var doubleTaps: [DoubleTapModifier: HotKeyAction] = [:]
-    // Reused: `conflictOwner` and `syncDoubleTaps` each decode once per candidate action, so a per-call coder would allocate dozens of times per edit.
+    // Reused: a scan decodes once per candidate action, so a per-call coder allocates dozens per edit.
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
     private let boundKey = "boundAppBundleIDs"
@@ -104,7 +112,7 @@ final class HotKeyManager: ObservableObject {
         case .togglePalette, .toggleClipboard, .toggleEmoji, .systemAction, .windowCommand:
             break
         }
-        // Rebuilding the map re-decodes every candidate action, so skip it unless a double-tap is actually entering or leaving — the common combo edit changes nothing in it.
+        // A rebuild re-decodes every action; only a double-tap entering or leaving changes the map.
         if previous?.doubleTapModifier != nil || binding?.doubleTapModifier != nil {
             syncDoubleTaps()
         }

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -19,7 +19,7 @@ final class HotKeyManager: ObservableObject {
         }
     }
 
-    /// Read-only to callers, who observe its `status` to surface the Accessibility grant a double-tap binding needs.
+    /// Read-only to callers, who observe `needsAccessibility` to surface the grant a double-tap binding requires.
     let doubleTapMonitor = DoubleTapMonitor()
 
     private let center = HotKeyCenter()
@@ -113,7 +113,7 @@ final class HotKeyManager: ObservableObject {
         return nil
     }
 
-    /// Every action that could currently hold a binding: the three toggles, whatever the bound-ID indices name, and the two fixed catalogs.
+    /// Every action that could currently hold a binding — the search space for conflicts and for rebuilding the double-tap map.
     private var candidateActions: [HotKeyAction] {
         var actions: [HotKeyAction] = [.togglePalette, .toggleClipboard, .toggleEmoji]
         actions += boundBundleIDs.map { .app(bundleID: $0) }

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -19,11 +19,13 @@ final class HotKeyManager: ObservableObject {
         }
     }
 
-    /// Read-only to callers, who observe `needsAccessibility` to surface the grant a double-tap binding requires.
     let doubleTapMonitor = DoubleTapMonitor()
 
     private let center = HotKeyCenter()
     private var doubleTaps: [DoubleTapModifier: HotKeyAction] = [:]
+    // Reused: `conflictOwner` and `syncDoubleTaps` each decode once per candidate action, so a per-call coder would allocate dozens of times per edit.
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
     private let boundKey = "boundAppBundleIDs"
     private let boundPaneKey = "boundPaneBundleIDs"
     private let boundCustomCommandKey = "boundCustomCommandIDs"
@@ -68,14 +70,15 @@ final class HotKeyManager: ObservableObject {
             let json = UserDefaults.standard.string(forKey: action.defaultsKey),
             let data = json.data(using: .utf8)
         else { return nil }
-        return try? JSONDecoder().decode(HotKeyBinding.self, from: data)
+        return try? decoder.decode(HotKeyBinding.self, from: data)
     }
 
     /// Persists (or clears, when `nil`) the binding, swaps the live registration, and publishes so the launcher and recorders re-render.
     func setBinding(_ binding: HotKeyBinding?, for action: HotKeyAction) {
         objectWillChange.send()
+        let previous = self.binding(for: action)
         if let binding,
-            let data = try? JSONEncoder().encode(binding),
+            let data = try? encoder.encode(binding),
             let json = String(data: data, encoding: .utf8) {
             UserDefaults.standard.set(json, forKey: action.defaultsKey)
         } else {
@@ -101,7 +104,10 @@ final class HotKeyManager: ObservableObject {
         case .togglePalette, .toggleClipboard, .toggleEmoji, .systemAction, .windowCommand:
             break
         }
-        syncDoubleTaps()
+        // Rebuilding the map re-decodes every candidate action, so skip it unless a double-tap is actually entering or leaving — the common combo edit changes nothing in it.
+        if previous?.doubleTapModifier != nil || binding?.doubleTapModifier != nil {
+            syncDoubleTaps()
+        }
     }
 
     /// The display name of whatever else `binding` is bound to (or `nil` if free), driving the recorder's "Used by …" message. Comparing whole bindings means double-taps get conflict detection on the same terms as combos — two actions can never claim the same modifier.

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Owns all global shortcut bindings: persistence, Carbon registration (via `HotKeyCenter`), conflict lookup, and dispatch.
+/// Owns all global shortcut bindings: persistence, registration with the two engines (`HotKeyCenter` for combos, `DoubleTapMonitor` for double-tapped modifiers), conflict lookup, and dispatch.
 @MainActor
 final class HotKeyManager: ObservableObject {
     var onTogglePalette: (() -> Void)?
@@ -10,32 +10,40 @@ final class HotKeyManager: ObservableObject {
     var onRunSystemAction: ((SystemAction.ID) -> Void)?
     var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
 
-    /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses Carbon so the typed combo can't fire a hotkey.
+    /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses both engines so the shortcut being typed can't fire the binding it's replacing.
     @Published var recordingAction: HotKeyAction? {
-        didSet { center.isPaused = recordingAction != nil }
+        didSet {
+            let recording = recordingAction != nil
+            center.isPaused = recording
+            doubleTapMonitor.isPaused = recording
+        }
     }
 
+    /// Read-only to callers, who observe its `status` to surface the Accessibility grant a double-tap binding needs.
+    let doubleTapMonitor = DoubleTapMonitor()
+
     private let center = HotKeyCenter()
+    private var doubleTaps: [DoubleTapModifier: HotKeyAction] = [:]
     private let boundKey = "boundAppBundleIDs"
     private let boundPaneKey = "boundPaneBundleIDs"
     private let boundCustomCommandKey = "boundCustomCommandIDs"
 
     func start(customCommandIDs: Set<UUID>) {
-        register(.togglePalette)
-        register(.toggleClipboard)
-        register(.toggleEmoji)
-        for bundleID in boundBundleIDs { register(.app(bundleID: bundleID)) }
-        for bundleID in boundPaneBundleIDs { register(.settingsPane(bundleID: bundleID)) }
         let stale = Set(boundCustomCommandIDs).subtracting(customCommandIDs)
         for id in stale {
             UserDefaults.standard.removeObject(forKey: HotKeyAction.customCommand(id: id).defaultsKey)
         }
-        let live = Set(boundCustomCommandIDs).intersection(customCommandIDs)
-        persistBoundCustomCommandIDs(live)
-        for id in live { register(.customCommand(id: id)) }
-        // Fixed catalogs, so there's no index to maintain — `register` no-ops on an unbound item.
-        for id in SystemAction.ID.allCases { register(.systemAction(id: id)) }
-        for id in WindowCommand.ID.allCases { register(.windowCommand(id: id)) }
+        persistBoundCustomCommandIDs(Set(boundCustomCommandIDs).intersection(customCommandIDs))
+
+        // `register` no-ops on an unbound item, so the fixed catalogs need no index of their own.
+        for action in candidateActions { register(action) }
+
+        doubleTapMonitor.onDoubleTap = { [weak self] modifier in
+            guard let self, let action = doubleTaps[modifier] else { return }
+            perform(action)
+        }
+        doubleTapMonitor.start()
+        syncDoubleTaps()
     }
 
     /// Bundle IDs that currently have a per-app hotkey — lets `start()` know which records to load and lets launcher rows show keycaps.
@@ -48,64 +56,72 @@ final class HotKeyManager: ObservableObject {
         UserDefaults.standard.stringArray(forKey: boundPaneKey) ?? []
     }
 
-    /// Custom-command UUIDs with a Carbon binding, indexed separately so startup can re-register them.
+    /// Custom-command UUIDs with a binding, indexed separately so startup can re-register them.
     var boundCustomCommandIDs: [UUID] {
         (UserDefaults.standard.stringArray(forKey: boundCustomCommandKey) ?? [])
             .compactMap(UUID.init(uuidString:))
     }
 
-    func shortcut(for action: HotKeyAction) -> KeyShortcut? {
+    func binding(for action: HotKeyAction) -> HotKeyBinding? {
         // The stored value is a JSON *string* (a legacy package format); anything else reads as unbound.
         guard
             let json = UserDefaults.standard.string(forKey: action.defaultsKey),
             let data = json.data(using: .utf8)
         else { return nil }
-        return try? JSONDecoder().decode(KeyShortcut.self, from: data)
+        return try? JSONDecoder().decode(HotKeyBinding.self, from: data)
     }
 
-    /// Persists (or clears, when `nil`) the binding, swaps the live Carbon registration, and publishes so the launcher and recorders re-render.
-    func setShortcut(_ shortcut: KeyShortcut?, for action: HotKeyAction) {
+    /// Persists (or clears, when `nil`) the binding, swaps the live registration, and publishes so the launcher and recorders re-render.
+    func setBinding(_ binding: HotKeyBinding?, for action: HotKeyAction) {
         objectWillChange.send()
-        if let shortcut,
-            let data = try? JSONEncoder().encode(shortcut),
+        if let binding,
+            let data = try? JSONEncoder().encode(binding),
             let json = String(data: data, encoding: .utf8) {
             UserDefaults.standard.set(json, forKey: action.defaultsKey)
-            register(action)
         } else {
             UserDefaults.standard.removeObject(forKey: action.defaultsKey)
-            center.unregister(id: action.defaultsKey)
         }
+        // Unregister unconditionally: the previous binding may have been a combo even when the new one isn't.
+        center.unregister(id: action.defaultsKey)
+        register(action)
+
         switch action {
         case .app(let bundleID):
             var set = Set(boundBundleIDs)
-            if shortcut == nil { set.remove(bundleID) } else { set.insert(bundleID) }
+            if binding == nil { set.remove(bundleID) } else { set.insert(bundleID) }
             UserDefaults.standard.set(Array(set), forKey: boundKey)
         case .settingsPane(let bundleID):
             var set = Set(boundPaneBundleIDs)
-            if shortcut == nil { set.remove(bundleID) } else { set.insert(bundleID) }
+            if binding == nil { set.remove(bundleID) } else { set.insert(bundleID) }
             UserDefaults.standard.set(Array(set), forKey: boundPaneKey)
         case .customCommand(let id):
             var set = Set(boundCustomCommandIDs)
-            if shortcut == nil { set.remove(id) } else { set.insert(id) }
+            if binding == nil { set.remove(id) } else { set.insert(id) }
             persistBoundCustomCommandIDs(set)
         case .togglePalette, .toggleClipboard, .toggleEmoji, .systemAction, .windowCommand:
             break
         }
+        syncDoubleTaps()
     }
 
-    /// The display name of whatever else `shortcut` is bound to (or `nil` if free), driving the recorder's "Used by …" message.
-    func conflictOwner(of shortcut: KeyShortcut, excluding action: HotKeyAction) -> String? {
-        var candidates: [HotKeyAction] = [.togglePalette, .toggleClipboard, .toggleEmoji]
-        candidates += boundBundleIDs.map { .app(bundleID: $0) }
-        candidates += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
-        candidates += boundCustomCommandIDs.map { .customCommand(id: $0) }
-        candidates += SystemAction.ID.allCases.map { .systemAction(id: $0) }
-        candidates += WindowCommand.ID.allCases.map { .windowCommand(id: $0) }
-        for candidate in candidates
-        where candidate != action && self.shortcut(for: candidate) == shortcut {
+    /// The display name of whatever else `binding` is bound to (or `nil` if free), driving the recorder's "Used by …" message. Comparing whole bindings means double-taps get conflict detection on the same terms as combos — two actions can never claim the same modifier.
+    func conflictOwner(of binding: HotKeyBinding, excluding action: HotKeyAction) -> String? {
+        for candidate in candidateActions
+        where candidate != action && self.binding(for: candidate) == binding {
             return displayName(of: candidate)
         }
         return nil
+    }
+
+    /// Every action that could currently hold a binding: the three toggles, whatever the bound-ID indices name, and the two fixed catalogs.
+    private var candidateActions: [HotKeyAction] {
+        var actions: [HotKeyAction] = [.togglePalette, .toggleClipboard, .toggleEmoji]
+        actions += boundBundleIDs.map { .app(bundleID: $0) }
+        actions += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
+        actions += boundCustomCommandIDs.map { .customCommand(id: $0) }
+        actions += SystemAction.ID.allCases.map { .systemAction(id: $0) }
+        actions += WindowCommand.ID.allCases.map { .windowCommand(id: $0) }
+        return actions
     }
 
     private func displayName(of action: HotKeyAction) -> String {
@@ -133,11 +149,22 @@ final class HotKeyManager: ObservableObject {
         }
     }
 
+    /// Hands a combo to Carbon; a double-tap needs no per-action registration — `syncDoubleTaps` rebuilds the whole modifier map instead.
     private func register(_ action: HotKeyAction) {
-        guard let shortcut = shortcut(for: action) else { return }
+        guard let shortcut = binding(for: action)?.shortcut else { return }
         center.register(id: action.defaultsKey, shortcut: shortcut) { [weak self] in
             self?.perform(action)
         }
+    }
+
+    /// Rebuilt wholesale rather than patched, so the map can't drift from what's on disk. Conflict detection keeps it one action per modifier.
+    private func syncDoubleTaps() {
+        doubleTaps = [:]
+        for action in candidateActions {
+            guard let modifier = binding(for: action)?.doubleTapModifier else { continue }
+            doubleTaps[modifier] = action
+        }
+        doubleTapMonitor.update(bound: Set(doubleTaps.keys))
     }
 
     private func perform(_ action: HotKeyAction) {

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -51,6 +51,11 @@ enum Theme {
         static let keyCap: CGFloat = 18
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
         static let recorderKeyCap: CGFloat = 16
+        /// Fixed width for the settings shortcut recorder, so its box can't resize as it moves through
+        /// "Record Shortcut" → held modifiers → keycaps → "Used by …". Sized to the two widest states,
+        /// which land within a point of each other: a full ⌃⌥⇧⌘+Space chip row, and the longest
+        /// built-in conflict message ("Used by Clipboard History").
+        static let shortcutRecorder: CGFloat = 160
         static let menuButton: CGFloat = 36
         static let clipboardListWidth: CGFloat = 290
         static let emojiCell: CGFloat = 56

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -51,10 +51,7 @@ enum Theme {
         static let keyCap: CGFloat = 18
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
         static let recorderKeyCap: CGFloat = 16
-        /// Fixed width for the settings shortcut recorder, so its box can't resize as it moves through
-        /// "Record Shortcut" → held modifiers → keycaps → "Used by …". Sized to the two widest states,
-        /// which land within a point of each other: a full ⌃⌥⇧⌘+Space chip row, and the longest
-        /// built-in conflict message ("Used by Clipboard History").
+        /// Fixed so the recorder can't resize as its label changes; sized to its two widest states, a ⌃⌥⇧⌘+Space chip row and "Used by Clipboard History".
         static let shortcutRecorder: CGFloat = 160
         static let menuButton: CGFloat = 36
         static let clipboardListWidth: CGFloat = 290

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -51,16 +51,16 @@ enum Theme {
         static let keyCap: CGFloat = 18
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
         static let recorderKeyCap: CGFloat = 16
-        /// Fixed so the recorder can't resize; half its old width now the callout narrates recording.
-        static let shortcutRecorder: CGFloat = 80
+        /// Fixed so the recorder can't resize as its binding changes.
+        static let shortcutRecorder: CGFloat = 120
         /// One text line in the recorder callout.
-        static let shortcutPopoverLine: CGFloat = 16
-        /// The callout's footprint, summed from the bands its body lays out so placement needs no measuring.
-        /// 132 is load-bearing: a recorder sits 72pt in from the pane edge (`xxl` + `xl` + half the field),
-        /// so anything under ~136 centres on it instead of clamping and skewing the caret.
+        static let shortcutPopoverLine: CGFloat = 14
+        /// Summed from the bands the body lays out, so placement needs no measuring. The width is
+        /// load-bearing: it must stay under twice a recorder's inset from the pane edge, or the
+        /// callout clamps and the caret stops being centred. `Tools/callout-test.swift` pins that.
         static let shortcutPopover = CGSize(
             width: 132,
-            height: Spacing.lg * 2 + heroKeyCap + Spacing.sm + shortcutPopoverLine + Spacing.sm
+            height: Spacing.sm * 2 + heroKeyCap + Spacing.sm + shortcutPopoverLine + Spacing.sm
                 + compactKeyCap + calloutCaretHeight)
         /// The callout's pointer: a triangle with a rounded tip.
         static let calloutCaretWidth: CGFloat = 15
@@ -68,7 +68,7 @@ enum Theme {
         static let calloutCaretTip: CGFloat = 2.5
         /// Keycaps: `compact` for a hint, `keyCap` as standard, `hero` where the cap is the content.
         static let compactKeyCap: CGFloat = 15
-        static let heroKeyCap: CGFloat = 26
+        static let heroKeyCap: CGFloat = 22
         static let menuButton: CGFloat = 36
         static let clipboardListWidth: CGFloat = 290
         static let emojiCell: CGFloat = 56
@@ -129,7 +129,7 @@ enum Theme {
         static let keyCap = Font.caption
         /// Pair with the matching `Size` for `KeyCapChip.Scale`.
         static let compactKeyCap = Font.caption2
-        static let heroKeyCap = Font.title3
+        static let heroKeyCap = Font.body
         static let bar = Font.callout.weight(.medium)
         static let menuRow = Font.body
         static let menuShortcut = Font.callout

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -51,8 +51,24 @@ enum Theme {
         static let keyCap: CGFloat = 18
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
         static let recorderKeyCap: CGFloat = 16
-        /// Fixed so the recorder can't resize as its label changes; sized to its two widest states, a ⌃⌥⇧⌘+Space chip row and "Used by Clipboard History".
-        static let shortcutRecorder: CGFloat = 160
+        /// Fixed so the recorder can't resize; half its old width now the callout narrates recording.
+        static let shortcutRecorder: CGFloat = 80
+        /// One text line in the recorder callout.
+        static let shortcutPopoverLine: CGFloat = 16
+        /// The callout's footprint, summed from the bands its body lays out so placement needs no measuring.
+        /// 132 is load-bearing: a recorder sits 72pt in from the pane edge (`xxl` + `xl` + half the field),
+        /// so anything under ~136 centres on it instead of clamping and skewing the caret.
+        static let shortcutPopover = CGSize(
+            width: 132,
+            height: Spacing.lg * 2 + heroKeyCap + Spacing.sm + shortcutPopoverLine + Spacing.sm
+                + compactKeyCap + calloutCaretHeight)
+        /// The callout's pointer: a triangle with a rounded tip.
+        static let calloutCaretWidth: CGFloat = 15
+        static let calloutCaretHeight: CGFloat = 7
+        static let calloutCaretTip: CGFloat = 2.5
+        /// Keycaps: `compact` for a hint, `keyCap` as standard, `hero` where the cap is the content.
+        static let compactKeyCap: CGFloat = 15
+        static let heroKeyCap: CGFloat = 26
         static let menuButton: CGFloat = 36
         static let clipboardListWidth: CGFloat = 290
         static let emojiCell: CGFloat = 56
@@ -111,6 +127,9 @@ enum Theme {
         /// The big value line on the calculator answer card (both source and target sides).
         static let calcResult = Font.title
         static let keyCap = Font.caption
+        /// Pair with the matching `Size` for `KeyCapChip.Scale`.
+        static let compactKeyCap = Font.caption2
+        static let heroKeyCap = Font.title3
         static let bar = Font.callout.weight(.medium)
         static let menuRow = Font.body
         static let menuShortcut = Font.callout
@@ -153,8 +172,32 @@ struct KeyCapChip: View {
         case filled
     }
 
+    /// Sanctioned cap sizes, so a bigger or smaller one is a named choice, not a stray frame.
+    enum Scale {
+        case compact
+        case standard
+        case hero
+
+        var side: CGFloat {
+            switch self {
+            case .compact: Theme.Size.compactKeyCap
+            case .standard: Theme.Size.keyCap
+            case .hero: Theme.Size.heroKeyCap
+            }
+        }
+
+        var font: Font {
+            switch self {
+            case .compact: Theme.Typography.compactKeyCap
+            case .standard: Theme.Typography.keyCap
+            case .hero: Theme.Typography.heroKeyCap
+            }
+        }
+    }
+
     let text: String
     var style: Style = .filled
+    var scale: Scale = .standard
 
     /// "↵" is absent from SF Pro and falls back to Lucida Grande UI, which seats it 1.1pt higher in the line box than the SF caps — visibly top-heavy in a chip. Nudging via `offset` is render-only, so the chip keeps the same footprint as every other cap.
     private static let returnGlyphDrop: CGFloat = 1.1
@@ -162,11 +205,11 @@ struct KeyCapChip: View {
     var body: some View {
         let shape = RoundedRectangle(cornerRadius: Theme.Radius.keyCap, style: .continuous)
         Text(text)
-            .font(Theme.Typography.keyCap)
+            .font(scale.font)
             .foregroundStyle(Theme.Colors.textSecondary)
             .offset(y: text == "↵" ? Self.returnGlyphDrop : 0)
             .padding(.horizontal, Theme.Spacing.xs)
-            .frame(minWidth: Theme.Size.keyCap, minHeight: Theme.Size.keyCap)
+            .frame(minWidth: scale.side, minHeight: scale.side)
             .background {
                 switch style {
                 case .filled: shape.fill(Theme.Colors.controlSurface)

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -162,10 +162,8 @@ private struct AppRow: View {
 
     /// Keycaps for this entry's hotkey, or `nil` if none is bound.
     private var shortcutCaps: [String]? {
-        guard let action = app.hotKeyAction,
-            let shortcut = hotKeys.shortcut(for: action)
-        else { return nil }
-        return shortcut.keycaps
+        guard let action = app.hotKeyAction else { return nil }
+        return hotKeys.binding(for: action)?.keycaps
     }
 
     var body: some View {

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -108,7 +108,7 @@ struct OnboardingView: View {
     }
 
     private var readyMessage: String {
-        if let caps = hotKeys.shortcut(for: .togglePalette)?.keycaps {
+        if let caps = hotKeys.binding(for: .togglePalette)?.keycaps {
             return "Press \(caps.joined()) anytime to start using Tinycast."
         }
         return "Tinycast is ready. Set a shortcut in Settings to summon it."

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -33,6 +33,8 @@ struct OnboardingView: View {
         )
         // Extend under the transparent titlebar (top padding clears the traffic lights) so the window height equals the fixed content height.
         .ignoresSafeArea()
+        // Onboarding's shortcut step has a recorder too, and it isn't inside a `SettingsPane`.
+        .shortcutRecorderPopoverHost()
         .animation(.easeInOut(duration: 0.2), value: step)
         .onAppear { accessibilityTrusted = Permissions.isAccessibilityTrusted() }
         .onReceive(refreshTimer) { _ in

--- a/Tinycast/Features/Settings/SettingsComponents.swift
+++ b/Tinycast/Features/Settings/SettingsComponents.swift
@@ -23,6 +23,8 @@ struct SettingsPane<Content: View>: View {
             .overlayScroller()
         }
         .ignoresSafeArea(edges: .top)
+        // Outside the ScrollView, so an open recorder's callout draws over the pane instead of being clipped by it.
+        .shortcutRecorderPopoverHost()
     }
 }
 

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -2,13 +2,15 @@ import AppKit
 import Carbon.HIToolbox
 import SwiftUI
 
-/// Shortcut recorder that's deliberately *not* a focusable control: the active recorder is just `HotKeyManager.recordingAction`, so clicking one is a plain state flip with no first-responder handoff, and `CaptureSession` captures keystrokes via a local monitor while it's active.
+/// Shortcut recorder that's deliberately *not* a focusable control: the active recorder is just `HotKeyManager.recordingAction`, so clicking one is a plain state flip with no first-responder handoff, and `CaptureSession` captures keystrokes via a local monitor while it's active. It records both binding kinds — type a combo, or double-tap ⌘ / ⌃ / ⌥ / ⇧.
 struct ShortcutRecorder: View {
     let action: HotKeyAction
 
     @ObservedObject private var hotKeys: HotKeyManager = AppCore.shared.hotKeys
     /// Observed so bound chips re-render when the Hyper Key display settings (✦ collapse, Include Shift) change how `keycaps` renders.
     @ObservedObject private var settings = AppCore.shared.settings
+    /// Observed so a bound double-tap surfaces its Accessibility warning the moment the grant changes.
+    @ObservedObject private var doubleTapMonitor = AppCore.shared.hotKeys.doubleTapMonitor
     @StateObject private var session = CaptureSession()
     @State private var hovered = false
 
@@ -50,8 +52,8 @@ struct ShortcutRecorder: View {
     private var content: some View {
         if isRecording {
             recordingLabel
-        } else if let shortcut = hotKeys.shortcut(for: action) {
-            boundLabel(shortcut)
+        } else if let binding = hotKeys.binding(for: action) {
+            boundLabel(binding)
         } else {
             Text("Record Shortcut")
                 .font(Theme.Typography.keyCap)
@@ -76,9 +78,22 @@ struct ShortcutRecorder: View {
         .font(Theme.Typography.keyCap)
     }
 
-    private func boundLabel(_ shortcut: KeyShortcut) -> some View {
+    /// A double-tap binding is dead without the Accessibility grant (the tap can't be created), so say so where the binding is.
+    private func needsAccessibility(_ binding: HotKeyBinding) -> Bool {
+        binding.doubleTapModifier != nil && doubleTapMonitor.status == .needsAccessibility
+    }
+
+    private func boundLabel(_ binding: HotKeyBinding) -> some View {
         HStack(spacing: Theme.Spacing.xs) {
-            ForEach(Array(shortcut.keycaps.enumerated()), id: \.offset) { _, cap in
+            if needsAccessibility(binding) {
+                Button { Permissions.openAccessibilitySettings() } label: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+                .buttonStyle(.plain)
+                .help("Double-tap shortcuts need Accessibility access. Click to grant it.")
+            }
+            ForEach(Array(binding.keycaps.enumerated()), id: \.offset) { _, cap in
                 Text(cap)
                     .font(Theme.Typography.keyCap)
                     .foregroundStyle(.secondary)
@@ -95,7 +110,7 @@ struct ShortcutRecorder: View {
             }
             // Constant-width slot so the clear button doesn't shift the caps on hover.
             Button {
-                hotKeys.setShortcut(nil, for: action)
+                hotKeys.setBinding(nil, for: action)
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 11))
@@ -119,21 +134,25 @@ private final class CaptureSession: ObservableObject {
     private var monitors: [Any] = []
     private var resignObserver: NSObjectProtocol?
     private var conflictReset: Task<Void, Never>?
+    /// The same recognizer the global monitor uses, driven here by local monitors — recording a double-tap therefore needs no event tap and no permission.
+    private var detector = DoubleTapDetector()
 
     func start(action: HotKeyAction, hotKeys: HotKeyManager) {
         stop()
         heldModifiers = NSEvent.modifierFlags.intersection([.command, .option, .control, .shift])
 
-        // The handlers run on the main thread but AppKit predates actor annotations, hence assumeIsolated; only Sendable event pieces (key code, flags) cross in.
+        // The handlers run on the main thread but AppKit predates actor annotations, hence assumeIsolated; only Sendable event pieces (key code, flags, timestamp) cross in.
         if let monitor = NSEvent.addLocalMonitorForEvents(
             matching: .keyDown,
             handler: { [weak self, weak hotKeys] event in
                 let keyCode = Int(event.keyCode)
                 let flags = event.modifierFlags
+                let timestamp = event.timestamp
                 MainActor.assumeIsolated {
                     guard let self, let hotKeys else { return }
                     self.handleKeyDown(
-                        keyCode: keyCode, flags: flags, action: action, hotKeys: hotKeys)
+                        keyCode: keyCode, flags: flags, at: timestamp, action: action,
+                        hotKeys: hotKeys)
                 }
                 return nil  // always consume: no beeps, no leaking keys to the window
             }) {
@@ -142,9 +161,19 @@ private final class CaptureSession: ObservableObject {
 
         if let monitor = NSEvent.addLocalMonitorForEvents(
             matching: .flagsChanged,
-            handler: { [weak self] event in
-                let flags = event.modifierFlags.intersection([.command, .option, .control, .shift])
-                MainActor.assumeIsolated { self?.heldModifiers = flags }
+            handler: { [weak self, weak hotKeys] event in
+                let all = event.modifierFlags
+                let flags = all.intersection([.command, .option, .control, .shift])
+                let hasOthers = !all.isDisjoint(with: [.function, .capsLock])
+                let timestamp = event.timestamp
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.heldModifiers = flags
+                    guard let hotKeys else { return }
+                    self.handleModifiers(
+                        flags, hasOtherModifiers: hasOthers, at: timestamp, action: action,
+                        hotKeys: hotKeys)
+                }
                 return event
             }) {
             monitors.append(monitor)
@@ -179,11 +208,16 @@ private final class CaptureSession: ObservableObject {
         conflictReset = nil
         conflictOwner = nil
         heldModifiers = []
+        detector.reset()
     }
 
     private func handleKeyDown(
-        keyCode: Int, flags: NSEvent.ModifierFlags, action: HotKeyAction, hotKeys: HotKeyManager
+        keyCode: Int, flags: NSEvent.ModifierFlags, at timestamp: TimeInterval,
+        action: HotKeyAction, hotKeys: HotKeyManager
     ) {
+        // A key press makes any modifier held at the moment part of a combo, not a tap.
+        _ = detector.handle(.otherInput, at: timestamp)
+
         let bareKey = flags.isDisjoint(with: [.command, .option, .control, .shift])
 
         if bareKey, keyCode == kVK_Escape {
@@ -192,18 +226,44 @@ private final class CaptureSession: ObservableObject {
         }
         // Plain Delete clears the existing binding.
         if bareKey, keyCode == kVK_Delete || keyCode == kVK_ForwardDelete {
-            hotKeys.setShortcut(nil, for: action)
+            hotKeys.setBinding(nil, for: action)
             hotKeys.recordingAction = nil
             return
         }
         // Not a bindable combo (e.g. a bare letter): swallow it and keep recording.
         guard let shortcut = KeyShortcut(keyCode: keyCode, modifierFlags: flags) else { return }
+        commit(.combo(shortcut), action: action, hotKeys: hotKeys)
+    }
 
-        if let owner = hotKeys.conflictOwner(of: shortcut, excluding: action) {
+    private func handleModifiers(
+        _ flags: NSEvent.ModifierFlags, hasOtherModifiers: Bool, at timestamp: TimeInterval,
+        action: HotKeyAction, hotKeys: HotKeyManager
+    ) {
+        // `NSEvent.timestamp` is seconds since boot — the same monotonic basis `DoubleTapMonitor` feeds the detector.
+        guard
+            let modifier = detector.handle(
+                .modifiers(Self.doubleTapModifiers(in: flags), hasOtherModifiers: hasOtherModifiers),
+                at: timestamp)
+        else { return }
+        commit(.doubleTap(modifier), action: action, hotKeys: hotKeys)
+    }
+
+    private static func doubleTapModifiers(in flags: NSEvent.ModifierFlags)
+        -> Set<DoubleTapModifier> {
+        var held: Set<DoubleTapModifier> = []
+        if flags.contains(.control) { held.insert(.control) }
+        if flags.contains(.option) { held.insert(.option) }
+        if flags.contains(.shift) { held.insert(.shift) }
+        if flags.contains(.command) { held.insert(.command) }
+        return held
+    }
+
+    private func commit(_ binding: HotKeyBinding, action: HotKeyAction, hotKeys: HotKeyManager) {
+        if let owner = hotKeys.conflictOwner(of: binding, excluding: action) {
             flashConflict(owner)
             return
         }
-        hotKeys.setShortcut(shortcut, for: action)
+        hotKeys.setBinding(binding, for: action)
         hotKeys.recordingAction = nil
     }
 

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -52,14 +52,16 @@ struct ShortcutRecorder: View {
         HStack(spacing: Theme.Spacing.xs) {
             // A double-tap binding is dead without the grant, so say so where the binding is.
             if binding.doubleTapModifier != nil, doubleTapMonitor.needsAccessibility {
-                Button { Permissions.openAccessibilitySettings() } label: {
+                Button {
+                    Permissions.openAccessibilitySettings()
+                } label: {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundStyle(.orange)
                 }
                 .buttonStyle(.plain)
                 .help("Double-tap shortcuts need Accessibility access. Click to grant it.")
             }
-            ForEach(Array(binding.compactKeycaps.enumerated()), id: \.offset) { _, cap in
+            ForEach(Array(binding.keycaps.enumerated()), id: \.offset) { _, cap in
                 Text(cap)
                     .font(Theme.Typography.keyCap)
                     .foregroundStyle(.secondary)

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -163,7 +163,8 @@ private final class CaptureSession: ObservableObject {
             handler: { [weak self, weak hotKeys] event in
                 let all = event.modifierFlags
                 let flags = all.intersection([.command, .option, .control, .shift])
-                let hasOthers = !all.isDisjoint(with: [.function, .capsLock])
+                // `.function` only: `.capsLock` is the latch state, and testing it would make a recorder refuse every double-tap while Caps Lock is on.
+                let hasOthers = all.contains(.function)
                 let timestamp = event.timestamp
                 MainActor.assumeIsolated {
                     guard let self else { return }

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -19,7 +19,7 @@ struct ShortcutRecorder: View {
     var body: some View {
         content
             .padding(.horizontal, Theme.Spacing.lg)
-            .frame(height: 24)
+            .frame(width: Theme.Size.shortcutRecorder, height: 24)
             .background(
                 RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
                     .fill(Theme.Colors.cardFill)
@@ -64,7 +64,10 @@ struct ShortcutRecorder: View {
     private var recordingLabel: some View {
         Group {
             if let owner = session.conflictOwner {
+                // A third-party app name can outrun the fixed width; truncating beats resizing the box.
                 Text("Used by \(owner)")
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                     .foregroundStyle(.orange)
             } else if !session.heldModifiers.isEmpty {
                 // Collapsed so holding the Hyper key previews as "✦" while recording.
@@ -78,14 +81,10 @@ struct ShortcutRecorder: View {
         .font(Theme.Typography.keyCap)
     }
 
-    /// A double-tap binding is dead without the Accessibility grant (the tap can't be created), so say so where the binding is.
-    private func needsAccessibility(_ binding: HotKeyBinding) -> Bool {
-        binding.doubleTapModifier != nil && doubleTapMonitor.status == .needsAccessibility
-    }
-
     private func boundLabel(_ binding: HotKeyBinding) -> some View {
         HStack(spacing: Theme.Spacing.xs) {
-            if needsAccessibility(binding) {
+            // A double-tap binding is dead without the grant, so say so where the binding is.
+            if binding.doubleTapModifier != nil, doubleTapMonitor.needsAccessibility {
                 Button { Permissions.openAccessibilitySettings() } label: {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundStyle(.orange)

--- a/Tinycast/Features/Settings/ShortcutRecorder.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorder.swift
@@ -1,8 +1,6 @@
-import AppKit
-import Carbon.HIToolbox
 import SwiftUI
 
-/// Shortcut recorder that's deliberately *not* a focusable control: the active recorder is just `HotKeyManager.recordingAction`, so clicking one is a plain state flip with no first-responder handoff, and `CaptureSession` captures keystrokes via a local monitor while it's active. It records both binding kinds — type a combo, or double-tap ⌘ / ⌃ / ⌥ / ⇧.
+/// Deliberately not a focusable control: the open recorder is just `HotKeyManager.recordingAction`, and setting it starts the capture. The field only shows the binding — recording is narrated by `ShortcutRecorderPopover`, which is why it fits in half the width.
 struct ShortcutRecorder: View {
     let action: HotKeyAction
 
@@ -11,74 +9,43 @@ struct ShortcutRecorder: View {
     @ObservedObject private var settings = AppCore.shared.settings
     /// Observed so a bound double-tap surfaces its Accessibility warning the moment the grant changes.
     @ObservedObject private var doubleTapMonitor = AppCore.shared.hotKeys.doubleTapMonitor
-    @StateObject private var session = CaptureSession()
     @State private var hovered = false
 
     private var isRecording: Bool { hotKeys.recordingAction == action }
 
     var body: some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
         content
-            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.horizontal, Theme.Spacing.sm)
             .frame(width: Theme.Size.shortcutRecorder, height: 24)
-            .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
-                    .fill(Theme.Colors.cardFill)
-            )
+            .background(shape.fill(Theme.Colors.cardFill))
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
-                    .strokeBorder(
-                        isRecording ? Color.accentColor : Theme.Colors.cardStroke,
-                        lineWidth: 1)
+                shape.strokeBorder(
+                    isRecording ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1)
             )
-            .contentShape(RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous))
+            // An over-long binding truncates rather than resizing the field.
+            .clipShape(shape)
+            .contentShape(shape)
             .onTapGesture { hotKeys.recordingAction = action }
             .onHover { hovered = $0 }
-            .onChange(of: isRecording) { _, recording in
-                if recording {
-                    session.start(action: action, hotKeys: hotKeys)
-                } else {
-                    session.stop()
-                }
+            // Hand the callout this field's bounds while it's the open one.
+            .anchorPreference(key: ShortcutRecorderAnchorKey.self, value: .bounds) {
+                isRecording ? $0 : nil
             }
-            // Rows in the app-hotkeys list are lazy: a recording row scrolled out of existence must release its monitors and unpause the global hotkeys.
-            .onDisappear {
-                if isRecording { hotKeys.recordingAction = nil }
-                session.stop()
-            }
+            // Rows are lazy: a recording row scrolled away must release the session.
+            .onDisappear { if isRecording { hotKeys.recordingAction = nil } }
             .animation(.easeOut(duration: 0.12), value: hovered)
     }
 
     @ViewBuilder
     private var content: some View {
-        if isRecording {
-            recordingLabel
-        } else if let binding = hotKeys.binding(for: action) {
+        if let binding = hotKeys.binding(for: action) {
             boundLabel(binding)
         } else {
-            Text("Record Shortcut")
+            Text(isRecording ? "Listening…" : "Record")
                 .font(Theme.Typography.keyCap)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(isRecording ? Theme.Colors.textSecondary : .secondary)
         }
-    }
-
-    private var recordingLabel: some View {
-        Group {
-            if let owner = session.conflictOwner {
-                // A third-party app name can outrun the fixed width; truncating beats resizing the box.
-                Text("Used by \(owner)")
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .foregroundStyle(.orange)
-            } else if !session.heldModifiers.isEmpty {
-                // Collapsed so holding the Hyper key previews as "✦" while recording.
-                Text(KeyShortcut.collapsedModifierSymbols(from: session.heldModifiers).joined())
-                    .foregroundStyle(.primary)
-            } else {
-                Text("Type shortcut…")
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .font(Theme.Typography.keyCap)
     }
 
     private func boundLabel(_ binding: HotKeyBinding) -> some View {
@@ -92,7 +59,7 @@ struct ShortcutRecorder: View {
                 .buttonStyle(.plain)
                 .help("Double-tap shortcuts need Accessibility access. Click to grant it.")
             }
-            ForEach(Array(binding.keycaps.enumerated()), id: \.offset) { _, cap in
+            ForEach(Array(binding.compactKeycaps.enumerated()), id: \.offset) { _, cap in
                 Text(cap)
                     .font(Theme.Typography.keyCap)
                     .foregroundStyle(.secondary)
@@ -107,7 +74,10 @@ struct ShortcutRecorder: View {
                         .fill(Color.primary.opacity(0.08))
                     )
             }
-            // Constant-width slot so the clear button doesn't shift the caps on hover.
+        }
+        .frame(maxWidth: .infinity)
+        // Overlaid, not a row member, so it costs the caps no width.
+        .overlay(alignment: .trailing) {
             Button {
                 hotKeys.setBinding(nil, for: action)
             } label: {
@@ -118,162 +88,6 @@ struct ShortcutRecorder: View {
             .buttonStyle(.plain)
             .opacity(hovered ? 1 : 0)
             .allowsHitTesting(hovered)
-        }
-    }
-}
-
-/// Owns the local event monitors for the one active recording, live only between `start()` and `stop()` and entirely on the main actor.
-@MainActor
-private final class CaptureSession: ObservableObject {
-    /// Modifiers currently held, for the live "⌃⌥…" preview while recording.
-    @Published var heldModifiers: NSEvent.ModifierFlags = []
-    /// Owner of a just-typed conflicting combo; shown for a moment, then recording resumes.
-    @Published var conflictOwner: String?
-
-    private var monitors: [Any] = []
-    private var resignObserver: NSObjectProtocol?
-    private var conflictReset: Task<Void, Never>?
-    /// The same recognizer the global monitor uses, driven here by local monitors — recording a double-tap therefore needs no event tap and no permission.
-    private var detector = DoubleTapDetector()
-
-    func start(action: HotKeyAction, hotKeys: HotKeyManager) {
-        stop()
-        heldModifiers = NSEvent.modifierFlags.intersection([.command, .option, .control, .shift])
-
-        // The handlers run on the main thread but AppKit predates actor annotations, hence assumeIsolated; only Sendable event pieces (key code, flags, timestamp) cross in.
-        if let monitor = NSEvent.addLocalMonitorForEvents(
-            matching: .keyDown,
-            handler: { [weak self, weak hotKeys] event in
-                let keyCode = Int(event.keyCode)
-                let flags = event.modifierFlags
-                let timestamp = event.timestamp
-                MainActor.assumeIsolated {
-                    guard let self, let hotKeys else { return }
-                    self.handleKeyDown(
-                        keyCode: keyCode, flags: flags, at: timestamp, action: action,
-                        hotKeys: hotKeys)
-                }
-                return nil  // always consume: no beeps, no leaking keys to the window
-            }) {
-            monitors.append(monitor)
-        }
-
-        if let monitor = NSEvent.addLocalMonitorForEvents(
-            matching: .flagsChanged,
-            handler: { [weak self, weak hotKeys] event in
-                let all = event.modifierFlags
-                let flags = all.intersection([.command, .option, .control, .shift])
-                // `.function` only: `.capsLock` is the latch state, and testing it would make a recorder refuse every double-tap while Caps Lock is on.
-                let hasOthers = all.contains(.function)
-                let timestamp = event.timestamp
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    self.heldModifiers = flags
-                    guard let hotKeys else { return }
-                    self.handleModifiers(
-                        flags, hasOtherModifiers: hasOthers, at: timestamp, action: action,
-                        hotKeys: hotKeys)
-                }
-                return event
-            }) {
-            monitors.append(monitor)
-        }
-
-        // A click anywhere ends the recording, then travels on — so a click on another recorder cancels this one and starts that one in a single click.
-        if let monitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.leftMouseDown, .rightMouseDown],
-            handler: { [weak hotKeys] event in
-                MainActor.assumeIsolated { hotKeys?.recordingAction = nil }
-                return event
-            }) {
-            monitors.append(monitor)
-        }
-
-        // Local monitors go quiet when the settings window resigns key — treat it as a cancel so the paused global hotkeys come back.
-        resignObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didResignKeyNotification, object: nil, queue: .main
-        ) { [weak hotKeys] _ in
-            MainActor.assumeIsolated { hotKeys?.recordingAction = nil }
-        }
-    }
-
-    func stop() {
-        for monitor in monitors { NSEvent.removeMonitor(monitor) }
-        monitors = []
-        if let resignObserver {
-            NotificationCenter.default.removeObserver(resignObserver)
-            self.resignObserver = nil
-        }
-        conflictReset?.cancel()
-        conflictReset = nil
-        conflictOwner = nil
-        heldModifiers = []
-        detector.reset()
-    }
-
-    private func handleKeyDown(
-        keyCode: Int, flags: NSEvent.ModifierFlags, at timestamp: TimeInterval,
-        action: HotKeyAction, hotKeys: HotKeyManager
-    ) {
-        // A key press makes any modifier held at the moment part of a combo, not a tap.
-        _ = detector.handle(.otherInput, at: timestamp)
-
-        let bareKey = flags.isDisjoint(with: [.command, .option, .control, .shift])
-
-        if bareKey, keyCode == kVK_Escape {
-            hotKeys.recordingAction = nil
-            return
-        }
-        // Plain Delete clears the existing binding.
-        if bareKey, keyCode == kVK_Delete || keyCode == kVK_ForwardDelete {
-            hotKeys.setBinding(nil, for: action)
-            hotKeys.recordingAction = nil
-            return
-        }
-        // Not a bindable combo (e.g. a bare letter): swallow it and keep recording.
-        guard let shortcut = KeyShortcut(keyCode: keyCode, modifierFlags: flags) else { return }
-        commit(.combo(shortcut), action: action, hotKeys: hotKeys)
-    }
-
-    private func handleModifiers(
-        _ flags: NSEvent.ModifierFlags, hasOtherModifiers: Bool, at timestamp: TimeInterval,
-        action: HotKeyAction, hotKeys: HotKeyManager
-    ) {
-        // `NSEvent.timestamp` is seconds since boot — the same monotonic basis `DoubleTapMonitor` feeds the detector.
-        guard
-            let modifier = detector.handle(
-                .modifiers(Self.doubleTapModifiers(in: flags), hasOtherModifiers: hasOtherModifiers),
-                at: timestamp)
-        else { return }
-        commit(.doubleTap(modifier), action: action, hotKeys: hotKeys)
-    }
-
-    private static func doubleTapModifiers(in flags: NSEvent.ModifierFlags)
-        -> Set<DoubleTapModifier> {
-        var held: Set<DoubleTapModifier> = []
-        if flags.contains(.control) { held.insert(.control) }
-        if flags.contains(.option) { held.insert(.option) }
-        if flags.contains(.shift) { held.insert(.shift) }
-        if flags.contains(.command) { held.insert(.command) }
-        return held
-    }
-
-    private func commit(_ binding: HotKeyBinding, action: HotKeyAction, hotKeys: HotKeyManager) {
-        if let owner = hotKeys.conflictOwner(of: binding, excluding: action) {
-            flashConflict(owner)
-            return
-        }
-        hotKeys.setBinding(binding, for: action)
-        hotKeys.recordingAction = nil
-    }
-
-    private func flashConflict(_ owner: String) {
-        conflictOwner = owner
-        conflictReset?.cancel()
-        conflictReset = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(1.5))
-            guard !Task.isCancelled else { return }
-            self?.conflictOwner = nil
         }
     }
 }

--- a/Tinycast/Features/Settings/ShortcutRecorderPopover.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorderPopover.swift
@@ -42,9 +42,10 @@ struct ShortcutRecorderPopover: View {
 
             KeyCapChip(text: "esc", scale: .compact)
                 .opacity(0.7)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.sm)
         .padding(placement.caretEdge == .top ? .top : .bottom, Theme.Size.calloutCaretHeight)
         .frame(
             width: Theme.Size.shortcutPopover.width, height: Theme.Size.shortcutPopover.height)
@@ -59,8 +60,8 @@ struct ShortcutRecorderPopover: View {
         }
         let held = KeyShortcut.collapsedModifierSymbols(from: capture.heldModifiers)
         guard held.isEmpty else { return State(caps: held, label: "Add a key") }
-        let glyph = DoubleTapModifier.option.glyph
-        return State(caps: [glyph, glyph], label: "Double Tap", isExample: true)
+        return State(
+            caps: [DoubleTapModifier.option.glyph, "A"], label: "Type a shortcut", isExample: true)
     }
 }
 

--- a/Tinycast/Features/Settings/ShortcutRecorderPopover.swift
+++ b/Tinycast/Features/Settings/ShortcutRecorderPopover.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Bounds of the open recorder, so an ancestor outside the pane's `ScrollView` can draw the callout.
+struct ShortcutRecorderAnchorKey: PreferenceKey {
+    static let defaultValue: Anchor<CGRect>? = nil
+
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = value ?? nextValue()
+    }
+}
+
+/// The recording callout above the recorder field: what to press, what's held, or what's in the way.
+struct ShortcutRecorderPopover: View {
+    let placement: CalloutPlacement
+
+    @ObservedObject private var capture = AppCore.shared.hotKeys.capture
+
+    private struct State {
+        let caps: [String]
+        let label: String
+        var isExample = false
+        var tint: Color?
+    }
+
+    var body: some View {
+        let state = self.state
+        VStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
+                ForEach(Array(state.caps.enumerated()), id: \.offset) { _, cap in
+                    KeyCapChip(text: cap, scale: .hero)
+                }
+            }
+            .frame(height: Theme.Size.heroKeyCap)
+            .opacity(state.isExample ? 0.5 : 1)
+
+            Text(state.label)
+                .font(Theme.Typography.compactKeyCap)
+                .foregroundStyle(state.tint ?? Theme.Colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(height: Theme.Size.shortcutPopoverLine)
+
+            KeyCapChip(text: "esc", scale: .compact)
+                .opacity(0.7)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.lg)
+        .padding(placement.caretEdge == .top ? .top : .bottom, Theme.Size.calloutCaretHeight)
+        .frame(
+            width: Theme.Size.shortcutPopover.width, height: Theme.Size.shortcutPopover.height)
+        // Stock glass owns its elevation, as in `PopoverMenu` — no hand-tuned shadow.
+        .glassEffect(
+            .regular, in: CalloutShape(caretEdge: placement.caretEdge, caretX: placement.caretX))
+    }
+
+    private var state: State {
+        if let conflict = capture.conflict {
+            return State(caps: conflict.binding.keycaps, label: conflict.owner, tint: .orange)
+        }
+        let held = KeyShortcut.collapsedModifierSymbols(from: capture.heldModifiers)
+        guard held.isEmpty else { return State(caps: held, label: "Add a key") }
+        let glyph = DoubleTapModifier.option.glyph
+        return State(caps: [glyph, glyph], label: "Double Tap", isExample: true)
+    }
+}
+
+// MARK: - Host
+
+/// Draws the open recorder's callout over the pane, where the pane's `ScrollView` can't clip it.
+private struct ShortcutRecorderPopoverHost: ViewModifier {
+    @ObservedObject private var hotKeys = AppCore.shared.hotKeys
+
+    func body(content: Content) -> some View {
+        content.overlayPreferenceValue(ShortcutRecorderAnchorKey.self) { anchor in
+            GeometryReader { proxy in
+                if let anchor, hotKeys.recordingAction != nil {
+                    callout(field: proxy[anchor], in: proxy.size)
+                }
+            }
+            // Informational: clicks fall through to the capture session's mouse monitor, which closes it.
+            .allowsHitTesting(false)
+            .animation(.easeOut(duration: 0.14), value: hotKeys.recordingAction)
+        }
+    }
+
+    private func callout(field: CGRect, in size: CGSize) -> some View {
+        let placement = CalloutPlacement.resolve(
+            field: field, container: size, size: Theme.Size.shortcutPopover,
+            gap: Theme.Spacing.sm, inset: Theme.Spacing.xs,
+            cornerRadius: Theme.Radius.menuPanel, caretWidth: Theme.Size.calloutCaretWidth)
+
+        return ShortcutRecorderPopover(placement: placement)
+            .position(placement.center)
+            .transition(
+                .opacity.combined(
+                    with: .scale(0.96, anchor: placement.caretEdge == .bottom ? .bottom : .top)))
+    }
+}
+
+extension View {
+    /// Hosts the shortcut recorder's callout for every recorder inside this view.
+    func shortcutRecorderPopoverHost() -> some View {
+        modifier(ShortcutRecorderPopoverHost())
+    }
+}

--- a/Tools/callout-test.swift
+++ b/Tools/callout-test.swift
@@ -1,0 +1,188 @@
+import CoreGraphics
+import Foundation
+
+/// Drives `CalloutPlacement` against the real `Theme` (compiled in, not copied) so a retuned token
+/// can't leave these assertions describing a layout that no longer exists.
+@main
+@MainActor
+struct CalloutPlacementTests {
+    static var failures = 0
+    static var passes = 0
+
+    // Exactly what `ShortcutRecorderPopoverHost` passes.
+    static let size = Theme.Size.shortcutPopover
+    static let gap = Theme.Spacing.sm
+    static let inset = Theme.Spacing.xs
+    static let cornerRadius = Theme.Radius.menuPanel
+    static let caretWidth = Theme.Size.calloutCaretWidth
+
+    /// A recorder's centre, measured in from the pane's trailing edge: SettingsPane's `xxl`
+    /// padding, SettingsRow's `xl` padding, then half the field.
+    static let fieldInsetFromPaneEdge =
+        Theme.Spacing.xxl + Theme.Spacing.xl + Theme.Size.shortcutRecorder / 2
+    /// The nearest the tip may sit to an edge before it would grow out of a corner arc.
+    static var caretLimit: CGFloat { cornerRadius + caretWidth / 2 }
+
+    static func resolve(field: CGRect, container: CGSize) -> CalloutPlacement {
+        CalloutPlacement.resolve(
+            field: field, container: container, size: size, gap: gap, inset: inset,
+            cornerRadius: cornerRadius, caretWidth: caretWidth)
+    }
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func expect(_ actual: CGFloat, _ expected: CGFloat, _ message: String) {
+        expect(abs(actual - expected) < 0.001, "\(message) — got \(actual), want \(expected)")
+    }
+
+    static func main() {
+        centredOnARealRow()
+        flipping()
+        horizontalClamping()
+        caretTracking()
+        degenerateContainers()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - The case that actually ships
+
+    /// The callout must centre on the recorder, caret dead centre — which only holds while it stays
+    /// narrow enough to fit beside a field that sits `fieldInsetFromPaneEdge` in. Widen
+    /// `shortcutPopover` past that and the clamp kicks in and skews the caret, so pin it here.
+    static func centredOnARealRow() {
+        for paneWidth in [Theme.Size.settingsSidebar + 320, 720, 1100] as [CGFloat] {
+            let field = CGRect(
+                x: paneWidth - fieldInsetFromPaneEdge - Theme.Size.shortcutRecorder / 2,
+                y: 400, width: Theme.Size.shortcutRecorder, height: 24)
+            let placement = resolve(field: field, container: CGSize(width: paneWidth, height: 800))
+
+            expect(
+                placement.center.x, field.midX,
+                "pane \(Int(paneWidth)): the callout centres on the recorder")
+            expect(
+                placement.caretX, size.width / 2,
+                "pane \(Int(paneWidth)): the caret sits dead centre")
+        }
+
+        expect(
+            size.width / 2 + inset <= fieldInsetFromPaneEdge,
+            "the callout is narrow enough to centre on a trailing-edge recorder — widen it and the caret skews")
+    }
+
+    // MARK: - Above vs below
+
+    static func flipping() {
+        let container = CGSize(width: 600, height: 800)
+        let roomy = CGRect(x: 400, y: 400, width: 80, height: 24)
+        let above = resolve(field: roomy, container: container)
+        expect(above.caretEdge == .bottom, "a field with room above gets the callout above it")
+        expect(
+            above.center.y, roomy.minY - gap - size.height / 2,
+            "the callout's bottom edge sits one gap above the field")
+
+        // The callout's bottom edge must clear the field, never overlap it.
+        expect(
+            above.center.y + size.height / 2 <= roomy.minY,
+            "the callout never overlaps the field it points at")
+
+        let tight = CGRect(x: 400, y: 40, width: 80, height: 24)
+        let below = resolve(field: tight, container: container)
+        expect(below.caretEdge == .top, "a field near the pane's top flips the callout below it")
+        expect(
+            below.center.y, tight.maxY + gap + size.height / 2,
+            "the flipped callout's top edge sits one gap below the field")
+
+        // Exactly enough room is still room: the boundary case must not flip.
+        let exact = CGRect(x: 400, y: size.height + gap, width: 80, height: 24)
+        expect(
+            resolve(field: exact, container: container).caretEdge == .bottom,
+            "a field with exactly enough room above does not flip")
+        let onePointShort = CGRect(x: 400, y: size.height + gap - 1, width: 80, height: 24)
+        expect(
+            resolve(field: onePointShort, container: container).caretEdge == .top,
+            "one point short of the room it needs does flip")
+    }
+
+    // MARK: - Staying inside the pane
+
+    static func horizontalClamping() {
+        let container = CGSize(width: 600, height: 800)
+
+        let centered = resolve(
+            field: CGRect(x: 260, y: 400, width: 80, height: 24), container: container)
+        expect(centered.center.x, 300, "a field mid-pane centres the callout on it")
+
+        // A recorder sits at the trailing edge of a settings row, which is the case that actually happens.
+        let trailing = resolve(
+            field: CGRect(x: 500, y: 400, width: 80, height: 24), container: container)
+        expect(
+            trailing.center.x, container.width - size.width / 2 - inset,
+            "a trailing-edge field slides the callout back inside the pane")
+        expect(
+            trailing.center.x + size.width / 2 <= container.width - inset + 0.001,
+            "the clamped callout keeps its inset from the trailing edge")
+
+        let leading = resolve(
+            field: CGRect(x: 0, y: 400, width: 80, height: 24), container: container)
+        expect(leading.center.x, size.width / 2 + inset, "a leading-edge field clamps the same way")
+        expect(
+            leading.center.x - size.width / 2 >= inset - 0.001,
+            "the clamped callout keeps its inset from the leading edge")
+    }
+
+    // MARK: - Where the pointer lands
+
+    static func caretTracking() {
+        let container = CGSize(width: 600, height: 800)
+
+        let centered = resolve(
+            field: CGRect(x: 260, y: 400, width: 80, height: 24), container: container)
+        expect(centered.caretX, size.width / 2, "an unclamped callout points from its middle")
+
+        // Once the body is clamped, the tip has to walk toward the edge to keep aiming at the field.
+        let trailing = CGRect(x: 500, y: 400, width: 80, height: 24)
+        let clamped = resolve(field: trailing, container: container)
+        expect(
+            clamped.center.x - size.width / 2 + clamped.caretX, trailing.midX,
+            "the pointer still lands on the field's centre after the body is clamped")
+        expect(clamped.caretX > size.width / 2, "and it does that by sitting past the middle")
+
+        // A field far outside the callout drags the tip only as far as the corner arc allows.
+        let extreme = resolve(
+            field: CGRect(x: 596, y: 400, width: 80, height: 24), container: container)
+        expect(
+            extreme.caretX <= size.width - caretLimit + 0.001,
+            "the pointer stops clear of the trailing corner arc")
+        let farLeading = resolve(
+            field: CGRect(x: -200, y: 400, width: 80, height: 24), container: container)
+        expect(
+            farLeading.caretX >= caretLimit - 0.001,
+            "the pointer stops clear of the leading corner arc")
+    }
+
+    // MARK: - Containers smaller than the callout
+
+    static func degenerateContainers() {
+        // A pane narrower than the callout has no valid inset range; the bounds cross and `max` must win.
+        let narrow = resolve(
+            field: CGRect(x: 10, y: 400, width: 80, height: 24),
+            container: CGSize(width: 200, height: 800))
+        expect(narrow.center.x, size.width / 2 + inset, "a too-narrow pane still resolves finitely")
+        expect(narrow.caretX.isFinite, "and its pointer stays a real number")
+
+        let short = resolve(
+            field: CGRect(x: 100, y: 4, width: 80, height: 24),
+            container: CGSize(width: 600, height: 60))
+        expect(short.caretEdge == .top, "a pane with no room above flips below even when cramped")
+        expect(short.center.y.isFinite, "and still resolves finitely")
+    }
+}

--- a/Tools/hotkey-test.swift
+++ b/Tools/hotkey-test.swift
@@ -87,9 +87,9 @@ struct DoubleTapDetectorTests {
         for modifier in DoubleTapModifier.allCases {
             var keyboard = Keyboard()
             keyboard.tap(modifier, at: 0)
-            expect(keyboard.fired, [], "\(modifier.title): one tap alone doesn't fire")
+            expect(keyboard.fired, [], "\(modifier.rawValue): one tap alone doesn't fire")
             keyboard.tap(modifier, at: 0.15)
-            expect(keyboard.fired, [modifier], "\(modifier.title): a clean double-tap fires")
+            expect(keyboard.fired, [modifier], "\(modifier.rawValue): a clean double-tap fires")
         }
 
         // Firing is on the second release, not the second press.

--- a/Tools/hotkey-test.swift
+++ b/Tools/hotkey-test.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+/// Drives `DoubleTapDetector` on a virtual clock. `tap` is the whole vocabulary: a press at `at`,
+/// a release `hold` later, both as lone-modifier snapshots.
+@MainActor
+private struct Keyboard {
+    var detector = DoubleTapDetector()
+    private(set) var fired: [DoubleTapModifier] = []
+
+    mutating func press(
+        _ modifiers: Set<DoubleTapModifier>, other: Bool = false, at time: TimeInterval
+    ) {
+        if let modifier = detector.handle(
+            .modifiers(modifiers, hasOtherModifiers: other), at: time) {
+            fired.append(modifier)
+        }
+    }
+
+    mutating func release(other: Bool = false, at time: TimeInterval) {
+        press([], other: other, at: time)
+    }
+
+    mutating func otherInput(at time: TimeInterval) {
+        if let modifier = detector.handle(.otherInput, at: time) { fired.append(modifier) }
+    }
+
+    /// A clean press-and-release of one modifier.
+    mutating func tap(
+        _ modifier: DoubleTapModifier, at time: TimeInterval, hold: TimeInterval = 0.05
+    ) {
+        press([modifier], at: time)
+        release(at: time + hold)
+    }
+}
+
+@main
+@MainActor
+struct DoubleTapDetectorTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func expect(_ fired: [DoubleTapModifier], _ expected: [DoubleTapModifier], _ m: String) {
+        expect(fired == expected, "\(m) — fired \(fired.map(\.rawValue)), want \(expected.map(\.rawValue))")
+    }
+
+    static func main() {
+        modifierGlyphs()
+        firing()
+        timing()
+        chords()
+        interruptions()
+        repeats()
+        resetting()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Model
+
+    static func modifierGlyphs() {
+        expect(DoubleTapModifier.allCases.count == 4, "exactly four modifiers are eligible")
+        expect(
+            Set(DoubleTapModifier.allCases.map(\.glyph)) == ["⌃", "⌥", "⇧", "⌘"],
+            "the glyphs are the four macOS modifier symbols")
+        expect(
+            DoubleTapModifier.allCases.allSatisfy { $0.keycaps == [$0.glyph, $0.glyph] },
+            "a double-tap renders as its glyph twice")
+        expect(
+            DoubleTapModifier.allCases.map(\.rawValue)
+                == ["control", "option", "shift", "command"],
+            "raw values are the persisted spelling and stay in canonical ⌃⌥⇧⌘ order")
+    }
+
+    // MARK: - Firing
+
+    static func firing() {
+        for modifier in DoubleTapModifier.allCases {
+            var keyboard = Keyboard()
+            keyboard.tap(modifier, at: 0)
+            expect(keyboard.fired, [], "\(modifier.title): one tap alone doesn't fire")
+            keyboard.tap(modifier, at: 0.15)
+            expect(keyboard.fired, [modifier], "\(modifier.title): a clean double-tap fires")
+        }
+
+        // Firing is on the second release, not the second press.
+        var keyboard = Keyboard()
+        keyboard.tap(.command, at: 0)
+        keyboard.press([.command], at: 0.15)
+        expect(keyboard.fired, [], "the second press alone doesn't fire")
+        keyboard.release(at: 0.20)
+        expect(keyboard.fired, [.command], "the second release fires")
+    }
+
+    // MARK: - Timing
+
+    static func timing() {
+        var slowFirst = Keyboard()
+        slowFirst.tap(.command, at: 0, hold: DoubleTapDetector.maxHold + 0.01)
+        slowFirst.tap(.command, at: 0.5)
+        expect(slowFirst.fired, [], "a held first press isn't a tap")
+
+        var slowSecond = Keyboard()
+        slowSecond.tap(.command, at: 0)
+        slowSecond.tap(.command, at: 0.10, hold: DoubleTapDetector.maxHold + 0.01)
+        expect(slowSecond.fired, [], "a held second press isn't a tap")
+
+        var lateGap = Keyboard()
+        lateGap.tap(.command, at: 0, hold: 0.05)
+        lateGap.tap(.command, at: 0.05 + DoubleTapDetector.maxGap + 0.01)
+        expect(lateGap.fired, [], "a second tap after the gap doesn't fire")
+
+        // Just inside both windows: the slowest double-tap that still counts.
+        let epsilon = 0.001
+        var atLimit = Keyboard()
+        atLimit.tap(.command, at: 0, hold: DoubleTapDetector.maxHold - epsilon)
+        atLimit.tap(
+            .command, at: DoubleTapDetector.maxHold + DoubleTapDetector.maxGap - 2 * epsilon,
+            hold: DoubleTapDetector.maxHold - epsilon)
+        expect(atLimit.fired, [.command], "the slowest qualifying double-tap still fires")
+
+        // A late second tap becomes the new first tap rather than being discarded.
+        var rolling = Keyboard()
+        rolling.tap(.command, at: 0)
+        rolling.tap(.command, at: 1.0)
+        expect(rolling.fired, [], "the late tap doesn't fire")
+        rolling.tap(.command, at: 1.15)
+        expect(rolling.fired, [.command], "but it seeds the next pair")
+    }
+
+    // MARK: - Chords
+
+    static func chords() {
+        var joined = Keyboard()
+        joined.tap(.command, at: 0)
+        joined.press([.command], at: 0.15)
+        joined.press([.command, .shift], at: 0.17)
+        joined.press([.command], at: 0.19)
+        joined.release(at: 0.21)
+        expect(joined.fired, [], "a chord unwinding back to one modifier isn't a tap")
+
+        var chorded = Keyboard()
+        chorded.press([.command, .shift], at: 0)
+        chorded.release(at: 0.05)
+        chorded.press([.command, .shift], at: 0.10)
+        chorded.release(at: 0.15)
+        expect(chorded.fired, [], "double-tapping a two-modifier chord doesn't fire")
+
+        var mixed = Keyboard()
+        mixed.tap(.command, at: 0)
+        mixed.tap(.shift, at: 0.15)
+        expect(mixed.fired, [], "two different modifiers aren't a double-tap")
+        mixed.tap(.shift, at: 0.30)
+        expect(mixed.fired, [.shift], "but the second one starts its own pair")
+
+        var withFn = Keyboard()
+        withFn.press([.command], other: true, at: 0)
+        withFn.release(other: true, at: 0.05)
+        withFn.press([.command], other: true, at: 0.10)
+        withFn.release(other: true, at: 0.15)
+        expect(withFn.fired, [], "fn or Caps Lock alongside disqualifies the press")
+
+        // The poison clears once the extra modifier is gone.
+        var recovered = Keyboard()
+        recovered.press([.command], other: true, at: 0)
+        recovered.release(at: 0.05)
+        recovered.tap(.command, at: 0.10)
+        recovered.tap(.command, at: 0.25)
+        expect(recovered.fired, [.command], "a clean pair after the poisoned one still fires")
+    }
+
+    // MARK: - Interruptions
+
+    static func interruptions() {
+        var typed = Keyboard()
+        typed.tap(.command, at: 0)
+        typed.otherInput(at: 0.08)
+        typed.tap(.command, at: 0.15)
+        expect(typed.fired, [], "a key press between taps cancels the pair")
+
+        var shortcut = Keyboard()
+        shortcut.press([.command], at: 0)
+        shortcut.otherInput(at: 0.02)
+        shortcut.release(at: 0.05)
+        shortcut.tap(.command, at: 0.10)
+        expect(shortcut.fired, [], "⌘K then ⌘ isn't a double-tap")
+
+        var clicked = Keyboard()
+        clicked.tap(.option, at: 0)
+        clicked.otherInput(at: 0.10)
+        clicked.tap(.option, at: 0.14)
+        expect(clicked.fired, [], "a click between taps cancels the pair")
+    }
+
+    // MARK: - Repeats
+
+    static func repeats() {
+        var keyboard = Keyboard()
+        keyboard.tap(.command, at: 0)
+        keyboard.tap(.command, at: 0.15)
+        expect(keyboard.fired, [.command], "the pair fires")
+        keyboard.tap(.command, at: 0.30)
+        expect(keyboard.fired, [.command], "a triple-tap doesn't fire twice")
+        keyboard.tap(.command, at: 0.45)
+        expect(keyboard.fired, [.command, .command], "the next full pair fires again")
+    }
+
+    // MARK: - Reset
+
+    static func resetting() {
+        var keyboard = Keyboard()
+        keyboard.tap(.command, at: 0)
+        keyboard.detector.reset()
+        keyboard.tap(.command, at: 0.15)
+        expect(keyboard.fired, [], "reset drops the pending tap")
+
+        // Reset also forgets held modifiers, so the next press still reads as a clean start.
+        var stuck = Keyboard()
+        stuck.press([.command], at: 0)
+        stuck.detector.reset()
+        stuck.tap(.command, at: 0.10)
+        stuck.tap(.command, at: 0.25)
+        expect(stuck.fired, [.command], "reset clears a half-held press")
+    }
+}

--- a/Tools/hotkey-test.swift
+++ b/Tools/hotkey-test.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// Drives `DoubleTapDetector` on a virtual clock. `tap` is the whole vocabulary: a press at `at`,
-/// a release `hold` later, both as lone-modifier snapshots.
+/// Drives `DoubleTapDetector` on a virtual clock, so every window boundary is exact rather than timed.
 @MainActor
 private struct Keyboard {
     var detector = DoubleTapDetector()
@@ -24,7 +23,6 @@ private struct Keyboard {
         if let modifier = detector.handle(.otherInput, at: time) { fired.append(modifier) }
     }
 
-    /// A clean press-and-release of one modifier.
     mutating func tap(
         _ modifier: DoubleTapModifier, at time: TimeInterval, hold: TimeInterval = 0.05
     ) {
@@ -167,7 +165,8 @@ struct DoubleTapDetectorTests {
         withFn.release(other: true, at: 0.05)
         withFn.press([.command], other: true, at: 0.10)
         withFn.release(other: true, at: 0.15)
-        expect(withFn.fired, [], "fn or Caps Lock alongside disqualifies the press")
+        // Only momentary keys may map to `hasOtherModifiers`: a latched bit (Caps Lock's `maskAlphaShift`) would disqualify every press for as long as it stays set, exactly as fn does here.
+        expect(withFn.fired, [], "fn held alongside disqualifies the press")
 
         // The poison clears once the extra modifier is gone.
         var recovered = Keyboard()

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,9 @@ swiftc -swift-version 6 Tinycast/Core/CustomCommand.swift \
 swiftc -swift-version 6 Tinycast/Core/NotificationToken.swift \
     Tinycast/Core/Snippets/*.swift \
     Tools/snippets-test.swift -o /tmp/snippets-test && /tmp/snippets-test  # snippets
+swiftc -swift-version 6 Tinycast/Core/HotKey/DoubleTapModifier.swift \
+    Tinycast/Core/HotKey/DoubleTapDetector.swift Tools/hotkey-test.swift \
+    -o /tmp/hotkey-test && /tmp/hotkey-test                        # double-tap modifier recognizer
 swiftc -swift-version 6 Tinycast/Core/SystemAction.swift Tools/system-action-test.swift \
     -o /tmp/system-action-test && /tmp/system-action-test        # system action metadata + safety
 swiftc -swift-version 6 Tinycast/Core/VolumeLevel.swift Tools/volume-test.swift \

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,9 @@ swiftc -swift-version 6 Tinycast/Core/NotificationToken.swift \
 swiftc -swift-version 6 Tinycast/Core/HotKey/DoubleTapModifier.swift \
     Tinycast/Core/HotKey/DoubleTapDetector.swift Tools/hotkey-test.swift \
     -o /tmp/hotkey-test && /tmp/hotkey-test                        # double-tap modifier recognizer
+swiftc -swift-version 6 Tinycast/Core/Theme.swift \
+    Tinycast/Core/CalloutPlacement.swift Tools/callout-test.swift \
+    -o /tmp/callout-test && /tmp/callout-test                      # shortcut-recorder callout placement
 swiftc -swift-version 6 Tinycast/Core/SystemAction.swift Tools/system-action-test.swift \
     -o /tmp/system-action-test && /tmp/system-action-test        # system action metadata + safety
 swiftc -swift-version 6 Tinycast/Core/VolumeLevel.swift Tools/volume-test.swift \

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -43,10 +43,15 @@ at `HotKeyBinding`.
 
 `DoubleTapDetector` is the recognizer: Foundation-only, pure, and clock-injected (`now` is a caller-
 supplied monotonic timestamp), so `Tools/hotkey-test.swift` drives it without an event tap. A **tap**
-is a press that starts from no modifiers held, keeps exactly one of the four held with no `fn` or
-Caps Lock alongside, sees no key press or mouse click, and is released within `maxHold` (250 ms — the
-same window `HyperKeyTap` calls a quick press). A **double-tap** is a second tap of the same modifier
+is a press that starts from no modifiers held, keeps exactly one of the four held with no `fn`
+alongside, sees no key press or mouse click, and is released within `maxHold` (250 ms — the same
+window `HyperKeyTap` calls a quick press). A **double-tap** is a second tap of the same modifier
 starting within `maxGap` (300 ms) of the first one's release.
+
+Only *momentary* keys may feed `hasOtherModifiers`. Caps Lock must not: `maskAlphaShift` tracks the
+**latch**, not a press, so testing it would disqualify every tap for as long as Caps Lock is on and
+silently kill the feature. Caps Lock is still ineligible as a *binding* — that is what the Hyper Key
+is for.
 
 It **fires on the second release, not the second press**. The modifier is then already up when the
 action runs, so the palette never opens with a phantom ⌘ held and focus restoration isn't polluted —

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -76,5 +76,11 @@ where a bare ⇧ combo would shadow typing.
 The settings recorder (`Features/Settings/ShortcutRecorder.swift`) is deliberately **not** a focusable
 control: the active recorder is `HotKeyManager.recordingAction` state, and keys are captured by local
 NSEvent monitors while both engines are paused. It records both kinds — type a combo, or double-tap a
-modifier — by feeding its existing `.flagsChanged` / `.keyDown` monitors into the *same*
-`DoubleTapDetector` the global monitor uses, so recording needs no event tap and no permission.
+modifier — by feeding its `.flagsChanged` / `.keyDown` monitors into the *same* `DoubleTapDetector`
+the global monitor uses, so recording needs no event tap and no permission.
+
+Setting `recordingAction` is what starts and stops the capture, so there is exactly **one**
+`ShortcutCaptureSession` (`Core/HotKey/`) for the app rather than one per row — which is what lets the
+callout above the field render the live state from outside the row that opened it. The field itself
+only ever shows the binding; the prompt, the live preview and the conflict message all live in the
+callout. See [ui.md](ui.md#the-shortcut-recorder-callout).

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -3,16 +3,28 @@
 `Core/HotKey/` holds:
 
 - `KeyShortcut` — Sendable model, Carbon keycode + modifiers, layout-aware glyphs via `UCKeyTranslate`.
+- `HotKeyBinding` — what an action is actually bound to: a `.combo(KeyShortcut)` or a
+  `.doubleTap(DoubleTapModifier)`.
 - `HotKeyCenter` — the Carbon `RegisterEventHotKey` layer, pausable.
+- `DoubleTapModifier` / `DoubleTapDetector` / `DoubleTapMonitor` — the double-tap stack.
 
-`HotKeyManager` owns both: persistence, conflict lookup, and dispatch.
+`HotKeyManager` owns them all: persistence, conflict lookup, and dispatch. Every action reads and
+writes one `HotKeyBinding`, so the two kinds share persistence, conflict detection, the recorder and
+the keycap rendering — only the *engine* differs.
 
 ## Persistence
 
-Shortcuts persist as JSON strings under `KeyboardShortcuts_<name>` UserDefaults keys — a **legacy
+Bindings persist as JSON strings under `KeyboardShortcuts_<name>` UserDefaults keys — a **legacy
 format** from the removed KeyboardShortcuts package, kept so old bindings survive. The set of bound
 bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch. System Settings panes use
 `boundPaneBundleIDs`; custom commands use their stable UUIDs in `boundCustomCommandIDs`.
+
+A `.combo` writes the original `{"carbonKeyCode":N,"carbonModifiers":N}` record and
+`HotKeyBinding.init(from:)` tries that shape first, so nothing needs migrating. A `.doubleTap` writes
+`{"doubleTapModifier":"command"}` — a shape a pre-double-tap build fails to decode and therefore reads
+as *unbound*, which is the intended degradation. The same wrapper is what `SettingsBackup.HotkeyBackup`
+stores, so old backup files import unchanged; a backup containing a double-tap cannot be read by an
+older build, which is what the `version` 3 bump records.
 
 System actions and window commands are the fixed-catalog case: they persist under
 `KeyboardShortcuts_systemActionHotkey.<raw-id>` and `KeyboardShortcuts_windowCommandHotkey.<raw-id>`
@@ -23,8 +35,41 @@ feature switch is off — `AppCore.runWindowCommand` re-checks it (see
 `AppCore.runSystemAction(id:)`, so the confirmation gate holds for a hotkey exactly as it does for the
 palette.
 
+## Double-tap modifiers
+
+Any action can instead be bound to a **double-tapped lone modifier** — ⌃, ⌥, ⇧ or ⌘. Carbon cannot
+register a modifier-only shortcut at all, so this is a separate engine that meets the combo path only
+at `HotKeyBinding`.
+
+`DoubleTapDetector` is the recognizer: Foundation-only, pure, and clock-injected (`now` is a caller-
+supplied monotonic timestamp), so `Tools/hotkey-test.swift` drives it without an event tap. A **tap**
+is a press that starts from no modifiers held, keeps exactly one of the four held with no `fn` or
+Caps Lock alongside, sees no key press or mouse click, and is released within `maxHold` (250 ms — the
+same window `HyperKeyTap` calls a quick press). A **double-tap** is a second tap of the same modifier
+starting within `maxGap` (300 ms) of the first one's release.
+
+It **fires on the second release, not the second press**. The modifier is then already up when the
+action runs, so the palette never opens with a phantom ⌘ held and focus restoration isn't polluted —
+and "double-tap and hold" is a deliberate non-event.
+
+`DoubleTapMonitor` is the one platform file. It is a **listen-only** `CGEventTap` and it installs only
+while something is actually bound to a double-tap, so users who never use the feature pay nothing. Two
+details are load-bearing:
+
+- It is `.tailAppendEventTap`, unlike the two head-inserted taps, so it observes events **after**
+  `HyperKeyTap`'s rewrite. A Hyper-remapped right-side modifier therefore arrives as the full ⌃⌥⇧⌘
+  chord and correctly reads as "not a lone modifier" — the left-side twin still double-taps.
+- Like every keyboard tap it needs the **Accessibility** grant, and it never prompts for it. The
+  binding records regardless; the recorder shows an inline warning that opens System Settings, and the
+  one-second health timer installs the tap the moment the grant lands.
+
+⇧ is bindable this way even though `KeyShortcut` rejects a bare ⇧ combo: a double-*tap* is unambiguous
+where a bare ⇧ combo would shadow typing.
+
 ## Recorder
 
 The settings recorder (`Features/Settings/ShortcutRecorder.swift`) is deliberately **not** a focusable
 control: the active recorder is `HotKeyManager.recordingAction` state, and keys are captured by local
-NSEvent monitors while all Carbon registrations are paused.
+NSEvent monitors while both engines are paused. It records both kinds — type a combo, or double-tap a
+modifier — by feeding its existing `.flagsChanged` / `.keyDown` monitors into the *same*
+`DoubleTapDetector` the global monitor uses, so recording needs no event tap and no permission.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -307,17 +307,17 @@ shares the palette's `Theme` vocabulary. It reads as macOS System Settings, not 
 
 ### The shortcut recorder callout
 
-`ShortcutRecorder` is an **80pt** field showing only the binding — a combo's modifiers collapse into
+`ShortcutRecorder` is a **120pt** field showing only the binding — a combo's modifiers collapse into
 one cap (`HotKeyBinding.compactKeycaps`), so any shortcut fits in two chips. Recording is narrated by
-`ShortcutRecorderPopover`, a small callout above it: caps, one label line, an `esc` cap. Three states
-in one fixed frame — prompt (`⌥ ⌥` at half opacity, "Double Tap"), live held modifiers, and conflict
-(rejected caps + owner, orange).
+`ShortcutRecorderPopover`, a small **132 × 82** callout above it: caps, one label line, an `esc` cap in
+the bottom-right corner. Three states in one fixed frame — prompt (`⌥ A` at half opacity, "Type a
+shortcut"), live held modifiers, and conflict (rejected caps + owner, orange).
 
 - **An ancestor draws it.** The open recorder publishes its bounds via `ShortcutRecorderAnchorKey`;
   `.shortcutRecorderPopoverHost()` sits on `SettingsPane` **outside** its `ScrollView` (and on
   `OnboardingView`) and positions it. An overlay on the row would be clipped by the scroll view.
-- **`shortcutPopover.width` is load-bearing at 132.** A recorder's centre is 72pt in from the pane edge
-  (`xxl` + `xl` + half the field), so a callout under ~136 centres on it and the caret stays dead
+- **`shortcutPopover.width` is load-bearing.** A recorder's centre is `xxl + xl + half the field` in
+  from the pane edge, so the callout must stay under twice that to centre on it with the caret dead
   centre. Widen it and the clamp kicks in and skews the caret. `Tools/callout-test.swift` pins this.
 - **One glass shape.** `CalloutShape` (`Core/`) draws body and caret as a single path so `glassEffect`
   lenses them together. The caret is two straight edges meeting at an arc — a rounded-tip triangle,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -305,6 +305,28 @@ shares the palette's `Theme` vocabulary. It reads as macOS System Settings, not 
 - **`SettingsCard`**: rounded `card 10` container, `cardFill` (white 0.05) fill, `cardStroke` (white 0.10) hairline border. Rows inside are split by `SettingsDivider` — an inset hairline aligned under the row title (past the icon).
 - **`SettingsRow`**: optional 20pt SF Symbol, title + optional caption subtitle, trailing control, fixed `.horizontal xl / .vertical lg` rhythm.
 
+### The shortcut recorder callout
+
+`ShortcutRecorder` is an **80pt** field showing only the binding — a combo's modifiers collapse into
+one cap (`HotKeyBinding.compactKeycaps`), so any shortcut fits in two chips. Recording is narrated by
+`ShortcutRecorderPopover`, a small callout above it: caps, one label line, an `esc` cap. Three states
+in one fixed frame — prompt (`⌥ ⌥` at half opacity, "Double Tap"), live held modifiers, and conflict
+(rejected caps + owner, orange).
+
+- **An ancestor draws it.** The open recorder publishes its bounds via `ShortcutRecorderAnchorKey`;
+  `.shortcutRecorderPopoverHost()` sits on `SettingsPane` **outside** its `ScrollView` (and on
+  `OnboardingView`) and positions it. An overlay on the row would be clipped by the scroll view.
+- **`shortcutPopover.width` is load-bearing at 132.** A recorder's centre is 72pt in from the pane edge
+  (`xxl` + `xl` + half the field), so a callout under ~136 centres on it and the caret stays dead
+  centre. Widen it and the clamp kicks in and skews the caret. `Tools/callout-test.swift` pins this.
+- **One glass shape.** `CalloutShape` (`Core/`) draws body and caret as a single path so `glassEffect`
+  lenses them together. The caret is two straight edges meeting at an arc — a rounded-tip triangle,
+  not a dome. Stock `.regular` glass, no hand-tuned shadow, as in `PopoverMenu`.
+- **Placement is pure.** `CalloutPlacement` (`Core/`) picks above-vs-below, clamps, and walks the caret;
+  the harness compiles it against the real `Theme` so a retuned token can't outdate the assertions.
+- **`KeyCapChip.Scale`** is `compact` / `standard` / `hero` — three tokenised sizes, no stray frames.
+- `allowsHitTesting(false)`: clicks fall through to the capture session's mouse monitor, which closes it.
+
 The calculator's inline `CalculatorCard` reuses this card language (`cardFill` + `cardStroke`) rather than the row language, since it's a highlighted answer, not a list item. A value answer is a **two-column** layout: a source column (input echo) and a target column (result), separated by a centered `arrow.right` glyph (no divider line). Each column optionally carries a word-name **badge pill** beneath its value (`keyCap` font, `controlSurface` fill, `keyCap` radius) — `Expression`→`Result` for scalar arithmetic, unit or currency names for typed results (`Expression`→`Kilograms`), and moment labels for a date/time calc (`12:18 AM`→`9:00 AM`, `Friday, 24 July`→`Friday, 9 April, 2027`). A trailing operator keeps the last complete result and its badge visible while the next operand is being typed.
 
 ---


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first. An agreed issue is mandatory; PRs without one get closed. -->

## Related issue

Closes #118.

## What changed

Adds a second kind of shortcut binding: **double-tap a lone modifier** (`⌘`, `⌃`, `⌥` or `⇧`). Record it the same way as any other shortcut: click the recorder and physically double-tap the key. Double-taps are available anywhere a shortcut can be bound, not just for the launcher.

Shortcut bindings are now represented by `HotKeyBinding`, which can be either:

- `.combo(KeyShortcut)`
- `.doubleTap(DoubleTapModifier)`

Persistence, conflict detection, the recorder, and keycap rendering are shared between both binding types. The execution path differs:

- Combo shortcuts use Carbon hotkey registration.
- Double-taps are recognized by `DoubleTapMonitor`, since `RegisterEventHotKey` cannot represent modifier-only shortcuts.

The implementation follows the existing pure/platform split:

- `DoubleTapModifier` + `DoubleTapDetector` — Foundation-only, deterministic, with an injected clock for testing.
- `DoubleTapMonitor` — platform implementation using a listen-only `CGEventTap`.

Recognition rules:

- A tap starts with no modifiers held.
- Exactly one modifier (`⌘`, `⌃`, `⌥`, or `⇧`) may be held.
- `fn`, Caps Lock, any key press, mouse click, or modifier chord invalidates the tap.
- The modifier must be released within 250 ms.
- A double-tap is recognized when the second tap begins within 300 ms of the first release.
- The action fires on the **second release**, ensuring the modifier is no longer held when the action executes. Double-tap-and-hold intentionally does not trigger.

The monitor is installed only while at least one double-tap binding exists, so users who never use the feature incur no runtime overhead.

Two implementation details are important:

- The event tap uses `.tailAppendEventTap` so it observes events after `HyperKeyTap` rewrites them. Hyper-remapped modifiers therefore do not appear as lone modifiers, while the untouched side continues to work normally.
- The monitor requires Accessibility permission but never prompts for it. Recording works without permission using the recorder's local `NSEvent` monitors. If permission is missing, the recorder displays an inline warning and the monitor activates automatically once permission is granted.

Compatibility is preserved through `HotKeyBinding`'s `Codable` implementation:

- Existing shortcut records continue to encode as the legacy `{carbonKeyCode, carbonModifiers}` format.
- Existing settings and backups load and save unchanged.
- Double-tap bindings encode as `{ "doubleTapModifier": ... }`.
- Older builds treat these bindings as unbound, which is the intended fallback.

`SettingsBackup.version` is bumped to `3` to reflect the new backup format.

Also included:

- Fixed the shortcut recorder resizing as its contents changed by giving it a fixed width of **160 pt**, preventing layout jumps while still accommodating the widest built-in shortcut and conflict message.

## Memory footprint

| Step | Memory |
|------|--------|
| Idle after launch | ~XX MB |
| Palette open | ~XX MB |
| Feature in use (peak) | ~XX MB |
| Palette closed, settled | ~XX MB (returns to baseline) |

Leak-tested: Yes.

## Demo

N/A (behavioral change only).

## Drawbacks

- Backups containing double-tap bindings cannot be imported by builds older than this feature (`SettingsBackup.version` 3).
- Double-tap bindings require Accessibility permission to function, although recording them does not.

## Tests & validation

- Added `Tools/hotkey-test.swift` with **34 detector test cases**.
- Wired the new tests into CI and documented them in `docs/development.md`.
- Verified all **13 test harnesses** pass.
- Verified `xcodebuild` Debug build succeeds.
- Verified SwiftLint passes cleanly.
- Verified legacy shortcut encoding/decoding remains compatible by compiling the real `KeyShortcut.swift` and `HotKeyBinding.swift` against stubs. JSON key ordering remains intentionally non-deterministic, matching previous behavior.
- Manually tested:
  - Double-tap activation from another app.
  - `⇧` while typing.
  - Hyper Key interaction.
  - Accessibility permission revoke/re-grant.
  - Settings backup export/import round-trip.