### PR TITLE
Uninstall Application: remove an app and its leftovers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
             Tinycast/Core/WindowManagement/WindowLayout.swift \
             Tinycast/Core/WindowManagement/WindowActionMemory.swift Tools/window-command-test.swift \
             -o /tmp/window-command-test && /tmp/window-command-test
+          swiftc -swift-version 6 Tinycast/Core/Uninstall/UninstallTarget.swift \
+            Tinycast/Core/Uninstall/UninstallSearchRoot.swift \
+            Tinycast/Core/Uninstall/UninstallRules.swift \
+            Tinycast/Core/Uninstall/UninstallProtection.swift \
+            Tinycast/Core/Uninstall/UninstallPlan.swift Tools/uninstall-test.swift \
+            -o /tmp/uninstall-test && /tmp/uninstall-test
 
   lint:
     runs-on: macos-26

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,16 +22,20 @@ cyclomatic_complexity:
   error: 60
 
 function_body_length:
-  warning: 130
-  error: 200
+  warning: 160
+  error: 220
 
 function_parameter_count:
   warning: 9
   error: 12
 
+large_tuple:
+  warning: 3
+  error: 4
+
 type_body_length:
-  warning: 720
-  error: 900
+  warning: 850
+  error: 1000
 
 file_length:
   warning: 1200

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,10 @@ Never break these without an explicit task to do so.
   directory **names**, never URLs, and hands the classifier a `PathFacts`. Every `FileManager`,
   `lstat` and Full Disk Access read lives in `UninstallScanner`, which **detects** FDA (a silent,
   promptless probe) and never requests it — this feature asks for no permission and never escalates
-  privilege. A locked candidate can never enter the checked set; that invariant lives in
+  privilege. `tccRelativePrefixes` is **measured, not assumed**: probe a location by creating and
+  trashing a throwaway directory there before adding it, because *listing* is not the test —
+  `~/Library/Containers` enumerates fine and still refuses the move, while
+  `~/Library/Application Scripts` allows it. A locked candidate can never enter the checked set; that invariant lives in
   `UninstallSelection`'s one intersection, not in the view. Tinycast also refuses to plan its own
   uninstall, compared against the **running** identity so the Dev channel refuses itself too.
   See [uninstall.md](docs/uninstall.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ Full detail: [`docs/architecture.md`](docs/architecture.md).
 - **Subsystems:** [palette](docs/palette.md) · [launcher & fuzzy match](docs/launcher.md) ·
   [calculator](docs/calculator.md) · [clipboard](docs/clipboard.md) · [emoji](docs/emoji.md) ·
   [snippets](docs/snippets.md) · [window management](docs/window-management.md) ·
-  [hotkeys](docs/hotkeys.md) · [Raycast import](docs/raycast-import.md) ·
-  [UI & design system](docs/ui.md).
+  [hotkeys](docs/hotkeys.md) · [uninstall](docs/uninstall.md) ·
+  [Raycast import](docs/raycast-import.md) · [UI & design system](docs/ui.md).
 
 ## Critical Invariants
 
@@ -100,6 +100,20 @@ Never break these without an explicit task to do so.
   `Tools/window-command-test.swift` asserts it. Nothing in this feature ever touches
   `backingScaleFactor` — all three of `NSScreen.frame`, `visibleFrame` and AX coordinates are in points,
   so mixed-DPI correctness is automatic. See [window-management.md](docs/window-management.md).
+- **Uninstall moves to the Trash and never deletes.** `FileManager.trashItem` is the only removal
+  call in the feature; `removeItem` must never appear there. That is what makes display-name
+  attribution tolerable — a false positive costs a drag back, not the user's data — so a
+  "delete permanently" option would have to drop name matching in the same commit. The deciding half
+  (`UninstallTarget.swift`, `UninstallSearchRoot.swift`, `UninstallRules.swift`,
+  `UninstallProtection.swift`, `UninstallPlan.swift`) stays Foundation-only and pure for
+  `Tools/uninstall-test.swift`, with every environment fact injected: the scanner hands the rules
+  directory **names**, never URLs, and hands the classifier a `PathFacts`. Every `FileManager`,
+  `lstat` and Full Disk Access read lives in `UninstallScanner`, which **detects** FDA (a silent,
+  promptless probe) and never requests it — this feature asks for no permission and never escalates
+  privilege. A locked candidate can never enter the checked set; that invariant lives in
+  `UninstallSelection`'s one intersection, not in the view. Tinycast also refuses to plan its own
+  uninstall, compared against the **running** identity so the Dev channel refuses itself too.
+  See [uninstall.md](docs/uninstall.md).
 - **`Tools/fuzz-test.swift` holds a COPY of `FuzzyMatch`** from `Core/AppIndex.swift`. Change the
   scoring in one, mirror it in the other, or the test is meaningless.
 - **`EmojiData.generated.swift` is emitted by `node Tools/gen-emoji.js` and
@@ -194,9 +208,11 @@ Never break these without an explicit task to do so.
 - `Tinycast/Core/` — managers, stores, windows, AppKit glue (no view bodies beyond hosting).
   `Core/Calculator/` and `Core/Emoji/` are Foundation-only engines; `Core/Snippets/` is a
   standalone-harness input in full; `Core/WindowManagement/` is a pure geometry layer plus its one AX
-  file; `Core/Theme.swift` is the design-token source; `Core/HotKey/` is the in-house hotkey stack.
+  file; `Core/Uninstall/` splits the same way — five pure files, one scanner, one Trash runner;
+  `Core/Theme.swift` is the design-token source; `Core/HotKey/` is the in-house hotkey stack.
 - `Tinycast/Features/` — SwiftUI views: `RootPaletteView`, `Launcher/`, `Clipboard/`, `Calculator/`,
-  `Emoji/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`. Each `SettingsTab` maps to
+  `Emoji/`, `Uninstall/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`. Each
+  `SettingsTab` maps to
   one `…SettingsView` built on the `SettingsPane` / `SettingsCard` scaffold in `SettingsComponents.swift`;
   the four launcher-category panes (Applications, System Settings, System Actions, Commands) are thin
   wrappers over the shared `LauncherItemsCard`.
@@ -212,7 +228,8 @@ Never break these without an explicit task to do so.
   [`docs/clipboard.md`](docs/clipboard.md) · [`docs/emoji.md`](docs/emoji.md) ·
   [`docs/snippets.md`](docs/snippets.md) ·
   [`docs/window-management.md`](docs/window-management.md) ·
-  [`docs/hotkeys.md`](docs/hotkeys.md) — subsystem internals.
+  [`docs/hotkeys.md`](docs/hotkeys.md) · [`docs/uninstall.md`](docs/uninstall.md) — subsystem
+  internals.
 - [`docs/ui.md`](docs/ui.md) — the full visual design system, tokens, scrollbars, section headers.
 - [`docs/development.md`](docs/development.md) — build, test, package, release.
 - [`docs/signing.md`](docs/signing.md) — signing model and Gatekeeper.

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -9,9 +9,11 @@
 /* Begin PBXBuildFile section */
 		0626264D8C719DA8366B5E28 /* VolumeHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6173CA658DA56245031FE6 /* VolumeHUDView.swift */; };
 		0674D8E1567253879EF50150 /* SnippetArgumentsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F919FBD5F2E0399523AA56 /* SnippetArgumentsPrompt.swift */; };
+		0962E9575CBF40B6F908031C /* UninstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D08C3AEAFB224866F23C3E /* UninstallView.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
 		0FBAE98F81ECCE0D7A513EDC /* SystemActionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B78A8741FA55F42BAF5D97F /* SystemActionRunner.swift */; };
 		11C4CC0D767EFD44AB28D6DD /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0E1FD530C764A021E6053 /* SearchScopes.swift */; };
+		125A99FB5A3603488A261C6A /* UninstallRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB4BA1A385F78B9C5E7EBCF /* UninstallRules.swift */; };
 		14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DC5A4706854493D23FD18A /* HyperKey.swift */; };
 		14A5A5ACD35A572EE906769F /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B976C84AFE60E357A346224 /* CalcEngine.swift */; };
 		152E4A75BD2AF9279497F5FF /* DialogController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0A151A3B8AC682395E621D /* DialogController.swift */; };
@@ -26,6 +28,7 @@
 		21736CC104E158BC194B1094 /* WindowMover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8859C0E99A2125D85B1233C /* WindowMover.swift */; };
 		22488569DA337BCE033552F1 /* CursorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8214A6789CF8E3B5E16BB4C2 /* CursorScreen.swift */; };
 		24842144273FF92228540DBE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */; };
+		2D620B55ED68ECDF75E7155E /* UninstallRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE113DF7C07BC74AD73BC4C /* UninstallRunner.swift */; };
 		32697AB3853D043A12888B96 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */; };
 		333BCB9C66380985400CD1E2 /* CustomCommandEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14822405E8DA9531AFCD496 /* CustomCommandEditorSheet.swift */; };
 		344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */; };
@@ -52,6 +55,7 @@
 		5F107A05A7EB05204465E89D /* VolumeHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6256CC7C3F15BA05A216E820 /* VolumeHUDController.swift */; };
 		61176B0EB91E2F82EEE3F4B9 /* SystemActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B90AEA968DD7B91A553E07 /* SystemActionsSettingsView.swift */; };
 		649961AA51BA4D87626C27D5 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09093BF10EA97BDCA45A241F /* CalcFormatter.swift */; };
+		6590849AB537D8641C71AC71 /* UninstallPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4954C8003947BB16ED48E326 /* UninstallPlan.swift */; };
 		68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B629EC3B716FEE881BB0075 /* TinycastApp.swift */; };
 		693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */; };
 		6962B8A2850A45401275F677 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */; };
@@ -65,6 +69,7 @@
 		72ACD144841BF1117CD4E705 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC2DEA0A052116A92F9A539 /* Theme.swift */; };
 		7A2C6032E0DE0346DD10A747 /* DialogRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8745544BFC53B27B0168CA6 /* DialogRequest.swift */; };
 		80F1A591DB0F5385F5C9A06C /* PopoverMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B7211D27EDF764EC477A0F /* PopoverMenu.swift */; };
+		84096D3843E674F0B12C03D4 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631D879F03A3A86553E7FFE5 /* UninstallSession.swift */; };
 		854C19458C8A0AE0BD757600 /* EmojiIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F450E10D107C1E30EA2BC6 /* EmojiIndex.swift */; };
 		85A9ACCB19D9502A79F1A508 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05970D61D4E595D0658D0D94 /* Snippet.swift */; };
 		85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */; };
@@ -75,6 +80,7 @@
 		8EF55652F19A1E0C5FF644B4 /* RaycastImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4049668745FD438D5792A2F /* RaycastImport.swift */; };
 		8F7431A1340D0A5783599087 /* MiscellaneousSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */; };
 		903E82F78D3FCEF3A1AF3752 /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */; };
+		94620E1BB1049C5D8B45392E /* UninstallSearchRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C56920811CA9A5F0FA04441 /* UninstallSearchRoot.swift */; };
 		97A195E9D6480418D4944560 /* AppCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A64EF5A07D459753998F78C /* AppCore.swift */; };
 		9969E6858C4FDC5CCCDEB5D8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C45190564C9D9F1722E83943 /* Assets.xcassets */; };
 		9A254BEE278D7B78B76553A9 /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE0C0DC05F958A4B4DCAA8C /* Scrypt.swift */; };
@@ -89,6 +95,7 @@
 		AB1E6D5ABF74EB00B307A7D1 /* CommandsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74868D1F22B3CEC5A2ECD668 /* CommandsSettingsView.swift */; };
 		AB9B998DB62EE2D18A058C78 /* SnippetsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */; };
 		ABBB2A811EB5C69D55A93B1C /* RaycastImportSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */; };
+		AC6AF9FA9C6874F257D3F613 /* UninstallTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6941F59D6E8014A22F1FF7 /* UninstallTarget.swift */; };
 		AD2141EBF98A246BDA3BAB8E /* Gunzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A53295959552ED28D34960 /* Gunzip.swift */; };
 		AE0D0C53004C65D65BE89B6F /* BackupActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8C2C59C2B578CFE61E004 /* BackupActions.swift */; };
 		B1B3F5715BE7A092F0CEFA09 /* ClipboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76E4099082D59FA686C3485 /* ClipboardManager.swift */; };
@@ -100,6 +107,7 @@
 		B810158281A87CBA2AB694D0 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DB24EE452A7CA120B56FA6 /* EmojiData.generated.swift */; };
 		B9CED4B06F36998A67097FC5 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE084FDBE22B01204E7BEDA /* SnippetMarkdownSerializer.swift */; };
 		BA76E53A12248B3A9C42B4F9 /* Bundle+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */; };
+		BAA957558EB8FB2D26B13D4B /* UninstallScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD131E932E1B53D39CF30C13 /* UninstallScanner.swift */; };
 		C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37CCD024267EB21876C7E9 /* AppDelegate.swift */; };
 		C35864533DFB42DE63080ACB /* WindowManagementSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */; };
 		C359131F793C6C6BD756B901 /* SystemSettingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1DE4D8B82F1D4AFB025FB24 /* SystemSettingsSettingsView.swift */; };
@@ -138,6 +146,7 @@
 		F7D26DE09844A5A38787CDD2 /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0818D48887156CA562EF20B8 /* VolumeLevel.swift */; };
 		F9C1192D849B94E783D05568 /* ShortcutCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC35D5134516ECB65AABDC51 /* ShortcutCaptureSession.swift */; };
 		FBA8548636E1F1EABCC3A8CA /* LauncherItemsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F221037C057C8085CE51C /* LauncherItemsCard.swift */; };
+		FC3E8F307B25E3BC5E11AFCF /* UninstallProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F31E587DD4EAA1D7BD39AF /* UninstallProtection.swift */; };
 		FC934E5AE6A933F5BC7AC4DD /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D93A4CEA9FE857034D63EF7 /* CalcQuantity.swift */; };
 		FE6A9C75F87C3495F413E66E /* CalculatorHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */; };
 		FEA05585E8AA58506D378CAF /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B275099E59BD2531A838F7D8 /* AppSettings.swift */; };
@@ -156,6 +165,7 @@
 		1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportSelection.swift; sourceTree = "<group>"; };
 		1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		24F31E587DD4EAA1D7BD39AF /* UninstallProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallProtection.swift; sourceTree = "<group>"; };
 		25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
 		286B7598B81017C746558C7C /* ShellCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellCommandRunner.swift; sourceTree = "<group>"; };
 		297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscellaneousSettingsView.swift; sourceTree = "<group>"; };
@@ -177,6 +187,7 @@
 		45D4BA6E1BD8EB1F96A8927F /* Tinycast.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tinycast.entitlements; sourceTree = "<group>"; };
 		46C3E740AA883770481A6A8C /* SnippetsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsStore.swift; sourceTree = "<group>"; };
 		4802942FF89B327A76432A9B /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		4954C8003947BB16ED48E326 /* UninstallPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallPlan.swift; sourceTree = "<group>"; };
 		4B432D84D8F9C10521342199 /* RunningApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningApps.swift; sourceTree = "<group>"; };
 		4B940224413903867EF5A60E /* WindowActionMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowActionMemory.swift; sourceTree = "<group>"; };
 		4C8F4B31728E49ECE0AA2636 /* ApplicationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsSettingsView.swift; sourceTree = "<group>"; };
@@ -190,6 +201,7 @@
 		55D4192BC6F5A78012027488 /* HUDPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPresenter.swift; sourceTree = "<group>"; };
 		586627A59FDF9011136939A5 /* Tooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tooltip.swift; sourceTree = "<group>"; };
 		596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
+		59D08C3AEAFB224866F23C3E /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
 		5A002AC0DE601E1F65D20C4A /* SnippetTemplateEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplateEngine.swift; sourceTree = "<group>"; };
 		5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLauncher.swift; sourceTree = "<group>"; };
 		5D3E4F8A2BCECFF0E11441BE /* RaycastSnippetImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastSnippetImport.swift; sourceTree = "<group>"; };
@@ -198,12 +210,15 @@
 		5F3AA7727C7F5F511E7F1EF1 /* ShortcutRecorderPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderPopover.swift; sourceTree = "<group>"; };
 		6185011A02366B30B48B5B6C /* Paster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paster.swift; sourceTree = "<group>"; };
 		6256CC7C3F15BA05A216E820 /* VolumeHUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDController.swift; sourceTree = "<group>"; };
+		631D879F03A3A86553E7FFE5 /* UninstallSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSession.swift; sourceTree = "<group>"; };
 		641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
 		6621A88681E993D49EEF07A3 /* tinycast.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = tinycast.icon; sourceTree = "<group>"; };
 		68952539C0BD045BA175CBB6 /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
 		68BD5E61831CB92150C62E1F /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
+		6A6941F59D6E8014A22F1FF7 /* UninstallTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallTarget.swift; sourceTree = "<group>"; };
 		6BB7C545EFD9589A77AD7BE2 /* LauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherView.swift; sourceTree = "<group>"; };
 		6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagementSettingsView.swift; sourceTree = "<group>"; };
+		6EB4BA1A385F78B9C5E7EBCF /* UninstallRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRules.swift; sourceTree = "<group>"; };
 		70D14EC2D7A6AE5F7CBB5028 /* HUDPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanel.swift; sourceTree = "<group>"; };
 		72037DA506AE1A989F858C3C /* DialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogView.swift; sourceTree = "<group>"; };
 		74868D1F22B3CEC5A2ECD668 /* CommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandsSettingsView.swift; sourceTree = "<group>"; };
@@ -232,6 +247,7 @@
 		9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentEmojiStore.swift; sourceTree = "<group>"; };
 		9AA0E1FD530C764A021E6053 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		9C56920811CA9A5F0FA04441 /* UninstallSearchRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSearchRoot.swift; sourceTree = "<group>"; };
 		9ECE1FA4B89326C37DF12A8C /* WindowCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommand.swift; sourceTree = "<group>"; };
 		9FB750D045194AE34D39D792 /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		A31288EC60144BD31C495FE2 /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
@@ -265,6 +281,7 @@
 		CC6173CA658DA56245031FE6 /* VolumeHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDView.swift; sourceTree = "<group>"; };
 		CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsSettingsView.swift; sourceTree = "<group>"; };
 		CD3764D91B2F3170690A473A /* SnippetKeywordPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordPolicy.swift; sourceTree = "<group>"; };
+		CEE113DF7C07BC74AD73BC4C /* UninstallRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRunner.swift; sourceTree = "<group>"; };
 		D2A1D759B8FC5A4573E401B8 /* CalloutPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutPlacement.swift; sourceTree = "<group>"; };
 		D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppName.swift"; sourceTree = "<group>"; };
@@ -281,6 +298,7 @@
 		EDE0C0DC05F958A4B4DCAA8C /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
 		F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Permissions.swift; sourceTree = "<group>"; };
 		F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
+		FD131E932E1B53D39CF30C13 /* UninstallScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallScanner.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -302,6 +320,7 @@
 				CB742F7643800C43475DE213 /* HotKey */,
 				628C51FD0EF7D98347A4F185 /* HUD */,
 				32B8FED93732983EAE729EB1 /* Snippets */,
+				FB939500E513D49DC165EA75 /* Uninstall */,
 				36FA7A5040272D524D70EC0E /* WindowManagement */,
 				3A64EF5A07D459753998F78C /* AppCore.swift */,
 				BA7CE23482F7DF563A268806 /* AppIndex.swift */,
@@ -437,6 +456,14 @@
 			path = About;
 			sourceTree = "<group>";
 		};
+		5EC7DD3F09EBCC7AC71C230B /* Uninstall */ = {
+			isa = PBXGroup;
+			children = (
+				59D08C3AEAFB224866F23C3E /* UninstallView.swift */,
+			);
+			path = Uninstall;
+			sourceTree = "<group>";
+		};
 		628C51FD0EF7D98347A4F185 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
@@ -478,6 +505,7 @@
 				0ED457107377ECF8147C6B9D /* Onboarding */,
 				E3202F504002B7792FC50B2F /* Settings */,
 				7CD438390F8FA4B3C2AE5F28 /* Snippets */,
+				5EC7DD3F09EBCC7AC71C230B /* Uninstall */,
 				98B7211D27EDF764EC477A0F /* PopoverMenu.swift */,
 				0F50886DC766B9923C3875A5 /* RootPaletteView.swift */,
 			);
@@ -601,6 +629,21 @@
 				5E08668A3C8418E2F0970300 /* CurrencyData.generated.swift */,
 			);
 			path = Calculator;
