### PR TITLE
Normalize uninstall row icon sizes to the app-icon extent

### DIFF
--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -168,8 +168,85 @@ enum IconCache {
         }
     }
 
+    /// The share of its square canvas a macOS **app** icon paints. Measured: folders paint 98% of the
+    /// width and documents 69%, so a column mixing types reads ragged until they're scaled to match.
+    private static let artworkExtent: CGFloat = 0.83
+
+    /// Cache-only lookup for `loadFittedAsync`.
+    static func cachedFitted(forFile path: String) -> NSImage? {
+        cache.object(forKey: fittedKey(path))
+    }
+
+    /// Like `loadAsync`, but normalized so the painted artwork spans `artworkExtent` whatever the file
+    /// type. An app icon comes back untouched; a folder or document shrinks to the same visual size.
+    static func loadFittedAsync(forFile path: String) async -> NSImage? {
+        if let cached = cachedFitted(forFile: path) { return cached }
+        return await Task.detached(priority: .userInitiated) { () -> Decoded in
+            guard FileManager.default.fileExists(atPath: path) else { return Decoded(image: nil) }
+            return Decoded(image: fittedIcon(forFile: path))
+        }.value.image
+    }
+
+    private static func fittedKey(_ path: String) -> NSString { ("fit:" + path) as NSString }
+
+    private static func fittedIcon(forFile path: String) -> NSImage {
+        let key = fittedKey(path)
+        if let cached = cache.object(forKey: key) { return cached }
+        let source = NSWorkspace.shared.icon(forFile: path)
+        // Drawing the source into a `side`-square box makes its artwork span `side * extent`; solving
+        // for `side * extent == displayPixel * artworkExtent` leaves an app icon exactly as it was.
+        let extent = paintedExtent(source) ?? artworkExtent
+        let side = displayPixel * artworkExtent / extent
+        let inset = (displayPixel - side) / 2
+        let (icon, cost) = rasterized(
+            source, into: NSRect(x: inset, y: inset, width: side, height: side))
+        cache.setObject(icon, forKey: key, cost: cost)
+        return icon
+    }
+
+    /// The larger dimension of the icon's non-transparent artwork, as a fraction of its canvas.
+    /// Measured at the raster's own 2× resolution: a 1× grid smears antialiased edges into the
+    /// bounding box and over-reads the extent, which would shrink app icons that should stay put.
+    private static func paintedExtent(_ source: NSImage) -> CGFloat? {
+        let pixels = Int(displayPixel * 2)
+        guard
+            let rep = NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: pixels, pixelsHigh: pixels, bitsPerSample: 8,
+                samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB,
+                bytesPerRow: 0, bitsPerPixel: 0),
+            let ctx = NSGraphicsContext(bitmapImageRep: rep)
+        else { return nil }
+        rep.size = NSSize(width: pixels, height: pixels)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = ctx
+        source.draw(in: NSRect(x: 0, y: 0, width: pixels, height: pixels))
+        NSGraphicsContext.restoreGraphicsState()
+
+        var minX = pixels, maxX = -1, minY = pixels, maxY = -1
+        for y in 0..<pixels {
+            for x in 0..<pixels {
+                // A faint antialiased edge isn't artwork; 0.06 keeps a drop shadow from counting.
+                guard let colour = rep.colorAt(x: x, y: y), colour.alphaComponent > 0.06 else {
+                    continue
+                }
+                minX = min(minX, x)
+                maxX = max(maxX, x)
+                minY = min(minY, y)
+                maxY = max(maxY, y)
+            }
+        }
+        guard maxX >= 0 else { return nil }
+        let side = max(maxX - minX + 1, maxY - minY + 1)
+        return CGFloat(side) / CGFloat(pixels)
+    }
+
     /// Rasterize the multi-rep workspace icon into one `displayPixel`-square bitmap, returning it and its decoded byte cost.
     private static func downsampled(_ source: NSImage) -> (NSImage, Int) {
+        rasterized(source, into: NSRect(origin: .zero, size: NSSize(width: displayPixel, height: displayPixel)))
+    }
+
+    /// Draws `source` into `frame` on a `displayPixel`-square canvas.
+    private static func rasterized(_ source: NSImage, into frame: NSRect) -> (NSImage, Int) {
         // Fixed 2× (not `NSScreen.main`, which is main-thread-only) so this can rasterize on a detached decode; 96px covers the ≤24pt draw on any display.
         let pixels = Int(displayPixel * 2)
         let fallbackCost = Int(displayPixel * displayPixel * 4)
@@ -187,7 +264,7 @@ enum IconCache {
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = ctx
         ctx.imageInterpolation = .high
-        source.draw(in: NSRect(origin: .zero, size: rep.size))
+        source.draw(in: frame)
         NSGraphicsContext.restoreGraphicsState()
 
         let image = NSImage(size: rep.size)

--- a/Tinycast/Features/Uninstall/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UninstallView.swift
@@ -135,7 +135,7 @@ private struct FileIconView: View {
 
     init(path: String) {
         self.path = path
-        _image = State(initialValue: IconCache.cached(forFile: path))
+        _image = State(initialValue: IconCache.cachedFitted(forFile: path))
     }
 
     var body: some View {
@@ -149,7 +149,7 @@ private struct FileIconView: View {
         }
         .task(id: path) {
             guard image == nil else { return }
-            image = await IconCache.loadAsync(forFile: path)
+            image = await IconCache.loadFittedAsync(forFile: path)
         }
     }
 }


### PR DESCRIPTION
## Related issue

Closes #

<!-- Follow-up polish on #145. -->

## What changed

The uninstall list's trailing icon column read as ragged: folders looked bigger than the app icon and
documents looked smaller, even though every icon already sat in an identical 24pt `rowIcon` slot.

The slot was never the problem. macOS paints a different **share of the square canvas** per file type,
measured with an alpha bounding-box probe:

| type | painted extent | at 24pt |
| --- | --- | --- |
| app bundle | 83% | 19.9pt |
| folder | **98%** wide, 78% tall | 23.5pt |
| plist document | 69% wide, 91% tall | 16.6pt |
| exec / symlink | 89% | 21.4pt |

`IconCache.loadFittedAsync(forFile:)` measures each icon's own artwork bounds and scales it uniformly
so the painted extent lands on the app-icon fraction. Verified, not assumed:

```
type            before →  after   (target 83%)
app bundle     83%   →  83%
app bundle 2   83%   →  83%
folder         98%   →  83%
plist doc      91%   →  82%
exec symlink   89%   →  83%
```

Three things worth a reviewer's attention:

- **App icons come back untouched** (83% → 83%), so the bundle row still matches the launcher exactly.
  Normalizing everything to *fill* the slot instead would have grown app icons and created a fresh
  inconsistency the moment you switched between the launcher and this screen.
- **No per-type constants.** The scale comes from each icon's actual alpha bounds at runtime, so it
  self-corrects if Apple changes the artwork. The one constant is the app-icon fraction, and it is
  measured rather than eyeballed.
- **`paintedExtent` measures at the raster's 2× resolution on purpose.** My first version measured on a
  1× (48px) grid, which smears antialiased edges into the bounding box and over-reads the extent — that
  shrank app icons from 83% to 76%, the exact thing this change exists to avoid. There's a comment on
  the line saying so.

`downsampled` is refactored into `rasterized(_:into:)` with identical behaviour (the full-canvas rect),
so the launcher's icon path is byte-for-byte unchanged. The new work is additive: a second cache key
(`fit:` + path) sharing the existing `NSCache` and its 32 MB cost limit, decoded off-main through the
same `Task.detached` path as `loadAsync`.

## Memory footprint

> **Not measured — I don't have these numbers.** Shape of the change: one extra cached `NSImage` per
> distinct uninstall row, in the existing `IconCache` `NSCache` under its existing 32 MB `totalCostLimit`,
> so it evicts under pressure like every other icon. Icons are 48pt @2× as before. Needs filling in.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

> Not recorded — screen recording isn't available from my shell. This is a purely visual change, so it
> wants a before/after of the uninstall list's trailing icon column (an app row plus folder and
> document rows in the same shot).

## Drawbacks

- Adds an alpha bounding-box scan per icon (96×96 = ~9k pixel reads). It runs once per path on the
  detached decode and is then cached, so it never touches the main actor, but it is strictly more work
  than the plain downsample.
- Doubles the cache entries for paths shown on the uninstall screen, since the fitted icon is stored
  under its own key rather than replacing the plain one. Both share the existing cost limit.
- The 83% target is derived from current macOS app-icon artwork. If Apple changes that convention the
  constant would need re-measuring — though the per-icon half of the calculation is already dynamic.
- Only the uninstall list uses the fitted variant. The launcher shows app icons exclusively, so it has
  no mixed-type raggedness to fix and is deliberately left alone.

## Tests & validation

No new harness — this is rendering, and the repo has no way to assert pixels.

- `xcodebuild` clean, `swiftlint` clean on the rebased branch.
- Harnesses re-run: `callout-test` 30/30 (it compiles `Theme.swift`), `uninstall-test` 117/117,
  `fuzz-test`, `ranking-test`, `scopes-test` all green.
- **Measured rather than eyeballed**: a throwaway `swiftc` probe rasterized real app / folder /
  document / symlink icons and printed the alpha bounding box before and after the transform — that is
  where both tables above come from. This follows `docs/ui.md` § Rules for agents ("verify AppKit
  rendering with a `swiftc` harness that prints layer state, and let the user do visual sign-off").

**Not done:** memory profiling, and no visual sign-off from me — both outstanding above.