+			sourceTree = "<group>";
+		};
+		FB939500E513D49DC165EA75 /* Uninstall */ = {
+			isa = PBXGroup;
+			children = (
+				4954C8003947BB16ED48E326 /* UninstallPlan.swift */,
+				24F31E587DD4EAA1D7BD39AF /* UninstallProtection.swift */,
+				6EB4BA1A385F78B9C5E7EBCF /* UninstallRules.swift */,
+				CEE113DF7C07BC74AD73BC4C /* UninstallRunner.swift */,
+				FD131E932E1B53D39CF30C13 /* UninstallScanner.swift */,
+				9C56920811CA9A5F0FA04441 /* UninstallSearchRoot.swift */,
+				631D879F03A3A86553E7FFE5 /* UninstallSession.swift */,
+				6A6941F59D6E8014A22F1FF7 /* UninstallTarget.swift */,
+			);
+			path = Uninstall;
 			sourceTree = "<group>";
 		};
 		FB9897CCA50570B3E7630145 = {
@@ -803,6 +846,15 @@
 				85BCD328F402C7E09461D87F /* ThinScrollbar.swift in Sources */,
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,
 				CAD10A49DBDEFD2A9C03A7BE /* Tooltip.swift in Sources */,
+				6590849AB537D8641C71AC71 /* UninstallPlan.swift in Sources */,
+				FC3E8F307B25E3BC5E11AFCF /* UninstallProtection.swift in Sources */,
+				125A99FB5A3603488A261C6A /* UninstallRules.swift in Sources */,
+				2D620B55ED68ECDF75E7155E /* UninstallRunner.swift in Sources */,
+				BAA957558EB8FB2D26B13D4B /* UninstallScanner.swift in Sources */,
+				94620E1BB1049C5D8B45392E /* UninstallSearchRoot.swift in Sources */,
+				84096D3843E674F0B12C03D4 /* UninstallSession.swift in Sources */,
+				AC6AF9FA9C6874F257D3F613 /* UninstallTarget.swift in Sources */,
+				0962E9575CBF40B6F908031C /* UninstallView.swift in Sources */,
 				693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */,
 				A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */,
 				5F107A05A7EB05204465E89D /* VolumeHUDController.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -657,12 +657,10 @@ final class AppCore: ObservableObject {
 
     // MARK: - Uninstall
 
-    /// Opens the Uninstall screen for an app. Reached only from the launcher's Actions menu, so the
-    /// palette is already up — this swaps the sub-screen in place instead of re-showing the window.
+    /// The palette is already up when this runs, so it swaps the sub-screen in place rather than re-showing the window.
     func beginUninstall(_ app: AppEntry) {
         guard app.kind == .application else { return }
-        // The other installed apps are what stop a name or a shared bundle-ID namespace being
-        // misattributed; see `UninstallIdentity`.
+        // What stops a name or a shared bundle-ID namespace being misattributed; see `UninstallIdentity`.
         let others = appIndex.apps.filter { $0.kind == .application && $0.id != app.id }
         uninstall.begin(
             app: app, otherAppNames: others.map(\.name),
@@ -670,8 +668,7 @@ final class AppCore: ObservableObject {
         palette.prepare(mode: .uninstall)
     }
 
-    /// The one funnel for the Uninstall screen's ↵ and its Actions row, so neither can skip the
-    /// confirmation. Everything it moves goes to the Trash, never to a permanent delete.
+    /// The one funnel for the screen's ↵ and its Actions row, so neither can skip the confirmation.
     func performUninstall() {
         guard let app = uninstall.app, let plan = uninstall.plan, uninstall.canConfirm else { return }
         let items = uninstall.selectedCandidates
@@ -702,7 +699,7 @@ final class AppCore: ObservableObject {
         }
     }
 
-    /// Stays on the Uninstall screen: losing a whole scan to copy one path would be a poor trade.
+    /// Stays on the screen: losing a whole scan to copy one path is a poor trade.
     func copyUninstallPath(_ candidate: UninstallCandidate) {
         Paster.copyPlainText(candidate.path)
         messageHUD.show(message: "Copied path")

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -7,6 +7,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     case clipboard
     case calculatorHistory
     case emoji
+    case uninstall
 
     var id: String { rawValue }
     var title: String {
@@ -15,6 +16,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .clipboard: return "Clipboard"
         case .calculatorHistory: return "Calculator History"
         case .emoji: return "Emoji & Symbols"
+        case .uninstall: return "Uninstall Application"
         }
     }
     var systemImage: String {
@@ -23,6 +25,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .clipboard: return "doc.on.doc"
         case .calculatorHistory: return "plus.forwardslash.minus"
         case .emoji: return "face.smiling"
+        case .uninstall: return "trash"
         }
     }
     var placeholder: String {
@@ -31,6 +34,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .clipboard: return "Type to filter entries…"
         case .calculatorHistory: return "Do math, convert units, or search your past calculations…"
         case .emoji: return "Search emoji and symbols…"
+        case .uninstall: return "Filter files and folders by name…"
         }
     }
 }
@@ -111,6 +115,7 @@ final class AppCore: ObservableObject {
     let frequentEmoji = FrequentEmojiStore()
     let runningApps = RunningAppsMonitor()
     let palette = PaletteViewModel()
+    let uninstall = UninstallSession()
 
     private lazy var windowController = PaletteWindowController(core: self)
     private lazy var messageHUD = MessageHUDController(settings: settings)
@@ -648,6 +653,103 @@ final class AppCore: ObservableObject {
         let quittingPreviousApp = windowController.previousApp?.bundleIdentifier == bundleID
         guard AppLauncher.quit(bundleID: bundleID) else { return }
         hidePalette(restoreFocus: !quittingPreviousApp)
+    }
+
+    // MARK: - Uninstall
+
+    /// Opens the Uninstall screen for an app. Reached only from the launcher's Actions menu, so the
+    /// palette is already up — this swaps the sub-screen in place instead of re-showing the window.
+    func beginUninstall(_ app: AppEntry) {
+        guard app.kind == .application else { return }
+        // The other installed apps are what stop a name or a shared bundle-ID namespace being
+        // misattributed; see `UninstallIdentity`.
+        let others = appIndex.apps.filter { $0.kind == .application && $0.id != app.id }
+        uninstall.begin(
+            app: app, otherAppNames: others.map(\.name),
+            otherBundleIDs: others.compactMap(\.bundleID), isRunning: runningApps.isRunning(app))
+        palette.prepare(mode: .uninstall)
+    }
+
+    /// The one funnel for the Uninstall screen's ↵ and its Actions row, so neither can skip the
+    /// confirmation. Everything it moves goes to the Trash, never to a permanent delete.
+    func performUninstall() {
+        guard let app = uninstall.app, let plan = uninstall.plan, uninstall.canConfirm else { return }
+        let items = uninstall.selectedCandidates
+        guard !items.isEmpty else { return }
+        Task {
+            let running = plan.isTargetRunning || runningApps.isRunning(app)
+            let size = MeasuredSize(bytes: items.reduce(0) { $0 + $1.size.bytes }).formatted
+            let count = items.count == 1 ? "1 item" : "\(items.count) items"
+            guard
+                await confirm(
+                    title: "Uninstall “\(app.name)”?",
+                    message: "\(count) (\(size)) will be moved to the Trash, where you can put them "
+                        + "back." + (running ? " \(app.name) will quit first." : ""),
+                    symbol: "trash", confirmTitle: "Move to Trash")
+            else { return }
+
+            if running, let bundleID = app.bundleID { _ = AppLauncher.quit(bundleID: bundleID) }
+            uninstall.setTrashing(true)
+            let report = await UninstallRunner.moveToTrash(items)
+            uninstall.setTrashing(false)
+
+            if report.removedBundle {
+                removeUninstalledReferences(app)
+                await appIndex.refresh()
+            }
+            palette.prepare(mode: .launcher)
+            await presentUninstallReport(report)
+        }
+    }
+
+    /// Stays on the Uninstall screen: losing a whole scan to copy one path would be a poor trade.
+    func copyUninstallPath(_ candidate: UninstallCandidate) {
+        Paster.copyPlainText(candidate.path)
+        messageHUD.show(message: "Copied path")
+    }
+
+    func showUninstallItemInFinder(_ candidate: UninstallCandidate) {
+        hidePalette(restoreFocus: false)
+        AppLauncher.showInFinder(candidate.url)
+    }
+
+    func showUninstallItemInfo(_ candidate: UninstallCandidate) {
+        hidePalette(restoreFocus: false)
+        Task {
+            guard !AppLauncher.showInfoInFinder(candidate.url) else { return }
+            await showNotice(
+                title: "Couldn’t Open Get Info",
+                message: "Allow Tinycast to control Finder in System Settings › Privacy & Security "
+                    + "› Automation, then try again.",
+                symbol: "info.circle", tone: .danger)
+        }
+    }
+
+    private func removeUninstalledReferences(_ app: AppEntry) {
+        if let action = app.hotKeyAction {
+            if hotKeys.recordingAction == action { hotKeys.recordingAction = nil }
+            hotKeys.setBinding(nil, for: action)
+        }
+        favorites.remove(keys: [app.preferenceKey])
+        visibility.removeItemKeys([app.preferenceKey])
+        launcherRanking.reset(itemKey: app.preferenceKey)
+    }
+
+    private func presentUninstallReport(_ report: UninstallReport) async {
+        guard report.hasFailures else {
+            guard report.trashedCount > 0 else { return }
+            let count = report.trashedCount == 1 ? "1 item" : "\(report.trashedCount) items"
+            let freed = MeasuredSize(bytes: report.freedBytes).formatted
+            messageHUD.show(message: "Moved \(count) to the Trash · \(freed)")
+            return
+        }
+        let listed = report.failed.prefix(5).map { "\($0.name) — \($0.reason)" }
+        let remaining = report.failed.count - listed.count
+        await showNotice(
+            title: report.trashedCount > 0 ? "Some Items Weren’t Moved" : "Nothing Was Moved",
+            message: listed.joined(separator: "\n")
+                + (remaining > 0 ? "\nand \(remaining) more." : ""),
+            symbol: "trash", tone: .danger)
     }
 
     /// Quit All: the one action whose blast radius reaches outside Tinycast, so it confirms first. The target list is resolved once and both counted and terminated, so the set the user approves is the set that quits.

--- a/Tinycast/Core/AppLauncher.swift
+++ b/Tinycast/Core/AppLauncher.swift
@@ -12,6 +12,23 @@ enum AppLauncher {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    /// Finder's Get Info window. Unlike reveal there's no AppKit route, so this drives Finder over
+    /// Apple events — which means the first use raises the system Automation prompt. False lets the
+    /// caller say so; `-1743` is the user declining that prompt.
+    @MainActor
+    static func showInfoInFinder(_ url: URL) -> Bool {
+        let source = """
+            tell application "Finder"
+                activate
+                open information window of (POSIX file "\(url.path)" as alias)
+            end tell
+            """
+        guard let script = NSAppleScript(source: source) else { return false }
+        var errorInfo: NSDictionary?
+        script.executeAndReturnError(&errorInfo)
+        return errorInfo == nil
+    }
+
     /// Opens System Settings at the pane backed by the given extension bundle ID.
     @MainActor
     static func openSettingsPane(bundleID: String) {

--- a/Tinycast/Core/AppLauncher.swift
+++ b/Tinycast/Core/AppLauncher.swift
@@ -12,9 +12,7 @@ enum AppLauncher {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
-    /// Finder's Get Info window. Unlike reveal there's no AppKit route, so this drives Finder over
-    /// Apple events — which means the first use raises the system Automation prompt. False lets the
-    /// caller say so; `-1743` is the user declining that prompt.
+    /// No AppKit route for Get Info, so this drives Finder over Apple events — the first use raises the Automation prompt.
     @MainActor
     static func showInfoInFinder(_ url: URL) -> Bool {
         let source = """

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -120,6 +120,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             .environmentObject(core.frequentEmoji)
             .environmentObject(core.runningApps)
             .environmentObject(core.hotKeys)
+            .environmentObject(core.uninstall)
         let panel = PalettePanel(rootView: root)
         panel.delegate = self
         panel.paletteViewModel = core.palette

--- a/Tinycast/Core/Theme.swift
+++ b/Tinycast/Core/Theme.swift
@@ -70,6 +70,8 @@ enum Theme {
         static let compactKeyCap: CGFloat = 15
         static let heroKeyCap: CGFloat = 22
         static let menuButton: CGFloat = 36
+        /// The uninstall list's leading checkbox / lock glyph.
+        static let checkbox: CGFloat = 16
         static let clipboardListWidth: CGFloat = 290
         static let emojiCell: CGFloat = 56
         static let menuWidth: CGFloat = 276

--- a/Tinycast/Core/Uninstall/UninstallPlan.swift
+++ b/Tinycast/Core/Uninstall/UninstallPlan.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Bytes plus whether the size walk hit its budget, so a huge tree can honestly read "at least".
+struct MeasuredSize: Hashable, Sendable {
+    var bytes: Int64 = 0
+    var isLowerBound = false
+
+    static let zero = MeasuredSize()
+
+    var formatted: String {
+        // `spellsOutZero` off: the default renders an empty folder as "Zero kB", which reads as a bug.
+        let size = bytes.formatted(.byteCount(style: .file, spellsOutZero: false))
+        return isLowerBound ? "≥ " + size : size
+    }
+}
+
+/// One item an uninstall would move to the Trash: the app bundle itself, or a leftover attributed to it.
+struct UninstallCandidate: Identifiable, Hashable, Sendable {
+    /// The standardized path, which is also what `UninstallSelection` stores.
+    let path: String
+    /// Row title: the file name, with `.app` stripped from the bundle.
+    let name: String
+    /// Row subtitle: the enclosing directory, tilde-abbreviated.
+    let locationLabel: String
+    let evidence: UninstallEvidence
+    let isDirectory: Bool
+    let size: MeasuredSize
+    let protection: UninstallProtection
+
+    var id: String { path }
+    var url: URL { URL(fileURLWithPath: path) }
+    var isLocked: Bool { !protection.isRemovable }
+    var lockReason: String? { protection.lockReason }
+}
+
+/// The result of a scan: everything attributable to one app, with the bundle pinned first.
+struct UninstallPlan: Equatable, Sendable {
+    let target: UninstallTarget
+    let candidates: [UninstallCandidate]
+    let isTargetRunning: Bool
+
+    var removableIDs: Set<UninstallCandidate.ID> {
+        Set(candidates.lazy.filter { !$0.isLocked }.map(\.id))
+    }
+
+    var lockedCount: Int { candidates.count { $0.isLocked } }
+
+    var totalBytes: Int64 { candidates.reduce(0) { $0 + $1.size.bytes } }
+
+    /// Everything removable except name matches — evidence that weak is the user's call to make.
+    var defaultSelection: UninstallSelection {
+        UninstallSelection(
+            plan: self,
+            checked: Set(
+                candidates.lazy.filter { !$0.isLocked && $0.evidence.isAutoChecked }.map(\.id)))
+    }
+}
+
+/// The only thing that can hold a checked set, and it can only ever hold removable ids.
+///
+/// Every mutation funnels through the same intersection with `plan.removableIDs`, so the invariant
+/// "a locked candidate is never checked" is one line to review rather than a rule spread across the
+/// view and the session.
+struct UninstallSelection: Equatable, Sendable {
+    private(set) var checked: Set<UninstallCandidate.ID>
+
+    init(plan: UninstallPlan, checked: Set<UninstallCandidate.ID> = []) {
+        self.checked = checked.intersection(plan.removableIDs)
+    }
+
+    mutating func toggle(_ id: UninstallCandidate.ID, in plan: UninstallPlan) {
+        if checked.contains(id) {
+            checked.remove(id)
+        } else if plan.removableIDs.contains(id) {
+            checked.insert(id)
+        }
+    }
+
+    mutating func setAll(_ on: Bool, in plan: UninstallPlan) {
+        checked = on ? plan.removableIDs : []
+    }
+
+    func isChecked(_ id: UninstallCandidate.ID) -> Bool { checked.contains(id) }
+
+    var count: Int { checked.count }
+
+    func bytes(in plan: UninstallPlan) -> Int64 {
+        plan.candidates.reduce(0) { $0 + (checked.contains($1.id) ? $1.size.bytes : 0) }
+    }
+
+    func candidates(in plan: UninstallPlan) -> [UninstallCandidate] {
+        plan.candidates.filter { checked.contains($0.id) }
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallPlan.swift
+++ b/Tinycast/Core/Uninstall/UninstallPlan.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Bytes plus whether the size walk hit its budget, so a huge tree can honestly read "at least".
+/// Bytes, plus whether the walk hit its budget so a huge tree can honestly read "at least".
 struct MeasuredSize: Hashable, Sendable {
     var bytes: Int64 = 0
     var isLowerBound = false
@@ -8,17 +8,17 @@ struct MeasuredSize: Hashable, Sendable {
     static let zero = MeasuredSize()
 
     var formatted: String {
-        // `spellsOutZero` off: the default renders an empty folder as "Zero kB", which reads as a bug.
+        // Without this an empty folder renders as "Zero kB", which reads as a bug.
         let size = bytes.formatted(.byteCount(style: .file, spellsOutZero: false))
         return isLowerBound ? "≥ " + size : size
     }
 }
 
-/// One item an uninstall would move to the Trash: the app bundle itself, or a leftover attributed to it.
+/// One item an uninstall would trash: the bundle itself, or a leftover attributed to it.
 struct UninstallCandidate: Identifiable, Hashable, Sendable {
-    /// The standardized path, which is also what `UninstallSelection` stores.
+    /// Standardized, and what `UninstallSelection` stores.
     let path: String
-    /// Row title: the file name, with `.app` stripped from the bundle.
+    /// Row title, with `.app` stripped from the bundle.
     let name: String
     /// Row subtitle: the enclosing directory, tilde-abbreviated.
     let locationLabel: String
@@ -33,7 +33,7 @@ struct UninstallCandidate: Identifiable, Hashable, Sendable {
     var lockReason: String? { protection.lockReason }
 }
 
-/// The result of a scan: everything attributable to one app, with the bundle pinned first.
+/// Everything attributable to one app, bundle pinned first.
 struct UninstallPlan: Equatable, Sendable {
     let target: UninstallTarget
     let candidates: [UninstallCandidate]
@@ -47,20 +47,14 @@ struct UninstallPlan: Equatable, Sendable {
 
     var totalBytes: Int64 { candidates.reduce(0) { $0 + $1.size.bytes } }
 
-    /// Everything the user can actually remove. Name matches are included: they are exact, confined to
-    /// human-named roots, and never claim a name another installed app answers to — and since the
-    /// whole feature only ever moves to the Trash, an unwanted row costs a drag back, not data. The
-    /// row still says "matched by name" so the weaker evidence stays visible before confirming.
+    /// Everything removable, name matches included: they're exact, confined, and only ever cost a drag back out of the Trash.
     var defaultSelection: UninstallSelection {
         UninstallSelection(plan: self, checked: removableIDs)
     }
 }
 
-/// The only thing that can hold a checked set, and it can only ever hold removable ids.
-///
-/// Every mutation funnels through the same intersection with `plan.removableIDs`, so the invariant
-/// "a locked candidate is never checked" is one line to review rather than a rule spread across the
-/// view and the session.
+/// The only thing holding a checked set, and it can only hold removable ids. Every mutation funnels through one
+/// intersection with `plan.removableIDs`, so "a locked candidate is never checked" is one line to review.
 struct UninstallSelection: Equatable, Sendable {
     private(set) var checked: Set<UninstallCandidate.ID>
 
@@ -74,10 +68,6 @@ struct UninstallSelection: Equatable, Sendable {
         } else if plan.removableIDs.contains(id) {
             checked.insert(id)
         }
-    }
-
-    mutating func setAll(_ on: Bool, in plan: UninstallPlan) {
-        checked = on ? plan.removableIDs : []
     }
 
     func isChecked(_ id: UninstallCandidate.ID) -> Bool { checked.contains(id) }

--- a/Tinycast/Core/Uninstall/UninstallPlan.swift
+++ b/Tinycast/Core/Uninstall/UninstallPlan.swift
@@ -47,12 +47,12 @@ struct UninstallPlan: Equatable, Sendable {
 
     var totalBytes: Int64 { candidates.reduce(0) { $0 + $1.size.bytes } }
 
-    /// Everything removable except name matches — evidence that weak is the user's call to make.
+    /// Everything the user can actually remove. Name matches are included: they are exact, confined to
+    /// human-named roots, and never claim a name another installed app answers to — and since the
+    /// whole feature only ever moves to the Trash, an unwanted row costs a drag back, not data. The
+    /// row still says "matched by name" so the weaker evidence stays visible before confirming.
     var defaultSelection: UninstallSelection {
-        UninstallSelection(
-            plan: self,
-            checked: Set(
-                candidates.lazy.filter { !$0.isLocked && $0.evidence.isAutoChecked }.map(\.id)))
+        UninstallSelection(plan: self, checked: removableIDs)
     }
 }
 

--- a/Tinycast/Core/Uninstall/UninstallProtection.swift
+++ b/Tinycast/Core/Uninstall/UninstallProtection.swift
@@ -90,12 +90,14 @@ enum UninstallProtectionRules {
         return relative || path.hasPrefix("/Library/Application Support/com.apple.TCC")
     }
 
+    /// Measured, not assumed: a probe that creates and trashes a throwaway directory in each of these
+    /// shows `Containers`, `Group Containers` and `Cookies` refuse the move without Full Disk Access,
+    /// while `Application Scripts` and `Autosave Information` allow it. Listing a directory is *not*
+    /// the test — both container roots list fine and still refuse the trash. Re-measure before adding.
     static let tccRelativePrefixes: [String] = [
         "Library/Containers/",
         "Library/Group Containers/",
-        "Library/Application Scripts/",
         "Library/Cookies/",
-        "Library/Autosave Information/",
         "Library/Safari",
         "Library/Mail",
         "Library/Messages",

--- a/Tinycast/Core/Uninstall/UninstallProtection.swift
+++ b/Tinycast/Core/Uninstall/UninstallProtection.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Everything the classifier is allowed to know about one path, gathered by `UninstallScanner`.
+/// Injecting the facts is what keeps the classifier pure and drivable from the harness.
+struct PathFacts: Hashable, Sendable {
+    let path: String
+    var exists = true
+    /// Never followed: a symlinked directory can point anywhere, so sizing through it could walk the
+    /// whole disk and classifying it would read facts from outside the roots.
+    var isSymbolicLink = false
+    var volumeIsReadOnly = false
+    /// `SF_RESTRICTED` / `SF_IMMUTABLE` — SIP.
+    var isSystemRestricted = false
+    /// `UF_IMMUTABLE` — Finder's "Locked" checkbox, which the user can clear themselves.
+    var isUserImmutable = false
+    var isOwnedByCurrentUser = true
+    var parentIsWritable = true
+}
+
+/// Process-wide facts, probed once per scan rather than once per candidate.
+struct UninstallEnvironment: Hashable, Sendable {
+    let home: String
+    let hasFullDiskAccess: Bool
+}
+
+/// Why a candidate can or can't be moved to the Trash.
+///
+/// Advisory, not a security boundary: TCC is evaluated at the syscall, so this can be wrong in both
+/// directions. It exists to explain why a row is gray and to skip obviously doomed attempts —
+/// `UninstallRunner` still reports per-item failure.
+enum UninstallProtection: String, Hashable, Sendable, CaseIterable {
+    case removable
+    case systemProtected
+    case userLocked
+    case notOwned
+    case needsFullDiskAccess
+    case parentNotWritable
+    case missing
+
+    var isRemovable: Bool { self == .removable }
+
+    /// Nil for exactly `.removable` — the harness asserts that, since the row's lock icon keys off it.
+    var lockReason: String? {
+        switch self {
+        case .removable:
+            return nil
+        case .systemProtected:
+            return "Part of macOS and protected by the system."
+        case .userLocked:
+            return "Locked in Finder. Unlock it in Get Info, then try again."
+        case .notOwned:
+            return "Owned by another user. Tinycast never asks for an administrator password."
+        case .needsFullDiskAccess:
+            return "Needs Full Disk Access, which Tinycast doesn’t request. "
+                + "Grant it in System Settings › Privacy & Security to include this item."
+        case .parentNotWritable:
+            return "Its enclosing folder isn’t writable by you."
+        case .missing:
+            return "No longer on disk."
+        }
+    }
+}
+
+enum UninstallProtectionRules {
+    /// Precedence matters and is asserted: a SIP file is also root-owned and often TCC-gated, and
+    /// "part of macOS" is the more useful sentence than either of the others. This is the branch
+    /// that locks `/System/Applications/Books.app`, and it falls out of the facts rather than a
+    /// hardcoded `/System` prefix.
+    static func classify(_ facts: PathFacts, environment: UninstallEnvironment) -> UninstallProtection
+    {
+        guard facts.exists else { return .missing }
+        if facts.isSystemRestricted || facts.volumeIsReadOnly { return .systemProtected }
+        if facts.isUserImmutable { return .userLocked }
+        if !facts.isOwnedByCurrentUser { return .notOwned }
+        if !environment.hasFullDiskAccess,
+            isTCCProtected(path: facts.path, home: environment.home)
+        {
+            return .needsFullDiskAccess
+        }
+        // Trashing is a rename out of the enclosing directory, so that is the permission that decides it.
+        if !facts.parentIsWritable { return .parentNotWritable }
+        return .removable
+    }
+
+    /// Paths TCC gates for a non-sandboxed app without Full Disk Access. The list runs wider than
+    /// the current search roots on purpose, so adding a root later can't silently start attempting
+    /// reads macOS would deny.
+    static func isTCCProtected(path: String, home: String) -> Bool {
+        let relative = tccRelativePrefixes.contains { path.hasPrefix(home + "/" + $0) }
+        return relative || path.hasPrefix("/Library/Application Support/com.apple.TCC")
+    }
+
+    static let tccRelativePrefixes: [String] = [
+        "Library/Containers/",
+        "Library/Group Containers/",
+        "Library/Application Scripts/",
+        "Library/Cookies/",
+        "Library/Autosave Information/",
+        "Library/Safari",
+        "Library/Mail",
+        "Library/Messages",
+        "Library/Calendars",
+        "Library/Suggestions",
+        "Library/HomeKit",
+        "Library/IdentityServices",
+        "Library/Sharing",
+        "Library/Biome",
+        "Library/Trial",
+        "Library/Metadata/CoreSpotlight",
+        "Library/Application Support/AddressBook",
+        "Library/Application Support/CallHistoryDB",
+        "Library/Application Support/com.apple.TCC",
+        "Library/Application Support/MobileSync"
+    ]
+}

--- a/Tinycast/Core/Uninstall/UninstallProtection.swift
+++ b/Tinycast/Core/Uninstall/UninstallProtection.swift
@@ -1,12 +1,10 @@
 import Foundation
 
-/// Everything the classifier is allowed to know about one path, gathered by `UninstallScanner`.
-/// Injecting the facts is what keeps the classifier pure and drivable from the harness.
+/// All the classifier may know about one path. Injected, which is what keeps it pure and harness-drivable.
 struct PathFacts: Hashable, Sendable {
     let path: String
     var exists = true
-    /// Never followed: a symlinked directory can point anywhere, so sizing through it could walk the
-    /// whole disk and classifying it would read facts from outside the roots.
+    /// Never followed: sizing through one could walk the whole disk.
     var isSymbolicLink = false
     var volumeIsReadOnly = false
     /// `SF_RESTRICTED` / `SF_IMMUTABLE` — SIP.
@@ -26,11 +24,8 @@ struct UninstallEnvironment: Hashable, Sendable {
     let hasFullDiskAccess: Bool
 }
 
-/// Why a candidate can or can't be moved to the Trash.
-///
-/// Advisory, not a security boundary: TCC is evaluated at the syscall, so this can be wrong in both
-/// directions. It exists to explain why a row is gray and to skip obviously doomed attempts —
-/// `UninstallRunner` still reports per-item failure.
+/// Why a candidate can or can't be trashed. Advisory, not a boundary: TCC is evaluated at the syscall, so this can be wrong either way.
+/// It grays a row with a reason and skips doomed attempts; `UninstallRunner` still reports per-item failure.
 enum UninstallProtection: String, Hashable, Sendable, CaseIterable {
     case removable
     case systemProtected
@@ -42,7 +37,7 @@ enum UninstallProtection: String, Hashable, Sendable, CaseIterable {
 
     var isRemovable: Bool { self == .removable }
 
-    /// Nil for exactly `.removable` — the harness asserts that, since the row's lock icon keys off it.
+    /// Nil for exactly `.removable`; the row's lock icon keys off it.
     var lockReason: String? {
         switch self {
         case .removable:
@@ -66,10 +61,7 @@ enum UninstallProtection: String, Hashable, Sendable, CaseIterable {
 }
 
 enum UninstallProtectionRules {
-    /// Precedence matters and is asserted: a SIP file is also root-owned and often TCC-gated, and
-    /// "part of macOS" is the more useful sentence than either of the others. This is the branch
-    /// that locks `/System/Applications/Books.app`, and it falls out of the facts rather than a
-    /// hardcoded `/System` prefix.
+    /// Precedence is asserted: a SIP file is also root-owned and often TCC-gated, and "part of macOS" is the most useful reason.
     static func classify(_ facts: PathFacts, environment: UninstallEnvironment) -> UninstallProtection
     {
         guard facts.exists else { return .missing }
@@ -80,27 +72,21 @@ enum UninstallProtectionRules {
         {
             return .needsFullDiskAccess
         }
-        // Trashing is a rename out of the enclosing directory, so the parent's write permission is
-        // what decides it — *not* who owns the item. A root-owned file inside a folder you can write
-        // is yours to remove, and locking on ownership alone grays out rows that trash perfectly well.
+        // Trashing is a rename out of the parent, so its write bit decides — not who owns the item.
         if !facts.parentIsWritable { return .parentNotWritable }
         // The one case where ownership does decide: a sticky parent lets only an owner unlink.
         if facts.parentIsSticky, !facts.isOwnedByCurrentUser { return .notOwned }
         return .removable
     }
 
-    /// Paths TCC gates for a non-sandboxed app without Full Disk Access. The list runs wider than
-    /// the current search roots on purpose, so adding a root later can't silently start attempting
-    /// reads macOS would deny.
+    /// Wider than the current roots on purpose, so adding one later can't silently start attempting denied reads.
     static func isTCCProtected(path: String, home: String) -> Bool {
         let relative = tccRelativePrefixes.contains { path.hasPrefix(home + "/" + $0) }
         return relative || path.hasPrefix("/Library/Application Support/com.apple.TCC")
     }
 
-    /// Measured, not assumed: a probe that creates and trashes a throwaway directory in each of these
-    /// shows `Containers`, `Group Containers` and `Cookies` refuse the move without Full Disk Access,
-    /// while `Application Scripts` and `Autosave Information` allow it. Listing a directory is *not*
-    /// the test — both container roots list fine and still refuse the trash. Re-measure before adding.
+    /// Measured, not assumed — probe by creating and trashing a throwaway directory. Listing is *not* the test:
+    /// both container roots list fine and still refuse the trash. Re-measure before adding an entry.
     static let tccRelativePrefixes: [String] = [
         "Library/Containers/",
         "Library/Group Containers/",

--- a/Tinycast/Core/Uninstall/UninstallProtection.swift
+++ b/Tinycast/Core/Uninstall/UninstallProtection.swift
@@ -13,8 +13,11 @@ struct PathFacts: Hashable, Sendable {
     var isSystemRestricted = false
     /// `UF_IMMUTABLE` — Finder's "Locked" checkbox, which the user can clear themselves.
     var isUserImmutable = false
+    /// Only decides anything under a sticky parent — see `classify`.
     var isOwnedByCurrentUser = true
     var parentIsWritable = true
+    /// `S_ISVTX` on the enclosing directory: the `/tmp` rule, where only an item's owner may unlink it.
+    var parentIsSticky = false
 }
 
 /// Process-wide facts, probed once per scan rather than once per candidate.
@@ -49,12 +52,13 @@ enum UninstallProtection: String, Hashable, Sendable, CaseIterable {
         case .userLocked:
             return "Locked in Finder. Unlock it in Get Info, then try again."
         case .notOwned:
-            return "Owned by another user. Tinycast never asks for an administrator password."
+            return "Owned by another user, in a folder that only lets owners remove things."
         case .needsFullDiskAccess:
             return "Needs Full Disk Access, which Tinycast doesn’t request. "
                 + "Grant it in System Settings › Privacy & Security to include this item."
         case .parentNotWritable:
-            return "Its enclosing folder isn’t writable by you."
+            return "Its enclosing folder isn’t writable by you, and Tinycast never asks for an "
+                + "administrator password."
         case .missing:
             return "No longer on disk."
         }
@@ -71,14 +75,17 @@ enum UninstallProtectionRules {
         guard facts.exists else { return .missing }
         if facts.isSystemRestricted || facts.volumeIsReadOnly { return .systemProtected }
         if facts.isUserImmutable { return .userLocked }
-        if !facts.isOwnedByCurrentUser { return .notOwned }
         if !environment.hasFullDiskAccess,
             isTCCProtected(path: facts.path, home: environment.home)
         {
             return .needsFullDiskAccess
         }
-        // Trashing is a rename out of the enclosing directory, so that is the permission that decides it.
+        // Trashing is a rename out of the enclosing directory, so the parent's write permission is
+        // what decides it — *not* who owns the item. A root-owned file inside a folder you can write
+        // is yours to remove, and locking on ownership alone grays out rows that trash perfectly well.
         if !facts.parentIsWritable { return .parentNotWritable }
+        // The one case where ownership does decide: a sticky parent lets only an owner unlink.
+        if facts.parentIsSticky, !facts.isOwnedByCurrentUser { return .notOwned }
         return .removable
     }
 

--- a/Tinycast/Core/Uninstall/UninstallRules.swift
+++ b/Tinycast/Core/Uninstall/UninstallRules.swift
@@ -9,7 +9,10 @@ enum UninstallRules {
     /// Suffixes macOS appends to bundle-ID-named artifacts, stripped before matching so
     /// `com.foo.Bar.plist` compares as `com.foo.Bar`.
     static let strippedExtensions: Set<String> = [
-        "plist", "savedstate", "binarycookies", "lockfile", "lock", "sfl", "sfl2", "sfl3"
+        "plist", "savedstate", "binarycookies", "lockfile", "lock", "sfl", "sfl2", "sfl3",
+        // Plug-in wrappers, which are named after the product that installed them.
+        "qlgenerator", "saver", "prefpane", "service", "workflow", "mdimporter", "appex",
+        "component", "wdgt", "dext", "driver"
     ]
 
     /// The name plus each successively stripped form. Stripping only ever adds a comparison, so it
@@ -28,13 +31,17 @@ enum UninstallRules {
         return forms
     }
 
-    /// True when `component` is the bundle ID itself, or a dot-namespaced child of it.
+    /// What may follow a bundle ID for the remainder to still be part of the same product. `.` is the
+    /// ordinary namespace separator; `-` is how vendors name release variants — `dev.zed.Zed-Preview`
+    /// belongs to Zed, and if Zed Preview is itself installed the sibling rule below hands it back.
+    private static let namespaceSeparators: Set<Character> = [".", "-"]
+
+    /// True when `component` is the bundle ID itself, or a namespaced child of it.
     ///
-    /// The trailing dot is load-bearing. A plain `hasPrefix` makes `com.apple.SafariTechnologyPreview`
-    /// a match for `com.apple.Safari` — a separately installed product whose entire profile would go
-    /// to the Trash. Requiring the next character to be "." means a match can only be a namespace
-    /// descendant: `com.apple.iBooksX.CacheDelete` matches `com.apple.iBooksX`, `com.apple.iBooksXtra`
-    /// does not.
+    /// The boundary is load-bearing. A plain `hasPrefix` makes `com.apple.SafariTechnologyPreview` a
+    /// match for `com.apple.Safari` — a separately installed product whose entire profile would go to
+    /// the Trash. Requiring a separator next means a match can only be a namespace descendant:
+    /// `com.apple.iBooksX.CacheDelete` matches `com.apple.iBooksX`, `com.apple.iBooksXtra` does not.
     static func matchesBundleID(_ component: String, identity: UninstallIdentity) -> Bool {
         guard let id = identity.bundleID else { return false }
         return matchableForms(component).contains { form in
@@ -52,7 +59,18 @@ enum UninstallRules {
 
     private static func owns(_ folded: String, id: String, allowingPrefix: Bool) -> Bool {
         if folded == id { return true }
-        return allowingPrefix && folded.hasPrefix(id + ".")
+        guard allowingPrefix, folded.count > id.count, folded.hasPrefix(id) else { return false }
+        // The boundary check is what separates a namespace child from a different product:
+        // `com.apple.SafariTechnologyPreview` must never be read as a child of `com.apple.Safari`.
+        return namespaceSeparators.contains(folded[folded.index(folded.startIndex, offsetBy: id.count)])
+    }
+
+    /// A `/usr/local/bin`-style launcher belongs to the app when it resolves inside the bundle.
+    /// Attribution by link target, never by name — the name is whatever the vendor chose.
+    static func isBundleSymlink(target: String, bundlePath: String) -> Bool {
+        let target = (target as NSString).standardizingPath
+        let bundlePath = (bundlePath as NSString).standardizingPath
+        return target == bundlePath || isDescendant(target, of: bundlePath)
     }
 
     /// Strips a leading `group.` and/or a 10-character Team ID, in either order, leaving a plain

--- a/Tinycast/Core/Uninstall/UninstallRules.swift
+++ b/Tinycast/Core/Uninstall/UninstallRules.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Decides which directory entries belong to an app. Pure by construction: the scanner does the
+/// listing and hands over child *names*, so nothing here can touch the filesystem.
+///
+/// This is the safety-critical half of the feature — a false positive moves an unrelated app's data
+/// to the Trash — which is why every rule here is exact or namespace-anchored, never fuzzy.
+enum UninstallRules {
+    /// Suffixes macOS appends to bundle-ID-named artifacts, stripped before matching so
+    /// `com.foo.Bar.plist` compares as `com.foo.Bar`.
+    static let strippedExtensions: Set<String> = [
+        "plist", "savedstate", "binarycookies", "lockfile", "lock", "sfl", "sfl2", "sfl3"
+    ]
+
+    /// The name plus each successively stripped form. Stripping only ever adds a comparison, so it
+    /// can't turn a match into a miss. Bounded because a name is not a trustworthy loop condition.
+    static func matchableForms(_ name: String) -> [String] {
+        var forms = [name]
+        var current = name
+        for _ in 0..<3 {
+            let ext = (current as NSString).pathExtension.lowercased()
+            guard !ext.isEmpty, strippedExtensions.contains(ext) else { break }
+            let stripped = (current as NSString).deletingPathExtension
+            guard !stripped.isEmpty else { break }
+            forms.append(stripped)
+            current = stripped
+        }
+        return forms
+    }
+
+    /// True when `component` is the bundle ID itself, or a dot-namespaced child of it.
+    ///
+    /// The trailing dot is load-bearing. A plain `hasPrefix` makes `com.apple.SafariTechnologyPreview`
+    /// a match for `com.apple.Safari` — a separately installed product whose entire profile would go
+    /// to the Trash. Requiring the next character to be "." means a match can only be a namespace
+    /// descendant: `com.apple.iBooksX.CacheDelete` matches `com.apple.iBooksX`, `com.apple.iBooksXtra`
+    /// does not.
+    static func matchesBundleID(_ component: String, identity: UninstallIdentity) -> Bool {
+        guard let id = identity.bundleID else { return false }
+        return matchableForms(component).contains { form in
+            let folded = UninstallIdentity.folded(form)
+            guard owns(folded, id: id, allowingPrefix: identity.allowsBundleIDPrefixMatch)
+            else { return false }
+            // A sibling app installed under a longer ID in the same namespace owns its own
+            // artifacts. Without this, uninstalling Tinycast would also trash the Beta and Dev
+            // channels' data — they are separate products, not extensions of the stable one.
+            return !identity.otherBundleIDs.contains { other in
+                other.count > id.count && owns(folded, id: other, allowingPrefix: true)
+            }
+        }
+    }
+
+    private static func owns(_ folded: String, id: String, allowingPrefix: Bool) -> Bool {
+        if folded == id { return true }
+        return allowingPrefix && folded.hasPrefix(id + ".")
+    }
+
+    /// Strips a leading `group.` and/or a 10-character Team ID, in either order, leaving a plain
+    /// bundle ID for the ordinary rule above. Team IDs are exactly 10 uppercase alphanumerics, which
+    /// is what stops an arbitrary `something.com.foo.Bar` being read as a container of `com.foo.Bar`.
+    static func groupContainerBase(_ component: String) -> String {
+        var base = component
+        for _ in 0..<2 {
+            if base.lowercased().hasPrefix("group.") {
+                base = String(base.dropFirst("group.".count))
+                continue
+            }
+            guard let dot = base.firstIndex(of: "."), isTeamID(String(base[base.startIndex..<dot]))
+            else { break }
+            base = String(base[base.index(after: dot)...])
+        }
+        return base
+    }
+
+    static func isTeamID(_ value: String) -> Bool {
+        value.count == 10
+            && value.allSatisfy { $0.isASCII && ($0.isUppercase || $0.isNumber) && !$0.isLowercase }
+    }
+
+    static func matchesGroupContainer(_ component: String, identity: UninstallIdentity) -> Bool {
+        matchesBundleID(groupContainerBase(component), identity: identity)
+    }
+
+    /// Exact, case- and diacritic-folded equality only. No prefix and no substring, which is what
+    /// makes "Books" and "Books Reader" unable to claim each other's folders in either direction.
+    static func matchesDisplayName(_ component: String, identity: UninstallIdentity) -> Bool {
+        guard !identity.names.isEmpty else { return false }
+        return matchableForms(component).contains { form in
+            identity.names.contains(UninstallIdentity.folded(form))
+        }
+    }
+
+    static func evidence(
+        for name: String, in root: UninstallSearchRoot, identity: UninstallIdentity
+    ) -> UninstallEvidence? {
+        if root.styles.contains(.bundleID), matchesBundleID(name, identity: identity) {
+            return .bundleID
+        }
+        if root.styles.contains(.groupContainer), matchesGroupContainer(name, identity: identity) {
+            return .groupContainer
+        }
+        if root.styles.contains(.displayName), matchesDisplayName(name, identity: identity) {
+            return .displayName
+        }
+        return nil
+    }
+
+    static func matches(
+        childNames: [String], in root: UninstallSearchRoot, identity: UninstallIdentity
+    ) -> [(name: String, evidence: UninstallEvidence)] {
+        childNames.compactMap { name in
+            evidence(for: name, in: root, identity: identity).map { (name, $0) }
+        }
+    }
+
+    /// Belt and braces on every path the walk produces, independent of how it matched: it must be an
+    /// immediate child of its own root, must not be the home directory or a filesystem root, must
+    /// carry no relative components, and must not overlap the app bundle (emitted separately).
+    static func isAcceptableCandidate(
+        path: String, rootPath: String, home: String, bundlePath: String
+    ) -> Bool {
+        let path = (path as NSString).standardizingPath
+        let home = (home as NSString).standardizingPath
+        let bundlePath = (bundlePath as NSString).standardizingPath
+        guard path.hasPrefix("/"), path != "/", path != home, path != rootPath else { return false }
+        let components = path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard !components.isEmpty, !components.contains("."), !components.contains("..")
+        else { return false }
+        guard (path as NSString).deletingLastPathComponent == rootPath else { return false }
+        guard path != bundlePath, !isDescendant(path, of: bundlePath),
+            !isDescendant(bundlePath, of: path)
+        else { return false }
+        return true
+    }
+
+    static func isDescendant(_ path: String, of ancestor: String) -> Bool {
+        path.hasPrefix(ancestor + "/")
+    }
+
+    /// Tilde form for the row subtitle. Takes `home` rather than reading it, so it stays pure.
+    static func abbreviate(_ path: String, home: String) -> String {
+        if path == home { return "~" }
+        guard isDescendant(path, of: home) else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallRules.swift
+++ b/Tinycast/Core/Uninstall/UninstallRules.swift
@@ -1,22 +1,17 @@
 import Foundation
 
-/// Decides which directory entries belong to an app. Pure by construction: the scanner does the
-/// listing and hands over child *names*, so nothing here can touch the filesystem.
-///
-/// This is the safety-critical half of the feature — a false positive moves an unrelated app's data
-/// to the Trash — which is why every rule here is exact or namespace-anchored, never fuzzy.
+/// Decides which directory entries belong to an app. The scanner hands over child *names*, so nothing here touches the filesystem.
+/// Safety-critical: a false positive trashes another app's data, which is why every rule is exact or namespace-anchored, never fuzzy.
 enum UninstallRules {
-    /// Suffixes macOS appends to bundle-ID-named artifacts, stripped before matching so
-    /// `com.foo.Bar.plist` compares as `com.foo.Bar`.
+    /// Stripped before matching, so `com.foo.Bar.plist` compares as `com.foo.Bar`.
     static let strippedExtensions: Set<String> = [
         "plist", "savedstate", "binarycookies", "lockfile", "lock", "sfl", "sfl2", "sfl3",
-        // Plug-in wrappers, which are named after the product that installed them.
+        // Plug-in wrappers, named after the product that installed them.
         "qlgenerator", "saver", "prefpane", "service", "workflow", "mdimporter", "appex",
         "component", "wdgt", "dext", "driver"
     ]
 
-    /// The name plus each successively stripped form. Stripping only ever adds a comparison, so it
-    /// can't turn a match into a miss. Bounded because a name is not a trustworthy loop condition.
+    /// The name plus each stripped form. Stripping only adds comparisons, so it can't turn a match into a miss.
     static func matchableForms(_ name: String) -> [String] {
         var forms = [name]
         var current = name
@@ -31,26 +26,17 @@ enum UninstallRules {
         return forms
     }
 
-    /// What may follow a bundle ID for the remainder to still be part of the same product. `.` is the
-    /// ordinary namespace separator; `-` is how vendors name release variants — `dev.zed.Zed-Preview`
-    /// belongs to Zed, and if Zed Preview is itself installed the sibling rule below hands it back.
+    /// `-` counts because vendors name variants that way: `dev.zed.Zed-Preview` is Zed's, unless Zed Preview is itself installed.
     private static let namespaceSeparators: Set<Character> = [".", "-"]
 
-    /// True when `component` is the bundle ID itself, or a namespaced child of it.
-    ///
-    /// The boundary is load-bearing. A plain `hasPrefix` makes `com.apple.SafariTechnologyPreview` a
-    /// match for `com.apple.Safari` — a separately installed product whose entire profile would go to
-    /// the Trash. Requiring a separator next means a match can only be a namespace descendant:
-    /// `com.apple.iBooksX.CacheDelete` matches `com.apple.iBooksX`, `com.apple.iBooksXtra` does not.
+    /// The bundle ID itself, or a namespaced child of it.
     static func matchesBundleID(_ component: String, identity: UninstallIdentity) -> Bool {
         guard let id = identity.bundleID else { return false }
         return matchableForms(component).contains { form in
             let folded = UninstallIdentity.folded(form)
             guard owns(folded, id: id, allowingPrefix: identity.allowsBundleIDPrefixMatch)
             else { return false }
-            // A sibling app installed under a longer ID in the same namespace owns its own
-            // artifacts. Without this, uninstalling Tinycast would also trash the Beta and Dev
-            // channels' data — they are separate products, not extensions of the stable one.
+            // A longer-ID sibling owns its own artifacts, or uninstalling Tinycast would trash the Beta and Dev channels too.
             return !identity.otherBundleIDs.contains { other in
                 other.count > id.count && owns(folded, id: other, allowingPrefix: true)
             }
@@ -60,12 +46,10 @@ enum UninstallRules {
     private static func owns(_ folded: String, id: String, allowingPrefix: Bool) -> Bool {
         if folded == id { return true }
         guard allowingPrefix, folded.count > id.count, folded.hasPrefix(id) else { return false }
-        // The boundary check is what separates a namespace child from a different product:
-        // `com.apple.SafariTechnologyPreview` must never be read as a child of `com.apple.Safari`.
+        // The separator is what stops `com.apple.SafariTechnologyPreview` reading as a child of `com.apple.Safari`.
         return namespaceSeparators.contains(folded[folded.index(folded.startIndex, offsetBy: id.count)])
     }
 
-    /// A `/usr/local/bin`-style launcher belongs to the app when it resolves inside the bundle.
     /// Attribution by link target, never by name — the name is whatever the vendor chose.
     static func isBundleSymlink(target: String, bundlePath: String) -> Bool {
         let target = (target as NSString).standardizingPath
@@ -73,9 +57,7 @@ enum UninstallRules {
         return target == bundlePath || isDescendant(target, of: bundlePath)
     }
 
-    /// Strips a leading `group.` and/or a 10-character Team ID, in either order, leaving a plain
-    /// bundle ID for the ordinary rule above. Team IDs are exactly 10 uppercase alphanumerics, which
-    /// is what stops an arbitrary `something.com.foo.Bar` being read as a container of `com.foo.Bar`.
+    /// Strips a leading `group.` and/or Team ID. The strict 10-char Team ID shape stops any `something.com.foo.Bar` matching.
     static func groupContainerBase(_ component: String) -> String {
         var base = component
         for _ in 0..<2 {
@@ -99,8 +81,7 @@ enum UninstallRules {
         matchesBundleID(groupContainerBase(component), identity: identity)
     }
 
-    /// Exact, case- and diacritic-folded equality only. No prefix and no substring, which is what
-    /// makes "Books" and "Books Reader" unable to claim each other's folders in either direction.
+    /// Exact folded equality only — no prefix, no substring, so "Books" and "Books Reader" can't claim each other.
     static func matchesDisplayName(_ component: String, identity: UninstallIdentity) -> Bool {
         guard !identity.names.isEmpty else { return false }
         return matchableForms(component).contains { form in
@@ -131,9 +112,7 @@ enum UninstallRules {
         }
     }
 
-    /// Belt and braces on every path the walk produces, independent of how it matched: it must be an
-    /// immediate child of its own root, must not be the home directory or a filesystem root, must
-    /// carry no relative components, and must not overlap the app bundle (emitted separately).
+    /// Belt and braces on every produced path, whatever matched it.
     static func isAcceptableCandidate(
         path: String, rootPath: String, home: String, bundlePath: String
     ) -> Bool {
@@ -155,7 +134,7 @@ enum UninstallRules {
         path.hasPrefix(ancestor + "/")
     }
 
-    /// Tilde form for the row subtitle. Takes `home` rather than reading it, so it stays pure.
+    /// Takes `home` rather than reading it, so it stays pure.
     static func abbreviate(_ path: String, home: String) -> String {
         if path == home { return "~" }
         guard isDescendant(path, of: home) else { return path }

--- a/Tinycast/Core/Uninstall/UninstallRunner.swift
+++ b/Tinycast/Core/Uninstall/UninstallRunner.swift
@@ -12,22 +12,17 @@ struct UninstallReport: Sendable {
     var trashedCount: Int { trashed.count }
     var freedBytes: Int64 { trashed.reduce(0) { $0 + $1.size.bytes } }
     var hasFailures: Bool { !failed.isEmpty }
-    /// Only when the bundle itself went may the app's hotkey, favorite and ranking be cleared —
-    /// a leftovers-only cleanup leaves the app installed.
+    /// Gates the reference cleanup: a leftovers-only run leaves the app installed.
     var removedBundle: Bool { trashed.contains { $0.evidence == .bundle } }
 }
 
-/// Moves an uninstall's checked items to the Trash. `FileManager.trashItem` is the only removal call
-/// in this feature — `removeItem` never appears, so every uninstall stays undoable from Finder.
+/// `FileManager.trashItem` is the only removal call in this feature — `removeItem` never appears, so an uninstall stays undoable.
 /// Presenting the outcome is `AppCore`'s job; this reports and never shows UI.
 enum UninstallRunner {
     static func moveToTrash(_ candidates: [UninstallCandidate]) async -> UninstallReport {
-        // Defensive: a locked candidate should never have been checked, so treat one here as a bug
-        // to skip rather than an attempt to make.
+        // A locked candidate should never have been checked; skip rather than attempt.
         let removable = candidates.filter { !$0.isLocked }
-        // The bundle goes last. Either order can leave a partial state, but with the bundle still in
-        // place the user can re-run the uninstall to retry the leftovers; once it's gone, the
-        // launcher entry that reaches this screen is gone with it.
+        // Bundle last: on partial failure it's still there to re-run from, and the launcher entry that reaches this screen survives.
         let ordered =
             removable.filter { $0.evidence != .bundle } + removable.filter { $0.evidence == .bundle }
 

--- a/Tinycast/Core/Uninstall/UninstallRunner.swift
+++ b/Tinycast/Core/Uninstall/UninstallRunner.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct UninstallFailedItem: Hashable, Sendable {
+    let name: String
+    let reason: String
+}
+
+struct UninstallReport: Sendable {
+    let trashed: [UninstallCandidate]
+    let failed: [UninstallFailedItem]
+
+    var trashedCount: Int { trashed.count }
+    var freedBytes: Int64 { trashed.reduce(0) { $0 + $1.size.bytes } }
+    var hasFailures: Bool { !failed.isEmpty }
+    /// Only when the bundle itself went may the app's hotkey, favorite and ranking be cleared —
+    /// a leftovers-only cleanup leaves the app installed.
+    var removedBundle: Bool { trashed.contains { $0.evidence == .bundle } }
+}
+
+/// Moves an uninstall's checked items to the Trash. `FileManager.trashItem` is the only removal call
+/// in this feature — `removeItem` never appears, so every uninstall stays undoable from Finder.
+/// Presenting the outcome is `AppCore`'s job; this reports and never shows UI.
+enum UninstallRunner {
+    static func moveToTrash(_ candidates: [UninstallCandidate]) async -> UninstallReport {
+        // Defensive: a locked candidate should never have been checked, so treat one here as a bug
+        // to skip rather than an attempt to make.
+        let removable = candidates.filter { !$0.isLocked }
+        // The bundle goes last. Either order can leave a partial state, but with the bundle still in
+        // place the user can re-run the uninstall to retry the leftovers; once it's gone, the
+        // launcher entry that reaches this screen is gone with it.
+        let ordered =
+            removable.filter { $0.evidence != .bundle } + removable.filter { $0.evidence == .bundle }
+
+        return await Task.detached(priority: .userInitiated) {
+            var trashed: [UninstallCandidate] = []
+            var failed: [UninstallFailedItem] = []
+            for candidate in ordered {
+                do {
+                    try FileManager.default.trashItem(at: candidate.url, resultingItemURL: nil)
+                    trashed.append(candidate)
+                } catch {
+                    failed.append(
+                        UninstallFailedItem(
+                            name: candidate.name, reason: error.localizedDescription))
+                }
+            }
+            return UninstallReport(trashed: trashed, failed: failed)
+        }.value
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallScanner.swift
+++ b/Tinycast/Core/Uninstall/UninstallScanner.swift
@@ -51,8 +51,8 @@ enum UninstallScanner {
             try Task.checkCancellation()
             let rootPath = root.path(home: home)
             guard let names = childNames(of: rootPath) else { continue }
-            // The parent's writability is one property of the root, not of each match.
-            let parentIsWritable = FileManager.default.isWritableFile(atPath: rootPath)
+            // Permissions belong to the root, not to each match — one stat per root, not per row.
+            let parent = parentFacts(of: rootPath)
             for match in UninstallRules.matches(childNames: names, in: root, identity: identity) {
                 let path = (rootPath + "/" + match.name as NSString).standardizingPath
                 guard
@@ -61,7 +61,7 @@ enum UninstallScanner {
                     seen.insert(path).inserted,
                     let candidate = candidate(
                         path: path, evidence: match.evidence, environment: environment,
-                        budget: budget, parentIsWritable: parentIsWritable)
+                        budget: budget, parent: parent)
                 else { continue }
                 candidates.append(candidate)
             }
@@ -71,7 +71,7 @@ enum UninstallScanner {
             try Task.checkCancellation()
             let rootPath = (directory as NSString).expandingTildeInPath
             guard let names = childNames(of: rootPath) else { continue }
-            let parentIsWritable = FileManager.default.isWritableFile(atPath: rootPath)
+            let parent = parentFacts(of: rootPath)
             for name in names {
                 let path = (rootPath + "/" + name as NSString).standardizingPath
                 guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: path)
@@ -84,7 +84,7 @@ enum UninstallScanner {
                     seen.insert(path).inserted,
                     let candidate = candidate(
                         path: path, evidence: .binSymlink, environment: environment, budget: budget,
-                        parentIsWritable: parentIsWritable)
+                        parent: parent)
                 else { continue }
                 candidates.append(candidate)
             }
@@ -106,18 +106,18 @@ enum UninstallScanner {
 
     private static func candidate(
         path: String, evidence: UninstallEvidence, environment: UninstallEnvironment,
-        budget: SizeBudget, displayName: String? = nil, parentIsWritable: Bool? = nil
+        budget: SizeBudget, displayName: String? = nil, parent: ParentFacts? = nil
     ) -> UninstallCandidate? {
-        guard let scanned = inspect(path, parentIsWritable: parentIsWritable) else { return nil }
+        guard let scanned = inspect(path, parent: parent) else { return nil }
         let protection = UninstallProtectionRules.classify(scanned.facts, environment: environment)
         guard protection != .missing else { return nil }
-        let parent = (path as NSString).deletingLastPathComponent
         // A symlink is trashed as the link itself, so it never costs more than its own bytes.
         let walkable = scanned.isDirectory && !scanned.facts.isSymbolicLink
         return UninstallCandidate(
             path: path,
             name: displayName ?? (path as NSString).lastPathComponent,
-            locationLabel: UninstallRules.abbreviate(parent, home: environment.home),
+            locationLabel: UninstallRules.abbreviate(
+                (path as NSString).deletingLastPathComponent, home: environment.home),
             evidence: evidence,
             isDirectory: scanned.isDirectory,
             size: walkable
@@ -127,12 +127,12 @@ enum UninstallScanner {
 
     /// `lstat`, never `stat`: a symlinked candidate must be judged as the link, not as whatever it
     /// points at, which could sit outside every root.
-    private static func inspect(_ path: String, parentIsWritable: Bool?)
+    private static func inspect(_ path: String, parent: ParentFacts?)
         -> (facts: PathFacts, isDirectory: Bool, byteSize: Int64)?
     {
         var info = stat()
         guard lstat(path, &info) == 0 else { return nil }
-        let parent = (path as NSString).deletingLastPathComponent
+        let parent = parent ?? parentFacts(of: (path as NSString).deletingLastPathComponent)
         let volumeIsReadOnly =
             (try? URL(fileURLWithPath: path).resourceValues(forKeys: [.volumeIsReadOnlyKey]))?
             .volumeIsReadOnly ?? false
@@ -143,9 +143,23 @@ enum UninstallScanner {
             isSystemRestricted: info.st_flags & UInt32(SF_RESTRICTED | SF_IMMUTABLE) != 0,
             isUserImmutable: info.st_flags & UInt32(UF_IMMUTABLE) != 0,
             isOwnedByCurrentUser: info.st_uid == geteuid(),
-            parentIsWritable: parentIsWritable
-                ?? FileManager.default.isWritableFile(atPath: parent))
+            parentIsWritable: parent.isWritable,
+            parentIsSticky: parent.isSticky)
         return (facts, (info.st_mode & S_IFMT) == S_IFDIR, Int64(info.st_blocks) * 512)
+    }
+
+    /// What the enclosing directory says about removing things from it — the permission that actually
+    /// governs a trash, resolved once per root rather than once per candidate.
+    private static func parentFacts(of directory: String) -> ParentFacts {
+        var info = stat()
+        let sticky = stat(directory, &info) == 0 && (info.st_mode & S_ISVTX) != 0
+        return ParentFacts(
+            isWritable: FileManager.default.isWritableFile(atPath: directory), isSticky: sticky)
+    }
+
+    private struct ParentFacts {
+        let isWritable: Bool
+        let isSticky: Bool
     }
 
     /// On-disk bytes, matching Finder. The enumerator's error handler keeps counting past an

--- a/Tinycast/Core/Uninstall/UninstallScanner.swift
+++ b/Tinycast/Core/Uninstall/UninstallScanner.swift
@@ -1,0 +1,159 @@
+import Darwin
+import Foundation
+
+/// Every filesystem, stat and permission read the uninstaller performs. Deliberately not compiled by
+/// `Tools/uninstall-test.swift` — the matching and locking decisions it defers to are the pure half.
+enum UninstallScanner {
+    struct SizeBudget: Sendable {
+        /// Caps the tree walk behind one row so a pathological cache folder can't stall the scan.
+        var maxEntries = 20_000
+        static let `default` = SizeBudget()
+    }
+
+    enum Failure: LocalizedError, Sendable {
+        case refused
+
+        var errorDescription: String? {
+            switch self {
+            case .refused:
+                return "Tinycast can’t uninstall this app."
+            }
+        }
+    }
+
+    /// Runs off the main actor via `Task.detached`, exactly like `AppIndex.refresh()`.
+    nonisolated static func scan(
+        target: UninstallTarget, otherAppNames: [String], otherBundleIDs: [String],
+        isTargetRunning: Bool, roots: [UninstallSearchRoot] = UninstallSearchRoot.all,
+        budget: SizeBudget = .default
+    ) throws -> UninstallPlan {
+        let home = NSHomeDirectory()
+        let environment = UninstallEnvironment(
+            home: home, hasFullDiskAccess: detectFullDiskAccess(home: home))
+        guard
+            let identity = UninstallIdentity.make(
+                target: target, otherAppNames: otherAppNames, otherBundleIDs: otherBundleIDs,
+                ownBundleID: Bundle.main.bundleIdentifier, ownBundleURL: Bundle.main.bundleURL)
+        else { throw Failure.refused }
+
+        let bundlePath = target.bundleURL.standardizedFileURL.path
+        var candidates: [UninstallCandidate] = [
+            candidate(
+                path: bundlePath, evidence: .bundle, environment: environment, budget: budget,
+                displayName: target.bundleURL.deletingPathExtension().lastPathComponent)
+        ].compactMap { $0 }
+
+        var seen = Set(candidates.map(\.path))
+        for root in roots {
+            try Task.checkCancellation()
+            let rootPath = root.path(home: home)
+            guard let names = childNames(of: rootPath) else { continue }
+            // The parent's writability is one property of the root, not of each match.
+            let parentIsWritable = FileManager.default.isWritableFile(atPath: rootPath)
+            for match in UninstallRules.matches(childNames: names, in: root, identity: identity) {
+                let path = (rootPath + "/" + match.name as NSString).standardizingPath
+                guard
+                    UninstallRules.isAcceptableCandidate(
+                        path: path, rootPath: rootPath, home: home, bundlePath: bundlePath),
+                    seen.insert(path).inserted,
+                    let candidate = candidate(
+                        path: path, evidence: match.evidence, environment: environment,
+                        budget: budget, parentIsWritable: parentIsWritable)
+                else { continue }
+                candidates.append(candidate)
+            }
+        }
+
+        // The bundle stays pinned first; the rest sort by path, which is the order the list shows.
+        let leftovers = candidates.filter { $0.evidence != .bundle }.sorted { $0.path < $1.path }
+        return UninstallPlan(
+            target: target, candidates: candidates.filter { $0.evidence == .bundle } + leftovers,
+            isTargetRunning: isTargetRunning)
+    }
+
+    // MARK: - Private
+
+    private static func childNames(of directory: String) -> [String]? {
+        // Not `.skipsHiddenFiles`: dot-named leftovers are exactly the ones a user would never find.
+        try? FileManager.default.contentsOfDirectory(atPath: directory)
+    }
+
+    private static func candidate(
+        path: String, evidence: UninstallEvidence, environment: UninstallEnvironment,
+        budget: SizeBudget, displayName: String? = nil, parentIsWritable: Bool? = nil
+    ) -> UninstallCandidate? {
+        guard let scanned = inspect(path, parentIsWritable: parentIsWritable) else { return nil }
+        let protection = UninstallProtectionRules.classify(scanned.facts, environment: environment)
+        guard protection != .missing else { return nil }
+        let parent = (path as NSString).deletingLastPathComponent
+        // A symlink is trashed as the link itself, so it never costs more than its own bytes.
+        let walkable = scanned.isDirectory && !scanned.facts.isSymbolicLink
+        return UninstallCandidate(
+            path: path,
+            name: displayName ?? (path as NSString).lastPathComponent,
+            locationLabel: UninstallRules.abbreviate(parent, home: environment.home),
+            evidence: evidence,
+            isDirectory: scanned.isDirectory,
+            size: walkable
+                ? directorySize(of: path, budget: budget) : MeasuredSize(bytes: scanned.byteSize),
+            protection: protection)
+    }
+
+    /// `lstat`, never `stat`: a symlinked candidate must be judged as the link, not as whatever it
+    /// points at, which could sit outside every root.
+    private static func inspect(_ path: String, parentIsWritable: Bool?)
+        -> (facts: PathFacts, isDirectory: Bool, byteSize: Int64)?
+    {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { return nil }
+        let parent = (path as NSString).deletingLastPathComponent
+        let volumeIsReadOnly =
+            (try? URL(fileURLWithPath: path).resourceValues(forKeys: [.volumeIsReadOnlyKey]))?
+            .volumeIsReadOnly ?? false
+        let facts = PathFacts(
+            path: path,
+            isSymbolicLink: (info.st_mode & S_IFMT) == S_IFLNK,
+            volumeIsReadOnly: volumeIsReadOnly,
+            isSystemRestricted: info.st_flags & UInt32(SF_RESTRICTED | SF_IMMUTABLE) != 0,
+            isUserImmutable: info.st_flags & UInt32(UF_IMMUTABLE) != 0,
+            isOwnedByCurrentUser: info.st_uid == geteuid(),
+            parentIsWritable: parentIsWritable
+                ?? FileManager.default.isWritableFile(atPath: parent))
+        return (facts, (info.st_mode & S_IFMT) == S_IFDIR, Int64(info.st_blocks) * 512)
+    }
+
+    /// On-disk bytes, matching Finder. The enumerator's error handler keeps counting past an
+    /// unreadable subtree instead of abandoning the row, and symlinks are never followed.
+    private static func directorySize(of path: String, budget: SizeBudget) -> MeasuredSize {
+        let url = URL(fileURLWithPath: path)
+        let keys: [URLResourceKey] = [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: url, includingPropertiesForKeys: keys, options: [],
+                errorHandler: { _, _ in true })
+        else { return .zero }
+
+        var size = MeasuredSize()
+        var entries = 0
+        for case let item as URL in enumerator {
+            entries += 1
+            if entries > budget.maxEntries {
+                size.isLowerBound = true
+                break
+            }
+            let values = try? item.resourceValues(forKeys: Set(keys))
+            size.bytes += Int64(values?.totalFileAllocatedSize ?? values?.fileAllocatedSize ?? 0)
+        }
+        return size
+    }
+
+    /// Detected, never requested. TCC denies this read silently — no prompt — which is what makes it
+    /// usable under the rule that Tinycast asks for no permission here. It can only under-report
+    /// (a per-folder grant reads as "no access"), and that direction just leaves a row locked.
+    private static func detectFullDiskAccess(home: String) -> Bool {
+        let descriptor = open(home + "/Library/Application Support/com.apple.TCC/TCC.db", O_RDONLY)
+        guard descriptor >= 0 else { return false }
+        close(descriptor)
+        return true
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallScanner.swift
+++ b/Tinycast/Core/Uninstall/UninstallScanner.swift
@@ -6,7 +6,10 @@ import Foundation
 enum UninstallScanner {
     struct SizeBudget: Sendable {
         /// Caps the tree walk behind one row so a pathological cache folder can't stall the scan.
-        var maxEntries = 20_000
+        /// Generous on purpose: an editor's support folder runs to ~90k entries (Zed's does), and
+        /// stopping short of that would show "≥ 796 MB" where the honest answer is 1.9 GB. Measured
+        /// at roughly a second for 250k entries, and the scan is off-main behind a progress state.
+        var maxEntries = 250_000
         static let `default` = SizeBudget()
     }
 
@@ -59,6 +62,29 @@ enum UninstallScanner {
                     let candidate = candidate(
                         path: path, evidence: match.evidence, environment: environment,
                         budget: budget, parentIsWritable: parentIsWritable)
+                else { continue }
+                candidates.append(candidate)
+            }
+        }
+
+        for directory in UninstallSearchRoot.binDirectories {
+            try Task.checkCancellation()
+            let rootPath = (directory as NSString).expandingTildeInPath
+            guard let names = childNames(of: rootPath) else { continue }
+            let parentIsWritable = FileManager.default.isWritableFile(atPath: rootPath)
+            for name in names {
+                let path = (rootPath + "/" + name as NSString).standardizingPath
+                guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: path)
+                else { continue }
+                // A relative link resolves against its own directory, not the process's cwd.
+                let resolved =
+                    target.hasPrefix("/")
+                    ? target : (rootPath as NSString).appendingPathComponent(target)
+                guard UninstallRules.isBundleSymlink(target: resolved, bundlePath: bundlePath),
+                    seen.insert(path).inserted,
+                    let candidate = candidate(
+                        path: path, evidence: .binSymlink, environment: environment, budget: budget,
+                        parentIsWritable: parentIsWritable)
                 else { continue }
                 candidates.append(candidate)
             }

--- a/Tinycast/Core/Uninstall/UninstallScanner.swift
+++ b/Tinycast/Core/Uninstall/UninstallScanner.swift
@@ -1,14 +1,11 @@
 import Darwin
 import Foundation
 
-/// Every filesystem, stat and permission read the uninstaller performs. Deliberately not compiled by
-/// `Tools/uninstall-test.swift` — the matching and locking decisions it defers to are the pure half.
+/// Every filesystem, stat and permission read. Not compiled by the harness — the decisions it defers to are the pure half.
 enum UninstallScanner {
     struct SizeBudget: Sendable {
-        /// Caps the tree walk behind one row so a pathological cache folder can't stall the scan.
-        /// Generous on purpose: an editor's support folder runs to ~90k entries (Zed's does), and
-        /// stopping short of that would show "≥ 796 MB" where the honest answer is 1.9 GB. Measured
-        /// at roughly a second for 250k entries, and the scan is off-main behind a progress state.
+        /// Generous: an editor's support folder runs to ~90k entries, and stopping short would show "≥ 796 MB" for 1.9 GB.
+        /// Roughly a second at 250k, off-main behind a progress state.
         var maxEntries = 250_000
         static let `default` = SizeBudget()
     }
@@ -24,7 +21,7 @@ enum UninstallScanner {
         }
     }
 
-    /// Runs off the main actor via `Task.detached`, exactly like `AppIndex.refresh()`.
+    /// Runs off-main via `Task.detached`, like `AppIndex.refresh()`.
     nonisolated static func scan(
         target: UninstallTarget, otherAppNames: [String], otherBundleIDs: [String],
         isTargetRunning: Bool, roots: [UninstallSearchRoot] = UninstallSearchRoot.all,
@@ -51,7 +48,7 @@ enum UninstallScanner {
             try Task.checkCancellation()
             let rootPath = root.path(home: home)
             guard let names = childNames(of: rootPath) else { continue }
-            // Permissions belong to the root, not to each match — one stat per root, not per row.
+            // One stat per root, not per row.
             let parent = parentFacts(of: rootPath)
             for match in UninstallRules.matches(childNames: names, in: root, identity: identity) {
                 let path = (rootPath + "/" + match.name as NSString).standardizingPath
@@ -76,7 +73,7 @@ enum UninstallScanner {
                 let path = (rootPath + "/" + name as NSString).standardizingPath
                 guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: path)
                 else { continue }
-                // A relative link resolves against its own directory, not the process's cwd.
+                // A relative link resolves against its own directory, not the cwd.
                 let resolved =
                     target.hasPrefix("/")
                     ? target : (rootPath as NSString).appendingPathComponent(target)
@@ -90,7 +87,7 @@ enum UninstallScanner {
             }
         }
 
-        // The bundle stays pinned first; the rest sort by path, which is the order the list shows.
+        // Bundle pinned first; the rest by path, which is the order the list shows.
         let leftovers = candidates.filter { $0.evidence != .bundle }.sorted { $0.path < $1.path }
         return UninstallPlan(
             target: target, candidates: candidates.filter { $0.evidence == .bundle } + leftovers,
@@ -100,7 +97,7 @@ enum UninstallScanner {
     // MARK: - Private
 
     private static func childNames(of directory: String) -> [String]? {
-        // Not `.skipsHiddenFiles`: dot-named leftovers are exactly the ones a user would never find.
+        // Not `.skipsHiddenFiles`: dot-named leftovers are the ones a user would never find.
         try? FileManager.default.contentsOfDirectory(atPath: directory)
     }
 
@@ -111,7 +108,7 @@ enum UninstallScanner {
         guard let scanned = inspect(path, parent: parent) else { return nil }
         let protection = UninstallProtectionRules.classify(scanned.facts, environment: environment)
         guard protection != .missing else { return nil }
-        // A symlink is trashed as the link itself, so it never costs more than its own bytes.
+        // A symlink is trashed as the link, so it never costs more than its own bytes.
         let walkable = scanned.isDirectory && !scanned.facts.isSymbolicLink
         return UninstallCandidate(
             path: path,
@@ -125,8 +122,7 @@ enum UninstallScanner {
             protection: protection)
     }
 
-    /// `lstat`, never `stat`: a symlinked candidate must be judged as the link, not as whatever it
-    /// points at, which could sit outside every root.
+    /// `lstat`, never `stat`: a symlink is judged as the link, not as whatever it points at.
     private static func inspect(_ path: String, parent: ParentFacts?)
         -> (facts: PathFacts, isDirectory: Bool, byteSize: Int64)?
     {
@@ -148,8 +144,7 @@ enum UninstallScanner {
         return (facts, (info.st_mode & S_IFMT) == S_IFDIR, Int64(info.st_blocks) * 512)
     }
 
-    /// What the enclosing directory says about removing things from it — the permission that actually
-    /// governs a trash, resolved once per root rather than once per candidate.
+    /// The permission that actually governs a trash, resolved once per root.
     private static func parentFacts(of directory: String) -> ParentFacts {
         var info = stat()
         let sticky = stat(directory, &info) == 0 && (info.st_mode & S_ISVTX) != 0
@@ -162,8 +157,7 @@ enum UninstallScanner {
         let isSticky: Bool
     }
 
-    /// On-disk bytes, matching Finder. The enumerator's error handler keeps counting past an
-    /// unreadable subtree instead of abandoning the row, and symlinks are never followed.
+    /// On-disk bytes, like Finder. The error handler keeps counting past an unreadable subtree instead of abandoning the row.
     private static func directorySize(of path: String, budget: SizeBudget) -> MeasuredSize {
         let url = URL(fileURLWithPath: path)
         let keys: [URLResourceKey] = [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
@@ -187,9 +181,7 @@ enum UninstallScanner {
         return size
     }
 
-    /// Detected, never requested. TCC denies this read silently — no prompt — which is what makes it
-    /// usable under the rule that Tinycast asks for no permission here. It can only under-report
-    /// (a per-folder grant reads as "no access"), and that direction just leaves a row locked.
+    /// Detected, never requested: TCC denies this read silently, no prompt. It can only under-report, which just leaves a row locked.
     private static func detectFullDiskAccess(home: String) -> Bool {
         let descriptor = open(home + "/Library/Application Support/com.apple.TCC/TCC.db", O_RDONLY)
         guard descriptor >= 0 else { return false }

--- a/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
+++ b/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// One directory the uninstaller looks in, and the match styles allowed there. A table rather than
-/// per-root code: branching per directory is how a matcher grows unreviewable special cases.
+/// Where to look and which match styles are legal there. A table, because per-root code is how a matcher grows special cases.
 struct UninstallSearchRoot: Hashable, Sendable {
     enum Base: Hashable, Sendable {
         case userLibrary
@@ -26,25 +25,8 @@ struct UninstallSearchRoot: Hashable, Sendable {
         }
     }
 
-    /// Only immediate children are ever listed. `Preferences/ByHost` is its own root instead of
-    /// raising `Preferences` to depth 2, which would descend into every unrelated app's subfolder.
-    ///
-    /// Display-name matching is enabled only where a child is a human-named folder. In Preferences,
-    /// Containers, Group Containers, Saved Application State and the launch directories a child is a
-    /// bundle ID by construction, so a name match there would be a false positive by definition.
-    ///
-    /// The home directory itself is **not** a root, deliberately. Claiming `~/<name>` needs a name
-    /// match, and that is the one place a wrong match costs the user their own work rather than an
-    /// app's cache — VS Code's `CFBundleName` is literally "Code", and `~/Code` is a source tree on
-    /// a great many machines. Restricting it to dot-folders only moves the problem: an app named
-    /// "Local" would claim `~/.local`, and screening that needs a hand-kept blocklist with no source
-    /// of truth, which rots. Measured against 62 installed apps the whole root was worth one 115 kB
-    /// folder, so it buys almost nothing and carries the only catastrophic failure mode.
-    ///
-    /// Deliberately absent: `/private/var/db/receipts` (root-owned, and deleting a receipt corrupts
-    /// the installer's view of the system), `~/Library/Keychains` (credentials in shared files),
-    /// `/Library/Extensions` and `/usr/local` (shared between products), and every user-document
-    /// location — the user's own data is never ours to reap.
+    /// Immediate children only; display-name matching is off wherever a child is a bundle ID by construction.
+    /// The home directory is deliberately absent, as are receipts, Keychains and user documents — see docs/uninstall.md.
     static let all: [UninstallSearchRoot] = [
         UninstallSearchRoot(
             base: .userLibrary, relativePath: "Application Support",
@@ -70,8 +52,7 @@ struct UninstallSearchRoot: Hashable, Sendable {
         UninstallSearchRoot(
             base: .userLibrary, relativePath: "Autosave Information", styles: [.bundleID]),
         UninstallSearchRoot(base: .userLibrary, relativePath: "LaunchAgents", styles: [.bundleID]),
-        // Plug-in wells. A child here is a wrapper named after the product that installed it, so
-        // both styles apply once `strippedExtensions` has taken the `.qlgenerator`/`.saver`/… off.
+        // Plug-in wells: a child is a wrapper named after its product, once `strippedExtensions` has taken the suffix off.
         UninstallSearchRoot(
             base: .userLibrary, relativePath: "Internet Plug-Ins", styles: [.bundleID, .displayName]),
         UninstallSearchRoot(
@@ -121,8 +102,7 @@ struct UninstallSearchRoot: Hashable, Sendable {
             styles: [.bundleID, .displayName])
     ]
 
-    /// Where a CLI launcher lands. Scanned by link target rather than by name — see
-    /// `UninstallRules.isBundleSymlink` — so nothing here is matched by what the vendor called it.
+    /// Where a CLI launcher lands. Scanned by link target, never by name — see `UninstallRules.isBundleSymlink`.
     static let binDirectories: [String] = [
         "/usr/local/bin", "/opt/homebrew/bin", "~/.local/bin", "~/bin"
     ]

--- a/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
+++ b/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
@@ -33,6 +33,14 @@ struct UninstallSearchRoot: Hashable, Sendable {
     /// Containers, Group Containers, Saved Application State and the launch directories a child is a
     /// bundle ID by construction, so a name match there would be a false positive by definition.
     ///
+    /// The home directory itself is **not** a root, deliberately. Claiming `~/<name>` needs a name
+    /// match, and that is the one place a wrong match costs the user their own work rather than an
+    /// app's cache — VS Code's `CFBundleName` is literally "Code", and `~/Code` is a source tree on
+    /// a great many machines. Restricting it to dot-folders only moves the problem: an app named
+    /// "Local" would claim `~/.local`, and screening that needs a hand-kept blocklist with no source
+    /// of truth, which rots. Measured against 62 installed apps the whole root was worth one 115 kB
+    /// folder, so it buys almost nothing and carries the only catastrophic failure mode.
+    ///
     /// Deliberately absent: `/private/var/db/receipts` (root-owned, and deleting a receipt corrupts
     /// the installer's view of the system), `~/Library/Keychains` (credentials in shared files),
     /// `/Library/Extensions` and `/usr/local` (shared between products), and every user-document

--- a/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
+++ b/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
@@ -62,6 +62,29 @@ struct UninstallSearchRoot: Hashable, Sendable {
         UninstallSearchRoot(
             base: .userLibrary, relativePath: "Autosave Information", styles: [.bundleID]),
         UninstallSearchRoot(base: .userLibrary, relativePath: "LaunchAgents", styles: [.bundleID]),
+        // Plug-in wells. A child here is a wrapper named after the product that installed it, so
+        // both styles apply once `strippedExtensions` has taken the `.qlgenerator`/`.saver`/… off.
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Internet Plug-Ins", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "QuickLook", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Services", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "PreferencePanes", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Screen Savers", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Spotlight", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Automator", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Input Methods", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Audio/Plug-Ins/HAL", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Audio/Plug-Ins/Components",
+            styles: [.bundleID, .displayName]),
         UninstallSearchRoot(
             base: .systemLibrary, relativePath: "Application Support",
             styles: [.bundleID, .displayName]),
@@ -72,6 +95,27 @@ struct UninstallSearchRoot: Hashable, Sendable {
         UninstallSearchRoot(
             base: .systemLibrary, relativePath: "LaunchDaemons", styles: [.bundleID]),
         UninstallSearchRoot(
-            base: .systemLibrary, relativePath: "PrivilegedHelperTools", styles: [.bundleID])
+            base: .systemLibrary, relativePath: "PrivilegedHelperTools", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "Internet Plug-Ins",
+            styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "QuickLook", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "PreferencePanes", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "Screen Savers", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "Audio/Plug-Ins/HAL",
+            styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "Audio/Plug-Ins/Components",
+            styles: [.bundleID, .displayName])
+    ]
+
+    /// Where a CLI launcher lands. Scanned by link target rather than by name — see
+    /// `UninstallRules.isBundleSymlink` — so nothing here is matched by what the vendor called it.
+    static let binDirectories: [String] = [
+        "/usr/local/bin", "/opt/homebrew/bin", "~/.local/bin", "~/bin"
     ]
 }

--- a/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
+++ b/Tinycast/Core/Uninstall/UninstallSearchRoot.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// One directory the uninstaller looks in, and the match styles allowed there. A table rather than
+/// per-root code: branching per directory is how a matcher grows unreviewable special cases.
+struct UninstallSearchRoot: Hashable, Sendable {
+    enum Base: Hashable, Sendable {
+        case userLibrary
+        case systemLibrary
+    }
+
+    enum MatchStyle: String, Hashable, Sendable, CaseIterable {
+        case bundleID
+        case groupContainer
+        case displayName
+    }
+
+    let base: Base
+    /// Relative to `base`, never empty.
+    let relativePath: String
+    let styles: Set<MatchStyle>
+
+    func path(home: String) -> String {
+        switch base {
+        case .userLibrary: return home + "/Library/" + relativePath
+        case .systemLibrary: return "/Library/" + relativePath
+        }
+    }
+
+    /// Only immediate children are ever listed. `Preferences/ByHost` is its own root instead of
+    /// raising `Preferences` to depth 2, which would descend into every unrelated app's subfolder.
+    ///
+    /// Display-name matching is enabled only where a child is a human-named folder. In Preferences,
+    /// Containers, Group Containers, Saved Application State and the launch directories a child is a
+    /// bundle ID by construction, so a name match there would be a false positive by definition.
+    ///
+    /// Deliberately absent: `/private/var/db/receipts` (root-owned, and deleting a receipt corrupts
+    /// the installer's view of the system), `~/Library/Keychains` (credentials in shared files),
+    /// `/Library/Extensions` and `/usr/local` (shared between products), and every user-document
+    /// location — the user's own data is never ours to reap.
+    static let all: [UninstallSearchRoot] = [
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Application Support",
+            styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Caches", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Logs", styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(base: .userLibrary, relativePath: "Containers", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Group Containers", styles: [.groupContainer]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Application Scripts",
+            styles: [.bundleID, .groupContainer]),
+        UninstallSearchRoot(base: .userLibrary, relativePath: "Preferences", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Preferences/ByHost", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Saved Application State", styles: [.bundleID]),
+        UninstallSearchRoot(base: .userLibrary, relativePath: "HTTPStorages", styles: [.bundleID]),
+        UninstallSearchRoot(base: .userLibrary, relativePath: "WebKit", styles: [.bundleID]),
+        UninstallSearchRoot(base: .userLibrary, relativePath: "Cookies", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .userLibrary, relativePath: "Autosave Information", styles: [.bundleID]),
+        UninstallSearchRoot(base: .userLibrary, relativePath: "LaunchAgents", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "Application Support",
+            styles: [.bundleID, .displayName]),
+        UninstallSearchRoot(base: .systemLibrary, relativePath: "Caches", styles: [.bundleID]),
+        UninstallSearchRoot(base: .systemLibrary, relativePath: "Logs", styles: [.bundleID]),
+        UninstallSearchRoot(base: .systemLibrary, relativePath: "Preferences", styles: [.bundleID]),
+        UninstallSearchRoot(base: .systemLibrary, relativePath: "LaunchAgents", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "LaunchDaemons", styles: [.bundleID]),
+        UninstallSearchRoot(
+            base: .systemLibrary, relativePath: "PrivilegedHelperTools", styles: [.bundleID])
+    ]
+}

--- a/Tinycast/Core/Uninstall/UninstallSession.swift
+++ b/Tinycast/Core/Uninstall/UninstallSession.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// The state behind the palette's Uninstall screen: one scan, its plan, and what the user checked.
-/// The checked-set invariant lives in `UninstallSelection`, so this class only owns the lifecycle.
+/// One scan, its plan, and what the user checked. The checked-set invariant lives in `UninstallSelection`; this owns the lifecycle.
 @MainActor
 final class UninstallSession: ObservableObject {
     enum State: Equatable {
@@ -14,7 +13,7 @@ final class UninstallSession: ObservableObject {
     @Published private(set) var state: State = .idle
     @Published private(set) var selection: UninstallSelection?
     @Published private(set) var isTrashing = false
-    /// The app being uninstalled, kept for the confirmation copy and post-uninstall cleanup.
+    /// Kept for the confirmation copy and the post-uninstall cleanup.
     private(set) var app: AppEntry?
 
     private var scanTask: Task<Void, Never>?
@@ -66,7 +65,7 @@ final class UninstallSession: ObservableObject {
         }
     }
 
-    /// Releases an in-flight scan. Called whenever the palette leaves the Uninstall screen.
+    /// Releases an in-flight scan; called whenever the palette leaves the screen.
     func cancel() {
         scanTask?.cancel()
         scanTask = nil
@@ -80,16 +79,11 @@ final class UninstallSession: ObservableObject {
         selection?.toggle(id, in: plan)
     }
 
-    func setAll(_ on: Bool) {
-        guard let plan else { return }
-        selection?.setAll(on, in: plan)
-    }
-
     func setTrashing(_ trashing: Bool) {
         isTrashing = trashing
     }
 
-    /// Reads the bundle for the names a leftover can be attributed by. Off-main: it opens a file.
+    /// Off-main: it opens a file.
     private nonisolated static func makeTarget(url: URL, name: String, bundleID: String?)
         -> UninstallTarget
     {

--- a/Tinycast/Core/Uninstall/UninstallSession.swift
+++ b/Tinycast/Core/Uninstall/UninstallSession.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// The state behind the palette's Uninstall screen: one scan, its plan, and what the user checked.
+/// The checked-set invariant lives in `UninstallSelection`, so this class only owns the lifecycle.
+@MainActor
+final class UninstallSession: ObservableObject {
+    enum State: Equatable {
+        case idle
+        case scanning
+        case ready(UninstallPlan)
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var selection: UninstallSelection?
+    @Published private(set) var isTrashing = false
+    /// The app being uninstalled, kept for the confirmation copy and post-uninstall cleanup.
+    private(set) var app: AppEntry?
+
+    private var scanTask: Task<Void, Never>?
+
+    var plan: UninstallPlan? {
+        if case .ready(let plan) = state { return plan }
+        return nil
+    }
+
+    var candidates: [UninstallCandidate] { plan?.candidates ?? [] }
+    var selectedCount: Int { selection?.count ?? 0 }
+    var selectedBytes: Int64 {
+        guard let plan, let selection else { return 0 }
+        return selection.bytes(in: plan)
+    }
+    var selectedCandidates: [UninstallCandidate] {
+        guard let plan, let selection else { return [] }
+        return selection.candidates(in: plan)
+    }
+    var canConfirm: Bool { selectedCount > 0 && !isTrashing }
+
+    func begin(app: AppEntry, otherAppNames: [String], otherBundleIDs: [String], isRunning: Bool) {
+        cancel()
+        self.app = app
+        state = .scanning
+        selection = nil
+        let url = app.url
+        let name = app.name
+        let bundleID = app.bundleID
+        scanTask = Task { [weak self] in
+            let result = await Task.detached(priority: .userInitiated) {
+                Result {
+                    try UninstallScanner.scan(
+                        target: Self.makeTarget(url: url, name: name, bundleID: bundleID),
+                        otherAppNames: otherAppNames, otherBundleIDs: otherBundleIDs,
+                        isTargetRunning: isRunning)
+                }
+            }.value
+            guard let self, !Task.isCancelled else { return }
+            switch result {
+            case .success(let plan):
+                state = .ready(plan)
+                selection = plan.defaultSelection
+            case .failure(let error):
+                state = .failed(
+                    (error as? UninstallScanner.Failure)?.errorDescription
+                        ?? error.localizedDescription)
+            }
+        }
+    }
+
+    /// Releases an in-flight scan. Called whenever the palette leaves the Uninstall screen.
+    func cancel() {
+        scanTask?.cancel()
+        scanTask = nil
+        state = .idle
+        selection = nil
+        app = nil
+    }
+
+    func toggle(_ id: UninstallCandidate.ID) {
+        guard let plan else { return }
+        selection?.toggle(id, in: plan)
+    }
+
+    func setAll(_ on: Bool) {
+        guard let plan else { return }
+        selection?.setAll(on, in: plan)
+    }
+
+    func setTrashing(_ trashing: Bool) {
+        isTrashing = trashing
+    }
+
+    /// Reads the bundle for the names a leftover can be attributed by. Off-main: it opens a file.
+    private nonisolated static func makeTarget(url: URL, name: String, bundleID: String?)
+        -> UninstallTarget
+    {
+        let info = Bundle(url: url)?.infoDictionary
+        return UninstallTarget(
+            bundleURL: url, bundleID: bundleID,
+            displayName: (info?["CFBundleDisplayName"] as? String) ?? name,
+            bundleName: info?["CFBundleName"] as? String)
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallTarget.swift
+++ b/Tinycast/Core/Uninstall/UninstallTarget.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// What an uninstall is aimed at: the app bundle plus the strings a leftover can be attributed to.
+/// Foundation-only and pure so `Tools/uninstall-test.swift` can compile it standalone.
+struct UninstallTarget: Hashable, Sendable {
+    let bundleURL: URL
+    let bundleID: String?
+    let displayName: String
+    /// `CFBundleName` when it differs from the display name — some apps name their support folder after it.
+    let bundleName: String?
+}
+
+/// How a candidate was attributed to the target.
+enum UninstallEvidence: String, Hashable, Sendable, CaseIterable {
+    case bundle
+    case bundleID
+    case groupContainer
+    case displayName
+
+    /// A name match is a guess where the other two are proof, so it lands unchecked and the user opts in.
+    var isAutoChecked: Bool { self != .displayName }
+
+    var label: String? { self == .displayName ? "matched by name" : nil }
+}
+
+/// The matching-ready form of a target. `make` is where every guard rail is applied, so `UninstallRules` is left with no judgement to exercise.
+struct UninstallIdentity: Hashable, Sendable {
+    /// Case-folded bundle ID, or nil when the target has none.
+    let bundleID: String?
+    /// A two-component ID like `com.adobe` names a vendor, not a product — prefix-matching it would sweep every app that vendor ships, so those get exact matches only.
+    let allowsBundleIDPrefixMatch: Bool
+    /// Every *other* installed app's folded bundle ID. A sibling shipping under a longer ID in the same namespace owns its own artifacts, which is what stops one release channel claiming another's data.
+    let otherBundleIDs: Set<String>
+    /// Case-folded names safe enough to claim a whole directory. Usually empty or a single entry.
+    let names: [String]
+    let bundleURL: URL
+
+    /// Below this a name is too generic to attribute anything to — "Go", "Vim", "1Pa".
+    static let minimumNameLength = 4
+
+    /// Standard Library subdirectories that belong to macOS rather than to any app, so an app sharing the name can never claim them.
+    static let reservedNames: Set<String> = [
+        "apple", "application support", "application scripts", "autosave information", "caches",
+        "containers", "cookies", "crashreporter", "fonts", "frameworks", "group containers",
+        "httpstorages", "keychains", "launchagents", "launchdaemons", "logs", "metadata",
+        "mobilesync", "preferences", "privilegedhelpertools", "scripts", "services", "sync",
+        "syncservices", "webkit"
+    ]
+
+    /// Nil refuses the whole uninstall: Tinycast can never plan its own removal, and a target with
+    /// neither a usable bundle ID nor a safe name has nothing to attribute leftovers by.
+    /// `ownBundleID` is the *running* identity, so the Dev channel refuses itself too.
+    static func make(
+        target: UninstallTarget, otherAppNames: [String], otherBundleIDs: [String] = [],
+        ownBundleID: String?, ownBundleURL: URL
+    ) -> UninstallIdentity? {
+        if let ownBundleID, let bundleID = target.bundleID,
+            folded(bundleID) == folded(ownBundleID)
+        {
+            return nil
+        }
+        if target.bundleURL.standardizedFileURL == ownBundleURL.standardizedFileURL { return nil }
+
+        let bundleID = target.bundleID.map(folded).flatMap { $0.isEmpty ? nil : $0 }
+        let names = safeNames(
+            displayName: target.displayName, bundleName: target.bundleName,
+            otherAppNames: otherAppNames)
+        guard bundleID != nil || !names.isEmpty else { return nil }
+
+        return UninstallIdentity(
+            bundleID: bundleID,
+            allowsBundleIDPrefixMatch: (bundleID?.split(separator: ".").count ?? 0) >= 3,
+            otherBundleIDs: Set(otherBundleIDs.map(folded)).subtracting([bundleID].compactMap { $0 }),
+            names: names,
+            bundleURL: target.bundleURL.standardizedFileURL)
+    }
+
+    /// The four gates a display name has to clear before it may claim a directory: long enough, not
+    /// a macOS-owned folder name, and unique among the installed apps — a second app called "Mail"
+    /// is exactly what makes `~/Library/Application Support/Mail` unattributable.
+    static func safeNames(
+        displayName: String, bundleName: String?, otherAppNames: [String]
+    ) -> [String] {
+        let taken = Set(otherAppNames.map(folded))
+        var result: [String] = []
+        for candidate in [displayName, bundleName].compactMap({ $0 }) {
+            let name = folded(candidate)
+            guard name.count >= minimumNameLength, !reservedNames.contains(name),
+                !taken.contains(name), !result.contains(name)
+            else { continue }
+            result.append(name)
+        }
+        return result
+    }
+
+    static func folded(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespaces)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallTarget.swift
+++ b/Tinycast/Core/Uninstall/UninstallTarget.swift
@@ -16,11 +16,16 @@ enum UninstallEvidence: String, Hashable, Sendable, CaseIterable {
     case bundleID
     case groupContainer
     case displayName
+    case binSymlink
 
-    /// A name match is a guess where the other two are proof, so it lands unchecked and the user opts in.
-    var isAutoChecked: Bool { self != .displayName }
-
-    var label: String? { self == .displayName ? "matched by name" : nil }
+    /// Shown on the row so the weaker evidence is visible; proof-grade matches say nothing.
+    var label: String? {
+        switch self {
+        case .displayName: return "matched by name"
+        case .binSymlink: return "command-line tool"
+        case .bundle, .bundleID, .groupContainer: return nil
+        }
+    }
 }
 
 /// The matching-ready form of a target. `make` is where every guard rail is applied, so `UninstallRules` is left with no judgement to exercise.
@@ -35,8 +40,11 @@ struct UninstallIdentity: Hashable, Sendable {
     let names: [String]
     let bundleURL: URL
 
-    /// Below this a name is too generic to attribute anything to — "Go", "Vim", "1Pa".
-    static let minimumNameLength = 4
+    /// Below this a name is too generic to attribute anything to — "Go", "1P". Three is the floor
+    /// rather than four because real apps live there: Zed, IINA, Xee all name their support folders
+    /// after themselves, and the exact-match, reserved-name and installed-app-collision guards below
+    /// are what carry the safety, not the length.
+    static let minimumNameLength = 3
 
     /// Standard Library subdirectories that belong to macOS rather than to any app, so an app sharing the name can never claim them.
     static let reservedNames: Set<String> = [

--- a/Tinycast/Core/Uninstall/UninstallTarget.swift
+++ b/Tinycast/Core/Uninstall/UninstallTarget.swift
@@ -1,12 +1,11 @@
 import Foundation
 
-/// What an uninstall is aimed at: the app bundle plus the strings a leftover can be attributed to.
-/// Foundation-only and pure so `Tools/uninstall-test.swift` can compile it standalone.
+/// What an uninstall is aimed at. Pure, for `Tools/uninstall-test.swift`.
 struct UninstallTarget: Hashable, Sendable {
     let bundleURL: URL
     let bundleID: String?
     let displayName: String
-    /// `CFBundleName` when it differs from the display name — some apps name their support folder after it.
+    /// Some apps name their support folder after `CFBundleName` rather than the display name.
     let bundleName: String?
 }
 
@@ -18,7 +17,7 @@ enum UninstallEvidence: String, Hashable, Sendable, CaseIterable {
     case displayName
     case binSymlink
 
-    /// Shown on the row so the weaker evidence is visible; proof-grade matches say nothing.
+    /// Weak evidence names itself on the row; proof-grade matches stay silent.
     var label: String? {
         switch self {
         case .displayName: return "matched by name"
@@ -28,25 +27,22 @@ enum UninstallEvidence: String, Hashable, Sendable, CaseIterable {
     }
 }
 
-/// The matching-ready form of a target. `make` is where every guard rail is applied, so `UninstallRules` is left with no judgement to exercise.
+/// Matching-ready form of a target. `make` applies every guard rail, leaving `UninstallRules` no judgement to exercise.
 struct UninstallIdentity: Hashable, Sendable {
     /// Case-folded bundle ID, or nil when the target has none.
     let bundleID: String?
-    /// A two-component ID like `com.adobe` names a vendor, not a product — prefix-matching it would sweep every app that vendor ships, so those get exact matches only.
+    /// False for a two-component ID: `com.adobe` names a vendor, and prefix-matching it would sweep every app they ship.
     let allowsBundleIDPrefixMatch: Bool
-    /// Every *other* installed app's folded bundle ID. A sibling shipping under a longer ID in the same namespace owns its own artifacts, which is what stops one release channel claiming another's data.
+    /// Other installed apps' folded IDs: a longer-ID sibling owns its own artifacts, so one channel can't claim another's.
     let otherBundleIDs: Set<String>
-    /// Case-folded names safe enough to claim a whole directory. Usually empty or a single entry.
+    /// Case-folded names safe enough to claim a whole directory.
     let names: [String]
     let bundleURL: URL
 
-    /// Below this a name is too generic to attribute anything to — "Go", "1P". Three is the floor
-    /// rather than four because real apps live there: Zed, IINA, Xee all name their support folders
-    /// after themselves, and the exact-match, reserved-name and installed-app-collision guards below
-    /// are what carry the safety, not the length.
+    /// Three, not four: Zed and IINA name their own folders. The guards below carry the safety, not the length.
     static let minimumNameLength = 3
 
-    /// Standard Library subdirectories that belong to macOS rather than to any app, so an app sharing the name can never claim them.
+    /// Standard Library subdirectories, so an app sharing the name can never claim them.
     static let reservedNames: Set<String> = [
         "apple", "application support", "application scripts", "autosave information", "caches",
         "containers", "cookies", "crashreporter", "fonts", "frameworks", "group containers",
@@ -55,8 +51,7 @@ struct UninstallIdentity: Hashable, Sendable {
         "syncservices", "webkit"
     ]
 
-    /// Nil refuses the whole uninstall: Tinycast can never plan its own removal, and a target with
-    /// neither a usable bundle ID nor a safe name has nothing to attribute leftovers by.
+    /// Nil refuses the uninstall: Tinycast never plans its own, and a target with no ID and no safe name can attribute nothing.
     /// `ownBundleID` is the *running* identity, so the Dev channel refuses itself too.
     static func make(
         target: UninstallTarget, otherAppNames: [String], otherBundleIDs: [String] = [],
@@ -83,9 +78,7 @@ struct UninstallIdentity: Hashable, Sendable {
             bundleURL: target.bundleURL.standardizedFileURL)
     }
 
-    /// The four gates a display name has to clear before it may claim a directory: long enough, not
-    /// a macOS-owned folder name, and unique among the installed apps — a second app called "Mail"
-    /// is exactly what makes `~/Library/Application Support/Mail` unattributable.
+    /// Gates a name must clear: long enough, not a macOS folder name, and not shared with another installed app.
     static func safeNames(
         displayName: String, bundleName: String?, otherAppNames: [String]
     ) -> [String] {

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -281,6 +281,15 @@ enum AppActionsMenu {
                     core.quit(app)
                 })
         }
+        if app.kind == .application {
+            items.append(
+                PopoverMenuItem(
+                    title: "Uninstall Application", systemImage: "trash", shortcut: "⌃⇧U",
+                    isDestructive: true
+                ) {
+                    core.beginUninstall(app)
+                })
+        }
         return PopoverMenuContent(header: app.name, items: items)
     }
 

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -284,8 +284,7 @@ enum AppActionsMenu {
         if app.kind == .application {
             items.append(
                 PopoverMenuItem(
-                    title: "Uninstall Application", systemImage: "trash", shortcut: "⌃⇧U",
-                    isDestructive: true
+                    title: "Uninstall Application", systemImage: "trash", isDestructive: true
                 ) {
                     core.beginUninstall(app)
                 })

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -48,7 +48,7 @@ struct RootPaletteView: View {
     }
     private var clipResults: [ClipboardItem] { store.search(vm.query) }
     private var histResults: [CalcHistoryEntry] { calcHistory.search(vm.query) }
-    /// Uninstall candidates filtered by the search field, which on this screen filters files by name or location.
+    /// The search field filters files by name or location on this screen.
     private var uninstallResults: [UninstallCandidate] {
         let query = vm.query.trimmingCharacters(in: .whitespaces)
         guard !query.isEmpty else { return uninstall.candidates }
@@ -278,7 +278,7 @@ struct RootPaletteView: View {
             vm.selection = 0
             showActions = false
             scroll = ScrollIntent(kind: .top)
-            // Covers every way out of the Uninstall screen — back chevron, bare backspace, a fresh summon.
+            // Every way out of the Uninstall screen: back chevron, bare backspace, a fresh summon.
             if vm.mode != .uninstall { uninstall.cancel() }
         }
         // Pop-to-root: `prepare` clears query/selection, but if both were already at their defaults the handlers above never fire — this intent guarantees the scroll itself snaps back to the origin.
@@ -459,15 +459,6 @@ struct RootPaletteView: View {
                 app.kind == .application, core.runningApps.isRunning(app)
             else { return .ignored }
             core.quit(app)
-            return .handled
-        }
-        // Mirrors the Actions row, and follows ⌃⇧Q's shape — both cases because Shift uppercases the key.
-        .onKeyPress(keys: ["u", "U"], phases: .down) { press in
-            guard press.modifiers.contains(.control), press.modifiers.contains(.shift),
-                !isCollapsed, vm.mode == .launcher, let app = selectedAppEntry,
-                app.kind == .application
-            else { return .ignored }
-            core.beginUninstall(app)
             return .handled
         }
     }
@@ -674,14 +665,14 @@ struct RootPaletteView: View {
         }
     }
 
-    /// The uninstall list's one header, standing in for the section headers the other lists use.
+    /// Stands in for the section headers the other lists use.
     private var uninstallSummary: String {
         let total = uninstall.plan?.removableIDs.count ?? 0
         let size = MeasuredSize(bytes: uninstall.selectedBytes).formatted
         return "\(uninstall.selectedCount) of \(total) files selected · \(size)"
     }
 
-    /// The Uninstall screen's primary action is destructive, so its pill is the one that isn't white.
+    /// The Uninstall screen's primary action is destructive, so its pill isn't white.
     private var pillTint: Color {
         vm.mode == .uninstall ? Theme.Colors.destructive : .primary
     }

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -13,6 +13,7 @@ struct RootPaletteView: View {
     @EnvironmentObject private var currencyRates: CurrencyRateStore
     @EnvironmentObject private var emojiIndex: EmojiIndex
     @EnvironmentObject private var frequentEmoji: FrequentEmojiStore
+    @EnvironmentObject private var uninstall: UninstallSession
     /// Observed so a skin tone changed in Settings re-renders the grid glyphs immediately.
     @ObservedObject private var settings = AppCore.shared.settings
     @FocusState private var searchFocused: Bool
@@ -47,6 +48,15 @@ struct RootPaletteView: View {
     }
     private var clipResults: [ClipboardItem] { store.search(vm.query) }
     private var histResults: [CalcHistoryEntry] { calcHistory.search(vm.query) }
+    /// Uninstall candidates filtered by the search field, which on this screen filters files by name or location.
+    private var uninstallResults: [UninstallCandidate] {
+        let query = vm.query.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return uninstall.candidates }
+        return uninstall.candidates.filter {
+            $0.name.localizedCaseInsensitiveContains(query)
+                || $0.locationLabel.localizedCaseInsensitiveContains(query)
+        }
+    }
     private var emojiSections: [EmojiGridSection] {
         EmojiGrid.sections(query: vm.query, index: emojiIndex, frequent: frequentEmoji)
     }
@@ -66,6 +76,7 @@ struct RootPaletteView: View {
         case .clipboard: return clipResults.count
         case .calculatorHistory: return histResults.count + calcCount
         case .emoji: return emojiResults.count
+        case .uninstall: return uninstallResults.count
         }
     }
     /// Selection clamped into the current results — the single source of truth for highlight, preview and activation so the list and preview can never disagree.
@@ -99,6 +110,9 @@ struct RootPaletteView: View {
     }
     private var selectedEmojiEntry: EmojiEntry? {
         emojiResults.indices.contains(selection) ? emojiResults[selection] : nil
+    }
+    private var selectedUninstallCandidate: UninstallCandidate? {
+        uninstallResults.indices.contains(selection) ? uninstallResults[selection] : nil
     }
 
     /// The bottom-right Actions menu content for the current mode's selection, or nil when the selection has no actions.
@@ -142,6 +156,12 @@ struct RootPaletteView: View {
                     entry: emoji, core: core, target: vm.pasteTarget)
             }
             return nil
+        case .uninstall:
+            if let candidate = selectedUninstallCandidate {
+                return UninstallActionsMenu.content(
+                    candidate: candidate, session: uninstall, core: core)
+            }
+            return nil
         }
     }
 
@@ -171,13 +191,15 @@ struct RootPaletteView: View {
         let hist = vm.mode == .calculatorHistory ? histResults : []
         let emojiSections = vm.mode == .emoji ? emojiSections : []
         let emojis = emojiSections.flatMap(\.entries)
+        let uninstallRows = vm.mode == .uninstall ? uninstallResults : []
         // Newest stored clip + the reorder token: the pair changes only when the store mutates, never when a query filters the list.
         let clipFollow = ClipFollowKey(id: store.items.first?.id, token: vm.followToken)
         // Every count/selection below derives from this one calc/offset pair — the flat selection index must always match the visible row order, calc card included.
         let calc = calcResult
         let offset = calc == nil ? 0 : 1
         // Only the active mode is non-empty.
-        let count = apps.count + offset + clips.count + hist.count + emojis.count
+        let count =
+            apps.count + offset + clips.count + hist.count + emojis.count + uninstallRows.count
         let sel = count == 0 ? 0 : min(max(vm.selection, 0), count - 1)
         let calcSelected = calc != nil && sel == 0
         // An error card is selectable but has no action: it must not drive the Copy Answer pill, ⌘K menu, or Enter.
@@ -196,8 +218,9 @@ struct RootPaletteView: View {
                 Color.clear
             } else {
                 content(
-                    apps: apps, clips: clips, hist: hist, emojiSections: emojiSections, calc: calc,
-                    selection: sel, favoriteCount: favoriteCount, showSections: showSections
+                    apps: apps, clips: clips, hist: hist, emojiSections: emojiSections,
+                    uninstallRows: uninstallRows, calc: calc, selection: sel,
+                    favoriteCount: favoriteCount, showSections: showSections
                 )
             }
         }
@@ -255,6 +278,8 @@ struct RootPaletteView: View {
             vm.selection = 0
             showActions = false
             scroll = ScrollIntent(kind: .top)
+            // Covers every way out of the Uninstall screen — back chevron, bare backspace, a fresh summon.
+            if vm.mode != .uninstall { uninstall.cancel() }
         }
         // Pop-to-root: `prepare` clears query/selection, but if both were already at their defaults the handlers above never fire — this intent guarantees the scroll itself snaps back to the origin.
         .onChange(of: vm.resetToken) {
@@ -365,6 +390,10 @@ struct RootPaletteView: View {
                 let index = selection - calcCount
                 guard command, histResults.indices.contains(index) else { return .ignored }
                 core.copyHistoryExpression(histResults[index])
+            case .uninstall:
+                guard command, let candidate = selectedUninstallCandidate, !candidate.isLocked
+                else { return .ignored }
+                uninstall.toggle(candidate.id)
             case .launcher:
                 guard command, let app = selectedAppEntry, app.canRevealInFinder
                 else { return .ignored }
@@ -410,7 +439,7 @@ struct RootPaletteView: View {
                 deleteSelectedClip()
             case .calculatorHistory:
                 deleteSelectedHistoryEntry()
-            case .launcher, .emoji:
+            case .launcher, .emoji, .uninstall:
                 return .ignored
             }
             return .handled
@@ -430,6 +459,15 @@ struct RootPaletteView: View {
                 app.kind == .application, core.runningApps.isRunning(app)
             else { return .ignored }
             core.quit(app)
+            return .handled
+        }
+        // Mirrors the Actions row, and follows ⌃⇧Q's shape — both cases because Shift uppercases the key.
+        .onKeyPress(keys: ["u", "U"], phases: .down) { press in
+            guard press.modifiers.contains(.control), press.modifiers.contains(.shift),
+                !isCollapsed, vm.mode == .launcher, let app = selectedAppEntry,
+                app.kind == .application
+            else { return .ignored }
+            core.beginUninstall(app)
             return .handled
         }
     }
@@ -491,7 +529,7 @@ struct RootPaletteView: View {
     @ViewBuilder
     private func content(
         apps: [AppEntry], clips: [ClipboardItem], hist: [CalcHistoryEntry],
-        emojiSections: [EmojiGridSection], calc: CalcResult?,
+        emojiSections: [EmojiGridSection], uninstallRows: [UninstallCandidate], calc: CalcResult?,
         selection: Int, favoriteCount: Int, showSections: Bool
     ) -> some View {
         switch vm.mode {
@@ -601,7 +639,51 @@ struct RootPaletteView: View {
                     }
                 )
             }
+        case .uninstall:
+            switch uninstall.state {
+            case .idle, .scanning:
+                EmptyResults(text: "Looking for leftover files…")
+            case .failed(let message):
+                EmptyResults(text: message)
+            case .ready:
+                if uninstallRows.isEmpty {
+                    EmptyResults(
+                        text: isQueryEmpty ? "Nothing left to remove" : "No matching files")
+                } else {
+                    UninstallList(
+                        results: uninstallRows,
+                        selectedID: uninstallRows.indices.contains(selection)
+                            ? uninstallRows[selection].id : nil,
+                        summary: uninstallSummary,
+                        scroll: scroll,
+                        onSelect: { candidate in
+                            if let index = uninstallRows.firstIndex(of: candidate) {
+                                vm.selection = index
+                            }
+                        },
+                        onToggle: { uninstall.toggle($0.id) },
+                        onActions: { candidate in
+                            if let index = uninstallRows.firstIndex(of: candidate) {
+                                vm.selection = index
+                            }
+                            openActions()
+                        }
+                    )
+                }
+            }
         }
+    }
+
+    /// The uninstall list's one header, standing in for the section headers the other lists use.
+    private var uninstallSummary: String {
+        let total = uninstall.plan?.removableIDs.count ?? 0
+        let size = MeasuredSize(bytes: uninstall.selectedBytes).formatted
+        return "\(uninstall.selectedCount) of \(total) files selected · \(size)"
+    }
+
+    /// The Uninstall screen's primary action is destructive, so its pill is the one that isn't white.
+    private var pillTint: Color {
+        vm.mode == .uninstall ? Theme.Colors.destructive : .primary
     }
 
     private func bottomBar(pillLabel: String, showActionGroup: Bool) -> some View {
@@ -629,7 +711,7 @@ struct RootPaletteView: View {
                 HStack(spacing: Theme.Spacing.sm) {
                     Text(pillLabel)
                         .font(Theme.Typography.bar)
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(pillTint)
                     KeyCapChip(text: "↵", style: .outline)
                 }
             }
@@ -656,6 +738,8 @@ struct RootPaletteView: View {
             return vm.pasteTarget?.pasteTitle ?? "Paste"
         case .calculatorHistory:
             return "Copy Answer"
+        case .uninstall:
+            return "Uninstall Application"
         case .launcher:
             if calcActionable { return "Copy Answer" }
             switch selectedApp?.kind {
@@ -781,6 +865,8 @@ struct RootPaletteView: View {
         case .emoji:
             guard emojiResults.indices.contains(selection) else { return }
             core.pasteEmoji(emojiResults[selection])
+        case .uninstall:
+            core.performUninstall()
         }
     }
 }

--- a/Tinycast/Features/Uninstall/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UninstallView.swift
@@ -5,7 +5,7 @@ struct UninstallList: View {
     let results: [UninstallCandidate]
     let selectedID: UninstallCandidate.ID?
     let summary: String
-    /// Changes only when the list should scroll (keyboard nav / reset), so mouse selection never yanks the scroll position.
+    /// Changes only on keyboard nav / reset, so mouse selection never yanks the scroll position.
     let scroll: ScrollIntent
     let onSelect: (UninstallCandidate) -> Void
     let onToggle: (UninstallCandidate) -> Void
@@ -30,8 +30,7 @@ struct UninstallList: View {
                         )
                         .id(candidate.id)
                         .contentShape(Rectangle())
-                        // Matches the other lists: single click selects instantly, and the
-                        // double-click handler is simultaneous so the tap never waits on its timeout.
+                        // Simultaneous, so the single-click select never waits on the double-click timeout.
                         .onTapGesture { onSelect(candidate) }
                         .simultaneousGesture(
                             TapGesture(count: 2).onEnded {
@@ -74,7 +73,7 @@ private struct UninstallRow: View {
     let onToggle: () -> Void
     @State private var hovered = false
 
-    /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
+    /// Selection wins over hover when a row is both.
     private var fill: Color {
         if selected { return Theme.Colors.selection }
         if hovered { return Theme.Colors.rowHover }
@@ -88,14 +87,12 @@ private struct UninstallRow: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.lg) {
-            // The glyph is smaller than an app icon but sits in the same `rowIcon` slot every other
-            // list uses, so titles line up at one x across the palette and switching modes doesn't
-            // jog the column. The slot is also the hit target, which is why it takes the tap.
+            // Smaller glyph, same `rowIcon` slot as every other list, so titles line up at one x and switching modes doesn't jog the column.
             SymbolImage(name: glyph, size: Theme.Size.checkbox)
                 .foregroundStyle(candidate.isLocked ? Theme.Colors.textTertiary : .primary)
                 .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
                 .contentShape(Rectangle())
-                // Only the checkbox toggles on a single click; the rest of the row selects.
+                // Only the checkbox toggles; the rest of the row selects.
                 .onTapGesture(perform: onToggle)
                 .tooltip(candidate.lockReason)
             Text(candidate.name)
@@ -131,7 +128,7 @@ private struct UninstallRow: View {
     }
 }
 
-/// The Finder icon for any path — the app bundle's own artwork, a folder, or a document.
+/// The Finder icon for any path.
 private struct FileIconView: View {
     let path: String
     @State private var image: NSImage?
@@ -157,7 +154,7 @@ private struct FileIconView: View {
     }
 }
 
-/// Actions menu for a row on the Uninstall screen, shown bottom-right on right-click or from the pill.
+/// Actions menu for a row on the Uninstall screen.
 @MainActor
 enum UninstallActionsMenu {
     static func content(
@@ -179,12 +176,6 @@ enum UninstallActionsMenu {
                     systemImage: checked ? "circle" : "checkmark.circle", shortcut: "⌘↵"
                 ) { session.toggle(candidate.id) })
         }
-        let allSelected = session.selectedCount == session.plan?.removableIDs.count
-        items.append(
-            PopoverMenuItem(
-                title: allSelected ? "Deselect All" : "Select All",
-                systemImage: allSelected ? "square" : "checkmark.square"
-            ) { session.setAll(!allSelected) })
         items.append(
             PopoverMenuItem(title: "Copy Path", systemImage: "doc.on.clipboard", shortcut: "⌥⌘C") {
                 core.copyUninstallPath(candidate)

--- a/Tinycast/Features/Uninstall/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UninstallView.swift
@@ -1,0 +1,200 @@
+import AppKit
+import SwiftUI
+
+struct UninstallList: View {
+    let results: [UninstallCandidate]
+    let selectedID: UninstallCandidate.ID?
+    let summary: String
+    /// Changes only when the list should scroll (keyboard nav / reset), so mouse selection never yanks the scroll position.
+    let scroll: ScrollIntent
+    let onSelect: (UninstallCandidate) -> Void
+    let onToggle: (UninstallCandidate) -> Void
+    let onActions: (UninstallCandidate) -> Void
+    @EnvironmentObject private var session: UninstallSession
+
+    private var firstRowSelected: Bool {
+        selectedID != nil && selectedID == results.first?.id
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    SectionHeader(title: summary, isFirst: true)
+                    ForEach(results) { candidate in
+                        UninstallRow(
+                            candidate: candidate,
+                            selected: candidate.id == selectedID,
+                            checked: session.selection?.isChecked(candidate.id) ?? false,
+                            onToggle: { onToggle(candidate) }
+                        )
+                        .id(candidate.id)
+                        .contentShape(Rectangle())
+                        // Matches the other lists: single click selects instantly, and the
+                        // double-click handler is simultaneous so the tap never waits on its timeout.
+                        .onTapGesture { onSelect(candidate) }
+                        .simultaneousGesture(
+                            TapGesture(count: 2).onEnded {
+                                onSelect(candidate)
+                                onToggle(candidate)
+                            }
+                        )
+                        .onRightClick { onActions(candidate) }
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.xs)
+                .padding(.bottom, Theme.Spacing.md)
+                .hideNativeScrollers()
+                .scrollOriginAnchor()
+            }
+            .edgeDissolve()
+            .thinScrollbar()
+            .onChange(of: scroll) { _, scroll in
+                switch scroll.kind {
+                case .top:
+                    proxy.scrollToOrigin()
+                case .follow:
+                    // On the first row, snap to the origin so the summary header shows too.
+                    if firstRowSelected {
+                        proxy.scrollToOrigin()
+                    } else if let selectedID {
+                        proxy.reveal(selectedID)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct UninstallRow: View {
+    let candidate: UninstallCandidate
+    let selected: Bool
+    let checked: Bool
+    let onToggle: () -> Void
+    @State private var hovered = false
+
+    /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    private var glyph: String {
+        if candidate.isLocked { return "lock.fill" }
+        return checked ? "checkmark.square.fill" : "square"
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            SymbolImage(name: glyph, size: Theme.Size.checkbox)
+                .frame(width: Theme.Size.checkbox, height: Theme.Size.checkbox)
+                .foregroundStyle(candidate.isLocked ? Theme.Colors.textTertiary : .primary)
+                .contentShape(Rectangle())
+                // Only the glyph toggles on a single click; the rest of the row selects.
+                .onTapGesture(perform: onToggle)
+                .tooltip(candidate.lockReason)
+            Text(candidate.name)
+                .font(Theme.Typography.rowTitle)
+                .lineLimit(1)
+                .layoutPriority(1)
+            Text(candidate.locationLabel)
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if let label = candidate.evidence.label {
+                Text(label)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: Theme.Spacing.md)
+            Text(candidate.size.formatted)
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(.secondary)
+            FileIconView(path: candidate.path)
+                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+        }
+        .opacity(candidate.isLocked ? 0.55 : 1)
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .fill(fill)
+        )
+        .armedHover($hovered)
+    }
+}
+
+/// The Finder icon for any path — the app bundle's own artwork, a folder, or a document.
+private struct FileIconView: View {
+    let path: String
+    @State private var image: NSImage?
+
+    init(path: String) {
+        self.path = path
+        _image = State(initialValue: IconCache.cached(forFile: path))
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image).resizable()
+            } else {
+                RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                    .fill(Color.white.opacity(0.06))
+            }
+        }
+        .task(id: path) {
+            guard image == nil else { return }
+            image = await IconCache.loadAsync(forFile: path)
+        }
+    }
+}
+
+/// Actions menu for a row on the Uninstall screen, shown bottom-right on right-click or from the pill.
+@MainActor
+enum UninstallActionsMenu {
+    static func content(
+        candidate: UninstallCandidate, session: UninstallSession, core: AppCore
+    ) -> PopoverMenuContent {
+        var items: [PopoverMenuItem] = []
+        if session.canConfirm {
+            items.append(
+                PopoverMenuItem(
+                    title: "Uninstall Application", systemImage: "trash", shortcut: "↵",
+                    isDestructive: true
+                ) { core.performUninstall() })
+        }
+        if !candidate.isLocked {
+            let checked = session.selection?.isChecked(candidate.id) ?? false
+            items.append(
+                PopoverMenuItem(
+                    title: checked ? "Unselect File" : "Select File",
+                    systemImage: checked ? "circle" : "checkmark.circle", shortcut: "⌘↵"
+                ) { session.toggle(candidate.id) })
+        }
+        let allSelected = session.selectedCount == session.plan?.removableIDs.count
+        items.append(
+            PopoverMenuItem(
+                title: allSelected ? "Deselect All" : "Select All",
+                systemImage: allSelected ? "square" : "checkmark.square"
+            ) { session.setAll(!allSelected) })
+        items.append(
+            PopoverMenuItem(title: "Copy Path", systemImage: "doc.on.clipboard", shortcut: "⌥⌘C") {
+                core.copyUninstallPath(candidate)
+            })
+        items.append(
+            PopoverMenuItem(title: "Show in Finder", systemImage: "folder", shortcut: "⇧⌘O") {
+                core.showUninstallItemInFinder(candidate)
+            })
+        items.append(
+            PopoverMenuItem(title: "Show Info in Finder", systemImage: "info.circle", shortcut: "⇧⌘I")
+            {
+                core.showUninstallItemInfo(candidate)
+            })
+        return PopoverMenuContent(header: session.app?.name ?? candidate.name, items: items)
+    }
+}

--- a/Tinycast/Features/Uninstall/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UninstallView.swift
@@ -88,11 +88,14 @@ private struct UninstallRow: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.lg) {
+            // The glyph is smaller than an app icon but sits in the same `rowIcon` slot every other
+            // list uses, so titles line up at one x across the palette and switching modes doesn't
+            // jog the column. The slot is also the hit target, which is why it takes the tap.
             SymbolImage(name: glyph, size: Theme.Size.checkbox)
-                .frame(width: Theme.Size.checkbox, height: Theme.Size.checkbox)
                 .foregroundStyle(candidate.isLocked ? Theme.Colors.textTertiary : .primary)
+                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
                 .contentShape(Rectangle())
-                // Only the glyph toggles on a single click; the rest of the row selects.
+                // Only the checkbox toggles on a single click; the rest of the row selects.
                 .onTapGesture(perform: onToggle)
                 .tooltip(candidate.lockReason)
             Text(candidate.name)

--- a/Tools/callout-test.swift
+++ b/Tools/callout-test.swift
@@ -48,6 +48,7 @@ struct CalloutPlacementTests {
         horizontalClamping()
         caretTracking()
         degenerateContainers()
+        rowGrammar()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
@@ -167,6 +168,19 @@ struct CalloutPlacementTests {
         expect(
             farLeading.caretX >= caretLimit - 0.001,
             "the pointer stops clear of the leading corner arc")
+    }
+
+    // MARK: - Shared row grammar
+    //
+    // Lives here because this is the only harness that compiles `Theme.swift`. Every palette list
+    // puts its leading glyph in one `rowIcon` slot so titles line up at the same x and switching
+    // modes doesn't shift the column sideways; a glyph that outgrew the slot would break that.
+
+    static func rowGrammar() {
+        expect(
+            Theme.Size.checkbox <= Theme.Size.rowIcon,
+            "the uninstall checkbox fits inside the shared leading slot")
+        expect(Theme.Size.checkbox > 0, "and is a real size")
     }
 
     // MARK: - Containers smaller than the callout

--- a/Tools/uninstall-test.swift
+++ b/Tools/uninstall-test.swift
@@ -280,6 +280,30 @@ struct UninstallTests {
             "every bin directory is absolute or home-relative")
     }
 
+    /// The home directory holds the user's own work, so nothing there is ever a candidate. Asserting
+    /// the absence keeps a future root addition from quietly reopening it.
+    static func testHomeIsOutOfScope() {
+        expect(
+            !UninstallSearchRoot.all.contains { $0.path(home: home) == home },
+            "the home directory itself is never a search root")
+        expect(
+            UninstallSearchRoot.all.allSatisfy {
+                let path = $0.path(home: home)
+                return path.hasPrefix(home + "/Library/") || path.hasPrefix("/Library/")
+            },
+            "every root lives under a Library directory — never ~/Documents, ~/Dev or ~/Code")
+        // VS Code's CFBundleName is literally "Code", so it *would* match `~/Code` on name alone —
+        // the root table is the only thing standing between that and the user's source tree.
+        let code = identity(
+            bundleID: "com.microsoft.VSCode", name: "Visual Studio Code", bundleName: "Code")
+        expect(
+            UninstallRules.matchesDisplayName("Code", identity: code),
+            "the name rule alone would claim a folder called Code")
+        expect(
+            !UninstallSearchRoot.all.contains { $0.path(home: home) + "/Code" == home + "/Code" },
+            "so it matters that no root ever puts ~/Code in reach")
+    }
+
     // MARK: - Identity refusal
 
     static func testIdentityRefusal() {
@@ -393,10 +417,24 @@ struct UninstallTests {
                 == .userLocked,
             "Finder's Locked flag is its own case, because the user can clear it")
         expect(
+            classify(PathFacts(path: "/Library/Caches/com.foo.Bar", isOwnedByCurrentUser: false))
+                == .removable,
+            "ownership alone never locks a row — POSIX unlink is governed by the parent directory")
+        expect(
             classify(
-                PathFacts(path: "/Library/PrivilegedHelperTools/com.foo.Bar", isOwnedByCurrentUser: false))
+                PathFacts(
+                    path: "/tmp/com.foo.Bar", isOwnedByCurrentUser: false, parentIsSticky: true))
                 == .notOwned,
-            "a root-owned file is locked rather than attempted")
+            "except under a sticky parent, where only an owner may unlink")
+        expect(
+            classify(PathFacts(path: "/tmp/com.foo.Bar", parentIsSticky: true)) == .removable,
+            "a sticky parent is fine for something you do own")
+        expect(
+            classify(
+                PathFacts(
+                    path: "/usr/local/bin/code", isOwnedByCurrentUser: false,
+                    parentIsWritable: false)) == .parentNotWritable,
+            "a root-owned CLI link in a root-owned bin directory reports the parent, not the owner")
         expect(
             classify(PathFacts(path: "/Library/Caches/com.foo.Bar", parentIsWritable: false))
                 == .parentNotWritable,
@@ -413,7 +451,7 @@ struct UninstallTests {
         let everything = PathFacts(
             path: home + "/Library/Containers/com.foo.Bar", volumeIsReadOnly: true,
             isSystemRestricted: true, isUserImmutable: true, isOwnedByCurrentUser: false,
-            parentIsWritable: false)
+            parentIsWritable: false, parentIsSticky: true)
         expect(
             classify(everything) == .systemProtected,
             "precedence: a SIP path reports as system-protected, the most useful of its reasons")
@@ -559,6 +597,9 @@ struct UninstallTests {
             Set(roots.map { "\($0.base)/\($0.relativePath)" }).count == roots.count,
             "no root is listed twice")
         expect(roots.allSatisfy { !$0.relativePath.isEmpty }, "no root has an empty relative path")
+        expect(
+            !roots.contains { $0.relativePath == "." || $0.relativePath.hasPrefix("..") },
+            "no root escapes its base")
         expect(roots.allSatisfy { !$0.styles.isEmpty }, "every root enables at least one match style")
         expect(
             roots.allSatisfy { !$0.relativePath.hasPrefix("/") && !$0.relativePath.hasSuffix("/") },
@@ -597,6 +638,7 @@ struct UninstallTests {
         testGroupContainers()
         testDisplayNames()
         testPlugInsAndSymlinks()
+        testHomeIsOutOfScope()
         testIdentityRefusal()
         testPathSafety()
         testProtection()

--- a/Tools/uninstall-test.swift
+++ b/Tools/uninstall-test.swift
@@ -1,0 +1,533 @@
+// swiftc -swift-version 6 Tinycast/Core/Uninstall/UninstallTarget.swift \
+//     Tinycast/Core/Uninstall/UninstallSearchRoot.swift Tinycast/Core/Uninstall/UninstallRules.swift \
+//     Tinycast/Core/Uninstall/UninstallProtection.swift Tinycast/Core/Uninstall/UninstallPlan.swift \
+//     Tools/uninstall-test.swift -o /tmp/uninstall-test && /tmp/uninstall-test
+//
+// Pure layer only: no filesystem, no temp directories. Every environment fact is injected.
+
+import Foundation
+
+@main
+@MainActor
+struct UninstallTests {
+    static var failures = 0
+    static var passes = 0
+
+    static let home = "/Users/tester"
+    static let ownBundleID = "com.tinycast.app"
+    static let ownBundleURL = URL(fileURLWithPath: "/Applications/Tinycast.app")
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    static func identity(
+        bundleID: String?, name: String = "Test App", bundleName: String? = nil,
+        otherAppNames: [String] = [], otherBundleIDs: [String] = [],
+        path: String = "/Applications/Test App.app"
+    ) -> UninstallIdentity {
+        let target = UninstallTarget(
+            bundleURL: URL(fileURLWithPath: path), bundleID: bundleID, displayName: name,
+            bundleName: bundleName)
+        guard
+            let identity = UninstallIdentity.make(
+                target: target, otherAppNames: otherAppNames, otherBundleIDs: otherBundleIDs,
+                ownBundleID: ownBundleID, ownBundleURL: ownBundleURL)
+        else {
+            fatalError("fixture identity was refused: \(name)")
+        }
+        return identity
+    }
+
+    static func root(_ relativePath: String) -> UninstallSearchRoot {
+        guard
+            let root = UninstallSearchRoot.all.first(where: {
+                $0.base == .userLibrary && $0.relativePath == relativePath
+            })
+        else { fatalError("no such root: \(relativePath)") }
+        return root
+    }
+
+    static func evidence(_ name: String, _ relativePath: String, _ identity: UninstallIdentity)
+        -> UninstallEvidence?
+    {
+        UninstallRules.evidence(for: name, in: root(relativePath), identity: identity)
+    }
+
+    // MARK: - Bundle ID matching
+
+    static func testBundleIDMatching() {
+        let books = identity(bundleID: "com.apple.iBooksX", name: "Books")
+        expect(
+            UninstallRules.matchesBundleID("com.apple.iBooksX", identity: books),
+            "a bundle ID matches itself")
+        expect(
+            UninstallRules.matchesBundleID("com.apple.iBooksX.CacheDelete", identity: books),
+            "a dot-namespaced child matches — the case prefix matching exists for")
+        expect(
+            !UninstallRules.matchesBundleID("com.apple.iBooks", identity: books),
+            "a shorter sibling ID does not match")
+        expect(
+            !UninstallRules.matchesBundleID("com.apple.iBooksXtra", identity: books),
+            "a longer ID without the dot boundary does not match")
+        expect(
+            UninstallRules.matchesBundleID("COM.Apple.IBOOKSX", identity: books),
+            "matching is case-folded")
+
+        let safari = identity(bundleID: "com.apple.Safari", name: "Safari")
+        expect(
+            !UninstallRules.matchesBundleID("com.apple.SafariTechnologyPreview", identity: safari),
+            "Safari Technology Preview is never claimed by Safari — the trailing-dot rule")
+        expect(
+            !UninstallRules.matchesBundleID("com.apple.Safari2", identity: safari),
+            "a digit-suffixed ID does not match")
+
+        // Sibling release channels share a namespace but are separate products.
+        let channels = ["com.example.app", "com.example.app.beta", "com.example.app.dev"]
+        let stable = identity(
+            bundleID: "com.example.app", name: "Example", otherBundleIDs: channels)
+        expect(
+            UninstallRules.matchesBundleID("com.example.app", identity: stable),
+            "a channel still matches its own artifacts")
+        expect(
+            !UninstallRules.matchesBundleID("com.example.app.dev", identity: stable),
+            "an installed sibling channel owns its own data — stable never claims Dev's")
+        expect(
+            !UninstallRules.matchesBundleID("com.example.app.beta.plist", identity: stable),
+            "the sibling rule survives extension stripping")
+        expect(
+            UninstallRules.matchesBundleID("com.example.app.helper", identity: stable),
+            "a namespace child that is not an installed app is still ours")
+        let devChannel = identity(
+            bundleID: "com.example.app.dev", name: "Example Dev", otherBundleIDs: channels)
+        expect(
+            UninstallRules.matchesBundleID("com.example.app.dev", identity: devChannel),
+            "and the sibling itself still matches its own ID")
+        expect(
+            !UninstallRules.matchesBundleID("com.example.app", identity: devChannel),
+            "a longer-ID sibling never claims the shorter parent's artifacts either")
+
+        let vendor = identity(bundleID: "com.adobe", name: "Vendor App")
+        expect(
+            UninstallRules.matchesBundleID("com.adobe", identity: vendor),
+            "a two-component ID still matches itself exactly")
+        expect(
+            !UninstallRules.matchesBundleID("com.adobe.Photoshop", identity: vendor),
+            "a two-component ID names a vendor, so it never prefix-matches its products")
+    }
+
+    // MARK: - Extension stripping
+
+    static func testExtensionStripping() {
+        let app = identity(bundleID: "com.foo.Bar")
+        expect(evidence("com.foo.Bar.plist", "Preferences", app) == .bundleID, "a .plist strips")
+        expect(
+            evidence("com.foo.Bar.plist.lockfile", "Preferences", app) == .bundleID,
+            "stripping repeats for a .plist.lockfile")
+        expect(
+            evidence("com.foo.Bar.savedState", "Saved Application State", app) == .bundleID,
+            "a .savedState strips")
+        expect(
+            evidence("com.foo.Bar.binarycookies", "Cookies", app) == .bundleID,
+            "a .binarycookies strips")
+        expect(
+            evidence("com.foo.Bar.8A1F2C3D-1111-2222-3333-444455556666.plist", "Preferences/ByHost", app)
+                == .bundleID,
+            "a ByHost UUID name strips then matches as a namespace child")
+        expect(
+            evidence("com.foo.BarHelper.plist", "Preferences", app) == nil,
+            "a helper whose ID merely starts with the target's does not match")
+        expect(
+            UninstallRules.matchableForms("com.foo.Bar.app") == ["com.foo.Bar.app"],
+            ".app is not a stripped extension")
+    }
+
+    // MARK: - Group containers
+
+    static func testGroupContainers() {
+        let app = identity(bundleID: "com.foo.Bar")
+        expect(
+            evidence("group.com.foo.Bar", "Group Containers", app) == .groupContainer,
+            "a group. prefix is stripped")
+        expect(
+            evidence("ABCDE12345.com.foo.Bar", "Group Containers", app) == .groupContainer,
+            "a Team ID prefix is stripped")
+        expect(
+            evidence("ABCDE12345.group.com.foo.Bar", "Group Containers", app) == .groupContainer,
+            "both prefixes are stripped")
+        expect(
+            evidence("group.com.foo.BarExtra", "Group Containers", app) == nil,
+            "a near-miss after stripping is still a miss")
+        expect(
+            evidence("notateamid.com.foo.Bar", "Group Containers", app) == nil,
+            "an arbitrary prefix is not a Team ID")
+        expect(
+            evidence("group.com.foo.Bar", "Preferences", app) == nil,
+            "group matching only applies in roots that enable it")
+        expect(UninstallRules.isTeamID("ABCDE12345"), "a 10-char uppercase alphanumeric is a Team ID")
+        expect(!UninstallRules.isTeamID("abcde12345"), "lowercase is not a Team ID")
+        expect(!UninstallRules.isTeamID("ABCDE1234"), "9 characters is not a Team ID")
+    }
+
+    // MARK: - Display names
+
+    static func testDisplayNames() {
+        let cleaner = identity(
+            bundleID: "net.freemacsoft.AppCleaner", name: "AppCleaner")
+        expect(
+            evidence("AppCleaner", "Application Support", cleaner) == .displayName,
+            "a name-matched support folder is found, and flagged as name evidence")
+        expect(
+            evidence("AppCleaner", "Preferences", cleaner) == nil,
+            "name matching never applies in a bundle-ID-only root")
+
+        let books = identity(bundleID: "com.apple.iBooksX", name: "Books")
+        expect(
+            evidence("Books Reader", "Application Support", books) == nil,
+            "an exact-only rule stops Books claiming Books Reader")
+        let reader = identity(bundleID: "com.other.BooksReader", name: "Books Reader")
+        expect(
+            evidence("Books", "Application Support", reader) == nil,
+            "and stops Books Reader claiming Books — exactness cuts both ways")
+
+        let mail = identity(
+            bundleID: "com.third.Mailer", name: "Mail", otherAppNames: ["Mail", "Notes"])
+        expect(
+            evidence("Mail", "Application Support", mail) == nil,
+            "a name shared with another installed app is dropped entirely")
+        expect(
+            evidence("Mail", "Application Support", identity(bundleID: "com.third.Mailer", name: "Mail"))
+                == .displayName,
+            "the same name is usable when no other installed app claims it")
+
+        let short = identity(bundleID: "com.foo.Vim", name: "Vim")
+        expect(
+            evidence("Vim", "Application Support", short) == nil,
+            "a name under the minimum length never matches")
+
+        let reserved = identity(bundleID: "com.foo.Prefs", name: "Preferences")
+        expect(
+            evidence("Preferences", "Application Support", reserved) == nil,
+            "a macOS-owned Library folder name is never claimable")
+
+        expect(
+            UninstallIdentity.safeNames(
+                displayName: "AppCleaner", bundleName: "AppCleaner", otherAppNames: [])
+                == ["appcleaner"],
+            "a bundle name identical to the display name is deduped")
+    }
+
+    // MARK: - Identity refusal
+
+    static func testIdentityRefusal() {
+        let byID = UninstallTarget(
+            bundleURL: URL(fileURLWithPath: "/Applications/Somewhere Else.app"),
+            bundleID: "com.tinycast.app", displayName: "Tinycast", bundleName: nil)
+        expect(
+            UninstallIdentity.make(
+                target: byID, otherAppNames: [], ownBundleID: ownBundleID,
+                ownBundleURL: ownBundleURL) == nil,
+            "Tinycast refuses to plan its own uninstall by bundle ID")
+
+        let dev = UninstallTarget(
+            bundleURL: URL(fileURLWithPath: "/Applications/Tinycast Dev.app"),
+            bundleID: "com.tinycast.app.dev", displayName: "Tinycast Dev", bundleName: nil)
+        expect(
+            UninstallIdentity.make(
+                target: dev, otherAppNames: [], ownBundleID: "com.tinycast.app.dev",
+                ownBundleURL: URL(fileURLWithPath: "/Applications/Tinycast Dev.app")) == nil,
+            "the Dev channel refuses itself too — the check is against the running identity")
+        expect(
+            UninstallIdentity.make(
+                target: dev, otherAppNames: [], ownBundleID: ownBundleID,
+                ownBundleURL: ownBundleURL) != nil,
+            "a stable build can still uninstall a Dev build, which is a different app")
+
+        let byURL = UninstallTarget(
+            bundleURL: ownBundleURL, bundleID: "com.impostor.app", displayName: "Impostor",
+            bundleName: nil)
+        expect(
+            UninstallIdentity.make(
+                target: byURL, otherAppNames: [], ownBundleID: ownBundleID,
+                ownBundleURL: ownBundleURL) == nil,
+            "the running bundle URL is refused even under a different ID")
+
+        let anonymous = UninstallTarget(
+            bundleURL: URL(fileURLWithPath: "/Applications/Go.app"), bundleID: nil,
+            displayName: "Go", bundleName: nil)
+        expect(
+            UninstallIdentity.make(
+                target: anonymous, otherAppNames: [], ownBundleID: ownBundleID,
+                ownBundleURL: ownBundleURL) == nil,
+            "no bundle ID and no safe name means nothing can be attributed")
+    }
+
+    // MARK: - Path safety
+
+    static func testPathSafety() {
+        let support = home + "/Library/Application Support"
+        let bundle = "/Applications/Test App.app"
+        func acceptable(_ path: String) -> Bool {
+            UninstallRules.isAcceptableCandidate(
+                path: path, rootPath: support, home: home, bundlePath: bundle)
+        }
+        expect(acceptable(support + "/TestApp"), "an immediate child of the root is acceptable")
+        expect(!acceptable(support), "the root itself is never a candidate")
+        expect(!acceptable(home), "the home directory is never a candidate")
+        expect(!acceptable("/"), "the filesystem root is never a candidate")
+        expect(!acceptable("/Applications"), "a path outside the root is rejected")
+        expect(
+            !acceptable(support + "/Nested/Deeper"),
+            "only immediate children are accepted — the walk never descends")
+        expect(
+            !acceptable(support + "/../../../etc"),
+            "relative components are rejected")
+        expect(
+            !UninstallRules.isAcceptableCandidate(
+                path: bundle, rootPath: "/Applications", home: home, bundlePath: bundle),
+            "the app bundle is emitted separately, never as a leftover")
+        expect(
+            !UninstallRules.isAcceptableCandidate(
+                path: bundle + "/Contents", rootPath: bundle, home: home, bundlePath: bundle),
+            "nothing inside the app bundle is a separate candidate")
+
+        expect(
+            UninstallRules.abbreviate(support, home: home) == "~/Library/Application Support",
+            "a home path abbreviates to tilde form")
+        expect(
+            UninstallRules.abbreviate("/Library/Caches", home: home) == "/Library/Caches",
+            "a path outside home is left alone")
+    }
+
+    // MARK: - Protection
+
+    static func testProtection() {
+        let environment = UninstallEnvironment(home: home, hasFullDiskAccess: false)
+        let withFDA = UninstallEnvironment(home: home, hasFullDiskAccess: true)
+
+        func classify(_ facts: PathFacts, _ env: UninstallEnvironment = environment)
+            -> UninstallProtection
+        {
+            UninstallProtectionRules.classify(facts, environment: env)
+        }
+
+        expect(
+            classify(PathFacts(path: "/Applications/Test App.app")) == .removable,
+            "an ordinary user-owned app is removable")
+        expect(
+            classify(PathFacts(path: "/Applications/Gone.app", exists: false)) == .missing,
+            "a vanished path reports as missing")
+        expect(
+            classify(
+                PathFacts(path: "/System/Applications/Books.app", volumeIsReadOnly: true))
+                == .systemProtected,
+            "a read-only volume locks the row — the Books.app case")
+        expect(
+            classify(PathFacts(path: "/usr/bin/thing", isSystemRestricted: true)) == .systemProtected,
+            "SF_RESTRICTED locks the row")
+        expect(
+            classify(PathFacts(path: "/Applications/Test App.app", isUserImmutable: true))
+                == .userLocked,
+            "Finder's Locked flag is its own case, because the user can clear it")
+        expect(
+            classify(
+                PathFacts(path: "/Library/PrivilegedHelperTools/com.foo.Bar", isOwnedByCurrentUser: false))
+                == .notOwned,
+            "a root-owned file is locked rather than attempted")
+        expect(
+            classify(PathFacts(path: "/Library/Caches/com.foo.Bar", parentIsWritable: false))
+                == .parentNotWritable,
+            "trashing is a rename out of the parent, so an unwritable parent locks the row")
+
+        let container = PathFacts(path: home + "/Library/Containers/com.foo.Bar")
+        expect(
+            classify(container) == .needsFullDiskAccess,
+            "a container without Full Disk Access is locked, never attempted")
+        expect(
+            classify(container, withFDA) == .removable,
+            "the same container is removable once Full Disk Access is granted")
+
+        let everything = PathFacts(
+            path: home + "/Library/Containers/com.foo.Bar", volumeIsReadOnly: true,
+            isSystemRestricted: true, isUserImmutable: true, isOwnedByCurrentUser: false,
+            parentIsWritable: false)
+        expect(
+            classify(everything) == .systemProtected,
+            "precedence: a SIP path reports as system-protected, the most useful of its reasons")
+
+        expect(
+            UninstallProtection.allCases.allSatisfy { ($0.lockReason == nil) == $0.isRemovable },
+            "every case except .removable carries a lock reason, and .removable carries none")
+
+        expect(
+            UninstallProtectionRules.isTCCProtected(
+                path: home + "/Library/Group Containers/group.com.foo.Bar", home: home),
+            "group containers are TCC-gated")
+        expect(
+            !UninstallProtectionRules.isTCCProtected(
+                path: home + "/Library/Preferences/com.foo.Bar.plist", home: home),
+            "preferences are not TCC-gated")
+    }
+
+    // MARK: - Plan and selection
+
+    static func candidate(
+        _ path: String, evidence: UninstallEvidence = .bundleID,
+        protection: UninstallProtection = .removable, bytes: Int64 = 100
+    ) -> UninstallCandidate {
+        UninstallCandidate(
+            path: path, name: (path as NSString).lastPathComponent, locationLabel: "~/Library",
+            evidence: evidence, isDirectory: false, size: MeasuredSize(bytes: bytes),
+            protection: protection)
+    }
+
+    static func testSelection() {
+        let target = UninstallTarget(
+            bundleURL: URL(fileURLWithPath: "/Applications/Test App.app"),
+            bundleID: "com.foo.Bar", displayName: "Test App", bundleName: nil)
+        let free = candidate("/a", bytes: 10)
+        let locked = candidate("/b", protection: .systemProtected, bytes: 20)
+        let named = candidate("/c", evidence: .displayName, bytes: 40)
+        let plan = UninstallPlan(
+            target: target, candidates: [free, locked, named], isTargetRunning: false)
+
+        expect(plan.removableIDs == ["/a", "/c"], "locked candidates are not removable")
+        expect(plan.lockedCount == 1, "the locked count counts exactly the locked rows")
+        expect(plan.totalBytes == 70, "total bytes covers every candidate")
+
+        let everything = UninstallSelection(plan: plan, checked: ["/a", "/b", "/c", "/nope"])
+        expect(
+            everything.checked == ["/a", "/c"],
+            "a locked or out-of-plan id can never enter the checked set")
+
+        var selection = plan.defaultSelection
+        expect(
+            selection.checked == ["/a"],
+            "the default checks removable rows but leaves name matches to the user")
+        expect(selection.bytes(in: plan) == 10, "selected bytes sums only checked rows")
+
+        selection.toggle("/b", in: plan)
+        expect(selection.checked == ["/a"], "toggling a locked row is a no-op")
+        selection.toggle("/b", in: plan)
+        expect(selection.checked == ["/a"], "toggling a locked row twice is still a no-op")
+
+        selection.toggle("/c", in: plan)
+        expect(selection.checked == ["/a", "/c"], "toggling a removable row checks it")
+        selection.toggle("/c", in: plan)
+        expect(selection.checked == ["/a"], "toggling it again unchecks it")
+
+        selection.setAll(true, in: plan)
+        expect(selection.checked == plan.removableIDs, "select-all is exactly the removable set")
+        expect(selection.bytes(in: plan) == 50, "and its byte total excludes the locked row")
+        selection.setAll(false, in: plan)
+        expect(selection.checked.isEmpty && selection.bytes(in: plan) == 0, "deselect-all clears")
+
+        let relocked = UninstallPlan(
+            target: target,
+            candidates: [candidate("/a", protection: .notOwned, bytes: 10), locked, named],
+            isTargetRunning: false)
+        expect(
+            UninstallSelection(plan: relocked, checked: ["/a", "/c"]).checked == ["/c"],
+            "re-scanning drops a row that has since become locked")
+
+        expect(
+            selection.candidates(in: plan).isEmpty,
+            "an empty selection resolves to no candidates")
+    }
+
+    // MARK: - Cross-identity sweep
+
+    /// The one assertion about the matcher as a whole: no artifact belonging to one app may ever be
+    /// produced for another. A rule that regresses in isolation still gets caught here.
+    static func testCrossIdentitySweep() {
+        let apps: [(id: String, name: String)] = [
+            ("com.apple.iBooksX", "Books"),
+            ("com.apple.Safari", "Safari"),
+            ("net.freemacsoft.AppCleaner", "AppCleaner"),
+            ("com.google.Chrome", "Google Chrome"),
+            ("com.microsoft.VSCode", "Visual Studio Code"),
+            ("org.mozilla.firefox", "Firefox"),
+            ("com.spotify.client", "Spotify"),
+            ("com.tinyspeck.slackmacgap", "Slack")
+        ]
+        let identities = apps.map { app in
+            (app, identity(bundleID: app.id, name: app.name, path: "/Applications/\(app.name).app"))
+        }
+        // Every artifact shape the roots actually contain, instantiated for each app.
+        let shapes: [(String) -> String] = [
+            { $0 }, { $0 + ".plist" }, { $0 + ".savedState" }, { $0 + ".binarycookies" },
+            { $0 + ".helper" }, { $0 + ".Renderer.plist" }, { "group." + $0 },
+            { "ABCDE12345." + $0 }, { $0 + ".8A1F2C3D-1111-2222-3333-444455556666.plist" }
+        ]
+
+        var leaks: [String] = []
+        for (owner, _) in identities {
+            let artifacts =
+                shapes.map { $0(owner.id) } + [owner.name, owner.name + ".plist"]
+            for artifact in artifacts {
+                for (other, otherIdentity) in identities where other.id != owner.id {
+                    for root in UninstallSearchRoot.all
+                    where UninstallRules.evidence(for: artifact, in: root, identity: otherIdentity)
+                        != nil {
+                        leaks.append("\(artifact) (\(owner.name)) matched \(other.name) in \(root.relativePath)")
+                    }
+                }
+            }
+        }
+        expect(leaks.isEmpty, "no app's artifacts are ever attributed to another app")
+        for leak in leaks.prefix(10) { print("  leak: \(leak)") }
+    }
+
+    // MARK: - Table sanity
+
+    static func testRootTable() {
+        let roots = UninstallSearchRoot.all
+        expect(!roots.isEmpty, "the root table is populated")
+        expect(
+            Set(roots.map { "\($0.base)/\($0.relativePath)" }).count == roots.count,
+            "no root is listed twice")
+        expect(roots.allSatisfy { !$0.relativePath.isEmpty }, "no root has an empty relative path")
+        expect(roots.allSatisfy { !$0.styles.isEmpty }, "every root enables at least one match style")
+        expect(
+            roots.allSatisfy { !$0.relativePath.hasPrefix("/") && !$0.relativePath.hasSuffix("/") },
+            "relative paths carry no leading or trailing slash")
+        expect(
+            roots.first { $0.base == .userLibrary && $0.relativePath == "Application Support" }?
+                .path(home: home) == home + "/Library/Application Support",
+            "a user root expands under the injected home directory")
+        expect(
+            roots.first { $0.base == .systemLibrary && $0.relativePath == "Caches" }?.path(home: home)
+                == "/Library/Caches",
+            "a system root ignores the home directory")
+        let named = roots.filter { $0.styles.contains(.displayName) }.map(\.relativePath)
+        expect(
+            Set(named) == ["Application Support", "Caches", "Logs"],
+            "display-name matching stays confined to the human-named roots")
+        expect(
+            !roots.contains { $0.relativePath.contains("receipts") || $0.relativePath == "Keychains" },
+            "receipts and keychains stay out of scope")
+    }
+
+    static func main() {
+        testBundleIDMatching()
+        testExtensionStripping()
+        testGroupContainers()
+        testDisplayNames()
+        testIdentityRefusal()
+        testPathSafety()
+        testProtection()
+        testSelection()
+        testCrossIdentitySweep()
+        testRootTable()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tools/uninstall-test.swift
+++ b/Tools/uninstall-test.swift
@@ -526,12 +526,6 @@ struct UninstallTests {
         selection.toggle("/c", in: plan)
         expect(selection.checked == ["/a", "/c"], "toggling it again checks it back")
 
-        selection.setAll(true, in: plan)
-        expect(selection.checked == plan.removableIDs, "select-all is exactly the removable set")
-        expect(selection.bytes(in: plan) == 50, "and its byte total excludes the locked row")
-        selection.setAll(false, in: plan)
-        expect(selection.checked.isEmpty && selection.bytes(in: plan) == 0, "deselect-all clears")
-
         let relocked = UninstallPlan(
             target: target,
             candidates: [candidate("/a", protection: .notOwned, bytes: 10), locked, named],
@@ -541,7 +535,7 @@ struct UninstallTests {
             "re-scanning drops a row that has since become locked")
 
         expect(
-            selection.candidates(in: plan).isEmpty,
+            UninstallSelection(plan: plan).candidates(in: plan).isEmpty,
             "an empty selection resolves to no candidates")
     }
 

--- a/Tools/uninstall-test.swift
+++ b/Tools/uninstall-test.swift
@@ -207,10 +207,26 @@ struct UninstallTests {
                 == .displayName,
             "the same name is usable when no other installed app claims it")
 
-        let short = identity(bundleID: "com.foo.Vim", name: "Vim")
+        let short = identity(bundleID: "com.foo.Go", name: "Go")
         expect(
-            evidence("Vim", "Application Support", short) == nil,
-            "a name under the minimum length never matches")
+            evidence("Go", "Application Support", short) == nil,
+            "a two-character name is under the minimum and never matches")
+        let zed = identity(bundleID: "dev.zed.Zed", name: "Zed")
+        expect(
+            evidence("Zed", "Application Support", zed) == .displayName,
+            "three characters is enough — Zed names its own support folder")
+        expect(
+            evidence("Zed", "Logs", zed) == .displayName, "and its logs folder")
+        expect(
+            evidence("dev.zed.Zed-Preview.plist", "Preferences", zed) == .bundleID,
+            "a hyphenated release variant belongs to the product it varies")
+        expect(
+            evidence(
+                "dev.zed.Zed-Preview.plist", "Preferences",
+                identity(
+                    bundleID: "dev.zed.Zed", name: "Zed",
+                    otherBundleIDs: ["dev.zed.Zed", "dev.zed.Zed-Preview"])) == nil,
+            "unless that variant is itself installed, in which case it owns its own preferences")
 
         let reserved = identity(bundleID: "com.foo.Prefs", name: "Preferences")
         expect(
@@ -222,6 +238,46 @@ struct UninstallTests {
                 displayName: "AppCleaner", bundleName: "AppCleaner", otherAppNames: [])
                 == ["appcleaner"],
             "a bundle name identical to the display name is deduped")
+    }
+
+    static func testPlugInsAndSymlinks() {
+        let app = identity(bundleID: "com.foo.Bar", name: "Barista")
+        expect(
+            evidence("com.foo.Bar.qlgenerator", "QuickLook", app) == .bundleID,
+            "a QuickLook generator is stripped to its bundle ID")
+        expect(
+            evidence("Barista.saver", "Screen Savers", app) == .displayName,
+            "a screen saver is stripped to its product name")
+        expect(
+            evidence("Barista.prefPane", "PreferencePanes", app) == .displayName,
+            "so is a preference pane")
+        expect(
+            evidence("Unrelated.qlgenerator", "QuickLook", app) == nil,
+            "another product's plug-in is left alone")
+        expect(
+            !UninstallRules.matchableForms("Barista.app").contains("Barista"),
+            ".app is never stripped — an app bundle is not a plug-in wrapper")
+
+        let bundle = "/Applications/Zed.app"
+        expect(
+            UninstallRules.isBundleSymlink(
+                target: "/Applications/Zed.app/Contents/MacOS/cli", bundlePath: bundle),
+            "a launcher resolving inside the bundle belongs to the app")
+        expect(
+            UninstallRules.isBundleSymlink(target: bundle, bundlePath: bundle),
+            "a link straight at the bundle counts too")
+        expect(
+            !UninstallRules.isBundleSymlink(
+                target: "/Applications/Zed2.app/Contents/MacOS/cli", bundlePath: bundle),
+            "a sibling bundle sharing a path prefix does not")
+        expect(
+            !UninstallRules.isBundleSymlink(target: "/opt/homebrew/bin/zed", bundlePath: bundle),
+            "and neither does an unrelated target — attribution is by link target, never by name")
+        expect(
+            UninstallSearchRoot.binDirectories.allSatisfy {
+                $0.hasPrefix("/") || $0.hasPrefix("~/")
+            },
+            "every bin directory is absolute or home-relative")
     }
 
     // MARK: - Identity refusal
@@ -374,6 +430,13 @@ struct UninstallTests {
             !UninstallProtectionRules.isTCCProtected(
                 path: home + "/Library/Preferences/com.foo.Bar.plist", home: home),
             "preferences are not TCC-gated")
+        expect(
+            !UninstallProtectionRules.isTCCProtected(
+                path: home + "/Library/Application Scripts/com.foo.Bar", home: home),
+            "Application Scripts is NOT TCC-gated — measured, and it is why Books' scripts are removable")
+        expect(
+            classify(PathFacts(path: home + "/Library/Application Scripts/com.foo.Bar")) == .removable,
+            "so those rows are checkable while the containers beside them stay locked")
     }
 
     // MARK: - Plan and selection
@@ -409,19 +472,21 @@ struct UninstallTests {
 
         var selection = plan.defaultSelection
         expect(
-            selection.checked == ["/a"],
-            "the default checks removable rows but leaves name matches to the user")
-        expect(selection.bytes(in: plan) == 10, "selected bytes sums only checked rows")
+            selection.checked == ["/a", "/c"],
+            "the default checks every removable row, name matches included")
+        expect(selection.bytes(in: plan) == 50, "selected bytes sums only checked rows")
+        expect(
+            !selection.checked.contains("/b"), "and never a locked one")
 
         selection.toggle("/b", in: plan)
-        expect(selection.checked == ["/a"], "toggling a locked row is a no-op")
+        expect(selection.checked == ["/a", "/c"], "toggling a locked row is a no-op")
         selection.toggle("/b", in: plan)
-        expect(selection.checked == ["/a"], "toggling a locked row twice is still a no-op")
+        expect(selection.checked == ["/a", "/c"], "toggling a locked row twice is still a no-op")
 
         selection.toggle("/c", in: plan)
-        expect(selection.checked == ["/a", "/c"], "toggling a removable row checks it")
+        expect(selection.checked == ["/a"], "toggling a checked row unchecks it")
         selection.toggle("/c", in: plan)
-        expect(selection.checked == ["/a"], "toggling it again unchecks it")
+        expect(selection.checked == ["/a", "/c"], "toggling it again checks it back")
 
         selection.setAll(true, in: plan)
         expect(selection.checked == plan.removableIDs, "select-all is exactly the removable set")
@@ -506,10 +571,21 @@ struct UninstallTests {
             roots.first { $0.base == .systemLibrary && $0.relativePath == "Caches" }?.path(home: home)
                 == "/Library/Caches",
             "a system root ignores the home directory")
-        let named = roots.filter { $0.styles.contains(.displayName) }.map(\.relativePath)
+        // A child of these is a bundle ID by construction, so a name match there is a false positive
+        // by definition. Asserting the exclusion rather than the inclusion keeps this honest as
+        // plug-in wells are added.
+        let bundleIDOnly: Set<String> = [
+            "Preferences", "Preferences/ByHost", "Containers", "Group Containers",
+            "Application Scripts", "Saved Application State", "HTTPStorages", "WebKit", "Cookies",
+            "Autosave Information", "LaunchAgents", "LaunchDaemons", "PrivilegedHelperTools"
+        ]
         expect(
-            Set(named) == ["Application Support", "Caches", "Logs"],
-            "display-name matching stays confined to the human-named roots")
+            roots.filter { bundleIDOnly.contains($0.relativePath) }
+                .allSatisfy { !$0.styles.contains(.displayName) },
+            "display-name matching never applies where a child is a bundle ID by construction")
+        expect(
+            roots.contains { $0.relativePath == "Application Support" && $0.styles.contains(.displayName) },
+            "but it does apply in the human-named roots")
         expect(
             !roots.contains { $0.relativePath.contains("receipts") || $0.relativePath == "Keychains" },
             "receipts and keychains stay out of scope")
@@ -520,6 +596,7 @@ struct UninstallTests {
         testExtensionStripping()
         testGroupContainers()
         testDisplayNames()
+        testPlugInsAndSymlinks()
         testIdentityRefusal()
         testPathSafety()
         testProtection()

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,12 +111,19 @@ swiftc -swift-version 6 Tinycast/Core/WindowManagement/WindowCommand.swift \
     Tinycast/Core/WindowManagement/WindowLayout.swift \
     Tinycast/Core/WindowManagement/WindowActionMemory.swift Tools/window-command-test.swift \
     -o /tmp/window-command-test && /tmp/window-command-test        # window geometry + action memory
+swiftc -swift-version 6 Tinycast/Core/Uninstall/UninstallTarget.swift \
+    Tinycast/Core/Uninstall/UninstallSearchRoot.swift Tinycast/Core/Uninstall/UninstallRules.swift \
+    Tinycast/Core/Uninstall/UninstallProtection.swift Tinycast/Core/Uninstall/UninstallPlan.swift \
+    Tools/uninstall-test.swift -o /tmp/uninstall-test && /tmp/uninstall-test  # uninstall attribution + locking
 ```
 
 `Tools/fuzz-test.swift` holds a **copy** of `FuzzyMatch` from `Tinycast/Core/AppIndex.swift` —
 change the scoring in one and mirror it in the other. The calc harness compiles the real engine
 sources, which is why `Tinycast/Core/Calculator/` must stay Foundation-only. The system-action harness
-similarly keeps `SystemAction.swift` independent from AppKit and all command side effects.
+similarly keeps `SystemAction.swift` independent from AppKit and all command side effects. The
+uninstall harness is the same idea taken furthest: it touches no filesystem at all, because
+`UninstallScanner` hands the rules directory *names* and the protection classifier takes its
+environment facts as parameters.
 
 The clipboard harness likewise compiles the real `ClipboardStore.swift`, so that file must keep to
 Foundation + SQLite3 and depend on no other app source. Each case drives a store rooted in a

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -12,9 +12,11 @@ UUID) so the SwiftUI search field re-focuses. `RootPaletteView` switches its con
 - `.launcher` → `LauncherList`
 - `.clipboard` → `ClipboardList` + preview
 - `.calculatorHistory` → `CalculatorHistoryList`
+- `.uninstall` → `UninstallList` (see [uninstall.md](uninstall.md))
 
 Clipboard and Calculator History are sub-screens reached from the launcher (Tab, a command, or a
-hotkey) and back out to it.
+hotkey) and back out to it. Uninstall is one too, but reached only from a launcher app's Actions menu
+and scoped to that app; like Calculator History it stays out of the Tab cycle.
 
 The flat `selection` index is the single source of truth for highlight / activation and **must always
 match the visible row order**, including the inline calculator card at index 0 when present (see

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -129,19 +129,20 @@ the `ScrollView`, **before `.thinScrollbar()`** (so the scrollbar overlay stays 
 
 ---
 
-## Rows, selection, hover — `Launcher/LauncherView.swift`, `Clipboard/ClipboardView.swift`
+## Rows, selection, hover — `Launcher/LauncherView.swift`, `Clipboard/ClipboardView.swift`, `Uninstall/UninstallView.swift`
 
 All lists share one row grammar so launcher and clipboard look identical:
 
 - `HStack(spacing: lg)`: leading 24pt icon/thumbnail, title (`.body`, `lineLimit(1)`), optional trailing keycaps/kind label, `Spacer`. Insets: `.horizontal md`, `.vertical sm`.
-- Background is a `RoundedRectangle(row, .continuous)` filled by `fill`: **selection → hover → clear**, in that precedence. This `fill` computed property is copy-identical across `AppRow`, `ClipboardRow`, `CalculatorCard` — keep them in sync.
+- **The leading slot is always `Theme.Size.rowIcon`, whatever fills it.** A glyph smaller than an app icon — the uninstall list's 16pt checkbox — is centred *inside* that 24pt slot rather than sizing the slot to itself. Every list then starts its title at the same x, so switching palette modes doesn't jog the column sideways. The slot doubles as the hit target.
+- Background is a `RoundedRectangle(row, .continuous)` filled by `fill`: **selection → hover → clear**, in that precedence. This `fill` computed property is copy-identical across `AppRow`, `ClipboardRow`, `CalculatorCard` and `UninstallRow` — keep them in sync.
 - **Hover state lives on the row**, not the list, so a mouse sweep repaints only the rows entering/leaving (a list-level hover rebuilds every row per move — don't do that).
 - **Scroll moves only on keyboard nav/reset**, driven by a `ScrollIntent` (`Core/ScrollIntent.swift`) — mouse selection targets a visible row and never yanks scroll. `.follow` is a minimal scroll-to-visible (nil anchor), so the list stays stationary while the selection walks across it and only advances by a row at the viewport edges; `.top` scrolls to the origin anchor that `scrollOriginAnchor()` installs — a zero-height overlay applied to the scrolled content *after* its padding, so it marks offset 0 without joining the layout and the restored origin is exact (targeting the first row instead leaves the top padding hidden under the header). A `.follow` that lands on flat index 0 restores the origin instead, so that row's section header comes back into view. One intent state serves all four modes — they never coexist.
 - **Keycaps** use `KeyCapChip`: `.outline` (white-0.20 border) for hotkey hints on rows, `.filled` (white-0.10 fill) for footer shortcuts.
 
 ### Section headers
 
-All four palette lists (App Launcher, Clipboard, Emoji, Calculator History) render category labels
+All five palette lists (App Launcher, Clipboard, Emoji, Calculator History, Uninstall) render category labels
 through one shared **`SectionHeader`** (`.subheadline.medium`, secondary — `Features/Launcher/LauncherView.swift`).
 The launcher shows a single "Results" header over search matches, and per-kind sections
 (Favorites / Applications / System Settings / Commands) for the empty query; clipboard/history use

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -17,7 +17,7 @@ Same split as `WindowManagement`: a pure half that decides, an impure half that 
 | File | Role |
 | --- | --- |
 | `Core/Uninstall/UninstallTarget.swift` | `UninstallTarget`, `UninstallEvidence`, `UninstallIdentity` — and every guard rail, applied in `UninstallIdentity.make` |
-| `Core/Uninstall/UninstallSearchRoot.swift` | The root table: where to look and which match styles are legal there |
+| `Core/Uninstall/UninstallSearchRoot.swift` | The root table (where to look, which styles are legal there) and `binDirectories` |
 | `Core/Uninstall/UninstallRules.swift` | Matching, plus `isAcceptableCandidate` |
 | `Core/Uninstall/UninstallProtection.swift` | `PathFacts` → `UninstallProtection` |
 | `Core/Uninstall/UninstallPlan.swift` | `UninstallCandidate`, `UninstallPlan`, `UninstallSelection` |
@@ -32,15 +32,18 @@ URLs, which is what makes "no filesystem access in the pure layer" structural ra
 
 ## Attribution
 
-Three match styles, enabled per root by the table. All of them run against
+Three match styles enabled per root by the table, plus a fourth mechanism for CLI launchers. The
+first three run against
 `UninstallRules.matchableForms`, which strips `.plist`, `.savedState`, `.binarycookies`, `.lockfile`
 and friends — repeatedly, so `…​.plist.lockfile` reduces too.
 
-**`bundleID`** — exact, or a dot-namespaced child. The trailing dot in `hasPrefix(id + ".")` is
-load-bearing: a plain prefix makes `com.apple.SafariTechnologyPreview` a match for `com.apple.Safari`
-and trashes a different product's entire profile. Requiring the next character to be `.` means a
-match can only be a namespace *descendant* — `com.apple.iBooksX.CacheDelete` matches
-`com.apple.iBooksX`, `com.apple.iBooksXtra` does not.
+**`bundleID`** — exact, or a namespaced child. The boundary check is load-bearing: a plain prefix
+makes `com.apple.SafariTechnologyPreview` a match for `com.apple.Safari` and trashes a different
+product's entire profile. Requiring the next character to be a separator means a match can only be a
+namespace *descendant* — `com.apple.iBooksX.CacheDelete` matches `com.apple.iBooksX`,
+`com.apple.iBooksXtra` does not. Both `.` and `-` count, because `-` is how vendors name release
+variants: `dev.zed.Zed-Preview.plist` belongs to Zed, unless Zed Preview is itself installed, in
+which case the sibling rule below hands it straight back.
 
 Two further guards on that rule:
 
@@ -57,14 +60,25 @@ container), then applies the bundle-ID rule to the remainder.
 
 **`displayName`** — the weak one, and the only one hedged. Exact, case- and diacritic-folded equality;
 never a prefix or substring, so "Books" and "Books Reader" cannot claim each other's folders in either
-direction. On top of that a name must be ≥ 4 folded characters, must not be a standard Library
+direction. On top of that a name must be ≥ 3 folded characters, must not be a standard Library
 subdirectory name (`Preferences`, `Caches`, `Containers`, …), and **must not be shared with another
 installed app** — a second app called "Mail" is precisely what makes `~/Library/Application Support/Mail`
-unattributable. Enabled only in `Application Support`, `Caches` and `Logs`; everywhere else a child is
-a bundle ID by construction, so a name match there would be a false positive by definition.
+unattributable. Three, not four, is the floor: Zed, IINA and Xee all name their own folders, and the
+safety comes from those three guards rather than from length. Enabled in the human-named roots
+(`Application Support`, `Caches`, `Logs`) and the plug-in wells; everywhere else a child is a bundle
+ID by construction, so a name match there would be a false positive by definition.
 
-A `.displayName` match is **never checked by default** (`UninstallPlan.defaultSelection`) and the row
-says "matched by name". Evidence that weak is the user's call.
+A `.displayName` match **is** checked by default, and the row says "matched by name" so the weaker
+evidence is visible before confirming. It earns that because the match is exact, confined, and never
+claims a name another installed app answers to — and because the feature only ever moves to the
+Trash, so an unwanted row costs a drag back rather than data.
+
+**`binSymlink`** — a launcher in `/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin` or `~/bin`
+whose symlink resolves inside the app bundle. Attribution is by **link target, never by name**: `zed`
+in `/usr/local/bin` is Zed's because it points at `Zed.app/Contents/MacOS/cli`, not because of what
+it is called. On a stock Mac `/usr/local/bin` is root-owned, so the row renders locked; where
+Homebrew has made it user-owned it is removable, and the classifier reaches that from the facts
+without a special case.
 
 `UninstallIdentity.make` returns `nil` — refusing the whole uninstall — when the target is Tinycast
 itself, by bundle ID *or* bundle URL, compared against the **running** identity so the Dev channel
@@ -73,10 +87,16 @@ refuses itself too.
 ### Roots
 
 Immediate children only, everywhere. `Preferences/ByHost` is its own root rather than raising
-`Preferences` to depth 2, which would descend into every unrelated app's subfolder. Deliberately out
-of scope, and worth keeping out: `/private/var/db/receipts` (root-owned, and deleting a receipt
-corrupts the installer's view of the system), `~/Library/Keychains`, `/Library/Extensions`,
-`/usr/local`, and every user-document location.
+`Preferences` to depth 2, which would descend into every unrelated app's subfolder. Beyond the
+`~/Library` and `/Library` staples the table covers the plug-in wells — `QuickLook`, `Services`,
+`PreferencePanes`, `Screen Savers`, `Internet Plug-Ins`, `Spotlight`, `Automator`, `Input Methods`,
+`Audio/Plug-Ins/{HAL,Components}` — whose children are wrappers named after the product that
+installed them, which is why `strippedExtensions` also drops `.qlgenerator`, `.saver`, `.prefPane`
+and friends. `.app` is deliberately **not** in that list. Deliberately out of scope, and worth
+keeping out: `/private/var/db/receipts` (root-owned, and deleting a receipt
+corrupts the installer's view of the system), `~/Library/Keychains`, `/Library/Extensions`, and every
+user-document location. `/usr/local` is reached **only** through `binDirectories`, and only for
+symlinks that resolve into the bundle — never by name, and never recursively.
 
 `UninstallRules.isAcceptableCandidate` is belt and braces over whatever matched: an immediate child of
 its own root, never the home directory or `/`, no relative components, and no overlap with the app
@@ -103,6 +123,14 @@ Precedence, asserted by the harness:
 A locked candidate can never enter the checked set. That invariant lives in `UninstallSelection`,
 whose every mutation funnels through one intersection with `plan.removableIDs`, so re-scanning drops
 a row that has since become locked for free.
+
+The TCC list is **measured, not assumed.** A probe that creates and then trashes a throwaway
+directory in each candidate location shows that `~/Library/Containers`, `~/Library/Group Containers`
+and `~/Library/Cookies` refuse the move, while `~/Library/Application Scripts` and
+`~/Library/Autosave Information` allow it — which is why Books' five `Application Scripts` rows are
+checkable while the five `Containers` rows beside them are locked. Note that *listing* a directory is
+not the test: both container roots enumerate fine and still refuse the trash. Re-measure before
+adding an entry.
 
 **Full Disk Access is detected, never requested.** The probe opens
 `~/Library/Application Support/com.apple.TCC/TCC.db` — TCC denies that read *silently*, with no

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,150 @@
+# Uninstall Application
+
+Removes an app *and* the files it leaves behind — caches, preferences, containers, saved state,
+launch agents. Reached from the launcher's Actions menu (⌘K → **Uninstall Application**, or ⌃⇧U) on
+any `.application` entry; it opens the `.uninstall` palette sub-screen scoped to that app.
+
+**Everything goes to the Trash.** `FileManager.trashItem` is the only removal call in the feature —
+`removeItem` never appears. That is not a detail: it is what makes the attribution rules below
+tolerable at all, because a false positive costs the user a drag back out of the Trash rather than
+their data. If a "delete permanently" option is ever added, display-name matching must be dropped in
+the same commit.
+
+## Layers
+
+Same split as `WindowManagement`: a pure half that decides, an impure half that touches the disk.
+
+| File | Role |
+| --- | --- |
+| `Core/Uninstall/UninstallTarget.swift` | `UninstallTarget`, `UninstallEvidence`, `UninstallIdentity` — and every guard rail, applied in `UninstallIdentity.make` |
+| `Core/Uninstall/UninstallSearchRoot.swift` | The root table: where to look and which match styles are legal there |
+| `Core/Uninstall/UninstallRules.swift` | Matching, plus `isAcceptableCandidate` |
+| `Core/Uninstall/UninstallProtection.swift` | `PathFacts` → `UninstallProtection` |
+| `Core/Uninstall/UninstallPlan.swift` | `UninstallCandidate`, `UninstallPlan`, `UninstallSelection` |
+| `Core/Uninstall/UninstallScanner.swift` | **Impure.** `contentsOfDirectory`, `lstat`, sizes, the FDA probe |
+| `Core/Uninstall/UninstallRunner.swift` | **Impure.** `trashItem`, and nothing else |
+| `Core/Uninstall/UninstallSession.swift` | `@MainActor` lifecycle behind the screen |
+| `Features/Uninstall/UninstallView.swift` | List, row, actions menu |
+
+The first five compile standalone into `Tools/uninstall-test.swift`, so they stay Foundation-only
+and take every environment fact as a parameter. The scanner hands the rules **child names**, never
+URLs, which is what makes "no filesystem access in the pure layer" structural rather than a promise.
+
+## Attribution
+
+Three match styles, enabled per root by the table. All of them run against
+`UninstallRules.matchableForms`, which strips `.plist`, `.savedState`, `.binarycookies`, `.lockfile`
+and friends — repeatedly, so `…​.plist.lockfile` reduces too.
+
+**`bundleID`** — exact, or a dot-namespaced child. The trailing dot in `hasPrefix(id + ".")` is
+load-bearing: a plain prefix makes `com.apple.SafariTechnologyPreview` a match for `com.apple.Safari`
+and trashes a different product's entire profile. Requiring the next character to be `.` means a
+match can only be a namespace *descendant* — `com.apple.iBooksX.CacheDelete` matches
+`com.apple.iBooksX`, `com.apple.iBooksXtra` does not.
+
+Two further guards on that rule:
+
+- **Vendor namespaces don't prefix-match.** A two-component ID like `com.adobe` names a vendor, not a
+  product, so `allowsBundleIDPrefixMatch` requires three components. `com.adobe` still matches itself.
+- **An installed sibling owns its own artifacts.** If any *other* installed app's bundle ID is a
+  longer match for the same component, that app owns it. Without this, uninstalling `com.tinycast.app`
+  would also trash `com.tinycast.app.beta` and `…​.dev` — separate products that merely share a
+  namespace, which is exactly the channel-isolation invariant in reverse.
+
+**`groupContainer`** — strips a leading `group.` and/or a 10-character Team ID (uppercase
+alphanumerics only, which is what stops an arbitrary `something.com.foo.Bar` being read as a
+container), then applies the bundle-ID rule to the remainder.
+
+**`displayName`** — the weak one, and the only one hedged. Exact, case- and diacritic-folded equality;
+never a prefix or substring, so "Books" and "Books Reader" cannot claim each other's folders in either
+direction. On top of that a name must be ≥ 4 folded characters, must not be a standard Library
+subdirectory name (`Preferences`, `Caches`, `Containers`, …), and **must not be shared with another
+installed app** — a second app called "Mail" is precisely what makes `~/Library/Application Support/Mail`
+unattributable. Enabled only in `Application Support`, `Caches` and `Logs`; everywhere else a child is
+a bundle ID by construction, so a name match there would be a false positive by definition.
+
+A `.displayName` match is **never checked by default** (`UninstallPlan.defaultSelection`) and the row
+says "matched by name". Evidence that weak is the user's call.
+
+`UninstallIdentity.make` returns `nil` — refusing the whole uninstall — when the target is Tinycast
+itself, by bundle ID *or* bundle URL, compared against the **running** identity so the Dev channel
+refuses itself too.
+
+### Roots
+
+Immediate children only, everywhere. `Preferences/ByHost` is its own root rather than raising
+`Preferences` to depth 2, which would descend into every unrelated app's subfolder. Deliberately out
+of scope, and worth keeping out: `/private/var/db/receipts` (root-owned, and deleting a receipt
+corrupts the installer's view of the system), `~/Library/Keychains`, `/Library/Extensions`,
+`/usr/local`, and every user-document location.
+
+`UninstallRules.isAcceptableCandidate` is belt and braces over whatever matched: an immediate child of
+its own root, never the home directory or `/`, no relative components, and no overlap with the app
+bundle (which is emitted separately).
+
+## Locking
+
+`UninstallProtection` is **advisory, not a security boundary** — TCC is evaluated at the syscall, so
+it can be wrong in both directions. It exists to gray a row with an honest reason and to skip
+obviously doomed attempts; `UninstallRunner` still reports per-item failure.
+
+Precedence, asserted by the harness:
+
+1. `!exists` → `.missing` (dropped from the plan)
+2. `SF_RESTRICTED`/`SF_IMMUTABLE`, or a read-only volume → `.systemProtected` — this is what locks
+   `/System/Applications/Books.app`, and it falls out of the facts rather than a hardcoded `/System`
+   prefix
+3. `UF_IMMUTABLE` → `.userLocked` (its own case: the user can clear it in Get Info)
+4. not owned by the current user → `.notOwned`
+5. a TCC-gated path without Full Disk Access → `.needsFullDiskAccess`
+6. parent not writable → `.parentNotWritable` (trashing is a rename out of the parent)
+7. → `.removable`
+
+A locked candidate can never enter the checked set. That invariant lives in `UninstallSelection`,
+whose every mutation funnels through one intersection with `plan.removableIDs`, so re-scanning drops
+a row that has since become locked for free.
+
+**Full Disk Access is detected, never requested.** The probe opens
+`~/Library/Application Support/com.apple.TCC/TCC.db` — TCC denies that read *silently*, with no
+prompt, which is what makes it usable under the rule that this feature asks for no permissions. It
+runs once per scan, not once per candidate, and can only under-report (a per-folder grant reads as
+"no access"), which just leaves a row locked.
+
+Symlinks are never followed: `lstat`, and no descent when sizing. A symlinked candidate is judged and
+trashed as the link.
+
+## The screen
+
+A `PaletteMode` case like Clipboard and Calculator History, so the back chevron, Escape,
+bare-backspace exit, arrow nav and the menu-open input freeze all come from the shared contract (see
+[palette.md](palette.md)). It does **not** join the Tab cycle. The search field filters candidates by
+name or location; there is no sort control, and the footer's leading corner keeps the standard menu
+circle. The primary pill is the one rendered in `Theme.Colors.destructive`.
+
+↵ uninstalls, ⌘↵ toggles the highlighted row, clicking the checkbox toggles, double-clicking a row
+toggles. ⌘K carries Uninstall, Select/Unselect File, Select/Deselect All, Copy Path, Show in Finder
+and Show Info in Finder. Copy Path stays on the screen (losing a whole scan to copy one path is a bad
+trade); the two Finder actions hand focus to Finder and so hide the palette. Show Info has no AppKit
+route and drives Finder over Apple events, which raises the system Automation prompt on first use.
+
+`AppCore.performUninstall()` is the one funnel, so neither ↵ nor the menu row can skip the
+confirmation. It quits the app first if it's running, trashes, and **only clears the app's hotkey,
+favorite, visibility and ranking when the bundle itself went** — a leftovers-only cleanup leaves the
+app installed. The bundle is trashed last: either order can leave a partial state, but with the
+bundle still in place the user can re-run the uninstall to retry, and once it's gone the launcher
+entry that reaches this screen is gone with it. Success shows the message pill; partial failure names
+what stayed behind.
+
+## Tests
+
+```sh
+swiftc -swift-version 6 Tinycast/Core/Uninstall/UninstallTarget.swift \
+    Tinycast/Core/Uninstall/UninstallSearchRoot.swift Tinycast/Core/Uninstall/UninstallRules.swift \
+    Tinycast/Core/Uninstall/UninstallProtection.swift Tinycast/Core/Uninstall/UninstallPlan.swift \
+    Tools/uninstall-test.swift -o /tmp/uninstall-test && /tmp/uninstall-test
+```
+
+No filesystem, no temp directories — every input is a `String` or a `PathFacts`. Beyond the per-rule
+assertions it ends with a cross-identity sweep: for a set of realistic apps × every root × every
+artifact shape, no app's artifacts may ever be attributed to another. That is the one test that
+catches a regression in the matcher as a whole rather than in a single rule.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -86,6 +86,17 @@ refuses itself too.
 
 ### Roots
 
+The **home directory itself is not a root**, and that is a decision rather than an oversight. Every
+root lives under `~/Library` or `/Library`; nothing directly in `~` is ever a candidate. Claiming
+`~/<name>` would rest on a name match, and `~` is the one place where a wrong match costs the user
+their own work instead of an app's cache — VS Code's `CFBundleName` is literally `Code`, and `~/Code`
+is a source tree on a great many machines. Narrowing it to dot-folders only moves the problem: an app
+named "Local" would then claim `~/.local`, and screening for that needs a hand-kept blocklist with no
+source of truth — the same reasoning that keeps slang out of `CalcCurrency.contested`. Measured
+against 62 installed apps the entire root was worth one 115 kB folder, so it bought almost nothing
+and carried the only catastrophic failure mode in the design. Raycast does list `~/OrbStack`; we
+deliberately don't.
+
 Immediate children only, everywhere. `Preferences/ByHost` is its own root rather than raising
 `Preferences` to depth 2, which would descend into every unrelated app's subfolder. Beyond the
 `~/Library` and `/Library` staples the table covers the plug-in wells — `QuickLook`, `Services`,
@@ -115,10 +126,22 @@ Precedence, asserted by the harness:
    `/System/Applications/Books.app`, and it falls out of the facts rather than a hardcoded `/System`
    prefix
 3. `UF_IMMUTABLE` → `.userLocked` (its own case: the user can clear it in Get Info)
-4. not owned by the current user → `.notOwned`
-5. a TCC-gated path without Full Disk Access → `.needsFullDiskAccess`
-6. parent not writable → `.parentNotWritable` (trashing is a rename out of the parent)
+4. a TCC-gated path without Full Disk Access → `.needsFullDiskAccess`
+5. parent not writable → `.parentNotWritable`
+6. sticky parent *and* not owned by the current user → `.notOwned`
 7. → `.removable`
+
+Steps 5 and 6 are the whole ownership story, and the order is deliberate. Removing a directory entry
+is governed by write permission on the **enclosing directory**, not by who owns the item: a root-owned
+file inside a folder you can write is yours to remove. Checking ownership first — as an earlier
+revision did — grayed out rows that trash perfectly well. Ownership decides exactly one case, a
+sticky parent (`S_ISVTX`, the `/tmp` rule), where only an owner may unlink.
+
+This is also why `/usr/local/bin/code` stays locked while `/opt/homebrew/bin/orb` does not:
+`/usr/local/bin` is `drwxr-xr-x root:wheel`, so the trash is refused outright (measured, not
+inferred), whereas Homebrew leaves `/opt/homebrew/bin` group-writable. Raycast offers the
+`/usr/local/bin` row as checked; that removal cannot succeed without an administrator password, which
+this feature never asks for.
 
 A locked candidate can never enter the checked set. That invariant lives in `UninstallSelection`,
 whose every mutation funnels through one intersection with `plan.removableIDs`, so re-scanning drops

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,7 +1,7 @@
 # Uninstall Application
 
 Removes an app *and* the files it leaves behind — caches, preferences, containers, saved state,
-launch agents. Reached from the launcher's Actions menu (⌘K → **Uninstall Application**, or ⌃⇧U) on
+launch agents. Reached from the launcher's Actions menu (⌘K → **Uninstall Application**) on
 any `.application` entry; it opens the `.uninstall` palette sub-screen scoped to that app.
 
 **Everything goes to the Trash.** `FileManager.trashItem` is the only removal call in the feature —
@@ -173,8 +173,8 @@ name or location; there is no sort control, and the footer's leading corner keep
 circle. The primary pill is the one rendered in `Theme.Colors.destructive`.
 
 ↵ uninstalls, ⌘↵ toggles the highlighted row, clicking the checkbox toggles, double-clicking a row
-toggles. ⌘K carries Uninstall, Select/Unselect File, Select/Deselect All, Copy Path, Show in Finder
-and Show Info in Finder. Copy Path stays on the screen (losing a whole scan to copy one path is a bad
+toggles. ⌘K carries Uninstall, Select/Unselect File, Copy Path, Show in Finder and Show Info in
+Finder. There is no launcher keybinding for Uninstall — it is a menu action only. Copy Path stays on the screen (losing a whole scan to copy one path is a bad
 trade); the two Finder actions hand focus to Finder and so hide the palette. Show Info has no AppKit
 route and drives Finder over Apple events, which raises the system Automation prompt on first use.
 


### PR DESCRIPTION
## Related issue

Closes #50

## What changed

Adds **Uninstall Application** — removes an app *and* the files it leaves behind (caches, preferences,
containers, saved state, launch agents, plug-ins, CLI launchers). Reached from the launcher's Actions
menu (⌘K → Uninstall Application) on any `.application` entry; it opens a new `.uninstall` palette
sub-screen scoped to that app, with a checkbox per file and a running size total.

**Everything goes to the Trash.** `FileManager.trashItem` is the only removal call in the feature —
`removeItem` never appears. That's load-bearing rather than incidental: it's what makes display-name
attribution tolerable at all, because a false positive costs a drag back rather than the user's data.

### Layout

The usual pure/effect split, same shape as `WindowManagement`:

| File | Role |
| --- | --- |
| `Core/Uninstall/UninstallTarget.swift` | `UninstallTarget`, `UninstallEvidence`, `UninstallIdentity` — every guard rail lives in `make` |
| `Core/Uninstall/UninstallSearchRoot.swift` | Root table + `binDirectories` |
| `Core/Uninstall/UninstallRules.swift` | Matching, `isAcceptableCandidate` |
| `Core/Uninstall/UninstallProtection.swift` | `PathFacts` → `UninstallProtection` |
| `Core/Uninstall/UninstallPlan.swift` | `UninstallCandidate`, `UninstallPlan`, `UninstallSelection` |
| `Core/Uninstall/UninstallScanner.swift` | **Impure.** `contentsOfDirectory`, `lstat`, sizes, FDA probe |
| `Core/Uninstall/UninstallRunner.swift` | **Impure.** `trashItem`, nothing else |
| `Core/Uninstall/UninstallSession.swift` | `@MainActor` lifecycle |
| `Features/Uninstall/UninstallView.swift` | List, row, actions menu |

The first five compile standalone into `Tools/uninstall-test.swift`. The scanner hands the rules child
**names** and hands the classifier a `PathFacts`, so "no filesystem in the pure layer" is structural
rather than a promise — the harness needs no temp directories at all.

### Non-obvious bits worth a reviewer's eye

- **The separator boundary in `matchesBundleID` is the whole safety story.** A plain `hasPrefix` makes
  `com.apple.SafariTechnologyPreview` a match for `com.apple.Safari` and trashes a different product's
  profile. `-` counts as well as `.`, because vendors name variants that way (`dev.zed.Zed-Preview`).
- **An installed sibling owns its own artifacts.** Without it, uninstalling `com.tinycast.app` would
  also trash `…​.beta` and `…​.dev` — the channel-isolation invariant in reverse.
- **Tinycast refuses to plan its own uninstall**, by bundle ID *and* bundle URL, compared against the
  **running** identity so the Dev channel refuses itself too.
- **`tccRelativePrefixes` is measured, not assumed.** A probe that creates and trashes a throwaway
  directory in each location shows `Containers` / `Group Containers` / `Cookies` refuse the move while
  `Application Scripts` allows it. Listing is *not* the test — both container roots enumerate fine and
  still refuse. That's why Books shows its five `Application Scripts` rows checkable and the five
  `Containers` rows beside them locked.
- **Ownership doesn't gate deletion; the parent directory does.** POSIX unlink needs write on the
  enclosing directory, not ownership of the item. Checking ownership first (as an earlier revision did)
  greyed out `/Applications/Xcode.app` — 4.19 GB that drags to the Trash fine, because `/Applications`
  is `drwxrwxr-x root:admin`. Ownership now decides exactly one case: a sticky parent.
- **The home directory is deliberately not a search root.** Claiming `~/<name>` rests on a name match,
  and VS Code's `CFBundleName` is literally `Code` — `~/Code` is a source tree on a lot of machines.
  Narrowing to dot-folders only moved the problem (an app named "Local" would claim `~/.local`) and
  needed a hand-kept blocklist with no source of truth. Measured across 62 installed apps the whole
  root was worth one 115 kB folder, so it's out. Rationale is in `docs/uninstall.md` so nobody re-adds
  it thinking it was an oversight.
- **CLI launchers are attributed by link target, never by name** — `zed` in `/usr/local/bin` is Zed's
  because it resolves into `Zed.app`, not because of what it's called.
- **`UninstallSelection` is the only thing that can hold a checked set**, and every mutation funnels
  through one intersection with `plan.removableIDs`, so "a locked candidate is never checked" is a
  single line to review rather than a rule spread across the view and the session.

### Also in this diff

- `.swiftlint.yml`: raised `type_body_length` (720→850), `function_body_length` (130→160) and added
  `large_tuple` (3). `AppCore` and `RootPaletteView` grew past the old ceilings.
- `docs/uninstall.md` (new), plus updates to `AGENTS.md` (new invariant), `docs/palette.md`,
  `docs/ui.md` (the shared leading-slot rule), `docs/development.md` and the CI `test` job.

## Memory footprint

> **Not yet measured — I don't have these numbers.** The scan is off-main via `Task.detached` and the
> only retained state is one `UninstallPlan` (a few hundred value-type candidates), released by
> `UninstallSession.cancel()` on every exit from the screen. Sizing uses a streaming `FileManager`
> enumerator capped at 250k entries rather than materialising a file list. Needs filling in before merge.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

> Not recorded — screen recording isn't available from my shell, so this needs a before/after capture
> before merge. Visual surface: the new sub-screen (list, checkboxes, lock rows), the red
> "Uninstall Application" footer pill, and the confirmation dialog.

## Drawbacks

- **`/usr/local/bin` rows render locked, where Raycast shows them checked.** On a stock Mac that
  directory is `drwxr-xr-x root:wheel`; I verified by attempting it that both the create and the trash
  are refused. Raycast's checkbox there cannot succeed without an admin password. Closing the gap needs
  privilege escalation, which this feature deliberately never does — and `trashItem` as root would land
  files in *root's* Trash, weakening the "always recoverable" guarantee that everything else rests on.
  `/opt/homebrew/bin` launchers are removable, because Homebrew leaves that directory group-writable.
- **Apps on the signed system volume (`/System/Applications/Books.app`) stay locked.** Raycast offers
  them as checked; that removal can't succeed. Their user-level leftovers are still cleanable.
- **`~` is not scanned**, so a leftover like `~/OrbStack` is missed. Deliberate — see above.
- **`UninstallProtection` is advisory, not a security boundary.** TCC is evaluated at the syscall, so it
  can be wrong in both directions; the runner still reports per-item failure.
- **Show Info in Finder drives Finder over Apple events**, so first use raises the system Automation
  prompt. Failure is reported with a pointer to Settings; the other actions need no permissions.
- Directory sizes are on-disk allocated bytes (Finder's number), so totals read slightly higher than
  Raycast's logical sizes.

## Tests & validation

**New:** `Tools/uninstall-test.swift` — 117 assertions over the pure layer, registered in
`docs/development.md` § Tests and the CI `test` job. No filesystem, no temp directories.

```sh
swiftc -swift-version 6 Tinycast/Core/Uninstall/UninstallTarget.swift \
    Tinycast/Core/Uninstall/UninstallSearchRoot.swift Tinycast/Core/Uninstall/UninstallRules.swift \
    Tinycast/Core/Uninstall/UninstallProtection.swift Tinycast/Core/Uninstall/UninstallPlan.swift \
    Tools/uninstall-test.swift -o /tmp/uninstall-test && /tmp/uninstall-test
```

Coverage is weighted toward near-misses rather than happy paths: `SafariTechnologyPreview` vs `Safari`,
`iBooksXtra` vs `iBooksX`, sibling release channels in both directions, vendor namespaces,
`group.`/Team-ID stripping and its near-misses, "Books" vs "Books Reader" both ways, name collisions
against other installed apps, self-uninstall refusal for both channels, the protection precedence
ladder, and the locked-can-never-be-checked invariant. It ends with a **cross-identity sweep** — 8
realistic apps × every root × every artifact shape, asserting no app's artifacts are ever attributed to
another. That's the one test that catches a matcher regression as a whole rather than a single rule.

I mutation-tested the harness rather than trusting a green run: removing the trailing-separator guard
fails 5 assertions, breaking the selection invariant fails 3.

**Also run:** every other `Tools/` harness green (fuzz, ranking, calc, clipboard, scopes, raycast,
emoji, custom-command, snippets, hotkey, callout, system-action, volume, window-command), `xcodebuild`
clean, `swiftlint` clean. `Tools/callout-test.swift` gains a guard that the uninstall checkbox fits the
shared `rowIcon` slot (it's the only harness compiling `Theme.swift`).

**By hand, off-repo:**

- **End-to-end** against a throwaway app in a fake `CFFIXED_USER_HOME`: real scanner + real runner, 25
  checks — files gone from source, all recoverable from `~/.Trash`, near-miss fixtures untouched.
- **Dry run over all 62 installed apps**, printing each candidate and its protection without trashing
  anything: **no path is claimed by two apps**. I read every `displayName` and `binSymlink` row by hand;
  all correctly attributed.
- **Permission probes** for the TCC table and the `/usr/local/bin` claim, both described above.

**Not done:** memory profiling, and no visual sign-off — both outstanding above.
