### PR TITLE
Add Quicklinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,8 @@ jobs:
             Tinycast/Core/Uninstall/UninstallProtection.swift \
             Tinycast/Core/Uninstall/UninstallPlan.swift Tools/uninstall-test.swift \
             -o /tmp/uninstall-test && /tmp/uninstall-test
+          swiftc -swift-version 6 Tinycast/Core/Quicklinks/Quicklink.swift \
+            Tinycast/Core/Quicklinks/QuicklinkDestination.swift \
+            Tinycast/Core/Quicklinks/QuicklinkStore.swift \
+            Tinycast/Core/Quicklinks/QuicklinkArchive.swift Tools/quicklink-test.swift \
+            -o /tmp/quicklink-test && /tmp/quicklink-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,8 @@ Full detail: [`docs/architecture.md`](docs/architecture.md).
   accessory apps).
 - **Subsystems:** [palette](docs/palette.md) · [launcher & fuzzy match](docs/launcher.md) ·
   [calculator](docs/calculator.md) · [clipboard](docs/clipboard.md) · [emoji](docs/emoji.md) ·
-  [snippets](docs/snippets.md) · [window management](docs/window-management.md) ·
+  [snippets](docs/snippets.md) · [quicklinks](docs/quicklinks.md) ·
+  [window management](docs/window-management.md) ·
   [hotkeys](docs/hotkeys.md) · [uninstall](docs/uninstall.md) ·
   [Raycast import](docs/raycast-import.md) · [UI & design system](docs/ui.md).
 
@@ -117,6 +118,19 @@ Never break these without an explicit task to do so.
   `UninstallSelection`'s one intersection, not in the view. Tinycast also refuses to plan its own
   uninstall, compared against the **running** identity so the Dev channel refuses itself too.
   See [uninstall.md](docs/uninstall.md).
+- **Quicklinks are authored data, and their store never deletes.** `Core/Quicklinks/` splits like
+  `Core/Uninstall/`: `Quicklink.swift`, `QuicklinkDestination.swift`, `QuicklinkStore.swift` and
+  `QuicklinkArchive.swift` stay Foundation-only (plus SQLite3) and pure for
+  `Tools/quicklink-test.swift` — the home directory is injected, never read — while `QuicklinkLauncher`
+  owns every `NSWorkspace` call and `QuicklinkArgumentSession` the prompt state. The database lives in
+  **Application Support**, not Caches, and a database that won't open is **reported, never discarded**:
+  `ClipboardStore`'s delete-and-recreate is only sound because history is regenerable, and a link
+  library is not. `Quicklink.precedes` is the one display order, sorted through by both the store and
+  the `AppIndex` slice. There is **one template engine**: quicklinks expand through
+  `SnippetTemplateEngine` rather than a second parser, which is what makes `| raw` mean something —
+  it opts a value out of the automatic percent-encoding a URL destination asks for. `{selectedText}`
+  is accepted as an alias for `{selection}`, but nothing ever *writes* it. See
+  [quicklinks.md](docs/quicklinks.md).
 - **`Core/SearchRelevance.swift` is Foundation-only and pure**, so `Tools/fuzz-test.swift` compiles
   the shipped scorer rather than a copy of it. It owns both `FuzzyMatch` (the tiered
   exact/prefix/word-start/substring/subsequence scorer) and the field bands. **Searchable fields stay
@@ -216,11 +230,14 @@ Never break these without an explicit task to do so.
 
 - `Tinycast/Core/` — managers, stores, windows, AppKit glue (no view bodies beyond hosting).
   `Core/Calculator/` and `Core/Emoji/` are Foundation-only engines; `Core/Snippets/` is a
-  standalone-harness input in full; `Core/WindowManagement/` is a pure geometry layer plus its one AX
-  file; `Core/Uninstall/` splits the same way — five pure files, one scanner, one Trash runner;
+  standalone-harness input in full (and owns the template engine both it and Quicklinks expand
+  through); `Core/WindowManagement/` is a pure geometry layer plus its one AX file; `Core/Uninstall/`
+  splits the same way — five pure files, one scanner, one Trash runner; `Core/Quicklinks/` is four
+  pure files plus the opener and the argument session;
   `Core/Theme.swift` is the design-token source; `Core/HotKey/` is the in-house hotkey stack.
 - `Tinycast/Features/` — SwiftUI views: `RootPaletteView`, `Launcher/`, `Clipboard/`, `Calculator/`,
-  `Emoji/`, `Uninstall/`, `Settings/`, `About/`, `Onboarding/`, plus shared `PopoverMenu`. Each
+  `Emoji/`, `Quicklinks/`, `Uninstall/`, `Settings/`, `About/`, `Onboarding/`, plus shared
+  `PopoverMenu`. Each
   `SettingsTab` maps to
   one `…SettingsView` built on the `SettingsPane` / `SettingsCard` scaffold in `SettingsComponents.swift`;
   the four launcher-category panes (Applications, System Settings, System Actions, Commands) are thin
@@ -235,7 +252,7 @@ Never break these without an explicit task to do so.
 - [`docs/palette.md`](docs/palette.md) — palette state flow, menu-open freeze, focus restoration.
 - [`docs/launcher.md`](docs/launcher.md) · [`docs/calculator.md`](docs/calculator.md) ·
   [`docs/clipboard.md`](docs/clipboard.md) · [`docs/emoji.md`](docs/emoji.md) ·
-  [`docs/snippets.md`](docs/snippets.md) ·
+  [`docs/snippets.md`](docs/snippets.md) · [`docs/quicklinks.md`](docs/quicklinks.md) ·
   [`docs/window-management.md`](docs/window-management.md) ·
   [`docs/hotkeys.md`](docs/hotkeys.md) · [`docs/uninstall.md`](docs/uninstall.md) — subsystem
   internals.

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		14712478C37E6E8760CA47EC /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DC5A4706854493D23FD18A /* HyperKey.swift */; };
 		14A5A5ACD35A572EE906769F /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B976C84AFE60E357A346224 /* CalcEngine.swift */; };
 		152E4A75BD2AF9279497F5FF /* DialogController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0A151A3B8AC682395E621D /* DialogController.swift */; };
+		1A899FE562A7344918CE1B44 /* QuicklinkLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECAB8490328EA3DADD05D9D /* QuicklinkLauncher.swift */; };
 		1AF562E00FCB98B12076F01D /* SnippetKeywordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5051622CC6497E2151326CA /* SnippetKeywordListener.swift */; };
 		1B90AA42601E3AE7EEE3AD5D /* WindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388A58EDB35AB0CB30EE20DE /* WindowLayout.swift */; };
 		1D0C2F452B3801503B70EA9E /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */; };
@@ -29,10 +30,12 @@
 		22488569DA337BCE033552F1 /* CursorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8214A6789CF8E3B5E16BB4C2 /* CursorScreen.swift */; };
 		22622CB1D2F679687D5C2B03 /* SearchRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E9B0F16CFCA5E4091178AF /* SearchRelevance.swift */; };
 		24842144273FF92228540DBE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A228BEF62103605DE7A8F38 /* FrequentEmojiStore.swift */; };
+		291F17D35D98BB5700640AA7 /* QuicklinkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F22CD63D23FC1808878DD /* QuicklinkListView.swift */; };
 		2D620B55ED68ECDF75E7155E /* UninstallRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE113DF7C07BC74AD73BC4C /* UninstallRunner.swift */; };
 		32697AB3853D043A12888B96 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E3ACB6D2C26ECA485C3DB /* Permissions.swift */; };
 		333BCB9C66380985400CD1E2 /* CustomCommandEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14822405E8DA9531AFCD496 /* CustomCommandEditorSheet.swift */; };
 		344D89B83B57C1DD1E7C0BFC /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B9F099ED1521F14D81E /* EmojiCatalog.swift */; };
+		34994B57DE0709CF5DCFC40C /* QuicklinkDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0E4F643A5094EA0F1D46F3 /* QuicklinkDestination.swift */; };
 		34CD5C2F15B1011434182CA7 /* SearchScopesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */; };
 		34E5FF0B3C9FD2FFE504D87A /* ClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ADC36002F1A5B04D61B4D3 /* ClipboardView.swift */; };
 		36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */ = {isa = PBXBuildFile; fileRef = 6621A88681E993D49EEF07A3 /* tinycast.icon */; };
@@ -55,6 +58,7 @@
 		5E49E070BDBB91A2829F5321 /* SnippetTextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309908BAB8C19B67F4608DA9 /* SnippetTextInjector.swift */; };
 		5F107A05A7EB05204465E89D /* VolumeHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6256CC7C3F15BA05A216E820 /* VolumeHUDController.swift */; };
 		61176B0EB91E2F82EEE3F4B9 /* SystemActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B90AEA968DD7B91A553E07 /* SystemActionsSettingsView.swift */; };
+		63E24116B4CCC95F4FA295E3 /* QuicklinkEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE92DB670B2EFA79FF9FAE /* QuicklinkEditorSheet.swift */; };
 		649961AA51BA4D87626C27D5 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09093BF10EA97BDCA45A241F /* CalcFormatter.swift */; };
 		6590849AB537D8641C71AC71 /* UninstallPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4954C8003947BB16ED48E326 /* UninstallPlan.swift */; };
 		67686B4D7A5922D9D1E1ADE1 /* SpotlightNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8925E80B57FDCEAB9764C65F /* SpotlightNames.swift */; };
@@ -62,6 +66,7 @@
 		693E88D22D00CF6FD9CD7413 /* VisibilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825AC18CE5DAFBEDA0CF3209 /* VisibilityStore.swift */; };
 		6962B8A2850A45401275F677 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC5F0D4ECE8F3888DEB7642 /* NotificationToken.swift */; };
 		6B4FB074DC1C263E22869B40 /* SymbolImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5175A8F8FED58C0DAEA2AFD6 /* SymbolImage.swift */; };
+		6C824F5B5099D36E73CF7E4C /* QuicklinkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC4A55E96BF19A8B1D71645 /* QuicklinkStore.swift */; };
 		6CDCE462405648998CDF1E77 /* CurrencyRateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6CB5CD6C0477BAC9FE383F /* CurrencyRateStore.swift */; };
 		6D3DBE00FCB757C67669CFBA /* CommandRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D57B0AE44D21035163BD422 /* CommandRegistry.swift */; };
 		6F08764D6CC09E9B3FD1E05A /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F50886DC766B9923C3875A5 /* RootPaletteView.swift */; };
@@ -79,9 +84,11 @@
 		861CB0B484C44D0D9A0DB74F /* VolumeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3499548D8C4A2FE4E7D3090B /* VolumeState.swift */; };
 		8631543D8E0E008E7C541345 /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC323070A08CD17DFFB2F8A /* BackupSettingsView.swift */; };
 		86D400D72735A8D0829029DE /* SettingsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */; };
+		8A75C5779712AEE0EE3DE568 /* QuicklinkArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCC54FC861BB11AB24357E /* QuicklinkArchive.swift */; };
 		8EF55652F19A1E0C5FF644B4 /* RaycastImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4049668745FD438D5792A2F /* RaycastImport.swift */; };
 		8F7431A1340D0A5783599087 /* MiscellaneousSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */; };
 		903E82F78D3FCEF3A1AF3752 /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */; };
+		9339A7E8F24DE1C66FFBC071 /* Quicklink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338EECB7D92DF7EA1E7133AA /* Quicklink.swift */; };
 		94620E1BB1049C5D8B45392E /* UninstallSearchRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C56920811CA9A5F0FA04441 /* UninstallSearchRoot.swift */; };
 		97A195E9D6480418D4944560 /* AppCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A64EF5A07D459753998F78C /* AppCore.swift */; };
 		9969E6858C4FDC5CCCDEB5D8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C45190564C9D9F1722E83943 /* Assets.xcassets */; };
@@ -91,6 +98,7 @@
 		A0C1BAEE55481326EEE81471 /* RaycastImportV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE385AAF41C4CB276025211 /* RaycastImportV1.swift */; };
 		A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D045D032498C2294A99890E /* LaunchAtLogin.swift */; };
 		A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */; };
+		A3855695DA55ADA137630DCE /* QuicklinkArgumentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031271DE1EEF68A443713D32 /* QuicklinkArgumentSession.swift */; };
 		A41C0DCB2DEBCCA46F6C4B10 /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB750D045194AE34D39D792 /* FavoritesStore.swift */; };
 		A9D8B54D88A60DE9FC1F43BF /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */; };
 		AA8050D9A547CDDD37C581C4 /* CurrencyData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E08668A3C8418E2F0970300 /* CurrencyData.generated.swift */; };
@@ -110,11 +118,13 @@
 		B9CED4B06F36998A67097FC5 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE084FDBE22B01204E7BEDA /* SnippetMarkdownSerializer.swift */; };
 		BA76E53A12248B3A9C42B4F9 /* Bundle+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */; };
 		BAA957558EB8FB2D26B13D4B /* UninstallScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD131E932E1B53D39CF30C13 /* UninstallScanner.swift */; };
+		BE9EE0864C315080A4E4780F /* AppPickerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = E874F8DFCBE0ACDD59C8664B /* AppPickerPopover.swift */; };
 		C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37CCD024267EB21876C7E9 /* AppDelegate.swift */; };
 		C35864533DFB42DE63080ACB /* WindowManagementSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */; };
 		C359131F793C6C6BD756B901 /* SystemSettingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1DE4D8B82F1D4AFB025FB24 /* SystemSettingsSettingsView.swift */; };
 		C3C45B2E5F0D05CD6E27D34C /* RaycastSnippetImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E4F8A2BCECFF0E11441BE /* RaycastSnippetImport.swift */; };
 		C526BEAA60A62E9BC78F309E /* CustomCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C105FED5D77A2392FDA3F0 /* CustomCommand.swift */; };
+		C5F3602E5C6F05E49B07AB46 /* QuicklinkArgumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA607D74B37C51BABA2B33A /* QuicklinkArgumentsView.swift */; };
 		C7D8BB669C3DBC0D26EB6E32 /* WindowActionMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B940224413903867EF5A60E /* WindowActionMemory.swift */; };
 		C7DD1345A6BFB1D9EB22FCEE /* RunningApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B432D84D8F9C10521342199 /* RunningApps.swift */; };
 		C8F4555ECA895F63A34A327C /* EmojiGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */; };
@@ -139,6 +149,7 @@
 		E8B6ADBCECD7CA81BC67EE78 /* CalloutPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1D759B8FC5A4573E401B8 /* CalloutPlacement.swift */; };
 		E952B659AEB905A3B233F78B /* EmojiGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94F0767AE0A5855FB22BF6 /* EmojiGridView.swift */; };
 		EDCEE2DDCF97C354AAC72BF2 /* RaycastImportV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6999B617ECF28C9021027B9 /* RaycastImportV2.swift */; };
+		EE12A8ECCC5F92553B24CD0F /* QuicklinksSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6D4DFAC1D761ECC2DE1112 /* QuicklinksSettingsView.swift */; };
 		F25D58ED6EF3308D38D01732 /* PaletteWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5447AEAD87BFE0E2D979B39 /* PaletteWindowController.swift */; };
 		F2B68DBA258D85DD5C6DC1CC /* Paster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6185011A02366B30B48B5B6C /* Paster.swift */; };
 		F457EB595789DD3A25E888DF /* SnippetsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3E740AA883770481A6A8C /* SnippetsStore.swift */; };
@@ -155,6 +166,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		031271DE1EEF68A443713D32 /* QuicklinkArgumentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentSession.swift; sourceTree = "<group>"; };
 		041AB49DDB9CA53148BB8A46 /* EmojiSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSettingsView.swift; sourceTree = "<group>"; };
 		05970D61D4E595D0658D0D94 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		0818D48887156CA562EF20B8 /* VolumeLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeLevel.swift; sourceTree = "<group>"; };
@@ -165,10 +177,12 @@
 		0F50886DC766B9923C3875A5 /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
 		1A4B045F847659544FA182D4 /* DoubleTapModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapModifier.swift; sourceTree = "<group>"; };
 		1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportSelection.swift; sourceTree = "<group>"; };
+		1C6D4DFAC1D761ECC2DE1112 /* QuicklinksSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinksSettingsView.swift; sourceTree = "<group>"; };
 		1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		24F31E587DD4EAA1D7BD39AF /* UninstallProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallProtection.swift; sourceTree = "<group>"; };
 		25B8A7D8DBB0CE2ACEDB3979 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
+		26CCC54FC861BB11AB24357E /* QuicklinkArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArchive.swift; sourceTree = "<group>"; };
 		286B7598B81017C746558C7C /* ShellCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellCommandRunner.swift; sourceTree = "<group>"; };
 		297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscellaneousSettingsView.swift; sourceTree = "<group>"; };
 		299122624B5E1BA2C5400478 /* CalcCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcCurrency.swift; sourceTree = "<group>"; };
@@ -178,12 +192,15 @@
 		2FC323070A08CD17DFFB2F8A /* BackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsView.swift; sourceTree = "<group>"; };
 		309908BAB8C19B67F4608DA9 /* SnippetTextInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTextInjector.swift; sourceTree = "<group>"; };
 		32A53295959552ED28D34960 /* Gunzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gunzip.swift; sourceTree = "<group>"; };
+		338EECB7D92DF7EA1E7133AA /* Quicklink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quicklink.swift; sourceTree = "<group>"; };
 		33A13DB27EE627AC08051165 /* EdgeDissolve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeDissolve.swift; sourceTree = "<group>"; };
 		3499548D8C4A2FE4E7D3090B /* VolumeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeState.swift; sourceTree = "<group>"; };
 		388A58EDB35AB0CB30EE20DE /* WindowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowLayout.swift; sourceTree = "<group>"; };
 		3A64EF5A07D459753998F78C /* AppCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCore.swift; sourceTree = "<group>"; };
 		3B78A8741FA55F42BAF5D97F /* SystemActionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionRunner.swift; sourceTree = "<group>"; };
 		3B976C84AFE60E357A346224 /* CalcEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcEngine.swift; sourceTree = "<group>"; };
+		3D0E4F643A5094EA0F1D46F3 /* QuicklinkDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkDestination.swift; sourceTree = "<group>"; };
+		3ECAB8490328EA3DADD05D9D /* QuicklinkLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkLauncher.swift; sourceTree = "<group>"; };
 		3FF10C4F5E4F73503F58D03B /* OverlayScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayScroller.swift; sourceTree = "<group>"; };
 		423CFE8AB90484D0309F24C0 /* CalcParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcParser.swift; sourceTree = "<group>"; };
 		45D4BA6E1BD8EB1F96A8927F /* Tinycast.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tinycast.entitlements; sourceTree = "<group>"; };
@@ -220,6 +237,7 @@
 		6A6941F59D6E8014A22F1FF7 /* UninstallTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallTarget.swift; sourceTree = "<group>"; };
 		6BB7C545EFD9589A77AD7BE2 /* LauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherView.swift; sourceTree = "<group>"; };
 		6E7DD73DC688DBFAFC4B04AC /* WindowManagementSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagementSettingsView.swift; sourceTree = "<group>"; };
+		6EA607D74B37C51BABA2B33A /* QuicklinkArgumentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsView.swift; sourceTree = "<group>"; };
 		6EB4BA1A385F78B9C5E7EBCF /* UninstallRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRules.swift; sourceTree = "<group>"; };
 		70D14EC2D7A6AE5F7CBB5028 /* HUDPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanel.swift; sourceTree = "<group>"; };
 		72037DA506AE1A989F858C3C /* DialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogView.swift; sourceTree = "<group>"; };
@@ -280,23 +298,27 @@
 		C8B33C0EA6D52B365B82752D /* RaycastV1Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastV1Decoder.swift; sourceTree = "<group>"; };
 		C9D8C2C59C2B578CFE61E004 /* BackupActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupActions.swift; sourceTree = "<group>"; };
 		CAE385AAF41C4CB276025211 /* RaycastImportV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV1.swift; sourceTree = "<group>"; };
+		CAFE92DB670B2EFA79FF9FAE /* QuicklinkEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkEditorSheet.swift; sourceTree = "<group>"; };
 		CC35D5134516ECB65AABDC51 /* ShortcutCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureSession.swift; sourceTree = "<group>"; };
 		CC6173CA658DA56245031FE6 /* VolumeHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDView.swift; sourceTree = "<group>"; };
 		CD3579618BC7FA235EBF9E93 /* SnippetsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsSettingsView.swift; sourceTree = "<group>"; };
 		CD3764D91B2F3170690A473A /* SnippetKeywordPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordPolicy.swift; sourceTree = "<group>"; };
 		CEE113DF7C07BC74AD73BC4C /* UninstallRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRunner.swift; sourceTree = "<group>"; };
 		D2A1D759B8FC5A4573E401B8 /* CalloutPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutPlacement.swift; sourceTree = "<group>"; };
+		D30F22CD63D23FC1808878DD /* QuicklinkListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkListView.swift; sourceTree = "<group>"; };
 		D37B6D29E8E23C6136EBFB38 /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppName.swift"; sourceTree = "<group>"; };
 		D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
 		D8745544BFC53B27B0168CA6 /* DialogRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogRequest.swift; sourceTree = "<group>"; };
 		D9E9B0F16CFCA5E4091178AF /* SearchRelevance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRelevance.swift; sourceTree = "<group>"; };
 		DABCE058D38F493D58F6E072 /* EmojiGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridGeometry.swift; sourceTree = "<group>"; };
+		DBC4A55E96BF19A8B1D71645 /* QuicklinkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkStore.swift; sourceTree = "<group>"; };
 		DFAB36FFE7E7108FB50E9134 /* VolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSlider.swift; sourceTree = "<group>"; };
 		E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateTime.swift; sourceTree = "<group>"; };
 		E312F99D07F01172202478C6 /* RaycastFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastFormat.swift; sourceTree = "<group>"; };
 		E5051622CC6497E2151326CA /* SnippetKeywordListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordListener.swift; sourceTree = "<group>"; };
 		E6999B617ECF28C9021027B9 /* RaycastImportV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV2.swift; sourceTree = "<group>"; };
+		E874F8DFCBE0ACDD59C8664B /* AppPickerPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPickerPopover.swift; sourceTree = "<group>"; };
 		EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		EDE084FDBE22B01204E7BEDA /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		EDE0C0DC05F958A4B4DCAA8C /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
@@ -323,6 +345,7 @@
 				E2E33C02FBE324BED2E84314 /* Emoji */,
 				CB742F7643800C43475DE213 /* HotKey */,
 				628C51FD0EF7D98347A4F185 /* HUD */,
+				C34A8B979D339766A184D225 /* Quicklinks */,
 				32B8FED93732983EAE729EB1 /* Snippets */,
 				FB939500E513D49DC165EA75 /* Uninstall */,
 				36FA7A5040272D524D70EC0E /* WindowManagement */,
@@ -470,6 +493,15 @@
 			path = Uninstall;
 			sourceTree = "<group>";
 		};
+		60DCE6A46E636364E5C3B5B4 /* Quicklinks */ = {
+			isa = PBXGroup;
+			children = (
+				6EA607D74B37C51BABA2B33A /* QuicklinkArgumentsView.swift */,
+				D30F22CD63D23FC1808878DD /* QuicklinkListView.swift */,
+			);
+			path = Quicklinks;
+			sourceTree = "<group>";
+		};
 		628C51FD0EF7D98347A4F185 /* HUD */ = {
 			isa = PBXGroup;
 			children = (
@@ -509,6 +541,7 @@
 				B23CD0D2FE6389E18D45AD51 /* HUD */,
 				7DE06EE636C14E50EE172D9E /* Launcher */,
 				0ED457107377ECF8147C6B9D /* Onboarding */,
+				60DCE6A46E636364E5C3B5B4 /* Quicklinks */,
 				E3202F504002B7792FC50B2F /* Settings */,
 				7CD438390F8FA4B3C2AE5F28 /* Snippets */,
 				5EC7DD3F09EBCC7AC71C230B /* Uninstall */,
@@ -548,6 +581,19 @@
 				2B629EC3B716FEE881BB0075 /* TinycastApp.swift */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		C34A8B979D339766A184D225 /* Quicklinks */ = {
+			isa = PBXGroup;
+			children = (
+				338EECB7D92DF7EA1E7133AA /* Quicklink.swift */,
+				26CCC54FC861BB11AB24357E /* QuicklinkArchive.swift */,
+				031271DE1EEF68A443713D32 /* QuicklinkArgumentSession.swift */,
+				3D0E4F643A5094EA0F1D46F3 /* QuicklinkDestination.swift */,
+				3ECAB8490328EA3DADD05D9D /* QuicklinkLauncher.swift */,
+				DBC4A55E96BF19A8B1D71645 /* QuicklinkStore.swift */,
+			);
+			path = Quicklinks;
 			sourceTree = "<group>";
 		};
 		C7693795CC6FB6188989435E /* Backup */ = {
@@ -598,6 +644,7 @@
 			isa = PBXGroup;
 			children = (
 				4C8F4B31728E49ECE0AA2636 /* ApplicationsSettingsView.swift */,
+				E874F8DFCBE0ACDD59C8664B /* AppPickerPopover.swift */,
 				2FC323070A08CD17DFFB2F8A /* BackupSettingsView.swift */,
 				849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */,
 				74868D1F22B3CEC5A2ECD668 /* CommandsSettingsView.swift */,
@@ -607,6 +654,8 @@
 				C75F221037C057C8085CE51C /* LauncherItemsCard.swift */,
 				297F819E291F33E43E490359 /* MiscellaneousSettingsView.swift */,
 				0C36D92A5018B9A7B33775DE /* PermissionsSettingsView.swift */,
+				CAFE92DB670B2EFA79FF9FAE /* QuicklinkEditorSheet.swift */,
+				1C6D4DFAC1D761ECC2DE1112 /* QuicklinksSettingsView.swift */,
 				1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */,
 				98AD515E679D78C6F2A37E03 /* SearchScopesCard.swift */,
 				D4777FBB3A4FBB2F95FDC250 /* SettingsComponents.swift */,
@@ -737,6 +786,7 @@
 				C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */,
 				D322804853973E1C19F2A408 /* AppIndex.swift in Sources */,
 				DA2EBB18F026BD055E0270CD /* AppLauncher.swift in Sources */,
+				BE9EE0864C315080A4E4780F /* AppPickerPopover.swift in Sources */,
 				FEA05585E8AA58506D378CAF /* AppSettings.swift in Sources */,
 				CDBB4E26FCABEEE8817D12B2 /* ApplicationsSettingsView.swift in Sources */,
 				AE0D0C53004C65D65BE89B6F /* BackupActions.swift in Sources */,
@@ -811,6 +861,16 @@
 				32697AB3853D043A12888B96 /* Permissions.swift in Sources */,
 				2085C9433B7534044E0A8A7D /* PermissionsSettingsView.swift in Sources */,
 				80F1A591DB0F5385F5C9A06C /* PopoverMenu.swift in Sources */,
+				9339A7E8F24DE1C66FFBC071 /* Quicklink.swift in Sources */,
+				8A75C5779712AEE0EE3DE568 /* QuicklinkArchive.swift in Sources */,
+				A3855695DA55ADA137630DCE /* QuicklinkArgumentSession.swift in Sources */,
+				C5F3602E5C6F05E49B07AB46 /* QuicklinkArgumentsView.swift in Sources */,
+				34994B57DE0709CF5DCFC40C /* QuicklinkDestination.swift in Sources */,
+				63E24116B4CCC95F4FA295E3 /* QuicklinkEditorSheet.swift in Sources */,
+				1A899FE562A7344918CE1B44 /* QuicklinkLauncher.swift in Sources */,
+				291F17D35D98BB5700640AA7 /* QuicklinkListView.swift in Sources */,
+				6C824F5B5099D36E73CF7E4C /* QuicklinkStore.swift in Sources */,
+				EE12A8ECCC5F92553B24CD0F /* QuicklinksSettingsView.swift in Sources */,
 				F69CB40ABBBAAB91322732AE /* RaycastFormat.swift in Sources */,
 				8EF55652F19A1E0C5FF644B4 /* RaycastImport.swift in Sources */,
 				ABBB2A811EB5C69D55A93B1C /* RaycastImportSelection.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -8,6 +8,10 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     case calculatorHistory
     case emoji
     case uninstall
+    case quicklinks
+    /// Collects a quicklink's `{argument}` values before it opens; the pending request lives on
+    /// `AppCore.quicklinkArguments`, the way `.uninstall`'s target lives on `UninstallSession`.
+    case quicklinkArguments
 
     var id: String { rawValue }
     var title: String {
@@ -17,6 +21,8 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "Calculator History"
         case .emoji: return "Emoji & Symbols"
         case .uninstall: return "Uninstall Application"
+        case .quicklinks: return "Quicklinks"
+        case .quicklinkArguments: return "Open Quicklink"
         }
     }
     var systemImage: String {
@@ -26,6 +32,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "plus.forwardslash.minus"
         case .emoji: return "face.smiling"
         case .uninstall: return "trash"
+        case .quicklinks, .quicklinkArguments: return Quicklink.sfSymbol
         }
     }
     var placeholder: String {
@@ -35,6 +42,9 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "Do math, convert units, or search your past calculations…"
         case .emoji: return "Search emoji and symbols…"
         case .uninstall: return "Filter files and folders by name…"
+        case .quicklinks: return "Search quicklinks…"
+        // Replaced by the pending argument's name; only reached if the session vanished mid-render.
+        case .quicklinkArguments: return "Enter a value…"
         }
     }
 }
@@ -97,6 +107,7 @@ final class AppCore: ObservableObject {
     let launcherRanking: LauncherRankingStore
     let appIndex: AppIndex
     let customCommands = CustomCommandStore()
+    let quicklinks = QuicklinkStore()
     let clipboardStore = ClipboardStore()
     let clipboardManager: ClipboardManager
     let snippetsStore: SnippetsStore
@@ -116,6 +127,12 @@ final class AppCore: ObservableObject {
     let runningApps = RunningAppsMonitor()
     let palette = PaletteViewModel()
     let uninstall = UninstallSession()
+    let quicklinkArguments = QuicklinkArgumentSession()
+
+    /// Set when a quicklink editor should open as the Settings window appears; the pane consumes it.
+    @Published var pendingQuicklinkEdit: QuicklinkEditRequest?
+    /// Carries the menu's default-app override across the quicklink argument prompt.
+    private var pendingQuicklinkForcesDefaultApp = false
 
     private lazy var windowController = PaletteWindowController(core: self)
     private lazy var messageHUD = MessageHUDController(settings: settings)
@@ -157,6 +174,14 @@ final class AppCore: ObservableObject {
         }
         applyCustomCommandsPresence()
         applyWindowCommandsPresence()
+        quicklinks.onChange = { [weak self] _ in
+            self?.applyQuicklinksPresence()
+        }
+        // Loaded even while the feature is off, and before `hotKeys.start`: its stale-binding prune
+        // reads this list, so an unloaded store would look like "every quicklink was deleted" and
+        // throw away the user's shortcuts. The library is small, so this is one short read.
+        quicklinks.load()
+        applyQuicklinksPresence()
         Task { await appIndex.refresh() }
         Task { await emojiIndex.load() }
         currencyRates.start()
@@ -167,7 +192,10 @@ final class AppCore: ObservableObject {
         hotKeys.onRunCustomCommand = { [weak self] id in self?.runCustomCommand(id: id) }
         hotKeys.onRunSystemAction = { [weak self] id in self?.runSystemAction(id: id) }
         hotKeys.onRunWindowCommand = { [weak self] id in self?.runWindowCommand(id: id) }
-        hotKeys.start(customCommandIDs: Set(customCommands.commands.map(\.id)))
+        hotKeys.onOpenQuicklink = { [weak self] id in self?.openQuicklink(id: id) }
+        hotKeys.start(
+            customCommandIDs: Set(customCommands.commands.map(\.id)),
+            quicklinkIDs: Set(quicklinks.quicklinks.map(\.id)))
         // Deliberately keeps running while `hotKeys.recordingAction` pauses Carbon: the recorder relies on the tap's rewritten flags to capture Hyper shortcuts.
         hyperKeyTap.start(settings: settings)
 
@@ -201,6 +229,16 @@ final class AppCore: ObservableObject {
                     MainActor.assumeIsolated {
                         guard let self else { return }
                         Task { self.applyCustomCommandsPresence() }
+                    }
+                }
+                .store(in: &cancellables)
+        }
+        for publisher in [settings.$quicklinksEnabled, settings.$quicklinksShowInLauncher] {
+            publisher.dropFirst()
+                .sink { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        guard let self else { return }
+                        Task { self.applyQuicklinksPresence() }
                     }
                 }
                 .store(in: &cancellables)
@@ -247,6 +285,15 @@ final class AppCore: ObservableObject {
     private func applyWindowCommandsPresence() {
         let visible = settings.windowManagementEnabled && settings.windowManagementShowInLauncher
         appIndex.setWindowCommandsVisible(visible)
+    }
+
+    /// The launcher section and the Quicklinks commands move together with the feature switch;
+    /// "show in launcher" hides only the section, leaving the commands reachable.
+    private func applyQuicklinksPresence() {
+        let enabled = settings.quicklinksEnabled
+        appIndex.setQuicklinks(
+            enabled && settings.quicklinksShowInLauncher ? quicklinks.quicklinks : [],
+            commandsVisible: enabled)
     }
 
     private func applySnippetsLauncherPresence() {
@@ -346,6 +393,7 @@ final class AppCore: ObservableObject {
                 .environmentObject(self.visibility)
                 .environmentObject(self.customCommands)
                 .environmentObject(self.snippetsStore)
+                .environmentObject(self.quicklinks)
         }
         if !isNew {
             NotificationCenter.default.post(name: .tinycastSelectSettingsTab, object: tab)
@@ -402,6 +450,13 @@ final class AppCore: ObservableObject {
             runWindowCommand(id: command.id)
             return
         }
+        // Also before the palette hides: a quicklink with an unfilled argument stays in the palette
+        // to ask for it, and only then opens.
+        if app.kind == .quicklink {
+            guard let id = Quicklink.id(fromEntryID: app.id) else { return }
+            openQuicklink(id: id)
+            return
+        }
         let previous = windowController.previousApp
         hidePalette(restoreFocus: false)
         switch app.kind {
@@ -413,7 +468,7 @@ final class AppCore: ObservableObject {
         case .snippet:
             let snippetID = String(app.id.dropFirst("snippet:".count))
             expandSnippet(id: snippetID, targetApp: previous)
-        case .command, .customCommand, .systemAction, .windowCommand:
+        case .command, .customCommand, .systemAction, .windowCommand, .quicklink:
             break  // handled above
         }
     }
@@ -542,6 +597,245 @@ final class AppCore: ObservableObject {
         }
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
             NSWorkspace.shared.open(url)
+        }
+    }
+
+    // MARK: - Quicklinks
+
+    /// The one funnel for palette activation, the ⌘K menu and a quicklink's global shortcut, so
+    /// neither the feature switch nor the argument prompt can be bypassed.
+    ///
+    /// `forcingDefaultApp` is the menu's "Open With Default App": it bypasses the saved handler for
+    /// one open without changing what the quicklink is saved as.
+    func openQuicklink(id: UUID, forcingDefaultApp: Bool = false) {
+        guard settings.quicklinksEnabled, let quicklink = quicklinks.quicklink(id: id) else {
+            return
+        }
+        // With the palette closed a shortcut still reads the selection from whatever is frontmost,
+        // exactly as a system action targets the window a palette launch would have.
+        let target =
+            windowController.isVisible
+            ? windowController.previousApp : NSWorkspace.shared.frontmostApplication
+        let encoding: SnippetTemplateEngine.ValueEncoding =
+            QuicklinkDestination.usesURLEncoding(quicklink.link) ? .percentEncoding : .none
+        var context = snippetTextInjector.captureExpansionContext(
+            targetApp: target, clipboardHistory: clipboardHistoryForExpansion())
+        var arguments: [SnippetTemplateEngine.MissingArgument] = []
+
+        // An unreadable selection is a missing value, not an empty one: substitute the clipboard, or
+        // collect it through the same prompt the template's own arguments use.
+        if context.selection.isEmpty, SnippetTemplateEngine.usesSelection(quicklink.link) {
+            switch settings.quicklinkSelectionFallback {
+            case .clipboard:
+                context = context.replacingSelection(with: context.clipboard)
+            case .ask:
+                arguments.append(Self.selectionArgument)
+            }
+        }
+
+        let expansion = SnippetTemplateEngine.expand(
+            text: quicklink.link, context: context, encoding: encoding)
+        arguments += expansion.missingArguments
+        guard arguments.isEmpty else {
+            quicklinkArguments.begin(
+                quicklink: quicklink, context: context, encoding: encoding, arguments: arguments)
+            pendingQuicklinkForcesDefaultApp = forcingDefaultApp
+            // Never `restoreAnyMode`: this screen is always a fresh prompt, never a restored one.
+            showPalette(mode: .quicklinkArguments)
+            return
+        }
+        performQuicklinkOpen(
+            quicklink, link: expansion.text, forcingDefaultApp: forcingDefaultApp)
+    }
+
+    /// `{selection}` promoted to an argument when there is nothing to read and the setting says ask.
+    private static let selectionArgument = SnippetTemplateEngine.MissingArgument(
+        name: "Selected Text", options: [])
+
+    /// ↵ in the argument form. Returns false while more arguments remain.
+    @discardableResult
+    func submitQuicklinkArgument(_ value: String) -> Bool {
+        guard let request = quicklinkArguments.request else { return false }
+        guard let values = quicklinkArguments.submit(value) else { return false }
+
+        var context = request.context
+        if let selection = values[Self.selectionArgument.name] {
+            context = context.replacingSelection(with: selection)
+        }
+        let expansion = SnippetTemplateEngine.expand(
+            text: request.quicklink.link, context: context, userArguments: values,
+            encoding: request.encoding)
+        let forcesDefault = pendingQuicklinkForcesDefaultApp
+        cancelQuicklinkArguments()
+        performQuicklinkOpen(
+            request.quicklink, link: expansion.text, forcingDefaultApp: forcesDefault)
+        return true
+    }
+
+    func cancelQuicklinkArguments() {
+        quicklinkArguments.cancel()
+        pendingQuicklinkForcesDefaultApp = false
+    }
+
+    private func performQuicklinkOpen(
+        _ quicklink: Quicklink, link: String, forcingDefaultApp: Bool
+    ) {
+        if windowController.isVisible { hidePalette(restoreFocus: false) }
+        let openWith = forcingDefaultApp ? nil : quicklink.openWithBundleID
+        Task {
+            do throws(QuicklinkLauncher.Failure) {
+                try await QuicklinkLauncher.open(
+                    link, openWithBundleID: openWith,
+                    inNewWindow: settings.quicklinkOpensNewWindow)
+            } catch {
+                await presentQuicklinkFailure(quicklink, link: link, failure: error)
+            }
+        }
+    }
+
+    private func presentQuicklinkFailure(
+        _ quicklink: Quicklink, link: String, failure: QuicklinkLauncher.Failure
+    ) async {
+        let symbol = quicklink.iconSymbol ?? Quicklink.sfSymbol
+        guard let bundleID = failure.missingApplicationBundleID else {
+            await showNotice(
+                title: "Couldn’t Open \(quicklink.name)",
+                message: failure.localizedDescription, symbol: symbol, tone: .danger)
+            return
+        }
+        // The only failure with a usable second option, so it offers it rather than dead-ending.
+        let name = applicationName(forBundleID: bundleID) ?? bundleID
+        guard
+            await dialogs.reportFailure(
+                title: "Couldn’t Open \(quicklink.name)",
+                message: "\(name) isn’t installed any more.", symbol: symbol,
+                recovery: "Open with Default")
+        else { return }
+        performQuicklinkOpen(quicklink, link: link, forcingDefaultApp: true)
+    }
+
+    private func applicationName(forBundleID bundleID: String) -> String? {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+            .flatMap { FileManager.default.displayName(atPath: $0.path) }
+    }
+
+    // MARK: - Quicklink library
+
+    @discardableResult
+    func addQuicklink(_ draft: Quicklink) throws -> Quicklink {
+        try quicklinks.add(draft)
+    }
+
+    func updateQuicklink(_ draft: Quicklink) throws {
+        try quicklinks.update(draft)
+    }
+
+    /// Confirms unless the user turned the gate off, then deletes and unwinds every reference the
+    /// quicklink owned. `confirming: false` is for the Settings pane, which already asked.
+    func deleteQuicklink(id: UUID, confirming: Bool = true) async {
+        guard let quicklink = quicklinks.quicklink(id: id) else { return }
+        if confirming, settings.quicklinkConfirmsBeforeDelete {
+            guard
+                await confirm(
+                    title: "Delete “\(quicklink.name)”?",
+                    message: "Its shortcut, favorite slot and learned ranking go with it.",
+                    symbol: quicklink.iconSymbol ?? Quicklink.sfSymbol, confirmTitle: "Delete")
+            else { return }
+        }
+        removeQuicklinkReferences(ids: [id], entryIDs: [quicklink.entryID])
+        try? quicklinks.remove(id: id)
+    }
+
+    func toggleQuicklinkPinned(id: UUID) {
+        try? quicklinks.togglePinned(id: id)
+    }
+
+    func setQuicklinkShowsInRootSearch(_ shows: Bool, id: UUID) {
+        try? quicklinks.setShowsInRootSearch(shows, id: id)
+    }
+
+    func duplicateQuicklink(id: UUID) {
+        _ = try? quicklinks.duplicate(id: id)
+    }
+
+    /// Opens Settings on the Quicklinks pane with the editor showing `quicklink` (nil for a new one).
+    func editQuicklink(_ quicklink: Quicklink?) {
+        pendingQuicklinkEdit = QuicklinkEditRequest(quicklink: quicklink)
+        showSettings(tab: .quicklinks)
+    }
+
+    @discardableResult
+    func replaceQuicklinks(_ incoming: [Quicklink]) -> Int {
+        let previous = quicklinks.quicklinks
+        let count = quicklinks.replace(with: incoming)
+        let liveIDs = Set(quicklinks.quicklinks.map(\.id))
+        let removed = previous.filter { !liveIDs.contains($0.id) }
+        removeQuicklinkReferences(
+            ids: Set(removed.map(\.id)), entryIDs: Set(removed.map(\.entryID)))
+        return count
+    }
+
+    private func removeQuicklinkReferences(ids: Set<UUID>, entryIDs: Set<String>) {
+        for id in ids {
+            let action = HotKeyAction.quicklink(id: id)
+            if hotKeys.recordingAction == action { hotKeys.recordingAction = nil }
+            hotKeys.setBinding(nil, for: action)
+        }
+        favorites.remove(keys: entryIDs)
+        visibility.removeItemKeys(entryIDs)
+        for entryID in entryIDs {
+            launcherRanking.reset(itemKey: entryID)
+        }
+    }
+
+    // MARK: - Quicklink import & export
+
+    func exportQuicklinks() async {
+        guard !quicklinks.quicklinks.isEmpty else {
+            await showNotice(
+                title: "Nothing to Export", message: "You haven’t created any quicklinks yet.",
+                symbol: Quicklink.sfSymbol, tone: .neutral)
+            return
+        }
+        guard let url = BackupActions.chooseSaveLocation(named: "Tinycast-Quicklinks") else {
+            return
+        }
+        do {
+            try QuicklinkArchive.encode(quicklinks.quicklinks).write(to: url, options: .atomic)
+            messageHUD.show(message: "Exported \(quicklinks.quicklinks.count) Quicklinks")
+        } catch {
+            await showNotice(
+                title: "Export Failed", message: error.localizedDescription,
+                symbol: Quicklink.sfSymbol, tone: .danger)
+        }
+    }
+
+    func importQuicklinks() async {
+        guard let url = BackupActions.chooseJSONFile() else { return }
+        do {
+            let incoming = try QuicklinkArchive.decode(Data(contentsOf: url))
+            let merge = QuicklinkArchive.merge(incoming, into: quicklinks.quicklinks)
+            let added = quicklinks.append(merge.additions)
+            // Everything the file offered was already here — say so rather than showing "0 imported".
+            guard !added.isEmpty else {
+                await showNotice(
+                    title: "Nothing to Import",
+                    message: "Every quicklink in this file is already in your library.",
+                    symbol: Quicklink.sfSymbol, tone: .neutral)
+                return
+            }
+            let skipped = merge.skipped + (merge.additions.count - added.count)
+            let summary =
+                skipped == 0
+                ? "Imported \(added.count) quicklinks."
+                : "Imported \(added.count) quicklinks. Skipped \(skipped) already in your library."
+            await showNotice(
+                title: "Quicklinks Imported", message: summary, symbol: Quicklink.sfSymbol,
+                tone: .success)
+        } catch {
+            await showNotice(
+                title: "Import Failed", message: error.localizedDescription,
+                symbol: Quicklink.sfSymbol, tone: .danger)
         }
     }
 
@@ -771,6 +1065,17 @@ final class AppCore: ObservableObject {
             showPalette(mode: .clipboard)
         case .searchEmoji:
             showPalette(mode: .emoji)
+        case .searchQuicklinks:
+            showPalette(mode: .quicklinks)
+        case .createQuicklink:
+            hidePalette(restoreFocus: false)
+            editQuicklink(nil)
+        case .importQuicklinks:
+            hidePalette(restoreFocus: false)
+            Task { await importQuicklinks() }
+        case .exportQuicklinks:
+            hidePalette(restoreFocus: false)
+            Task { await exportQuicklinks() }
         case .exportSettings:
             hidePalette(restoreFocus: false)
             Task { await BackupActions.exportSettings() }

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -10,6 +10,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case snippet
         case systemAction
         case windowCommand
+        case quicklink
     }
 
     let id: String  // file path (or "command:…" id) — always unique
@@ -19,6 +20,8 @@ struct AppEntry: Identifiable, Hashable, Sendable {
     let kind: Kind
     /// Extra strings this entry matches on as strongly as its name — a snippet's keyword. Empty for every other kind.
     var matchAliases: [String] = []
+    /// Per-item SF Symbol, for the one kind whose glyph is the user's choice rather than its kind's. Nil elsewhere.
+    var symbolName: String?
     /// Spotlight's `kMDItemAlternateNames`, ranked below the display name. Applications only.
     var alternateNames: [String] = []
     /// `CFBundleExecutable`, matched literally as a last resort. Applications only.
@@ -42,6 +45,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case .snippet: return "Snippet"
         case .systemAction: return "System Action"
         case .windowCommand: return "Window Command"
+        case .quicklink: return "Quicklink"
         }
     }
 
@@ -58,19 +62,24 @@ struct AppEntry: Identifiable, Hashable, Sendable {
             return SystemActionCatalog.action(forEntryID: id).map { .systemAction(id: $0.id) }
         case .windowCommand:
             return WindowCommandCatalog.command(forEntryID: id).map { .windowCommand(id: $0.id) }
+        case .quicklink:
+            return Quicklink.id(fromEntryID: id).map { .quicklink(id: $0) }
         case .command, .snippet:
             return nil
         }
     }
 
-    /// Synthetic command entries have no file behind them to reveal.
+    /// Synthetic command entries have no file behind them to reveal. A quicklink's own entry is
+    /// synthetic too — revealing the *destination* is an action on the record, in its own menu.
     var canRevealInFinder: Bool { kind == .application || kind == .systemSettings || kind == .snippet }
 
     /// Synthetic entries draw an SF Symbol tile; everything else uses its file icon.
     var isSymbolIcon: Bool { kind != .application && kind != .systemSettings }
 
     var symbolIconName: String {
+        if let symbolName { return symbolName }
         switch kind {
+        case .quicklink: return Quicklink.sfSymbol
         case .snippet: return "text.quote"
         case .customCommand: return CustomCommand.sfSymbol
         case .command: return CommandRegistry.command(for: self)?.sfSymbol ?? "questionmark"
@@ -319,6 +328,9 @@ final class AppIndex: ObservableObject {
     private var discoveredEntries: [AppEntry] = []
     private var customCommandEntries: [AppEntry] = []
     private var windowCommandEntries: [AppEntry] = []
+    private var quicklinkEntries: [AppEntry] = []
+    /// Built-in commands minus the quicklink ones while the feature is off.
+    private var commandEntries: [AppEntry] = CommandRegistry.all
     private var alternateNameCache = SpotlightNames.Cache()
     private var isRefreshing = false
     /// Set when a refresh is requested mid-scan, so a scope edit landing during an in-flight scan isn't silently dropped.
@@ -342,6 +354,31 @@ final class AppIndex: ObservableObject {
         .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         guard entries != customCommandEntries else { return }
         customCommandEntries = entries
+        publishEntries()
+    }
+
+    /// Replaces the quicklink slice and, in the same publish, the built-in commands that only make
+    /// sense while the feature is on — one call so a toggle can't leave the two out of step.
+    func setQuicklinks(_ quicklinks: [Quicklink], commandsVisible: Bool) {
+        let entries = quicklinks
+            .filter(\.showsInRootSearch)
+            .sorted(by: Quicklink.precedes)
+            .map { quicklink in
+                AppEntry(
+                    id: quicklink.entryID, name: quicklink.name,
+                    url: URL(string: "tinycast://quicklink/" + quicklink.id.uuidString)!,
+                    bundleID: nil, kind: .quicklink,
+                    symbolName: quicklink.iconSymbol
+                        ?? QuicklinkDestination.detect(quicklink.link)?.defaultSymbol)
+            }
+        let commands = commandsVisible
+            ? CommandRegistry.all
+            : CommandRegistry.all.filter { entry in
+                CommandRegistry.command(for: entry).map { !$0.isQuicklinkCommand } ?? true
+            }
+        guard entries != quicklinkEntries || commands != commandEntries else { return }
+        quicklinkEntries = entries
+        commandEntries = commands
         publishEntries()
     }
 
@@ -445,10 +482,10 @@ final class AppIndex: ObservableObject {
     }
 
     private func publishEntries() {
-        // Each slice is already alphabetical; the slice order is the launcher's section order (LauncherList mirrors it), so custom commands sit in their own section ahead of the built-ins.
+        // Each slice is already in its own display order — alphabetical, or pinned-first for quicklinks. The slice order is the launcher's section order (LauncherList mirrors it), so custom commands sit in their own section ahead of the built-ins.
         let updated =
-            discoveredEntries + snippetEntries + Self.systemActionEntries + windowCommandEntries
-            + customCommandEntries + CommandRegistry.all
+            discoveredEntries + quicklinkEntries + snippetEntries + Self.systemActionEntries
+            + windowCommandEntries + customCommandEntries + commandEntries
         guard updated != apps else { return }
         apps = updated
         matchCache = nil

--- a/Tinycast/Core/AppSettings.swift
+++ b/Tinycast/Core/AppSettings.swift
@@ -48,6 +48,11 @@ final class AppSettings: ObservableObject {
         static let windowManagementShowInLauncher = "windowManagementShowInLauncher"
         static let windowGap = "windowManagementGap"
         static let windowCycleOnRepeat = "windowManagementCycleOnRepeat"
+        static let quicklinksEnabled = "quicklinksEnabled"
+        static let quicklinksShowInLauncher = "quicklinksShowInLauncher"
+        static let quicklinkOpensNewWindow = "quicklinkOpensNewWindow"
+        static let quicklinkSelectionFallback = "quicklinkSelectionFallback"
+        static let quicklinkConfirmsBeforeDelete = "quicklinkConfirmsBeforeDelete"
     }
 
     /// Folders (and individual `.app` bundles) `AppIndex` scans, in scan order. Editing this re-indexes — `AppIndex.start(settings:)` observes it.
@@ -154,6 +159,35 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(windowCycleOnRepeat, forKey: Key.windowCycleOnRepeat) }
     }
 
+    /// Off means fully off: no launcher entries, no Quicklinks commands, and a still-registered
+    /// shortcut opens nothing.
+    @Published var quicklinksEnabled: Bool {
+        didSet { defaults.set(quicklinksEnabled, forKey: Key.quicklinksEnabled) }
+    }
+
+    @Published var quicklinksShowInLauncher: Bool {
+        didSet { defaults.set(quicklinksShowInLauncher, forKey: Key.quicklinksShowInLauncher) }
+    }
+
+    /// Ask the handler for a new window rather than reusing its frontmost tab. Off is the macOS
+    /// default, which is what "prefer existing tabs" means.
+    @Published var quicklinkOpensNewWindow: Bool {
+        didSet { defaults.set(quicklinkOpensNewWindow, forKey: Key.quicklinkOpensNewWindow) }
+    }
+
+    /// What `{selection}` does when there is no readable selection to pass.
+    @Published var quicklinkSelectionFallback: QuicklinkSelectionFallback {
+        didSet {
+            defaults.set(quicklinkSelectionFallback.rawValue, forKey: Key.quicklinkSelectionFallback)
+        }
+    }
+
+    @Published var quicklinkConfirmsBeforeDelete: Bool {
+        didSet {
+            defaults.set(quicklinkConfirmsBeforeDelete, forKey: Key.quicklinkConfirmsBeforeDelete)
+        }
+    }
+
     init() {
         // integer(forKey:) returns 0 when unset, which no case matches — falls through to 3 Months.
         clipboardRetention =
@@ -207,5 +241,16 @@ final class AppSettings: ObservableObject {
         // Unset reads as 0, which is the intended default anyway — no gap.
         windowGap = defaults.integer(forKey: Key.windowGap)
         windowCycleOnRepeat = defaults.bool(forKey: Key.windowCycleOnRepeat)
+        quicklinksEnabled = defaults.bool(forKey: Key.quicklinksEnabled)
+        quicklinksShowInLauncher =
+            defaults.object(forKey: Key.quicklinksShowInLauncher) == nil
+            || defaults.bool(forKey: Key.quicklinksShowInLauncher)
+        quicklinkOpensNewWindow = defaults.bool(forKey: Key.quicklinkOpensNewWindow)
+        quicklinkSelectionFallback =
+            defaults.string(forKey: Key.quicklinkSelectionFallback)
+            .flatMap(QuicklinkSelectionFallback.init) ?? .ask
+        quicklinkConfirmsBeforeDelete =
+            defaults.object(forKey: Key.quicklinkConfirmsBeforeDelete) == nil
+            || defaults.bool(forKey: Key.quicklinkConfirmsBeforeDelete)
     }
 }

--- a/Tinycast/Core/Backup/BackupActions.swift
+++ b/Tinycast/Core/Backup/BackupActions.swift
@@ -15,13 +15,29 @@ enum BackupActions {
 
     // MARK: - Tinycast native (own file panels; dialogs come from `AppCore`)
 
-    static func exportSettings() async {
+    /// The JSON save panel, shared with the quicklinks archive. Tinycast is an accessory app, so it
+    /// has to activate itself before a modal panel or the panel opens behind everything.
+    static func chooseSaveLocation(named base: String) -> URL? {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.json]
-        panel.nameFieldStringValue = "Tinycast-Settings-\(dateStamp()).json"
+        panel.nameFieldStringValue = "\(base)-\(dateStamp()).json"
         panel.canCreateDirectories = true
         NSApp.activate(ignoringOtherApps: true)
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard panel.runModal() == .OK else { return nil }
+        return panel.url
+    }
+
+    static func chooseJSONFile() -> URL? {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        NSApp.activate(ignoringOtherApps: true)
+        guard panel.runModal() == .OK else { return nil }
+        return panel.url
+    }
+
+    static func exportSettings() async {
+        guard let url = chooseSaveLocation(named: "Tinycast-Settings") else { return }
         do {
             try SettingsBackup.gather().encoded().write(to: url, options: .atomic)
         } catch {
@@ -32,11 +48,7 @@ enum BackupActions {
     }
 
     static func importSettings() async {
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.json]
-        panel.allowsMultipleSelection = false
-        NSApp.activate(ignoringOtherApps: true)
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let url = chooseJSONFile() else { return }
         do {
             let backup = try SettingsBackup(json: try Data(contentsOf: url))
             let commandCount = backup.customCommands?.count ?? 0
@@ -134,6 +146,7 @@ enum BackupActions {
         if s.favorites > 0 { parts.append("\(s.favorites) favorites") }
         if s.hiddenItems > 0 { parts.append("\(s.hiddenItems) hidden items") }
         if s.customCommands > 0 { parts.append("\(s.customCommands) custom commands") }
+        if s.quicklinks > 0 { parts.append("\(s.quicklinks) quicklinks") }
         guard !parts.isEmpty else { return nil }
         return "Applied " + parts.joined(separator: ", ") + "."
     }

--- a/Tinycast/Core/Backup/SettingsBackup.swift
+++ b/Tinycast/Core/Backup/SettingsBackup.swift
@@ -2,10 +2,11 @@ import Foundation
 
 /// A passwordless, human-readable snapshot of Tinycast's configuration. Every field is optional so an import applies only the keys actually present (non-destructive merge): a partial file — or one from Raycast — leaves everything it omits untouched.
 struct SettingsBackup: Codable {
-    var version = 3
+    var version = 4
     var settings: SettingsData?
     var hotkeys: HotkeyBackup?
     var customCommands: [CustomCommand]?
+    var quicklinks: [Quicklink]?
     var favoriteApps: [String]?
     var hiddenLauncherItems: [String]?
     var hiddenLauncherKinds: [String]?
@@ -36,6 +37,12 @@ struct SettingsBackup: Codable {
         var windowManagementShowInLauncher: Bool?
         var windowGap: Int?
         var windowCycleOnRepeat: Bool?
+        // Carried, unlike `snippetsEnabled`: opening a link grants no permission class of its own.
+        var quicklinksEnabled: Bool?
+        var quicklinksShowInLauncher: Bool?
+        var quicklinkOpensNewWindow: Bool?
+        var quicklinkSelectionFallback: String?
+        var quicklinkConfirmsBeforeDelete: Bool?
     }
 
     /// `HotKeyBinding` encodes a combo in the legacy `KeyShortcut` shape, so files written before double-tap bindings existed import unchanged. The reverse doesn't hold: a file containing a double-tap can't be read by a pre-double-tap build, which is what the `version` bump records.
@@ -48,6 +55,7 @@ struct SettingsBackup: Codable {
         var customCommands: [String: HotKeyBinding]?
         var systemActions: [String: HotKeyBinding]?
         var windowCommands: [String: HotKeyBinding]?
+        var quicklinks: [String: HotKeyBinding]?
     }
 
     /// A tally of what an import touched, for user-facing confirmation.
@@ -57,6 +65,7 @@ struct SettingsBackup: Codable {
         var favorites = 0
         var hiddenItems = 0
         var customCommands = 0
+        var quicklinks = 0
     }
 }
 
@@ -89,7 +98,12 @@ extension SettingsBackup {
             windowManagementEnabled: s.windowManagementEnabled,
             windowManagementShowInLauncher: s.windowManagementShowInLauncher,
             windowGap: s.windowGap,
-            windowCycleOnRepeat: s.windowCycleOnRepeat)
+            windowCycleOnRepeat: s.windowCycleOnRepeat,
+            quicklinksEnabled: s.quicklinksEnabled,
+            quicklinksShowInLauncher: s.quicklinksShowInLauncher,
+            quicklinkOpensNewWindow: s.quicklinkOpensNewWindow,
+            quicklinkSelectionFallback: s.quicklinkSelectionFallback.rawValue,
+            quicklinkConfirmsBeforeDelete: s.quicklinkConfirmsBeforeDelete)
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
@@ -116,9 +130,14 @@ extension SettingsBackup {
             uniqueKeysWithValues: WindowCommand.ID.allCases.compactMap { id in
                 hk.binding(for: .windowCommand(id: id)).map { (id.rawValue, $0) }
             })
+        hotkeys.quicklinks = Dictionary(
+            uniqueKeysWithValues: hk.boundQuicklinkIDs.compactMap { id in
+                hk.binding(for: .quicklink(id: id)).map { (id.uuidString.lowercased(), $0) }
+            })
         backup.hotkeys = hotkeys
 
         backup.customCommands = core.customCommands.commands
+        backup.quicklinks = core.quicklinks.quicklinks
         backup.favoriteApps = core.favorites.keys
         backup.hiddenLauncherItems = Array(core.visibility.hiddenItemKeys)
         backup.hiddenLauncherKinds = Array(core.visibility.hiddenKinds)
@@ -131,6 +150,10 @@ extension SettingsBackup {
         if let s = settings { summary.settingsFields = applySettings(s, to: core) }
         if let customCommands {
             summary.customCommands = core.replaceCustomCommands(customCommands)
+        }
+        // Before the hotkeys, so a restored binding has its quicklink to attach to.
+        if let quicklinks {
+            summary.quicklinks = core.replaceQuicklinks(quicklinks)
         }
         if let hotkeys { summary.hotkeys = applyHotkeys(hotkeys, to: core) }
         if let favoriteApps {
@@ -236,6 +259,27 @@ extension SettingsBackup {
             settings.windowCycleOnRepeat = flag
             count += 1
         }
+        if let flag = s.quicklinksEnabled {
+            settings.quicklinksEnabled = flag
+            count += 1
+        }
+        if let flag = s.quicklinksShowInLauncher {
+            settings.quicklinksShowInLauncher = flag
+            count += 1
+        }
+        if let flag = s.quicklinkOpensNewWindow {
+            settings.quicklinkOpensNewWindow = flag
+            count += 1
+        }
+        if let raw = s.quicklinkSelectionFallback,
+            let fallback = QuicklinkSelectionFallback(rawValue: raw) {
+            settings.quicklinkSelectionFallback = fallback
+            count += 1
+        }
+        if let flag = s.quicklinkConfirmsBeforeDelete {
+            settings.quicklinkConfirmsBeforeDelete = flag
+            count += 1
+        }
         return count
     }
 
@@ -266,6 +310,12 @@ extension SettingsBackup {
         for (rawID, b) in hotkeys.windowCommands ?? [:] {
             guard let id = WindowCommand.ID(rawValue: rawID) else { continue }
             apply(b, .windowCommand(id: id))
+        }
+        for (rawID, b) in hotkeys.quicklinks ?? [:] {
+            guard let id = UUID(uuidString: rawID), core.quicklinks.quicklink(id: id) != nil else {
+                continue
+            }
+            apply(b, .quicklink(id: id))
         }
         return count
     }

--- a/Tinycast/Core/CommandRegistry.swift
+++ b/Tinycast/Core/CommandRegistry.swift
@@ -5,6 +5,10 @@ enum CommandID: String, CaseIterable, Sendable {
     case calculatorHistory = "command:calculator-history"
     case clipboardHistory = "command:clipboard-history"
     case searchEmoji = "command:search-emoji"
+    case createQuicklink = "command:create-quicklink"
+    case searchQuicklinks = "command:search-quicklinks"
+    case importQuicklinks = "command:import-quicklinks"
+    case exportQuicklinks = "command:export-quicklinks"
     case exportSettings = "command:export-settings"
     case importSettings = "command:import-settings"
     case importFromRaycast = "command:import-from-raycast"
@@ -17,6 +21,10 @@ enum CommandID: String, CaseIterable, Sendable {
         case .calculatorHistory: return "Calculator History"
         case .clipboardHistory: return "Clipboard History"
         case .searchEmoji: return "Search Emoji & Symbols"
+        case .createQuicklink: return "Create Quicklink"
+        case .searchQuicklinks: return "Search Quicklinks"
+        case .importQuicklinks: return "Import Quicklinks"
+        case .exportQuicklinks: return "Export Quicklinks"
         case .exportSettings: return "Export Settings"
         case .importSettings: return "Import Settings"
         case .importFromRaycast: return "Import from Raycast"
@@ -31,12 +39,25 @@ enum CommandID: String, CaseIterable, Sendable {
         case .calculatorHistory: return "plus.forwardslash.minus"
         case .clipboardHistory: return "doc.on.clipboard"
         case .searchEmoji: return "face.smiling"
+        case .createQuicklink: return "link.badge.plus"
+        case .searchQuicklinks: return Quicklink.sfSymbol
+        case .importQuicklinks: return "square.and.arrow.down"
+        case .exportQuicklinks: return "square.and.arrow.up"
         case .exportSettings: return "square.and.arrow.up"
         case .importSettings: return "square.and.arrow.down"
         case .importFromRaycast: return "arrow.down.doc"
         case .settings: return "gearshape"
         case .about: return "info.circle"
         case .quit: return "power"
+        }
+    }
+
+    /// Only meaningful while Quicklinks is on, so `AppIndex` drops these from the built-in slice
+    /// when the feature is off.
+    var isQuicklinkCommand: Bool {
+        switch self {
+        case .createQuicklink, .searchQuicklinks, .importQuicklinks, .exportQuicklinks: return true
+        default: return false
         }
     }
 }

--- a/Tinycast/Core/HotKey/KeyShortcut.swift
+++ b/Tinycast/Core/HotKey/KeyShortcut.swift
@@ -155,6 +155,7 @@ enum HotKeyAction: Hashable, Sendable {
     case customCommand(id: UUID)
     case systemAction(id: SystemAction.ID)
     case windowCommand(id: WindowCommand.ID)
+    case quicklink(id: UUID)
 
     /// UserDefaults key holding the shortcut JSON; the `KeyboardShortcuts_` prefix is a fossil of the replaced package, kept verbatim so existing bindings need no migration.
     var defaultsKey: String {
@@ -168,6 +169,8 @@ enum HotKeyAction: Hashable, Sendable {
             "KeyboardShortcuts_customCommandHotkey." + id.uuidString.lowercased()
         case .systemAction(let id): "KeyboardShortcuts_systemActionHotkey." + id.rawValue
         case .windowCommand(let id): "KeyboardShortcuts_windowCommandHotkey." + id.rawValue
+        case .quicklink(let id):
+            "KeyboardShortcuts_quicklinkHotkey." + id.uuidString.lowercased()
         }
     }
 }

--- a/Tinycast/Core/HotKeyManager.swift
+++ b/Tinycast/Core/HotKeyManager.swift
@@ -9,6 +9,7 @@ final class HotKeyManager: ObservableObject {
     var onRunCustomCommand: ((UUID) -> Void)?
     var onRunSystemAction: ((SystemAction.ID) -> Void)?
     var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
+    var onOpenQuicklink: ((UUID) -> Void)?
 
     /// The recorder currently capturing keystrokes, or `nil`; keeping this as plain app state makes recorders glitch-free, and any active recorder pauses both engines so the shortcut being typed can't fire the binding it's replacing. Setting it also starts/stops `capture`.
     @Published var recordingAction: HotKeyAction? {
@@ -37,13 +38,11 @@ final class HotKeyManager: ObservableObject {
     private let boundKey = "boundAppBundleIDs"
     private let boundPaneKey = "boundPaneBundleIDs"
     private let boundCustomCommandKey = "boundCustomCommandIDs"
+    private let boundQuicklinkKey = "boundQuicklinkIDs"
 
-    func start(customCommandIDs: Set<UUID>) {
-        let stale = Set(boundCustomCommandIDs).subtracting(customCommandIDs)
-        for id in stale {
-            UserDefaults.standard.removeObject(forKey: HotKeyAction.customCommand(id: id).defaultsKey)
-        }
-        persistBoundCustomCommandIDs(Set(boundCustomCommandIDs).intersection(customCommandIDs))
+    func start(customCommandIDs: Set<UUID>, quicklinkIDs: Set<UUID>) {
+        prune(key: boundCustomCommandKey, live: customCommandIDs) { .customCommand(id: $0) }
+        prune(key: boundQuicklinkKey, live: quicklinkIDs) { .quicklink(id: $0) }
 
         // `register` no-ops on an unbound item, so the fixed catalogs need no index of their own.
         for action in candidateActions { register(action) }
@@ -67,10 +66,10 @@ final class HotKeyManager: ObservableObject {
     }
 
     /// Custom-command UUIDs with a binding, indexed separately so startup can re-register them.
-    var boundCustomCommandIDs: [UUID] {
-        (UserDefaults.standard.stringArray(forKey: boundCustomCommandKey) ?? [])
-            .compactMap(UUID.init(uuidString:))
-    }
+    var boundCustomCommandIDs: [UUID] { boundIDs(key: boundCustomCommandKey) }
+
+    /// Quicklink UUIDs with a binding — the same index, its own namespace.
+    var boundQuicklinkIDs: [UUID] { boundIDs(key: boundQuicklinkKey) }
 
     func binding(for action: HotKeyAction) -> HotKeyBinding? {
         // The stored value is a JSON *string* (a legacy package format); anything else reads as unbound.
@@ -106,9 +105,9 @@ final class HotKeyManager: ObservableObject {
             if binding == nil { set.remove(bundleID) } else { set.insert(bundleID) }
             UserDefaults.standard.set(Array(set), forKey: boundPaneKey)
         case .customCommand(let id):
-            var set = Set(boundCustomCommandIDs)
-            if binding == nil { set.remove(id) } else { set.insert(id) }
-            persistBoundCustomCommandIDs(set)
+            index(id, bound: binding != nil, key: boundCustomCommandKey)
+        case .quicklink(let id):
+            index(id, bound: binding != nil, key: boundQuicklinkKey)
         case .togglePalette, .toggleClipboard, .toggleEmoji, .systemAction, .windowCommand:
             break
         }
@@ -133,6 +132,7 @@ final class HotKeyManager: ObservableObject {
         actions += boundBundleIDs.map { .app(bundleID: $0) }
         actions += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
         actions += boundCustomCommandIDs.map { .customCommand(id: $0) }
+        actions += boundQuicklinkIDs.map { .quicklink(id: $0) }
         actions += SystemAction.ID.allCases.map { .systemAction(id: $0) }
         actions += WindowCommand.ID.allCases.map { .windowCommand(id: $0) }
         return actions
@@ -160,6 +160,8 @@ final class HotKeyManager: ObservableObject {
             return SystemActionCatalog.action(id: id).name
         case .windowCommand(let id):
             return WindowCommandCatalog.command(id: id)?.name ?? "Window Command"
+        case .quicklink(let id):
+            return AppCore.shared.quicklinks.quicklink(id: id)?.name ?? "Quicklink"
         }
     }
 
@@ -191,11 +193,35 @@ final class HotKeyManager: ObservableObject {
         case .customCommand(let id): onRunCustomCommand?(id)
         case .systemAction(let id): onRunSystemAction?(id)
         case .windowCommand(let id): onRunWindowCommand?(id)
+        case .quicklink(let id): onOpenQuicklink?(id)
         }
     }
 
-    private func persistBoundCustomCommandIDs(_ ids: Set<UUID>) {
-        UserDefaults.standard.set(
-            ids.map { $0.uuidString.lowercased() }.sorted(), forKey: boundCustomCommandKey)
+    // MARK: - UUID-keyed indexes
+    //
+    // Custom commands and quicklinks are bound per item rather than per fixed catalog entry, so each
+    // needs an index of the UUIDs that currently hold a binding for `start()` to re-register.
+
+    private func boundIDs(key: String) -> [UUID] {
+        (UserDefaults.standard.stringArray(forKey: key) ?? []).compactMap(UUID.init(uuidString:))
+    }
+
+    private func index(_ id: UUID, bound: Bool, key: String) {
+        var set = Set(boundIDs(key: key))
+        if bound { set.insert(id) } else { set.remove(id) }
+        persist(set, key: key)
+    }
+
+    /// Drops bindings whose item no longer exists — a record deleted while Tinycast wasn't running.
+    private func prune(key: String, live: Set<UUID>, action: (UUID) -> HotKeyAction) {
+        let stored = Set(boundIDs(key: key))
+        for id in stored.subtracting(live) {
+            UserDefaults.standard.removeObject(forKey: action(id).defaultsKey)
+        }
+        persist(stored.intersection(live), key: key)
+    }
+
+    private func persist(_ ids: Set<UUID>, key: String) {
+        UserDefaults.standard.set(ids.map { $0.uuidString.lowercased() }.sorted(), forKey: key)
     }
 }

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -122,15 +122,24 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             .environmentObject(core.runningApps)
             .environmentObject(core.hotKeys)
             .environmentObject(core.uninstall)
+            .environmentObject(core.quicklinks)
+            .environmentObject(core.quicklinkArguments)
         let panel = PalettePanel(rootView: root)
         panel.delegate = self
         panel.paletteViewModel = core.palette
         // Backspace in an already-empty search backs out of a sub-screen to a fresh root launcher; `prepare` clears state and re-focuses the field.
         panel.onBareBackspace = { [weak self] in
-            guard let vm = self?.core.palette, vm.mode != .launcher, vm.query.isEmpty else {
-                return false
+            guard let core = self?.core, core.palette.mode != .launcher, core.palette.query.isEmpty
+            else { return false }
+            // In the argument form it steps back through the answers first, so a typo in the second
+            // of three fields costs one keypress rather than the whole flow.
+            if core.palette.mode == .quicklinkArguments,
+                let previous = core.quicklinkArguments.retreat() {
+                core.palette.query = previous
+                core.palette.selection = 0
+                return true
             }
-            vm.prepare(mode: .launcher)
+            core.palette.prepare(mode: .launcher)
             return true
         }
         // The field editor swallows some `⌘` chords (e.g. `⌘,`) before SwiftUI `.onKeyPress` can fire, and `LSUIElement` apps have no main menu for `⌘W` or `⌘Esc`. Handle them at the panel level.

--- a/Tinycast/Core/Quicklinks/Quicklink.swift
+++ b/Tinycast/Core/Quicklinks/Quicklink.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// A user-authored destination — a URL, search, file, folder or deeplink — surfaced as a launcher command.
+struct Quicklink: Codable, Hashable, Identifiable, Sendable {
+    static let entryIDPrefix = "quicklink:"
+    /// Fallback glyph when a quicklink has no icon of its own and its destination can't be detected.
+    static let sfSymbol = "link"
+
+    let id: UUID
+    var name: String
+    /// The raw destination template; may still contain `{argument}`-style placeholders.
+    var link: String
+    /// Bundle id of the app to open with, or nil for the system default handler.
+    var openWithBundleID: String?
+    /// SF Symbol override; nil takes the glyph the detected destination suggests.
+    var iconSymbol: String?
+    var showsInRootSearch: Bool
+    /// A stamp rather than a flag, so the pinned block is ordered by *when* you pinned.
+    var pinnedAt: Date?
+    var createdAt: Date
+
+    init(
+        id: UUID = UUID(), name: String, link: String, openWithBundleID: String? = nil,
+        iconSymbol: String? = nil, showsInRootSearch: Bool = true, pinnedAt: Date? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.link = link
+        self.openWithBundleID = openWithBundleID
+        self.iconSymbol = iconSymbol
+        self.showsInRootSearch = showsInRootSearch
+        self.pinnedAt = pinnedAt
+        self.createdAt = createdAt
+    }
+
+    var isPinned: Bool { pinnedAt != nil }
+
+    var entryID: String { Self.entryIDPrefix + id.uuidString.lowercased() }
+
+    static func id(fromEntryID entryID: String) -> UUID? {
+        guard entryID.hasPrefix(entryIDPrefix) else { return nil }
+        return UUID(uuidString: String(entryID.dropFirst(entryIDPrefix.count)))
+    }
+
+    /// The one display order — pinned first in the order they were pinned, then the rest by name.
+    /// Both the store and the launcher slice sort through this so the two can never disagree.
+    static func precedes(_ lhs: Quicklink, _ rhs: Quicklink) -> Bool {
+        switch (lhs.pinnedAt, rhs.pinnedAt) {
+        case (let left?, let right?):
+            return left != right ? left < right : lhs.id.uuidString < rhs.id.uuidString
+        case (.some, .none): return true
+        case (.none, .some): return false
+        case (.none, .none):
+            let order = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+            return order != .orderedSame ? order == .orderedAscending
+                : lhs.id.uuidString < rhs.id.uuidString
+        }
+    }
+
+    // Hand-written so an exported file stays importable after a field is added, and so a
+    // hand-authored import only has to supply a name and a link.
+    private enum CodingKeys: String, CodingKey {
+        case id, name, link, openWithBundleID, iconSymbol, showsInRootSearch, pinnedAt, createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        name = try container.decode(String.self, forKey: .name)
+        link = try container.decode(String.self, forKey: .link)
+        openWithBundleID = try container.decodeIfPresent(String.self, forKey: .openWithBundleID)
+        iconSymbol = try container.decodeIfPresent(String.self, forKey: .iconSymbol)
+        showsInRootSearch =
+            try container.decodeIfPresent(Bool.self, forKey: .showsInRootSearch) ?? true
+        pinnedAt = try container.decodeIfPresent(Date.self, forKey: .pinnedAt)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+    }
+}
+
+/// What `{selection}` falls back to when the target app exposes no readable selection.
+enum QuicklinkSelectionFallback: String, CaseIterable, Identifiable, Sendable {
+    case ask
+    case clipboard
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .ask: return "Ask for it"
+        case .clipboard: return "Use the clipboard"
+        }
+    }
+}
+
+enum QuicklinkError: LocalizedError, Equatable {
+    case emptyName
+    case emptyLink
+    case duplicateName
+    case unresolvableLink
+    case invalidCharacter
+    case storageUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName: return "Enter a name for the quicklink."
+        case .emptyLink: return "Enter a link to open."
+        case .duplicateName: return "A quicklink with this name already exists."
+        case .unresolvableLink:
+            return "This doesn't look like a URL, file path, or deeplink."
+        case .invalidCharacter: return "Names and links cannot contain null characters."
+        case .storageUnavailable:
+            return "The quicklinks database could not be opened, so changes can't be saved."
+        }
+    }
+}

--- a/Tinycast/Core/Quicklinks/QuicklinkArchive.swift
+++ b/Tinycast/Core/Quicklinks/QuicklinkArchive.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// The JSON interchange format for Import/Export Quicklinks.
+enum QuicklinkArchive {
+    static let version = 1
+
+    struct Document: Codable, Sendable {
+        var version: Int
+        var quicklinks: [Quicklink]
+    }
+
+    /// What an import did, so the summary can name both halves.
+    struct MergeResult: Equatable, Sendable {
+        var additions: [Quicklink]
+        var skipped: Int
+        var imported: Int { additions.count }
+    }
+
+    enum ArchiveError: LocalizedError, Equatable {
+        case unreadable
+        case empty
+
+        var errorDescription: String? {
+            switch self {
+            case .unreadable: return "This file isn't a Tinycast quicklinks export."
+            case .empty: return "This file contains no quicklinks."
+            }
+        }
+    }
+
+    static func encode(_ quicklinks: [Quicklink]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(Document(version: version, quicklinks: quicklinks))
+    }
+
+    /// Accepts the wrapped document and a bare array alike, so a hand-written list still imports.
+    static func decode(_ data: Data) throws(ArchiveError) -> [Quicklink] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded =
+            (try? decoder.decode(Document.self, from: data))?.quicklinks
+            ?? (try? decoder.decode([Quicklink].self, from: data))
+        guard let decoded else { throw .unreadable }
+        guard !decoded.isEmpty else { throw .empty }
+        return decoded
+    }
+
+    /// Duplicate detection is by name **or** destination — either match means the user already has
+    /// this quicklink, so it is skipped rather than creating a near-identical second row. Incoming
+    /// entries are also compared against each other, so one file can't import its own duplicates.
+    static func merge(_ incoming: [Quicklink], into existing: [Quicklink]) -> MergeResult {
+        var names = Set(existing.map(normalizedName))
+        var links = Set(existing.map(normalizedLink))
+        var additions: [Quicklink] = []
+        var skipped = 0
+        for candidate in incoming {
+            let name = normalizedName(candidate)
+            let link = normalizedLink(candidate)
+            guard !name.isEmpty, !link.isEmpty else {
+                skipped += 1
+                continue
+            }
+            guard names.insert(name).inserted, links.insert(link).inserted else {
+                skipped += 1
+                continue
+            }
+            // A fresh identity: an import must never collide with a hotkey or visibility reference
+            // an existing quicklink already owns.
+            additions.append(
+                Quicklink(
+                    name: candidate.name.trimmingCharacters(in: .whitespacesAndNewlines),
+                    link: candidate.link.trimmingCharacters(in: .whitespacesAndNewlines),
+                    openWithBundleID: candidate.openWithBundleID,
+                    iconSymbol: candidate.iconSymbol,
+                    showsInRootSearch: candidate.showsInRootSearch,
+                    pinnedAt: candidate.pinnedAt))
+        }
+        return MergeResult(additions: additions, skipped: skipped)
+    }
+
+    private static func normalizedName(_ quicklink: Quicklink) -> String {
+        quicklink.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive], locale: .current)
+    }
+
+    private static func normalizedLink(_ quicklink: Quicklink) -> String {
+        quicklink.link.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Tinycast/Core/Quicklinks/QuicklinkArgumentSession.swift
+++ b/Tinycast/Core/Quicklinks/QuicklinkArgumentSession.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// The quicklink waiting on its `{argument}` values, and how far through them the user is.
+///
+/// Arguments are collected one at a time because the palette has exactly one text field; the field
+/// *is* the current argument's input, which is also why ↵ can open as soon as the last one is typed.
+/// The expansion context is captured once, before the first prompt, so `{clipboard}`, `{selection}`
+/// and `{date}` can't drift while the form is open.
+@MainActor
+final class QuicklinkArgumentSession: ObservableObject {
+    struct Request {
+        let quicklink: Quicklink
+        let context: SnippetTemplateEngine.ExpansionContext
+        let encoding: SnippetTemplateEngine.ValueEncoding
+        let arguments: [SnippetTemplateEngine.MissingArgument]
+        var values: [String: String]
+        var index: Int
+    }
+
+    @Published private(set) var request: Request?
+
+    var isActive: Bool { request != nil }
+    var quicklinkName: String? { request?.quicklink.name }
+
+    var current: SnippetTemplateEngine.MissingArgument? {
+        guard let request, request.arguments.indices.contains(request.index) else { return nil }
+        return request.arguments[request.index]
+    }
+
+    /// The options to choose from, or empty when the argument takes free text.
+    var options: [String] { current?.options ?? [] }
+
+    /// True when submitting opens the quicklink rather than advancing — what the ↵ pill announces.
+    var isLastArgument: Bool {
+        guard let request else { return false }
+        return request.index == request.arguments.count - 1
+    }
+
+    var prompt: String { current.map { "\($0.name)…" } ?? PaletteMode.quicklinkArguments.placeholder }
+
+    /// Every argument, in order, paired with what has been entered so far — the form's own rows.
+    var progress: [(name: String, value: String?)] {
+        guard let request else { return [] }
+        return request.arguments.map { ($0.name, request.values[$0.name]) }
+    }
+
+    func begin(
+        quicklink: Quicklink,
+        context: SnippetTemplateEngine.ExpansionContext,
+        encoding: SnippetTemplateEngine.ValueEncoding,
+        arguments: [SnippetTemplateEngine.MissingArgument]
+    ) {
+        request = Request(
+            quicklink: quicklink, context: context, encoding: encoding, arguments: arguments,
+            values: [:], index: 0)
+    }
+
+    /// Records `value` for the current argument. Returns the complete set once the last one is
+    /// filled, or nil while more remain.
+    func submit(_ value: String) -> [String: String]? {
+        guard var request, let argument = current else { return nil }
+        request.values[argument.name] = value
+        request.index += 1
+        self.request = request
+        guard request.index >= request.arguments.count else { return nil }
+        return request.values
+    }
+
+    /// Steps back to the previous argument, returning the value it already held so the field can be
+    /// refilled. False when there is nothing to step back to.
+    func retreat() -> String? {
+        guard var request, request.index > 0 else { return nil }
+        request.index -= 1
+        let previous = request.arguments[request.index].name
+        let value = request.values[previous]
+        request.values[previous] = nil
+        self.request = request
+        return value ?? ""
+    }
+
+    func cancel() {
+        request = nil
+    }
+}

--- a/Tinycast/Core/Quicklinks/QuicklinkDestination.swift
+++ b/Tinycast/Core/Quicklinks/QuicklinkDestination.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// What a resolved quicklink link points at. Detection is by shape alone — no filesystem or
+/// Launch Services read — so the whole rule set is covered by `Tools/quicklink-test.swift`.
+enum QuicklinkDestination: Hashable, Sendable {
+    case web(URL)
+    /// A mountable share: `smb://`, `afp://`, `nfs://`, `ftp://`, `sftp://`, `ftps://`.
+    case network(URL)
+    /// Any other registered scheme — `spotify://`, `slack://`, `shortcuts://`, `mailto:`.
+    case deeplink(URL)
+    /// An absolute local path, tilde already expanded.
+    case path(String)
+
+    var defaultSymbol: String {
+        switch self {
+        case .web: return "globe"
+        case .network: return "externaldrive.connected.to.line.below"
+        case .deeplink: return "arrow.up.forward.app"
+        case .path: return "folder"
+        }
+    }
+
+    /// What the row and the editor preview show under the name.
+    var displayText: String {
+        switch self {
+        case .web(let url), .network(let url), .deeplink(let url): return url.absoluteString
+        case .path(let path): return path
+        }
+    }
+
+    private static let networkSchemes: Set<String> = ["smb", "afp", "nfs", "ftp", "sftp", "ftps"]
+
+    /// `homeDirectory` is injected rather than read, so a harness run can't depend on the machine.
+    static func detect(_ link: String, homeDirectory: String = NSHomeDirectory()) -> Self? {
+        let trimmed = link.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let path = absolutePath(trimmed, homeDirectory: homeDirectory) {
+            return .path(path)
+        }
+        if let scheme = scheme(of: trimmed) {
+            guard let url = url(from: trimmed) else { return nil }
+            // A file: URL names a local path, so it resolves to one rather than to a deeplink.
+            if scheme == "file" { return url.isFileURL ? .path(url.path) : nil }
+            if scheme == "http" || scheme == "https" { return .web(url) }
+            return networkSchemes.contains(scheme) ? .network(url) : .deeplink(url)
+        }
+        // A bare host is the way people actually write a website down, so `github.com/a?b=c` is
+        // treated as https rather than rejected.
+        guard looksLikeBareHost(trimmed), let url = url(from: "https://" + trimmed) else {
+            return nil
+        }
+        return .web(url)
+    }
+
+    /// Whether values substituted into this link need percent-encoding. Answered from the link's
+    /// prefix rather than from a parsed destination, because the encoding has to be chosen *before*
+    /// placeholders are resolved. A local path is the one kind that must not be encoded — `%20` in
+    /// a path is a literal, not a space.
+    static func usesURLEncoding(_ link: String, homeDirectory: String = NSHomeDirectory()) -> Bool {
+        let trimmed = link.trimmingCharacters(in: .whitespacesAndNewlines)
+        return absolutePath(trimmed, homeDirectory: homeDirectory) == nil
+    }
+
+    /// True when the link still carries a placeholder. Such a link can only be checked after
+    /// expansion, so validation accepts it and the open path reports a bad *resolved* value instead.
+    static func containsPlaceholder(_ link: String) -> Bool {
+        guard let opening = link.firstIndex(of: "{") else { return false }
+        return link[link.index(after: opening)...].contains("}")
+    }
+
+    private static func absolutePath(_ value: String, homeDirectory: String) -> String? {
+        if value.hasPrefix("/") { return value }
+        guard value.hasPrefix("~") else { return nil }
+        let home = homeDirectory.hasSuffix("/") ? String(homeDirectory.dropLast()) : homeDirectory
+        if value == "~" { return home }
+        guard value.hasPrefix("~/") else { return nil }
+        return home + String(value.dropFirst(1))
+    }
+
+    /// The lowercased scheme when the value starts with an RFC 3986 `scheme:`.
+    private static func scheme(of value: String) -> String? {
+        guard let colon = value.firstIndex(of: ":") else { return nil }
+        let candidate = value[value.startIndex..<colon]
+        guard let first = candidate.first, first.isLetter else { return nil }
+        guard candidate.dropFirst().allSatisfy({ $0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" })
+        else { return nil }
+        // Two false positives worth excluding, since both are far more common than the schemes they
+        // would shadow: a Windows drive letter ("C:/…"), and a host:port ("example.com:8080") whose
+        // dot already fails the loop above but whose port would otherwise read as a path.
+        guard candidate.count > 1 else { return nil }
+        let remainder = value[value.index(after: colon)...]
+        guard !remainder.isEmpty, !remainder.allSatisfy(\.isNumber) else { return nil }
+        return candidate.lowercased()
+    }
+
+    /// A space is the one authoring mistake worth rescuing — anything else illegal is a real error,
+    /// and blanket re-encoding would corrupt the `%xx` the template engine already produced.
+    private static func url(from value: String) -> URL? {
+        URL(string: value) ?? URL(string: value.replacingOccurrences(of: " ", with: "%20"))
+    }
+
+    private static func looksLikeBareHost(_ value: String) -> Bool {
+        guard !value.contains(where: \.isWhitespace) else { return false }
+        var host = value.prefix { $0 != "/" && $0 != "?" && $0 != "#" }
+        if let colon = host.firstIndex(of: ":") {
+            let port = host[host.index(after: colon)...]
+            guard !port.isEmpty, port.allSatisfy(\.isNumber) else { return false }
+            host = host[host.startIndex..<colon]
+        }
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.count >= 2, labels.allSatisfy({ !$0.isEmpty }) else { return false }
+        // Requiring a letter-led final label keeps version numbers and decimals out.
+        guard let tld = labels.last, tld.count >= 2, tld.first?.isLetter == true else { return false }
+        return tld.allSatisfy(\.isLetter)
+    }
+}

--- a/Tinycast/Core/Quicklinks/QuicklinkLauncher.swift
+++ b/Tinycast/Core/Quicklinks/QuicklinkLauncher.swift
@@ -1,0 +1,76 @@
+import AppKit
+
+/// Opens a resolved quicklink destination. Every platform effect the feature has lives here, which
+/// is what keeps `QuicklinkDestination` pure and covered by `Tools/quicklink-test.swift`.
+@MainActor
+enum QuicklinkLauncher {
+    enum Failure: LocalizedError, Equatable {
+        case unresolvable(String)
+        case missingFile(String)
+        case missingApplication(String)
+        case openFailed(target: String, detail: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unresolvable(let link):
+                return "“\(link)” isn't a URL, file path, or deeplink."
+            case .missingFile(let path):
+                return "Nothing exists at \(path) any more."
+            case .missingApplication:
+                return "The app this quicklink opens with isn't installed any more."
+            case .openFailed(let target, let detail):
+                return "macOS could not open \(target).\n\n\(detail)"
+            }
+        }
+
+        /// A missing handler is the one failure with a usable second option — the system default.
+        var missingApplicationBundleID: String? {
+            if case .missingApplication(let bundleID) = self { return bundleID }
+            return nil
+        }
+    }
+
+    /// Chromium and Firefox both accept this; Safari ignores it, and an app that doesn't understand
+    /// an argument drops it, so passing it unconditionally is safe.
+    private static let newWindowArgument = "--new-window"
+
+    /// `openWithBundleID` nil means the system default handler.
+    static func open(
+        _ link: String, openWithBundleID: String?, inNewWindow: Bool
+    ) async throws(Failure) {
+        guard let destination = QuicklinkDestination.detect(link) else {
+            throw .unresolvable(link)
+        }
+        let url: URL
+        switch destination {
+        case .web(let value), .network(let value), .deeplink(let value):
+            url = value
+        case .path(let path):
+            // Checked first so a deleted folder names itself instead of failing as a silent no-op.
+            guard FileManager.default.fileExists(atPath: path) else { throw .missingFile(path) }
+            url = URL(fileURLWithPath: path)
+        }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        if inNewWindow { configuration.arguments = [newWindowArgument] }
+
+        var application: URL?
+        if let openWithBundleID {
+            application = NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: openWithBundleID)
+            guard application != nil else { throw .missingApplication(openWithBundleID) }
+        }
+
+        do {
+            if let application {
+                _ = try await NSWorkspace.shared.open(
+                    [url], withApplicationAt: application, configuration: configuration)
+            } else {
+                _ = try await NSWorkspace.shared.open(url, configuration: configuration)
+            }
+        } catch {
+            throw .openFailed(
+                target: destination.displayText, detail: error.localizedDescription)
+        }
+    }
+}

--- a/Tinycast/Core/Quicklinks/QuicklinkStore.swift
+++ b/Tinycast/Core/Quicklinks/QuicklinkStore.swift
@@ -1,0 +1,312 @@
+import Foundation
+import SQLite3
+
+// Spelled as the C macro in sqlite3.h, which isn't imported into Swift.
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+/// SQLite-backed library of the user's quicklinks.
+///
+/// Unlike `ClipboardStore` this is **authored data, not a regenerable cache**, which decides two
+/// things: it lives in Application Support rather than Caches, and a database that won't open is
+/// never deleted — the store goes read-only and says so instead of silently starting empty.
+@MainActor
+final class QuicklinkStore: ObservableObject {
+    /// Display order is `Quicklink.precedes`: pinned first by pin time, then the rest by name.
+    @Published private(set) var quicklinks: [Quicklink] = []
+    /// False when the database could not be opened; every mutation then refuses rather than
+    /// pretending to save.
+    @Published private(set) var isAvailable = false
+    var onChange: (([Quicklink]) -> Void)?
+
+    private static let schema = """
+        CREATE TABLE IF NOT EXISTS quicklinks(
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL,
+          link TEXT NOT NULL,
+          open_with TEXT,
+          icon TEXT,
+          in_root_search INTEGER NOT NULL DEFAULT 1,
+          pinned_at REAL,
+          created_at REAL NOT NULL
+        );
+        """
+
+    private let dbURL: URL
+    private var db: OpaquePointer?
+    private var upsertStmt: OpaquePointer?
+    private var loadStmt: OpaquePointer?
+    private var deleteStmt: OpaquePointer?
+
+    /// `directory` defaults to the per-channel Application Support folder; the harness passes a
+    /// throwaway one so a run can never reach a real library.
+    init(directory: URL? = nil) {
+        let base = directory ?? Self.defaultDirectory
+        dbURL = base.appendingPathComponent("quicklinks.sqlite3")
+        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        isAvailable = openDatabase()
+        // A failed open leaves the file exactly as it was: this is the user's library, so a bad
+        // read is a problem to report, never one to fix by deleting.
+        if !isAvailable { closeDatabase() }
+    }
+
+    /// Under ~/Library/Application Support/<bundle-id> — the same per-channel root snippets use,
+    /// since neither is something Tinycast could rebuild.
+    private static var defaultDirectory: URL {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
+        return FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(bundleID, isDirectory: true)
+    }
+
+    // Isolated so teardown may touch the main-actor statement/db pointers; AppCore only ever
+    // releases the store on the main actor, so no hop.
+    isolated deinit {
+        closeDatabase()
+    }
+
+    func load() {
+        guard let stmt = loadStmt else { return }
+        var loaded: [Quicklink] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let row = Self.row(stmt) { loaded.append(row) }
+        }
+        sqlite3_reset(stmt)
+        quicklinks = loaded.sorted(by: Quicklink.precedes)
+    }
+
+    func quicklink(id: UUID) -> Quicklink? {
+        quicklinks.first { $0.id == id }
+    }
+
+    func quicklink(entryID: String) -> Quicklink? {
+        Quicklink.id(fromEntryID: entryID).flatMap(quicklink)
+    }
+
+    // Takes a whole draft rather than a parameter per field so adding an option doesn't churn
+    // every call site.
+    @discardableResult
+    func add(_ draft: Quicklink) throws(QuicklinkError) -> Quicklink {
+        let value = try validated(draft)
+        try write(value)
+        return value
+    }
+
+    func update(_ draft: Quicklink) throws(QuicklinkError) {
+        guard quicklinks.contains(where: { $0.id == draft.id }) else { return }
+        try write(validated(draft))
+    }
+
+    func remove(id: UUID) throws(QuicklinkError) {
+        guard let stmt = deleteStmt else { throw .storageUnavailable }
+        sqlite3_bind_text(stmt, 1, id.uuidString, -1, SQLITE_TRANSIENT)
+        let status = sqlite3_step(stmt)
+        sqlite3_reset(stmt)
+        sqlite3_clear_bindings(stmt)
+        guard status == SQLITE_DONE else { throw .storageUnavailable }
+        commit(quicklinks.filter { $0.id != id })
+    }
+
+    func togglePinned(id: UUID) throws(QuicklinkError) {
+        guard var value = quicklink(id: id) else { return }
+        value.pinnedAt = value.isPinned ? nil : Date()
+        try write(value)
+    }
+
+    func setShowsInRootSearch(_ shows: Bool, id: UUID) throws(QuicklinkError) {
+        guard var value = quicklink(id: id), value.showsInRootSearch != shows else { return }
+        value.showsInRootSearch = shows
+        try write(value)
+    }
+
+    /// "Duplicate" in the actions menu: a new identity, so hotkey and visibility references stay
+    /// with the original, and a distinct name so validation passes.
+    @discardableResult
+    func duplicate(id: UUID) throws(QuicklinkError) -> Quicklink {
+        guard let source = quicklink(id: id) else { throw .storageUnavailable }
+        return try add(
+            Quicklink(
+                name: Self.uniqueName(basedOn: source.name, taken: quicklinks.map(\.name)),
+                link: source.link, openWithBundleID: source.openWithBundleID,
+                iconSymbol: source.iconSymbol, showsInRootSearch: source.showsInRootSearch))
+    }
+
+    /// Adds a batch, skipping anything invalid — the import and backup path. Returns what landed.
+    @discardableResult
+    func append(_ incoming: [Quicklink]) -> [Quicklink] {
+        var added: [Quicklink] = []
+        for candidate in incoming {
+            if let stored = try? add(candidate) { added.append(stored) }
+        }
+        return added
+    }
+
+    /// Replaces the complete set during native-backup import, dropping invalid and duplicate records.
+    @discardableResult
+    func replace(with incoming: [Quicklink]) -> Int {
+        guard isAvailable, sqlite3_exec(db, "DELETE FROM quicklinks", nil, nil, nil) == SQLITE_OK
+        else { return 0 }
+        commit([])
+        return append(Self.sanitized(incoming)).count
+    }
+
+    private func write(_ value: Quicklink) throws(QuicklinkError) {
+        guard let stmt = upsertStmt else { throw .storageUnavailable }
+        sqlite3_bind_text(stmt, 1, value.id.uuidString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, value.name, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, value.link, -1, SQLITE_TRANSIENT)
+        bind(stmt, 4, value.openWithBundleID)
+        bind(stmt, 5, value.iconSymbol)
+        sqlite3_bind_int(stmt, 6, value.showsInRootSearch ? 1 : 0)
+        if let pinnedAt = value.pinnedAt {
+            sqlite3_bind_double(stmt, 7, pinnedAt.timeIntervalSince1970)
+        } else {
+            sqlite3_bind_null(stmt, 7)
+        }
+        sqlite3_bind_double(stmt, 8, value.createdAt.timeIntervalSince1970)
+        let status = sqlite3_step(stmt)
+        sqlite3_reset(stmt)
+        sqlite3_clear_bindings(stmt)
+        guard status == SQLITE_DONE else { throw .storageUnavailable }
+
+        var updated = quicklinks.filter { $0.id != value.id }
+        updated.append(value)
+        commit(updated.sorted(by: Quicklink.precedes))
+    }
+
+    private func bind(_ stmt: OpaquePointer, _ index: Int32, _ value: String?) {
+        if let value {
+            sqlite3_bind_text(stmt, index, value, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, index)
+        }
+    }
+
+    private func commit(_ updated: [Quicklink]) {
+        guard updated != quicklinks else { return }
+        quicklinks = updated
+        onChange?(updated)
+    }
+
+    private func validated(_ draft: Quicklink) throws(QuicklinkError) -> Quicklink {
+        guard isAvailable else { throw .storageUnavailable }
+        var value = draft
+        value.name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        value.link = draft.link.trimmingCharacters(in: .whitespacesAndNewlines)
+        value.iconSymbol = draft.iconSymbol?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+        value.openWithBundleID = draft.openWithBundleID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        guard !value.name.isEmpty else { throw .emptyName }
+        guard !value.link.isEmpty else { throw .emptyLink }
+        guard !value.name.contains("\0"), !value.link.contains("\0") else {
+            throw .invalidCharacter
+        }
+        // A templated link's destination is only knowable once its placeholders carry real values,
+        // so it is accepted here and reported at open time instead.
+        guard QuicklinkDestination.containsPlaceholder(value.link)
+            || QuicklinkDestination.detect(value.link) != nil
+        else { throw .unresolvableLink }
+        guard
+            !quicklinks.contains(where: {
+                $0.id != value.id
+                    && $0.name.compare(value.name, options: .caseInsensitive) == .orderedSame
+            })
+        else { throw .duplicateName }
+        return value
+    }
+
+    private static func uniqueName(basedOn name: String, taken: [String]) -> String {
+        let folded = Set(taken.map { $0.folding(options: [.caseInsensitive], locale: .current) })
+        var candidate = name + " Copy"
+        var suffix = 2
+        while folded.contains(candidate.folding(options: [.caseInsensitive], locale: .current)) {
+            candidate = "\(name) Copy \(suffix)"
+            suffix += 1
+        }
+        return candidate
+    }
+
+    private static func sanitized(_ values: [Quicklink]) -> [Quicklink] {
+        var ids = Set<UUID>()
+        // Copy-and-clean rather than rebuild, so a new option can never be dropped on import.
+        return values.filter { ids.insert($0.id).inserted }
+    }
+
+    // MARK: - SQLite
+
+    private func openDatabase() -> Bool {
+        guard
+            sqlite3_open_v2(dbURL.path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil)
+                == SQLITE_OK,
+            sqlite3_exec(db, "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;", nil, nil, nil)
+                == SQLITE_OK,
+            sqlite3_exec(db, Self.schema, nil, nil, nil) == SQLITE_OK
+        else { return false }
+        // Created after the schema rather than inside it, so a column added by a future migration
+        // can be indexed the same way.
+        sqlite3_exec(
+            db,
+            "CREATE INDEX IF NOT EXISTS quicklinks_pinned_at ON quicklinks(pinned_at) WHERE pinned_at IS NOT NULL",
+            nil, nil, nil)
+        upsertStmt = prepare(
+            """
+            INSERT INTO quicklinks(id, name, link, open_with, icon, in_root_search, pinned_at, created_at)
+            VALUES(?,?,?,?,?,?,?,?)
+            ON CONFLICT(id) DO UPDATE SET
+              name = excluded.name, link = excluded.link, open_with = excluded.open_with,
+              icon = excluded.icon, in_root_search = excluded.in_root_search,
+              pinned_at = excluded.pinned_at
+            """
+        )
+        loadStmt = prepare(
+            """
+            SELECT id, name, link, open_with, icon, in_root_search, pinned_at, created_at
+            FROM quicklinks
+            """
+        )
+        deleteStmt = prepare("DELETE FROM quicklinks WHERE id = ?")
+        return upsertStmt != nil && loadStmt != nil && deleteStmt != nil
+    }
+
+    private func prepare(_ sql: String) -> OpaquePointer? {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        return stmt
+    }
+
+    private func closeDatabase() {
+        [upsertStmt, loadStmt, deleteStmt].forEach { sqlite3_finalize($0) }
+        upsertStmt = nil
+        loadStmt = nil
+        deleteStmt = nil
+        sqlite3_close_v2(db)
+        db = nil
+    }
+
+    private static func row(_ stmt: OpaquePointer?) -> Quicklink? {
+        guard let idString = columnString(stmt, 0), let id = UUID(uuidString: idString),
+            let name = columnString(stmt, 1), let link = columnString(stmt, 2)
+        else { return nil }
+        return Quicklink(
+            id: id, name: name, link: link, openWithBundleID: columnString(stmt, 3),
+            iconSymbol: columnString(stmt, 4),
+            showsInRootSearch: sqlite3_column_int(stmt, 5) != 0,
+            pinnedAt: columnDate(stmt, 6),
+            createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 7)))
+    }
+
+    private static func columnDate(_ stmt: OpaquePointer?, _ index: Int32) -> Date? {
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL else { return nil }
+        return Date(timeIntervalSince1970: sqlite3_column_double(stmt, index))
+    }
+
+    private static func columnString(_ stmt: OpaquePointer?, _ index: Int32) -> String? {
+        guard let ptr = sqlite3_column_text(stmt, index) else { return nil }
+        let count = Int(sqlite3_column_bytes(stmt, index))
+        return String(decoding: UnsafeBufferPointer(start: ptr, count: count), as: UTF8.self)
+    }
+}
+
+extension String {
+    fileprivate var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Tinycast/Core/Snippets/SnippetTemplateEngine.swift
+++ b/Tinycast/Core/Snippets/SnippetTemplateEngine.swift
@@ -14,6 +14,14 @@ enum SnippetTemplateEngine {
 
         var clipboard: String { clipboardHistory.first ?? "" }
 
+        /// A copy reading a different selection, for a caller that only learns the value after the
+        /// context was captured — a quicklink whose selection had to be asked for or fallen back to.
+        func replacingSelection(with selection: String) -> Self {
+            Self(
+                clipboardHistory: clipboardHistory, selection: selection, now: now,
+                calendar: calendar, locale: locale, timeZone: timeZone, makeUUID: makeUUID)
+        }
+
         init(
             clipboardHistory: [String],
             selection: String,
@@ -67,6 +75,14 @@ enum SnippetTemplateEngine {
         let missingArguments: [MissingArgument]
     }
 
+    /// Formatting the *result* asks for, applied to every value a token produces. A snippet expands
+    /// into plain text and wants none; a quicklink expands into a URL, where an unescaped space or
+    /// `&` would silently truncate the destination.
+    enum ValueEncoding: Sendable {
+        case none
+        case percentEncoding
+    }
+
     private static let maximumReferenceDepth = 5
     private static let comparisonLocale = Locale(identifier: "en_US_POSIX")
 
@@ -76,19 +92,51 @@ enum SnippetTemplateEngine {
         context: ExpansionContext,
         userArguments: [String: String] = [:]
     ) -> ExpansionResult {
-        let orderedSnippets = snippets.sorted { $0.id < $1.id }
-        let expansion = expandRecord(
-            record,
-            snippets: orderedSnippets,
-            context: context,
-            userArguments: userArguments,
-            depth: 0,
-            visitedIDs: [record.id]
-        )
-        let cursorOffset = expansion.cursorCharacterOffset.map { expansion.text.count - $0 }
-        return ExpansionResult(
+        result(
+            of: expandText(
+                record.snippet.text,
+                snippets: snippets.sorted { $0.id < $1.id },
+                context: context,
+                userArguments: userArguments,
+                encoding: .none,
+                depth: 0,
+                visitedIDs: [record.id]
+            ))
+    }
+
+    /// Expands a template that isn't a snippet. `{snippet:…}` has nothing to resolve against here,
+    /// so it is left in the text like any other token the engine can't complete.
+    static func expand(
+        text: String,
+        context: ExpansionContext,
+        userArguments: [String: String] = [:],
+        encoding: ValueEncoding = .none
+    ) -> ExpansionResult {
+        result(
+            of: expandText(
+                text,
+                snippets: [],
+                context: context,
+                userArguments: userArguments,
+                encoding: encoding,
+                depth: 0,
+                visitedIDs: []
+            ))
+    }
+
+    /// Whether the template reads the selection. Parsed rather than searched for, so a `{selection}`
+    /// inside a literal brace run or a malformed token doesn't count.
+    static func usesSelection(_ text: String) -> Bool {
+        parseSegments(text).contains { segment in
+            if case .selection = segment { return true }
+            return false
+        }
+    }
+
+    private static func result(of expansion: Expansion) -> ExpansionResult {
+        ExpansionResult(
             text: expansion.text,
-            cursorOffsetFromEnd: cursorOffset,
+            cursorOffsetFromEnd: expansion.cursorCharacterOffset.map { expansion.text.count - $0 },
             missingArguments: expansion.missingArguments
         )
     }
@@ -179,32 +227,34 @@ enum SnippetTemplateEngine {
 
     // MARK: - Expansion
 
-    private static func expandRecord(
-        _ record: StoredSnippet,
+    private static func expandText(
+        _ text: String,
         snippets: [StoredSnippet],
         context: ExpansionContext,
         userArguments: [String: String],
+        encoding: ValueEncoding,
         depth: Int,
         visitedIDs: Set<StoredSnippet.ID>
     ) -> Expansion {
         var result = Expansion()
-        for segment in parseSegments(record.snippet.text) {
+        for segment in parseSegments(text) {
             switch segment {
             case .literal(let value):
                 result.append(value)
             case .clipboard(let offset, let modifiers):
                 let value = offset < context.clipboardHistory.count
                     ? context.clipboardHistory[offset] : ""
-                result.append(apply(modifiers, to: value))
+                result.append(apply(modifiers, to: value, encoding: encoding))
             case .selection(let modifiers):
-                result.append(apply(modifiers, to: context.selection))
+                result.append(apply(modifiers, to: context.selection, encoding: encoding))
             case .dateTime(let token, let modifiers):
-                result.append(apply(modifiers, to: format(token, context: context)))
+                result.append(
+                    apply(modifiers, to: format(token, context: context), encoding: encoding))
             case .uuid(let modifiers):
-                result.append(apply(modifiers, to: context.makeUUID()))
+                result.append(apply(modifiers, to: context.makeUUID(), encoding: encoding))
             case .argument(let token, let source, let modifiers):
                 if let value = userArguments[token.name] ?? token.defaultValue {
-                    result.append(apply(modifiers, to: value))
+                    result.append(apply(modifiers, to: value, encoding: encoding))
                 } else {
                     result.append(source)
                     result.addMissingArgument(
@@ -222,11 +272,12 @@ enum SnippetTemplateEngine {
                 }
                 var nestedVisited = visitedIDs
                 nestedVisited.insert(target.id)
-                result.append(expandRecord(
-                    target,
+                result.append(expandText(
+                    target.snippet.text,
                     snippets: snippets,
                     context: context,
                     userArguments: userArguments,
+                    encoding: encoding,
                     depth: depth + 1,
                     visitedIDs: nestedVisited
                 ))
@@ -235,8 +286,10 @@ enum SnippetTemplateEngine {
         return result
     }
 
-    private static func apply(_ modifiers: [Modifier], to value: String) -> String {
-        modifiers.reduce(value) { partial, modifier in
+    private static func apply(
+        _ modifiers: [Modifier], to value: String, encoding: ValueEncoding
+    ) -> String {
+        let modified = modifiers.reduce(value) { partial, modifier in
             switch modifier {
             case .uppercase: return partial.uppercased()
             case .lowercase: return partial.lowercased()
@@ -246,6 +299,12 @@ enum SnippetTemplateEngine {
             case .raw: return partial
             }
         }
+        // Applied last so `| uppercase` can't rewrite the `%xx` hex, and skipped when the template
+        // already spoke for itself — `raw` opts out, `percent-encode` has done it once already.
+        guard encoding == .percentEncoding,
+            !modifiers.contains(.raw), !modifiers.contains(.percentEncode)
+        else { return modified }
+        return percentEncoded(modified)
     }
 
     /// Percent-encodes everything outside RFC 3986's unreserved set, so the result is safe in any URL component.
@@ -335,7 +394,10 @@ enum SnippetTemplateEngine {
                 token.hasOnly(["offset"])
             else { return nil }
             return .clipboard(offset: offset, modifiers: modifiers)
-        case "selection":
+        // `selectedText` is the spelling Raycast's own documentation uses; both name the captured
+        // selection. Nothing ever writes the alias — the Insert… menus emit `{selection}` — so it is
+        // accepted on the way in without becoming a second name in saved data.
+        case "selection", "selectedtext":
             guard token.parameters.isEmpty else { return nil }
             return .selection(modifiers: modifiers)
         case "uuid":

--- a/Tinycast/Features/Launcher/LauncherView.swift
+++ b/Tinycast/Features/Launcher/LauncherView.swift
@@ -49,20 +49,22 @@ struct LauncherList: View {
         var rows: [Row] = calcRows
         let favorites = results.prefix(favoriteCount)
         let rest = results.dropFirst(favoriteCount)
-        // `rest` is apps, panes, snippets, system actions, window commands, custom commands, then
-        // built-in commands by the AppIndex sort invariant, so filtering by kind keeps row order
-        // identical and the flat selection index valid.
-        for (title, group) in [
+        // `rest` is apps, panes, quicklinks, snippets, system actions, window commands, custom
+        // commands, then built-in commands by the AppIndex sort invariant, so filtering by kind
+        // keeps row order identical and the flat selection index valid.
+        // Annotated: with this many sections the inference pass times out.
+        let sections: [(String, [AppEntry])] = [
             ("Favorites", Array(favorites)),
             ("Applications", rest.filter { $0.kind == .application }),
             ("System Settings", rest.filter { $0.kind == .systemSettings }),
+            ("Quicklinks", rest.filter { $0.kind == .quicklink }),
             ("Snippets", rest.filter { $0.kind == .snippet }),
             ("System Actions", rest.filter { $0.kind == .systemAction }),
             ("Window Management", rest.filter { $0.kind == .windowCommand }),
             ("Custom Commands", rest.filter { $0.kind == .customCommand }),
             ("Commands", rest.filter { $0.kind == .command })
         ]
-        where !group.isEmpty {
+        for (title, group) in sections where !group.isEmpty {
             rows.append(.header(title))
             rows.append(contentsOf: group.map(Row.app))
         }
@@ -301,6 +303,7 @@ enum AppActionsMenu {
         case .snippet: return "Paste Snippet"
         case .systemAction: return "Run System Action"
         case .windowCommand: return "Move Window"
+        case .quicklink: return "Open Quicklink"
         }
     }
 }

--- a/Tinycast/Features/Quicklinks/QuicklinkArgumentsView.swift
+++ b/Tinycast/Features/Quicklinks/QuicklinkArgumentsView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// The form shown before a quicklink with placeholders opens.
+///
+/// The palette's own search field is the input for whichever argument is current, so this view only
+/// draws what has been answered and what is left — and, for an argument with `options=`, the choices
+/// as ordinary selectable rows so the flat selection index behaves exactly as it does in every other
+/// list.
+struct QuicklinkArgumentsView: View {
+    let options: [String]
+    let selection: Int
+    let scroll: ScrollIntent
+    let onSelect: (Int) -> Void
+    let onActivate: () -> Void
+
+    @EnvironmentObject private var session: QuicklinkArgumentSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            summary
+            if options.isEmpty {
+                Spacer(minLength: 0)
+            } else {
+                optionList
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var summary: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            if let name = session.quicklinkName {
+                Text(name)
+                    .font(Theme.Typography.rowTitle.weight(.semibold))
+            }
+            ForEach(Array(session.progress.enumerated()), id: \.offset) { _, argument in
+                HStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: argument.value == nil ? "circle" : "checkmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(
+                            argument.value == nil
+                                ? Theme.Colors.textTertiary : Theme.Colors.success)
+                    Text(argument.name)
+                        .font(Theme.Typography.rowTrailing)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                    if let value = argument.value {
+                        Text(value.isEmpty ? "—" : value)
+                            .font(Theme.Typography.rowTrailing)
+                            .foregroundStyle(Theme.Colors.textTertiary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md * 2)
+        .padding(.top, Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.lg)
+    }
+
+    private var optionList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    SectionHeader(title: "Choices", isFirst: true)
+                    ForEach(Array(options.enumerated()), id: \.offset) { index, option in
+                        OptionRow(title: option, selected: index == selection)
+                            .id(String(index))
+                            .contentShape(Rectangle())
+                            .onTapGesture { onSelect(index) }
+                            .simultaneousGesture(
+                                TapGesture(count: 2).onEnded {
+                                    onSelect(index)
+                                    onActivate()
+                                }
+                            )
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.bottom, Theme.Spacing.md)
+                .hideNativeScrollers()
+                .scrollOriginAnchor()
+            }
+            .edgeDissolve()
+            .thinScrollbar()
+            .onChange(of: scroll) { _, scroll in
+                switch scroll.kind {
+                case .top: proxy.scrollToOrigin()
+                case .follow: proxy.reveal(String(selection))
+                }
+            }
+        }
+    }
+}
+
+private struct OptionRow: View {
+    let title: String
+    let selected: Bool
+    @State private var hovered = false
+
+    /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            Text(title)
+                .font(Theme.Typography.rowTitle)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .fill(fill)
+        )
+        .armedHover($hovered)
+    }
+}

--- a/Tinycast/Features/Quicklinks/QuicklinkListView.swift
+++ b/Tinycast/Features/Quicklinks/QuicklinkListView.swift
@@ -1,0 +1,221 @@
+import AppKit
+import SwiftUI
+
+/// The Search Quicklinks screen: the whole library, pinned entries first.
+struct QuicklinkList: View {
+    let results: [Quicklink]
+    let selectedID: Quicklink.ID?
+    /// Changes only when the list should scroll (keyboard nav / reset), so mouse selection never yanks the scroll position.
+    let scroll: ScrollIntent
+    let onSelect: (Quicklink) -> Void
+    let onActivate: () -> Void
+    let onActions: (Quicklink) -> Void
+
+    private enum Row: Identifiable {
+        case header(String)
+        case item(Quicklink)
+        var id: String {
+            switch self {
+            case .header(let title): return "header-" + title
+            case .item(let quicklink): return quicklink.id.uuidString
+            }
+        }
+    }
+
+    /// Whether the selection sits on flat index 0, whose section header should stay visible.
+    private var firstRowSelected: Bool {
+        selectedID != nil && selectedID == results.first?.id
+    }
+
+    /// The store already publishes pinned-first order, so this walks and emits a header on the one
+    /// boundary — mirrors the clipboard's Pinned section.
+    private var rows: [Row] {
+        var rows: [Row] = []
+        var currentTitle: String?
+        for quicklink in results {
+            let title = quicklink.isPinned ? "Pinned" : "Quicklinks"
+            if title != currentTitle {
+                rows.append(.header(title))
+                currentTitle = title
+            }
+            rows.append(.item(quicklink))
+        }
+        return rows
+    }
+
+    var body: some View {
+        let rows = rows
+        return ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(rows) { row in
+                        switch row {
+                        case .header(let title):
+                            SectionHeader(title: title, isFirst: row.id == rows.first?.id)
+                        case .item(let quicklink):
+                            QuicklinkRow(
+                                quicklink: quicklink, selected: quicklink.id == selectedID
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture { onSelect(quicklink) }
+                            .simultaneousGesture(
+                                TapGesture(count: 2).onEnded {
+                                    onSelect(quicklink)
+                                    onActivate()
+                                }
+                            )
+                            .onRightClick { onActions(quicklink) }
+                        }
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.xs)
+                .padding(.bottom, Theme.Spacing.md)
+                .hideNativeScrollers()
+                .scrollOriginAnchor()
+            }
+            .edgeDissolve()
+            .thinScrollbar()
+            .onChange(of: scroll) { _, scroll in
+                switch scroll.kind {
+                case .top:
+                    proxy.scrollToOrigin()
+                case .follow:
+                    if firstRowSelected {
+                        proxy.scrollToOrigin()
+                    } else if let selectedID {
+                        proxy.reveal(selectedID.uuidString)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct QuicklinkRow: View {
+    let quicklink: Quicklink
+    let selected: Bool
+    @EnvironmentObject private var hotKeys: HotKeyManager
+    @State private var hovered = false
+
+    /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            Image(nsImage: IconCache.symbolIcon(named: symbol))
+                .resizable()
+                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                Text(quicklink.name)
+                    .font(Theme.Typography.rowTitle)
+                    .lineLimit(1)
+                Text(quicklink.link)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: Theme.Spacing.lg)
+            if !quicklink.showsInRootSearch {
+                Image(systemName: "eye.slash")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+            if let keycaps = hotKeys.binding(for: .quicklink(id: quicklink.id))?.keycaps {
+                HStack(spacing: Theme.Spacing.xxs) {
+                    ForEach(Array(keycaps.enumerated()), id: \.offset) { _, cap in
+                        KeyCapChip(text: cap, style: .outline)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .fill(fill)
+        )
+        .armedHover($hovered)
+    }
+
+    private var symbol: String {
+        quicklink.iconSymbol ?? QuicklinkDestination.detect(quicklink.link)?.defaultSymbol
+            ?? Quicklink.sfSymbol
+    }
+}
+
+/// The ⌘K menu for a quicklink row.
+@MainActor
+enum QuicklinkActionsMenu {
+    static func content(quicklink: Quicklink, core: AppCore) -> PopoverMenuContent {
+        var items: [PopoverMenuItem] = [
+            PopoverMenuItem(title: "Open Quicklink", systemImage: symbol(quicklink), shortcut: "↵") {
+                core.openQuicklink(id: quicklink.id)
+            }
+        ]
+        // `PopoverMenu` is a flat list with no picker, so choosing an *arbitrary* app belongs to the
+        // editor, which has one. What the palette can usefully offer is the one alternative that
+        // always exists: bypass the saved app and use the system handler, once.
+        if quicklink.openWithBundleID != nil {
+            items.append(
+                PopoverMenuItem(
+                    title: "Open With Default App", systemImage: "arrow.up.forward.app",
+                    shortcut: "⌘↵"
+                ) {
+                    core.openQuicklink(id: quicklink.id, forcingDefaultApp: true)
+                })
+        }
+        items.append(
+            PopoverMenuItem(title: "Edit Quicklink", systemImage: "pencil") {
+                core.hidePalette(restoreFocus: false)
+                core.editQuicklink(quicklink)
+            })
+        items.append(
+            PopoverMenuItem(title: "Duplicate Quicklink", systemImage: "plus.square.on.square") {
+                core.duplicateQuicklink(id: quicklink.id)
+            })
+        items.append(
+            quicklink.isPinned
+                ? PopoverMenuItem(title: "Unpin Quicklink", systemImage: "pin.slash", shortcut: "⌘P")
+                { core.toggleQuicklinkPinned(id: quicklink.id) }
+                : PopoverMenuItem(title: "Pin Quicklink", systemImage: "pin", shortcut: "⌘P") {
+                    core.toggleQuicklinkPinned(id: quicklink.id)
+                })
+        items.append(
+            PopoverMenuItem(
+                title: quicklink.showsInRootSearch
+                    ? "Hide from Root Search" : "Show in Root Search",
+                systemImage: quicklink.showsInRootSearch ? "eye.slash" : "eye"
+            ) {
+                core.setQuicklinkShowsInRootSearch(!quicklink.showsInRootSearch, id: quicklink.id)
+            })
+        // Revealing only makes sense once the destination is a real path — a template's isn't known
+        // until it expands, and a URL has no file to show.
+        if case .path(let path)? = QuicklinkDestination.detect(quicklink.link),
+            !QuicklinkDestination.containsPlaceholder(quicklink.link) {
+            items.append(
+                PopoverMenuItem(title: "Show in Finder", systemImage: "folder", shortcut: "⌘F") {
+                    core.hidePalette(restoreFocus: false)
+                    AppLauncher.showInFinder(URL(fileURLWithPath: path))
+                })
+        }
+        items.append(
+            PopoverMenuItem(
+                title: "Delete Quicklink", systemImage: "trash", shortcut: "⌘⌫",
+                isDestructive: true
+            ) {
+                Task { await core.deleteQuicklink(id: quicklink.id) }
+            })
+        return PopoverMenuContent(header: quicklink.name, items: items)
+    }
+
+    private static func symbol(_ quicklink: Quicklink) -> String {
+        quicklink.iconSymbol ?? QuicklinkDestination.detect(quicklink.link)?.defaultSymbol
+            ?? Quicklink.sfSymbol
+    }
+}

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -559,16 +559,35 @@ struct RootPaletteView: View {
     }
 
     /// The one search field, kept in a single tree position (the `header`) so its focus survives the compact↔expanded swap.
+    ///
+    /// The placeholder is drawn here rather than passed as the field's `prompt`. AppKit gives an
+    /// `NSTextField` a field editor one point taller than the field itself, and a prompt is rendered
+    /// by whichever of the two currently owns the text — so the *same* placeholder glyphs sit a point
+    /// higher once the field takes the panel's shared field editor. That editor is created lazily and
+    /// then cached on the window, which is why the step was only ever visible on the first summon
+    /// after launch. Drawing it here pins it to SwiftUI's layout, where nothing can move it —
+    /// measured identical in both focus states, against a one-point step for the real prompt.
+    ///
+    /// A background rather than an overlay, so the caret still draws over it.
     private var searchField: some View {
-        TextField(
-            "", text: $vm.query,
-            prompt: Text(searchPrompt).foregroundStyle(Theme.Colors.textTertiary)
-        )
-        .textFieldStyle(.plain)
-        .font(Theme.Typography.searchField)
-        .tint(.white)
-        .focused($searchFocused)
-        .onSubmit(activateSelection)
+        TextField("", text: $vm.query)
+            .textFieldStyle(.plain)
+            .font(Theme.Typography.searchField)
+            .tint(.white)
+            .focused($searchFocused)
+            .onSubmit(activateSelection)
+            .background(alignment: .leading) {
+                if vm.query.isEmpty {
+                    Text(searchPrompt)
+                        .font(Theme.Typography.searchField)
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                        .lineLimit(1)
+                        // Never a click target: tapping the placeholder must still land the caret.
+                        .allowsHitTesting(false)
+                }
+            }
+            // The prompt used to carry this; without it the field would be unlabelled.
+            .accessibilityLabel(Text(searchPrompt))
     }
 
     @ViewBuilder

--- a/Tinycast/Features/RootPaletteView.swift
+++ b/Tinycast/Features/RootPaletteView.swift
@@ -14,6 +14,8 @@ struct RootPaletteView: View {
     @EnvironmentObject private var emojiIndex: EmojiIndex
     @EnvironmentObject private var frequentEmoji: FrequentEmojiStore
     @EnvironmentObject private var uninstall: UninstallSession
+    @EnvironmentObject private var quicklinks: QuicklinkStore
+    @EnvironmentObject private var quicklinkArguments: QuicklinkArgumentSession
     /// Observed so a skin tone changed in Settings re-renders the grid glyphs immediately.
     @ObservedObject private var settings = AppCore.shared.settings
     @FocusState private var searchFocused: Bool
@@ -57,6 +59,20 @@ struct RootPaletteView: View {
                 || $0.locationLabel.localizedCaseInsensitiveContains(query)
         }
     }
+    private var quicklinkResults: [Quicklink] {
+        let query = vm.query.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return quicklinks.quicklinks }
+        return quicklinks.quicklinks.filter { $0.name.localizedCaseInsensitiveContains(query) }
+    }
+    /// An argument taking `options=` renders them as rows, filtered by the field like every other
+    /// list; a free-text one has none, so the screen is a form with nothing to index and the flat
+    /// selection stays at zero.
+    private var argumentOptions: [String] {
+        let query = vm.query.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return quicklinkArguments.options }
+        return quicklinkArguments.options.filter { $0.localizedCaseInsensitiveContains(query) }
+    }
+
     private var emojiSections: [EmojiGridSection] {
         EmojiGrid.sections(query: vm.query, index: emojiIndex, frequent: frequentEmoji)
     }
@@ -77,6 +93,8 @@ struct RootPaletteView: View {
         case .calculatorHistory: return histResults.count + calcCount
         case .emoji: return emojiResults.count
         case .uninstall: return uninstallResults.count
+        case .quicklinks: return quicklinkResults.count
+        case .quicklinkArguments: return argumentOptions.count
         }
     }
     /// Selection clamped into the current results — the single source of truth for highlight, preview and activation so the list and preview can never disagree.
@@ -113,6 +131,9 @@ struct RootPaletteView: View {
     }
     private var selectedUninstallCandidate: UninstallCandidate? {
         uninstallResults.indices.contains(selection) ? uninstallResults[selection] : nil
+    }
+    private var selectedQuicklink: Quicklink? {
+        quicklinkResults.indices.contains(selection) ? quicklinkResults[selection] : nil
     }
 
     /// The bottom-right Actions menu content for the current mode's selection, or nil when the selection has no actions.
@@ -162,6 +183,14 @@ struct RootPaletteView: View {
                     candidate: candidate, session: uninstall, core: core)
             }
             return nil
+        case .quicklinks:
+            if let quicklink = selectedQuicklink {
+                return QuicklinkActionsMenu.content(quicklink: quicklink, core: core)
+            }
+            return nil
+        case .quicklinkArguments:
+            // The argument form has one action — submit — and it is already ↵.
+            return nil
         }
     }
 
@@ -192,6 +221,8 @@ struct RootPaletteView: View {
         let emojiSections = vm.mode == .emoji ? emojiSections : []
         let emojis = emojiSections.flatMap(\.entries)
         let uninstallRows = vm.mode == .uninstall ? uninstallResults : []
+        let links = vm.mode == .quicklinks ? quicklinkResults : []
+        let argumentOptions = vm.mode == .quicklinkArguments ? argumentOptions : []
         // Newest stored clip + the reorder token: the pair changes only when the store mutates, never when a query filters the list.
         let clipFollow = ClipFollowKey(id: store.items.first?.id, token: vm.followToken)
         // Every count/selection below derives from this one calc/offset pair — the flat selection index must always match the visible row order, calc card included.
@@ -200,6 +231,7 @@ struct RootPaletteView: View {
         // Only the active mode is non-empty.
         let count =
             apps.count + offset + clips.count + hist.count + emojis.count + uninstallRows.count
+            + links.count + argumentOptions.count
         let sel = count == 0 ? 0 : min(max(vm.selection, 0), count - 1)
         let calcSelected = calc != nil && sel == 0
         // An error card is selectable but has no action: it must not drive the Copy Answer pill, ⌘K menu, or Enter.
@@ -210,7 +242,10 @@ struct RootPaletteView: View {
         let selectedApp = apps.indices.contains(sel - offset) ? apps[sel - offset] : nil
         // Derive the footer label from the already-resolved selection so `bottomBar` doesn't re-run `appResults` (its filter/sort aren't memoized). The primary/Actions group is hidden when there's nothing to act on: no results in any mode, or an error calc card (selectable but action-less).
         let pillLabel = actionPillLabel(selectedApp: selectedApp, calcActionable: calcActionable)
-        let showActionGroup = count > 0 && !(calcSelected && !calcActionable)
+        // The argument form has no rows to count when its argument takes free text, but ↵ still
+        // does something — and the pill is the only thing that says what.
+        let showActionGroup =
+            (count > 0 || vm.mode == .quicklinkArguments) && !(calcSelected && !calcActionable)
 
         // The `header` (and its single search field) is always attached in the same position via safeAreaInset so its focus survives the compact↔expanded swap — only the results below it toggle. Collapsed shows the bar alone; expanded floats header + action bar over the list with edge-dissolve (see docs/ui.md).
         return Group {
@@ -219,7 +254,8 @@ struct RootPaletteView: View {
             } else {
                 content(
                     apps: apps, clips: clips, hist: hist, emojiSections: emojiSections,
-                    uninstallRows: uninstallRows, calc: calc, selection: sel,
+                    uninstallRows: uninstallRows, links: links, argumentOptions: argumentOptions,
+                    calc: calc, selection: sel,
                     favoriteCount: favoriteCount, showSections: showSections
                 )
             }
@@ -280,6 +316,8 @@ struct RootPaletteView: View {
             scroll = ScrollIntent(kind: .top)
             // Every way out of the Uninstall screen: back chevron, bare backspace, a fresh summon.
             if vm.mode != .uninstall { uninstall.cancel() }
+            // Same for a half-filled argument form: leaving the screen abandons the pending open.
+            if vm.mode != .quicklinkArguments { core.cancelQuicklinkArguments() }
         }
         // Pop-to-root: `prepare` clears query/selection, but if both were already at their defaults the handlers above never fire — this intent guarantees the scroll itself snaps back to the origin.
         .onChange(of: vm.resetToken) {
@@ -394,6 +432,13 @@ struct RootPaletteView: View {
                 guard command, let candidate = selectedUninstallCandidate, !candidate.isLocked
                 else { return .ignored }
                 uninstall.toggle(candidate.id)
+            case .quicklinks:
+                guard command, let quicklink = selectedQuicklink,
+                    quicklink.openWithBundleID != nil
+                else { return .ignored }
+                core.openQuicklink(id: quicklink.id, forcingDefaultApp: true)
+            case .quicklinkArguments:
+                return .ignored
             case .launcher:
                 guard command, let app = selectedAppEntry, app.canRevealInFinder
                 else { return .ignored }
@@ -434,18 +479,26 @@ struct RootPaletteView: View {
                 deleteSelectedClip()
             case .calculatorHistory:
                 deleteSelectedHistoryEntry()
-            case .launcher, .emoji, .uninstall:
+            case .quicklinks:
+                guard let quicklink = selectedQuicklink else { return .ignored }
+                Task { await core.deleteQuicklink(id: quicklink.id) }
+            case .launcher, .emoji, .uninstall, .quicklinkArguments:
                 return .ignored
             }
             return .handled
         }
         // ⌘P pins/unpins the selected clip — mirrors the Actions menu row, and works while that menu is open like the other advertised chords.
         .onKeyPress(keys: ["p"], phases: .down) { press in
-            guard press.modifiers.contains(.command), vm.mode == .clipboard,
-                clipResults.indices.contains(selection)
-            else { return .ignored }
-            core.togglePinnedClip(clipResults[selection])
-            return .handled
+            guard press.modifiers.contains(.command) else { return .ignored }
+            if vm.mode == .clipboard, clipResults.indices.contains(selection) {
+                core.togglePinnedClip(clipResults[selection])
+                return .handled
+            }
+            if vm.mode == .quicklinks, let quicklink = selectedQuicklink {
+                core.toggleQuicklinkPinned(id: quicklink.id)
+                return .handled
+            }
+            return .ignored
         }
         // Both cases are listed because Shift uppercases the reported key. The compact bar is excluded like ⌘K — it shows no selection to aim a destructive action at.
         .onKeyPress(keys: ["q", "Q"], phases: .down) { press in
@@ -499,11 +552,17 @@ struct RootPaletteView: View {
         .frame(maxWidth: .infinity)
     }
 
+    /// In the argument form the field *is* the current argument's input, so it names that argument
+    /// rather than the screen.
+    private var searchPrompt: String {
+        vm.mode == .quicklinkArguments ? quicklinkArguments.prompt : vm.mode.placeholder
+    }
+
     /// The one search field, kept in a single tree position (the `header`) so its focus survives the compact↔expanded swap.
     private var searchField: some View {
         TextField(
             "", text: $vm.query,
-            prompt: Text(vm.mode.placeholder).foregroundStyle(Theme.Colors.textTertiary)
+            prompt: Text(searchPrompt).foregroundStyle(Theme.Colors.textTertiary)
         )
         .textFieldStyle(.plain)
         .font(Theme.Typography.searchField)
@@ -515,7 +574,8 @@ struct RootPaletteView: View {
     @ViewBuilder
     private func content(
         apps: [AppEntry], clips: [ClipboardItem], hist: [CalcHistoryEntry],
-        emojiSections: [EmojiGridSection], uninstallRows: [UninstallCandidate], calc: CalcResult?,
+        emojiSections: [EmojiGridSection], uninstallRows: [UninstallCandidate],
+        links: [Quicklink], argumentOptions: [String], calc: CalcResult?,
         selection: Int, favoriteCount: Int, showSections: Bool
     ) -> some View {
         switch vm.mode {
@@ -657,6 +717,34 @@ struct RootPaletteView: View {
                     )
                 }
             }
+        case .quicklinks:
+            if links.isEmpty {
+                EmptyResults(
+                    text: quicklinks.quicklinks.isEmpty
+                        ? "No quicklinks yet" : "No matching quicklinks")
+            } else {
+                QuicklinkList(
+                    results: links,
+                    selectedID: links.indices.contains(selection) ? links[selection].id : nil,
+                    scroll: scroll,
+                    onSelect: { link in
+                        if let index = links.firstIndex(of: link) { vm.selection = index }
+                    },
+                    onActivate: activateSelection,
+                    onActions: { link in
+                        if let index = links.firstIndex(of: link) { vm.selection = index }
+                        openActions()
+                    }
+                )
+            }
+        case .quicklinkArguments:
+            QuicklinkArgumentsView(
+                options: argumentOptions,
+                selection: selection,
+                scroll: scroll,
+                onSelect: { vm.selection = $0 },
+                onActivate: activateSelection
+            )
         }
     }
 
@@ -726,6 +814,10 @@ struct RootPaletteView: View {
             return "Copy Answer"
         case .uninstall:
             return "Uninstall Application"
+        case .quicklinks:
+            return "Open Quicklink"
+        case .quicklinkArguments:
+            return quicklinkArguments.isLastArgument ? "Open Quicklink" : "Next"
         case .launcher:
             if calcActionable { return "Copy Answer" }
             switch selectedApp?.kind {
@@ -733,6 +825,7 @@ struct RootPaletteView: View {
             case .command: return "Run Command"
             case .customCommand: return "Run Custom Command"
             case .systemAction: return "Run System Action"
+            case .quicklink: return "Open Quicklink"
             default: return "Open Application"
             }
         }
@@ -853,6 +946,26 @@ struct RootPaletteView: View {
             core.pasteEmoji(emojiResults[selection])
         case .uninstall:
             core.performUninstall()
+        case .quicklinks:
+            guard quicklinkResults.indices.contains(selection) else { return }
+            core.openQuicklink(id: quicklinkResults[selection].id)
+        case .quicklinkArguments:
+            // An options argument submits the highlighted choice; a free-text one submits the field.
+            let options = argumentOptions
+            let value: String
+            if quicklinkArguments.options.isEmpty {
+                value = vm.query
+            } else {
+                guard options.indices.contains(selection) else { return }
+                value = options[selection]
+            }
+            core.submitQuicklinkArgument(value)
+            // More arguments to go: clear the field for the next one and reset the choice list.
+            if quicklinkArguments.isActive {
+                vm.query = ""
+                vm.selection = 0
+                scroll = ScrollIntent(kind: .top)
+            }
         }
     }
 }

--- a/Tinycast/Features/Settings/AppPickerPopover.swift
+++ b/Tinycast/Features/Settings/AppPickerPopover.swift
@@ -1,0 +1,84 @@
+import AppKit
+import SwiftUI
+
+/// Searchable list of installed apps, drawn from the launcher's own index. Shared by the clipboard
+/// pane's exclusion list and by the two places a quicklink chooses an app to open with.
+struct AppPickerPopover: View {
+    /// Bundle IDs to leave out — the ones already chosen.
+    var excluded: Set<String> = []
+    /// Shown above the list when the caller can also clear its choice.
+    var clearTitle: String?
+    /// Nil means the caller's `clearTitle` row was tapped.
+    let onSelect: (String?) -> Void
+
+    @EnvironmentObject private var appIndex: AppIndex
+    @State private var query = ""
+
+    private var candidates: [AppEntry] {
+        (query.isEmpty ? appIndex.apps : appIndex.matches(query))
+            .filter { $0.kind == .application }
+            .filter { $0.bundleID.map { !excluded.contains($0) } ?? false }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("Search apps…", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .padding(Theme.Spacing.md)
+            Divider()
+            ScrollView {
+                LazyVStack(spacing: 1) {
+                    if let clearTitle, query.isEmpty {
+                        row(title: clearTitle, icon: nil) { onSelect(nil) }
+                    }
+                    ForEach(candidates) { app in
+                        row(title: app.name, icon: app.icon) {
+                            if let id = app.bundleID { onSelect(id) }
+                        }
+                    }
+                }
+                .padding(Theme.Spacing.sm)
+            }
+        }
+        .frame(width: 280, height: 320)
+    }
+
+    private func row(title: String, icon: NSImage?, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: Theme.Spacing.lg) {
+                Group {
+                    if let icon {
+                        Image(nsImage: icon).resizable()
+                    } else {
+                        Image(systemName: "app.dashed")
+                            .font(.system(size: 14))
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                    }
+                }
+                .frame(width: 20, height: 20)
+                Text(title)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Resolves a stored bundle ID to something showable: the launcher index first, then LaunchServices,
+/// then a placeholder for an app that has since been uninstalled.
+@MainActor
+enum AppPresentation {
+    static func resolve(bundleID: String, in appIndex: AppIndex) -> (name: String, icon: NSImage) {
+        if let app = appIndex.apps.first(where: { $0.bundleID == bundleID }) {
+            return (app.name, app.icon)
+        }
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+            return (url.deletingPathExtension().lastPathComponent, IconCache.icon(forFile: url.path))
+        }
+        return (bundleID, NSWorkspace.shared.icon(for: .applicationBundle))
+    }
+}

--- a/Tinycast/Features/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Settings/ClipboardSettingsView.swift
@@ -66,7 +66,7 @@ struct ClipboardSettingsView: View {
                     .buttonStyle(.borderless)
                     .popover(isPresented: $showingAppPicker, arrowEdge: .bottom) {
                         AppPickerPopover(excluded: Set(settings.clipboardDisabledApps)) { bundleID in
-                            settings.clipboardDisabledApps.append(bundleID)
+                            if let bundleID { settings.clipboardDisabledApps.append(bundleID) }
                             showingAppPicker = false
                         }
                     }
@@ -110,7 +110,7 @@ private struct DisabledAppRow: View {
     @EnvironmentObject private var appIndex: AppIndex
 
     var body: some View {
-        let (name, icon) = resolve()
+        let (name, icon) = AppPresentation.resolve(bundleID: bundleID, in: appIndex)
         HStack(spacing: Theme.Spacing.lg) {
             Image(nsImage: icon)
                 .resizable()
@@ -127,64 +127,5 @@ private struct DisabledAppRow: View {
         }
         .padding(.horizontal, Theme.Spacing.xl)
         .padding(.vertical, Theme.Spacing.lg)
-    }
-
-    private func resolve() -> (String, NSImage) {
-        if let app = appIndex.apps.first(where: { $0.bundleID == bundleID }) {
-            return (app.name, app.icon)
-        }
-        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
-            let name = url.deletingPathExtension().lastPathComponent
-            return (name, IconCache.icon(forFile: url.path))
-        }
-        return (bundleID, NSWorkspace.shared.icon(for: .applicationBundle))
-    }
-}
-
-/// Searchable list of installed apps (from the launcher's index) used to add a disabled app.
-private struct AppPickerPopover: View {
-    let excluded: Set<String>
-    let onSelect: (String) -> Void
-
-    @EnvironmentObject private var appIndex: AppIndex
-    @State private var query = ""
-
-    private var candidates: [AppEntry] {
-        (query.isEmpty ? appIndex.apps : appIndex.matches(query))
-            .filter { $0.kind == .application }
-            .filter { $0.bundleID.map { !excluded.contains($0) } ?? false }
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            TextField("Search apps…", text: $query)
-                .textFieldStyle(.roundedBorder)
-                .padding(Theme.Spacing.md)
-            Divider()
-            ScrollView {
-                LazyVStack(spacing: 1) {
-                    ForEach(candidates) { app in
-                        Button {
-                            if let id = app.bundleID { onSelect(id) }
-                        } label: {
-                            HStack(spacing: Theme.Spacing.lg) {
-                                Image(nsImage: app.icon)
-                                    .resizable()
-                                    .frame(width: 20, height: 20)
-                                Text(app.name)
-                                    .lineLimit(1)
-                                Spacer(minLength: 0)
-                            }
-                            .padding(.horizontal, Theme.Spacing.md)
-                            .padding(.vertical, Theme.Spacing.sm)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(Theme.Spacing.sm)
-            }
-        }
-        .frame(width: 280, height: 320)
     }
 }

--- a/Tinycast/Features/Settings/QuicklinkEditorSheet.swift
+++ b/Tinycast/Features/Settings/QuicklinkEditorSheet.swift
@@ -1,0 +1,300 @@
+import AppKit
+import SwiftUI
+
+/// Identifies the editor a caller wants opened, so `.sheet(item:)` can present it. A nil quicklink
+/// is "add"; the UUID makes two consecutive opens distinct presentations.
+struct QuicklinkEditRequest: Identifiable {
+    let id = UUID()
+    var quicklink: Quicklink?
+}
+
+/// Add / edit sheet for a single quicklink, presented from the Quicklinks pane.
+struct QuicklinkEditorSheet: View {
+    let quicklink: Quicklink?
+
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appIndex: AppIndex
+    @State private var name: String
+    @State private var link: String
+    @State private var iconSymbol: String?
+    @State private var openWithBundleID: String?
+    @State private var showsInRootSearch: Bool
+    @State private var isPinned: Bool
+    @State private var errorMessage: String?
+    @State private var showingAppPicker = false
+    @State private var showingIconPicker = false
+
+    init(quicklink: Quicklink?) {
+        self.quicklink = quicklink
+        _name = State(initialValue: quicklink?.name ?? "")
+        _link = State(initialValue: quicklink?.link ?? "")
+        _iconSymbol = State(initialValue: quicklink?.iconSymbol)
+        _openWithBundleID = State(initialValue: quicklink?.openWithBundleID)
+        _showsInRootSearch = State(initialValue: quicklink?.showsInRootSearch ?? true)
+        _isPinned = State(initialValue: quicklink?.isPinned ?? false)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+            Text(quicklink == nil ? "Add Quicklink" : "Edit Quicklink")
+                .font(.title2.weight(.bold))
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Name")
+                    .font(.callout.weight(.medium))
+                TextField("Search GitHub", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                HStack {
+                    Text("Link")
+                        .font(.callout.weight(.medium))
+                    Spacer()
+                    insertMenu
+                }
+                TextField("https://github.com/search?q={argument}", text: $link)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.body.monospaced())
+                destinationPreview
+            }
+
+            HStack(spacing: Theme.Spacing.xl) {
+                iconField
+                openWithField
+            }
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                optionToggle(
+                    "Show in root search", isOn: $showsInRootSearch,
+                    detail: "List this quicklink alongside apps and commands.")
+                optionToggle(
+                    "Pin to top", isOn: $isPinned,
+                    detail: "Keep it above the other quicklinks.")
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save", action: save)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(trimmed(name).isEmpty || trimmed(link).isEmpty)
+            }
+        }
+        .padding(Theme.Spacing.xxl)
+        .frame(width: Theme.Size.editorSheetWidth)
+    }
+
+    // MARK: - Fields
+
+    /// The destination as it will actually be opened — the only feedback a templated link can give
+    /// before it runs, since its real value isn't known until the arguments are filled in.
+    @ViewBuilder
+    private var destinationPreview: some View {
+        let value = trimmed(link)
+        if value.isEmpty {
+            EmptyView()
+        } else if QuicklinkDestination.containsPlaceholder(value) {
+            Text("Resolved when you open it — placeholders are filled in first.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if let destination = QuicklinkDestination.detect(value) {
+            Label(destination.displayText, systemImage: destination.defaultSymbol)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        } else {
+            Text("This doesn't look like a URL, file path, or deeplink.")
+                .font(.caption)
+                .foregroundStyle(.orange)
+        }
+    }
+
+    /// Only the tokens that mean something in a destination: `{cursor}` and `{snippet:…}` are text
+    /// concerns and would be left literal here.
+    private var insertMenu: some View {
+        Menu("Insert…") {
+            Button("Argument") { insert("{argument}") }
+            Button("Named Argument") { insert("{argument name=\"Query\"}") }
+            Divider()
+            Button("Clipboard") { insert("{clipboard}") }
+            Button("Selected Text") { insert("{selection}") }
+            Divider()
+            Button("Date") { insert("{date}") }
+            Button("Time") { insert("{time}") }
+            Button("Date & Time") { insert("{datetime}") }
+            Button("Custom Date Format") { insert("{date format=\"yyyy-MM-dd\"}") }
+            Divider()
+            Button("UUID") { insert("{uuid}") }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var iconField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Icon")
+                .font(.callout.weight(.medium))
+            Button {
+                showingIconPicker = true
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    SymbolImage(name: resolvedSymbol, size: 14)
+                    Text(iconSymbol == nil ? "Automatic" : "Custom")
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                .frame(width: 150)
+            }
+            .popover(isPresented: $showingIconPicker, arrowEdge: .bottom) {
+                QuicklinkIconPicker(selection: $iconSymbol, automatic: automaticSymbol) {
+                    showingIconPicker = false
+                }
+            }
+        }
+    }
+
+    private var openWithField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Open With")
+                .font(.callout.weight(.medium))
+            Button {
+                showingAppPicker = true
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    if let openWithBundleID {
+                        let app = AppPresentation.resolve(bundleID: openWithBundleID, in: appIndex)
+                        Image(nsImage: app.icon).resizable().frame(width: 16, height: 16)
+                        Text(app.name).lineLimit(1)
+                    } else {
+                        Text("Default app")
+                    }
+                    Spacer(minLength: 0)
+                }
+                .frame(width: 180)
+            }
+            .popover(isPresented: $showingAppPicker, arrowEdge: .bottom) {
+                AppPickerPopover(clearTitle: "Default app") { bundleID in
+                    openWithBundleID = bundleID
+                    showingAppPicker = false
+                }
+            }
+        }
+    }
+
+    private func optionToggle(_ title: String, isOn: Binding<Bool>, detail: String) -> some View {
+        Toggle(isOn: isOn) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                Text(title)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.checkbox)
+    }
+
+    // MARK: - Behaviour
+
+    private var automaticSymbol: String {
+        QuicklinkDestination.detect(trimmed(link))?.defaultSymbol ?? Quicklink.sfSymbol
+    }
+
+    private var resolvedSymbol: String { iconSymbol ?? automaticSymbol }
+
+    private func insert(_ token: String) {
+        link += token
+    }
+
+    private func trimmed(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func save() {
+        // Editing keeps the UUID, and with it the quicklink's shortcut, favorite and visibility.
+        let existing = quicklink
+        let draft = Quicklink(
+            id: existing?.id ?? UUID(), name: name, link: link,
+            openWithBundleID: openWithBundleID, iconSymbol: iconSymbol,
+            showsInRootSearch: showsInRootSearch,
+            // Re-pinning keeps the original stamp, so saving an edit doesn't move the row.
+            pinnedAt: isPinned ? (existing?.pinnedAt ?? Date()) : nil,
+            createdAt: existing?.createdAt ?? Date())
+        do {
+            if existing == nil {
+                try AppCore.shared.addQuicklink(draft)
+            } else {
+                try AppCore.shared.updateQuicklink(draft)
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+/// A small fixed grid — enough to tell one quicklink from another at a glance without becoming a
+/// symbol browser. "Automatic" is always first, since the detected destination is the better default.
+private struct QuicklinkIconPicker: View {
+    @Binding var selection: String?
+    let automatic: String
+    let onPick: () -> Void
+
+    private static let symbols = [
+        "globe", "folder", "doc.text", "link", "star", "bookmark", "magnifyingglass", "cart",
+        "envelope", "message", "calendar", "clock", "checklist", "chart.bar", "hammer", "wrench",
+        "ladybug", "terminal", "chevron.left.forwardslash.chevron.right", "cloud", "server.rack",
+        "lock", "person.2", "building.2", "graduationcap", "book", "music.note", "play.rectangle",
+        "photo", "paintbrush", "creditcard", "map"
+    ]
+
+    private let columns = Array(repeating: GridItem(.fixed(30), spacing: Theme.Spacing.sm), count: 6)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            Button {
+                selection = nil
+                onPick()
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    SymbolImage(name: automatic, size: 14)
+                    Text("Automatic")
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            Divider()
+            LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
+                ForEach(Self.symbols, id: \.self) { symbol in
+                    Button {
+                        selection = symbol
+                        onPick()
+                    } label: {
+                        SymbolImage(name: symbol, size: 15)
+                            .frame(width: 30, height: 26)
+                            .background(
+                                RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                                    .fill(
+                                        selection == symbol
+                                            ? Theme.Colors.selection : Color.clear)
+                            )
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .frame(width: 244)
+    }
+}

--- a/Tinycast/Features/Settings/QuicklinksSettingsView.swift
+++ b/Tinycast/Features/Settings/QuicklinksSettingsView.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+/// The quicklink library plus the behaviour that applies to all of them.
+struct QuicklinksSettingsView: View {
+    @EnvironmentObject private var store: QuicklinkStore
+    @ObservedObject private var core = AppCore.shared
+    @ObservedObject private var settings = AppCore.shared.settings
+    @State private var query = ""
+    @State private var pendingDeletion: Quicklink?
+
+    var body: some View {
+        SettingsPane(
+            title: "Quicklinks",
+            subtitle: "Turn a URL, search, file, folder or deeplink into its own command."
+        ) {
+            FeatureSwitchCard(
+                header: "Quicklinks",
+                enableTitle: "Enable quicklinks",
+                enableSubtitle:
+                    "Open saved destinations from the launcher, a shortcut, or Search Quicklinks.",
+                systemImage: Quicklink.sfSymbol,
+                launcherSubtitle: "Find your quicklinks in launcher search.",
+                isEnabled: $settings.quicklinksEnabled,
+                showsInLauncher: $settings.quicklinksShowInLauncher)
+
+            Group {
+                if !store.isAvailable { storageCallout }
+                library
+                behaviour
+                transfer
+            }
+            // Same dim as a hidden launcher category; the switch above stays live.
+            .opacity(settings.quicklinksEnabled ? 1 : 0.45)
+            .disabled(!settings.quicklinksEnabled)
+        }
+        // Presented from the pane rather than the row, so "Create Quicklink" can open it from the
+        // palette by handing `AppCore` a request.
+        .sheet(item: $core.pendingQuicklinkEdit) { request in
+            QuicklinkEditorSheet(quicklink: request.quicklink)
+        }
+        .alert(item: $pendingDeletion) { quicklink in
+            Alert(
+                title: Text("Delete “\(quicklink.name)”?"),
+                message: Text("Its global shortcut and launcher references will also be removed."),
+                primaryButton: .destructive(Text("Delete")) {
+                    Task { await AppCore.shared.deleteQuicklink(id: quicklink.id, confirming: false) }
+                },
+                secondaryButton: .cancel())
+        }
+    }
+
+    // MARK: - Cards
+
+    private var storageCallout: some View {
+        SettingsCallout(
+            title: "Quicklinks can't be saved",
+            message:
+                "The quicklinks database couldn't be opened, so nothing you change here will stick. "
+                + "The existing file was left untouched.",
+            systemImage: "exclamationmark.triangle.fill",
+            tint: .orange)
+    }
+
+    @ViewBuilder
+    private var library: some View {
+        if !store.quicklinks.isEmpty {
+            SettingsSearchField(prompt: "Search quicklinks…", query: $query)
+        }
+        SettingsCard {
+            if results.isEmpty {
+                SettingsRow(
+                    title: store.quicklinks.isEmpty ? "No quicklinks" : "No matches",
+                    subtitle: store.quicklinks.isEmpty
+                        ? "Add one to make it searchable from the launcher."
+                        : "No quicklink matches “\(query)”.",
+                    systemImage: Quicklink.sfSymbol,
+                    tint: .secondary
+                ) {
+                    EmptyView()
+                }
+            } else {
+                ForEach(Array(results.enumerated()), id: \.element.id) { index, quicklink in
+                    if index > 0 { SettingsDivider() }
+                    QuicklinkSettingsRow(
+                        quicklink: quicklink,
+                        onEdit: { core.editQuicklink(quicklink) },
+                        onDelete: { pendingDeletion = quicklink })
+                }
+            }
+            SettingsDivider()
+
+            SettingsRow(
+                title: "Add Quicklink",
+                subtitle: "Name it, paste a link, then give it a shortcut if you want one.",
+                systemImage: "plus.circle",
+                tint: .green
+            ) {
+                Button("Add…") { core.editQuicklink(nil) }
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    private var behaviour: some View {
+        SettingsCard(header: "Behaviour") {
+            SettingsRow(
+                title: "Open in a new window",
+                subtitle:
+                    "Ask the handler for a new window instead of reusing its frontmost tab. "
+                    + "Only apps that accept a new-window argument can honour this.",
+                systemImage: "macwindow.badge.plus",
+                tint: .blue
+            ) {
+                Toggle("", isOn: $settings.quicklinkOpensNewWindow).labelsHidden()
+            }
+            SettingsDivider()
+            SettingsRow(
+                title: "When there's no selected text",
+                subtitle: "What {selection} does when the app in front exposes nothing to read.",
+                systemImage: "text.cursor",
+                tint: .indigo
+            ) {
+                Picker("", selection: $settings.quicklinkSelectionFallback) {
+                    ForEach(QuicklinkSelectionFallback.allCases) { option in
+                        Text(option.title).tag(option)
+                    }
+                }
+                .labelsHidden()
+                .fixedSize()
+            }
+            SettingsDivider()
+            SettingsRow(
+                title: "Confirm before deleting",
+                subtitle: "Ask first when deleting a quicklink from the launcher's Actions menu.",
+                systemImage: "trash",
+                tint: .red
+            ) {
+                Toggle("", isOn: $settings.quicklinkConfirmsBeforeDelete).labelsHidden()
+            }
+        }
+    }
+
+    private var transfer: some View {
+        SettingsCard(header: "Import & Export") {
+            SettingsRow(
+                title: "Import quicklinks",
+                subtitle: "Add quicklinks from a JSON file, skipping any you already have.",
+                systemImage: "square.and.arrow.down",
+                tint: .teal
+            ) {
+                Button("Import…") { Task { await core.importQuicklinks() } }
+                    .controlSize(.small)
+            }
+            SettingsDivider()
+            SettingsRow(
+                title: "Export quicklinks",
+                subtitle: "Write your whole library to a JSON file.",
+                systemImage: "square.and.arrow.up",
+                tint: .teal
+            ) {
+                Button("Export…") { Task { await core.exportQuicklinks() } }
+                    .controlSize(.small)
+                    .disabled(store.quicklinks.isEmpty)
+            }
+        }
+    }
+
+    /// The store already publishes display order, so filtering keeps pins at the top.
+    private var results: [Quicklink] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return store.quicklinks }
+        return store.quicklinks.filter {
+            $0.name.localizedCaseInsensitiveContains(trimmed)
+                || $0.link.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+}
+
+private struct QuicklinkSettingsRow: View {
+    let quicklink: Quicklink
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            SymbolImage(name: symbol, size: 13)
+                .foregroundStyle(.cyan)
+                .frame(width: Theme.Size.settingsRowIcon)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs / 2) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Text(quicklink.name)
+                        .font(.body)
+                        .lineLimit(1)
+                    if quicklink.isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .help("Pinned to the top")
+                    }
+                    if !quicklink.showsInRootSearch {
+                        Image(systemName: "eye.slash")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .help("Hidden from root search")
+                    }
+                }
+                Text(quicklink.link)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(quicklink.link)
+            }
+
+            Spacer(minLength: Theme.Spacing.lg)
+            ShortcutRecorder(action: .quicklink(id: quicklink.id))
+
+            Button(action: onEdit) {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.plain)
+            .help("Edit Quicklink")
+            .accessibilityLabel("Edit \(quicklink.name)")
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .help("Delete Quicklink")
+            .accessibilityLabel("Delete \(quicklink.name)")
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+        .padding(.vertical, Theme.Spacing.lg)
+    }
+
+    private var symbol: String {
+        quicklink.iconSymbol ?? QuicklinkDestination.detect(quicklink.link)?.defaultSymbol
+            ?? Quicklink.sfSymbol
+    }
+}

--- a/Tinycast/Features/Settings/SettingsRootView.swift
+++ b/Tinycast/Features/Settings/SettingsRootView.swift
@@ -7,8 +7,8 @@ extension Notification.Name {
 
 enum SettingsTab: Int, CaseIterable, Identifiable {
     // Declaration order is sidebar order: general, then one pane per launcher category, then the rest.
-    case general, applications, systemSettings, systemActions, commands, snippets, windowManagement,
-        clipboard, emoji, permissions, backup, miscellaneous, about
+    case general, applications, systemSettings, systemActions, commands, quicklinks, snippets,
+        windowManagement, clipboard, emoji, permissions, backup, miscellaneous, about
     var id: Int { rawValue }
 
     var title: String {
@@ -18,6 +18,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .systemSettings: return "System Settings"
         case .systemActions: return "System Actions"
         case .commands: return "Commands"
+        case .quicklinks: return "Quicklinks"
         case .snippets: return "Snippets"
         case .windowManagement: return "Window Management"
         case .clipboard: return "Clipboard"
@@ -36,6 +37,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .systemSettings: return "gearshape"
         case .systemActions: return "bolt"
         case .commands: return "terminal"
+        case .quicklinks: return "link"
         case .snippets: return "curlybraces"
         case .windowManagement: return "macwindow"
         case .clipboard: return "doc.on.clipboard"
@@ -55,6 +57,7 @@ enum SettingsTab: Int, CaseIterable, Identifiable {
         case .systemSettings: return .indigo
         case .systemActions: return .orange
         case .commands: return .green
+        case .quicklinks: return .cyan
         case .snippets: return .green
         case .windowManagement: return .blue
         case .clipboard: return .orange
@@ -86,6 +89,7 @@ struct SettingsRootView: View {
                 case .systemSettings: SystemSettingsSettingsView()
                 case .systemActions: SystemActionsSettingsView()
                 case .commands: CommandsSettingsView()
+                case .quicklinks: QuicklinksSettingsView()
                 case .snippets: SnippetsSettingsView()
                 case .windowManagement: WindowManagementSettingsView()
                 case .clipboard: ClipboardSettingsView()

--- a/Tools/quicklink-test.swift
+++ b/Tools/quicklink-test.swift
@@ -1,0 +1,465 @@
+// Standalone test for the quicklinks model, destination detection, store and archive — compiles the
+// *real* sources (no copy to sync):
+// swiftc -swift-version 6 Tinycast/Core/Quicklinks/Quicklink.swift Tinycast/Core/Quicklinks/QuicklinkDestination.swift Tinycast/Core/Quicklinks/QuicklinkStore.swift Tinycast/Core/Quicklinks/QuicklinkArchive.swift Tools/quicklink-test.swift -o /tmp/quicklink-test && /tmp/quicklink-test
+//
+// Every store here is built on a throwaway directory under the system temp dir and every path rule
+// is asked against an injected home, so a run can never see or touch a real quicklink library.
+
+import Foundation
+
+@main
+@MainActor
+struct QuicklinkTests {
+    static var failures = 0
+    static var passes = 0
+
+    /// Injected everywhere a path is resolved, so no assertion depends on the machine.
+    static let home = "/Users/tinycast-harness"
+
+    static func main() {
+        destinationDetection()
+        pathDetection()
+        encodingChoice()
+        placeholderDetection()
+        displayOrder()
+        storeCRUD()
+        storeValidation()
+        pinning()
+        persistence()
+        readsADatabaseWrittenElsewhere()
+        corruptDatabaseIsPreserved()
+        archiveRoundTrip()
+        archiveMerge()
+        archiveAcceptsAHandWrittenFile()
+
+        print("\(passes)/\(passes + failures) passed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Destination detection
+
+    static func destinationDetection() {
+        expect(detect("https://example.com") == .web(url("https://example.com")), "https is a website")
+        expect(detect("http://example.com/a") == .web(url("http://example.com/a")), "http is a website")
+        expect(
+            detect("example.com/search?q=1") == .web(url("https://example.com/search?q=1")),
+            "a bare host gains https, keeping its path and query")
+        expect(
+            detect("sub.example.co.uk") == .web(url("https://sub.example.co.uk")),
+            "a multi-label host is still a website")
+        expect(
+            detect("example.com:8080/x") == .web(url("https://example.com:8080/x")),
+            "a port does not stop a bare host being a website")
+        expect(
+            detect("spotify://track/1") == .deeplink(url("spotify://track/1")),
+            "an unknown scheme is a deeplink")
+        expect(
+            detect("shortcuts://run-shortcut?name=Focus")
+                == .deeplink(url("shortcuts://run-shortcut?name=Focus")),
+            "a deeplink keeps its query")
+        expect(
+            detect("mailto:someone@example.com") == .deeplink(url("mailto:someone@example.com")),
+            "a schemeless-authority scheme is still a deeplink")
+        expect(
+            detect("smb://server/share") == .network(url("smb://server/share")),
+            "smb is a network path")
+        expect(
+            detect("afp://server/share") == .network(url("afp://server/share")),
+            "afp is a network path")
+        expect(
+            detect("http://example.com/a b") == .web(url("http://example.com/a%20b")),
+            "a literal space is rescued rather than rejected")
+        expect(
+            detect("https://example.com/a%20b") == .web(url("https://example.com/a%20b")),
+            "an already-encoded value is not encoded twice")
+
+        expect(detect("") == nil, "an empty link resolves to nothing")
+        expect(detect("   ") == nil, "a whitespace-only link resolves to nothing")
+        expect(detect("not a url") == nil, "prose is not a destination")
+        expect(detect("{argument}") == nil, "a bare leftover placeholder is not a destination")
+        expect(detect("1.5") == nil, "a decimal is not a host")
+        expect(detect("C:/Users/x") == nil, "a drive letter is not a scheme")
+    }
+
+    static func pathDetection() {
+        expect(detect("/tmp") == .path("/tmp"), "an absolute path is a path")
+        expect(
+            detect("~/Downloads") == .path("\(home)/Downloads"),
+            "a tilde expands against the injected home")
+        expect(detect("~") == .path(home), "a bare tilde is the home directory")
+        expect(
+            detect("  ~/Projects/Tinycast  ") == .path("\(home)/Projects/Tinycast"),
+            "surrounding whitespace is trimmed before detection")
+        expect(
+            detect("file:///Users/x/notes.md") == .path("/Users/x/notes.md"),
+            "a file URL resolves to the path it names, not to a deeplink")
+        expect(
+            QuicklinkDestination.detect("~/Downloads", homeDirectory: "/Users/other/")
+                == .path("/Users/other/Downloads"),
+            "a trailing slash on the home directory does not double up")
+    }
+
+    static func encodingChoice() {
+        expect(
+            QuicklinkDestination.usesURLEncoding("https://x.com/?q={argument}", homeDirectory: home),
+            "values going into a URL are encoded")
+        expect(
+            QuicklinkDestination.usesURLEncoding("spotify://search/{argument}", homeDirectory: home),
+            "values going into a deeplink are encoded")
+        expect(
+            !QuicklinkDestination.usesURLEncoding("~/Notes/{date}.md", homeDirectory: home),
+            "values going into a path are not encoded")
+        expect(
+            !QuicklinkDestination.usesURLEncoding("/tmp/{argument}", homeDirectory: home),
+            "an absolute path is not encoded either")
+    }
+
+    static func placeholderDetection() {
+        expect(
+            QuicklinkDestination.containsPlaceholder("https://x.com/?q={argument}"),
+            "a token is a placeholder")
+        expect(
+            !QuicklinkDestination.containsPlaceholder("https://x.com/?q=1"),
+            "a plain link has no placeholder")
+        expect(
+            !QuicklinkDestination.containsPlaceholder("https://x.com/{unterminated"),
+            "an unclosed brace is not a placeholder")
+    }
+
+    // MARK: - Model
+
+    static func displayOrder() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let zulu = link("Zulu")
+        let alpha = link("alpha")
+        var pinnedLate = link("Late Pin")
+        pinnedLate.pinnedAt = base.addingTimeInterval(60)
+        var pinnedEarly = link("Early Pin")
+        pinnedEarly.pinnedAt = base
+
+        let sorted = [zulu, alpha, pinnedLate, pinnedEarly].sorted(by: Quicklink.precedes)
+        expect(
+            sorted.map(\.name) == ["Early Pin", "Late Pin", "alpha", "Zulu"],
+            "pins lead in pin order, then the rest sort case-insensitively by name")
+    }
+
+    // MARK: - Store
+
+    static func storeCRUD() {
+        withStore { store in
+            guard let github = try? store.add(link("GitHub", "https://github.com")) else {
+                return fail("adding a quicklink succeeds")
+            }
+            expect(store.quicklinks.map(\.name) == ["GitHub"], "an added quicklink is listed")
+            expect(store.quicklink(entryID: github.entryID)?.id == github.id, "entry id round-trips")
+
+            var edited = github
+            edited.name = "GitHub Issues"
+            edited.link = "https://github.com/issues"
+            try? store.update(edited)
+            expect(
+                store.quicklink(id: github.id)?.name == "GitHub Issues",
+                "an edit is stored under the same identity")
+            expect(
+                store.quicklink(id: github.id)?.link == "https://github.com/issues",
+                "the edited link is stored")
+
+            try? store.setShowsInRootSearch(false, id: github.id)
+            expect(
+                store.quicklink(id: github.id)?.showsInRootSearch == false,
+                "hiding from root search is stored")
+
+            guard let copy = try? store.duplicate(id: github.id) else {
+                return fail("duplicating a quicklink succeeds")
+            }
+            expect(copy.id != github.id, "a duplicate is a new identity")
+            expect(copy.name == "GitHub Issues Copy", "a duplicate gets a distinct name")
+            expect(copy.link == "https://github.com/issues", "a duplicate keeps the destination")
+
+            try? store.remove(id: copy.id)
+            expect(store.quicklinks.map(\.id) == [github.id], "removing drops only that row")
+        }
+    }
+
+    static func storeValidation() {
+        withStore { store in
+            expect(throwsError(store, link("", "https://x.com")) == .emptyName, "a name is required")
+            expect(throwsError(store, link("Name", "")) == .emptyLink, "a link is required")
+            expect(
+                throwsError(store, link("Name", "not a url")) == .unresolvableLink,
+                "a link that resolves to nothing is rejected")
+            expect(
+                throwsError(store, link("Na\0me", "https://x.com")) == .invalidCharacter,
+                "a null character is rejected")
+
+            _ = try? store.add(link("Search", "https://x.com/?q={argument}"))
+            expect(
+                store.quicklinks.count == 1,
+                "a templated link is accepted, since its destination is only knowable once expanded")
+            expect(
+                throwsError(store, link("search", "https://other.com")) == .duplicateName,
+                "a duplicate name is rejected case-insensitively")
+
+            var renamed = store.quicklinks[0]
+            renamed.name = "  Search  "
+            expect(
+                (try? store.update(renamed)) != nil,
+                "a quicklink does not collide with its own name when edited")
+            expect(store.quicklinks[0].name == "Search", "names are trimmed on save")
+        }
+    }
+
+    static func pinning() {
+        withStore { store in
+            _ = try? store.add(link("Alpha"))
+            _ = try? store.add(link("Bravo"))
+            _ = try? store.add(link("Charlie"))
+            expect(names(store) == ["Alpha", "Bravo", "Charlie"], "unpinned rows sort by name")
+
+            let charlie = store.quicklinks[2].id
+            let alpha = store.quicklinks[0].id
+            try? store.togglePinned(id: charlie)
+            expect(names(store) == ["Charlie", "Alpha", "Bravo"], "a pin lifts the row to the top")
+
+            try? store.togglePinned(id: alpha)
+            expect(
+                names(store) == ["Charlie", "Alpha", "Bravo"],
+                "a second pin joins below the first rather than displacing it")
+
+            var pinned = store.quicklink(id: charlie)!
+            pinned.name = "Charlie Renamed"
+            try? store.update(pinned)
+            expect(
+                names(store) == ["Charlie Renamed", "Alpha", "Bravo"],
+                "editing a pinned row keeps its pin stamp and its place")
+
+            try? store.togglePinned(id: charlie)
+            expect(
+                names(store) == ["Alpha", "Bravo", "Charlie Renamed"],
+                "unpinning drops the row back into the alphabetical block")
+        }
+    }
+
+    static func persistence() {
+        let dir = scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var stored: UUID?
+        do {
+            let store = QuicklinkStore(directory: dir)
+            var draft = link("Downloads", "~/Downloads")
+            draft.iconSymbol = "folder"
+            draft.openWithBundleID = "com.apple.finder"
+            stored = try? store.add(draft).id
+            try? store.togglePinned(id: stored!)
+        }
+
+        let reopened = QuicklinkStore(directory: dir)
+        reopened.load()
+        expect(reopened.isAvailable, "a reopened database is available")
+        guard let restored = reopened.quicklinks.first, reopened.quicklinks.count == 1 else {
+            return fail("the quicklink survives a close and reopen")
+        }
+        expect(restored.id == stored, "identity survives")
+        expect(restored.name == "Downloads" && restored.link == "~/Downloads", "fields survive")
+        expect(restored.iconSymbol == "folder", "the icon survives")
+        expect(restored.openWithBundleID == "com.apple.finder", "the open-with app survives")
+        expect(restored.isPinned, "the pin stamp survives")
+    }
+
+    /// Proves the column order the store binds matches the column order it reads, independently of
+    /// its own writer.
+    static func readsADatabaseWrittenElsewhere() {
+        let dir = scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let id = UUID()
+        sqlite(
+            dir.appendingPathComponent("quicklinks.sqlite3"),
+            """
+            CREATE TABLE quicklinks(
+              id TEXT PRIMARY KEY NOT NULL, name TEXT NOT NULL, link TEXT NOT NULL,
+              open_with TEXT, icon TEXT, in_root_search INTEGER NOT NULL DEFAULT 1,
+              pinned_at REAL, created_at REAL NOT NULL
+            );
+            INSERT INTO quicklinks(id, name, link, open_with, icon, in_root_search, created_at)
+              VALUES('\(id.uuidString)', 'Jira', 'https://jira.example.com', NULL, 'ticket', 0, 1000);
+            """)
+
+        let store = QuicklinkStore(directory: dir)
+        store.load()
+        guard let row = store.quicklinks.first else {
+            return fail("an externally written row loads")
+        }
+        expect(row.id == id, "the external id is read")
+        expect(row.name == "Jira" && row.link == "https://jira.example.com", "the text columns line up")
+        expect(row.iconSymbol == "ticket", "the icon column lines up")
+        expect(row.openWithBundleID == nil, "a null open-with reads as none")
+        expect(!row.showsInRootSearch, "the root-search flag lines up")
+        expect(!row.isPinned, "a null pin stamp reads as unpinned")
+    }
+
+    /// The invariant that separates this store from `ClipboardStore`: quicklinks are authored data,
+    /// so an unreadable database is reported, never deleted and recreated.
+    static func corruptDatabaseIsPreserved() {
+        let dir = scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let dbURL = dir.appendingPathComponent("quicklinks.sqlite3")
+        let garbage = Data("this is definitely not a database".utf8)
+        try? garbage.write(to: dbURL)
+
+        let store = QuicklinkStore(directory: dir)
+        expect(!store.isAvailable, "an unreadable database reports itself unavailable")
+        expect(store.quicklinks.isEmpty, "no rows are invented")
+        expect(
+            (try? Data(contentsOf: dbURL)) == garbage,
+            "the unreadable file is left exactly as it was — never deleted or overwritten")
+        expect(
+            throwsError(store, link("Anything")) == .storageUnavailable,
+            "a mutation refuses rather than pretending to save")
+    }
+
+    // MARK: - Archive
+
+    static func archiveRoundTrip() {
+        // Whole seconds throughout: the archive is ISO 8601 so a reader can hand-edit it, which
+        // means sub-second precision is deliberately not part of the format.
+        let stamp = Date(timeIntervalSince1970: 500)
+        let pinned = Quicklink(
+            name: "Pinned", link: "~/Downloads", openWithBundleID: "com.apple.finder",
+            iconSymbol: "folder", showsInRootSearch: false, pinnedAt: stamp, createdAt: stamp)
+        let plain = Quicklink(name: "GitHub", link: "https://github.com", createdAt: stamp)
+        let source = [plain, pinned]
+
+        guard let data = try? QuicklinkArchive.encode(source),
+            let decoded = try? QuicklinkArchive.decode(data)
+        else { return fail("an exported archive decodes again") }
+        expect(decoded == source, "every field survives an export and import round trip")
+    }
+
+    static func archiveMerge() {
+        let existing = [link("GitHub", "https://github.com"), link("Downloads", "~/Downloads")]
+        let incoming = [
+            link("github", "https://elsewhere.com"),  // same name
+            link("Repos", "https://github.com"),  // same destination
+            link("Jira", "https://jira.example.com"),  // new
+            link("Jira Two", "https://jira.example.com")  // duplicate of the one above, in-batch
+        ]
+
+        let result = QuicklinkArchive.merge(incoming, into: existing)
+        expect(result.imported == 1, "only the genuinely new quicklink is imported")
+        expect(result.skipped == 3, "the duplicates are counted rather than silently dropped")
+        expect(result.additions.first?.name == "Jira", "the imported quicklink is the new one")
+        expect(
+            result.additions.first?.id != incoming[2].id,
+            "an import takes a fresh identity so it cannot inherit another item's hotkey")
+
+        let reimported = QuicklinkArchive.merge(existing, into: existing)
+        expect(
+            reimported.imported == 0 && reimported.skipped == 2,
+            "importing the same file twice adds nothing")
+    }
+
+    static func archiveAcceptsAHandWrittenFile() {
+        let handWritten = Data(
+            """
+            { "version": 1, "quicklinks": [ { "name": "Staging", "link": "https://staging.example.com" } ] }
+            """.utf8)
+        guard let decoded = try? QuicklinkArchive.decode(handWritten), let first = decoded.first
+        else { return fail("a hand-written archive decodes") }
+        expect(first.name == "Staging", "the name is read")
+        expect(first.showsInRootSearch, "an omitted root-search flag defaults to shown")
+        expect(first.pinnedAt == nil, "an omitted pin stamp reads as unpinned")
+
+        let bareArray = Data(#"[{ "name": "A", "link": "https://a.example.com" }]"#.utf8)
+        expect((try? QuicklinkArchive.decode(bareArray))?.count == 1, "a bare array also decodes")
+        expect(
+            throwsArchiveError(Data("{}".utf8)) == .unreadable, "an unrelated JSON file is rejected")
+        expect(
+            throwsArchiveError(Data(#"{"version":1,"quicklinks":[]}"#.utf8)) == .empty,
+            "an archive with no quicklinks is reported as empty rather than imported")
+    }
+
+    // MARK: - Helpers
+
+    static func detect(_ value: String) -> QuicklinkDestination? {
+        QuicklinkDestination.detect(value, homeDirectory: home)
+    }
+
+    static func url(_ value: String) -> URL {
+        guard let url = URL(string: value) else {
+            fail("harness could not build \(value)")
+            exit(1)
+        }
+        return url
+    }
+
+    static func link(_ name: String, _ target: String = "https://example.com") -> Quicklink {
+        Quicklink(name: name, link: target)
+    }
+
+    static func names(_ store: QuicklinkStore) -> [String] {
+        store.quicklinks.map(\.name)
+    }
+
+    static func throwsError(_ store: QuicklinkStore, _ draft: Quicklink) -> QuicklinkError? {
+        do {
+            _ = try store.add(draft)
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    static func throwsArchiveError(_ data: Data) -> QuicklinkArchive.ArchiveError? {
+        do {
+            _ = try QuicklinkArchive.decode(data)
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    static func withStore(_ body: (QuicklinkStore) -> Void) {
+        let dir = scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        body(QuicklinkStore(directory: dir))
+    }
+
+    static func scratchDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-quicklink-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Writes a database the store didn't create, which is the only way to prove it reads one.
+    @discardableResult
+    static func sqlite(_ database: URL, _ sql: String) -> Set<String> {
+        let task = Process()
+        let pipe = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        task.arguments = [database.path, sql]
+        task.standardOutput = pipe
+        guard (try? task.run()) != nil else {
+            fail("could not run sqlite3")
+            return []
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        if task.terminationStatus != 0 { fail("sqlite3 failed: \(sql.prefix(60))") }
+        return Set(String(decoding: data, as: UTF8.self).split(separator: "\n").map(String.init))
+    }
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition {
+            passes += 1
+        } else {
+            fail(label)
+        }
+    }
+
+    static func fail(_ label: String) {
+        print("FAIL: \(label)")
+        failures += 1
+    }
+}

--- a/Tools/snippets-test.swift
+++ b/Tools/snippets-test.swift
@@ -19,6 +19,7 @@ struct SnippetsTests {
         try await testStoreWatcher()
         testTemplateExpansion()
         testDynamicPlaceholders()
+        testTemplateEncodingAndSelectionAlias()
         testKeywordPolicy()
         testKeywordLifecycle()
         testKeywordListenerLifecycle()
@@ -1020,6 +1021,85 @@ struct SnippetsTests {
                     locale: Locale(identifier: "en_US_POSIX"),
                     timeZone: timeZone)
             ).text == "[]")
+    }
+
+    /// The engine is shared with Quicklinks: it also expands a bare string, can percent-encode every
+    /// value it produces, and accepts Raycast's `{selectedText}` spelling of `{selection}`.
+    private static func testTemplateEncodingAndSelectionAlias() {
+        var calendar = Calendar(identifier: .gregorian)
+        let timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.timeZone = timeZone
+        let context = SnippetTemplateEngine.ExpansionContext(
+            clipboardHistory: ["a b&c"],
+            selection: "a b&c",
+            now: calendar.date(from: DateComponents(year: 2026, month: 7, day: 24))!,
+            calendar: calendar,
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: timeZone)
+
+        func expand(
+            _ text: String,
+            encoding: SnippetTemplateEngine.ValueEncoding = .none,
+            arguments: [String: String] = [:]
+        ) -> SnippetTemplateEngine.ExpansionResult {
+            SnippetTemplateEngine.expand(
+                text: text, context: context, userArguments: arguments, encoding: encoding)
+        }
+
+        // The text entry point.
+        check("a bare template expands without a snippet record",
+            expand("q={clipboard}").text == "q=a b&c")
+        check("a snippet reference has nothing to resolve against and stays literal",
+            expand("{snippet:Child}").text == "{snippet:Child}")
+        check("missing arguments are reported from the text entry point too",
+            expand("{argument name=\"Repository\"}").missingArguments
+                == [.init(name: "Repository", options: [])])
+
+        // Percent encoding of produced values.
+        check("percent encoding escapes a value substituted into a URL",
+            expand("https://x.com/?q={clipboard}", encoding: .percentEncoding).text
+                == "https://x.com/?q=a%20b%26c")
+        check("the literal parts of the template are never encoded",
+            expand("https://x.com/a b?q={selection}", encoding: .percentEncoding).text
+                == "https://x.com/a b?q=a%20b%26c")
+        check("encoding runs after the pipeline, so uppercase cannot rewrite the hex",
+            expand("{clipboard | uppercase}", encoding: .percentEncoding).text == "A%20B%26C")
+        check("raw opts a value out of automatic encoding",
+            expand("{clipboard | raw}", encoding: .percentEncoding).text == "a b&c")
+        check("an explicit percent-encode is not applied twice",
+            expand("{clipboard | percent-encode}", encoding: .percentEncoding).text
+                == "a%20b%26c")
+        check("encoding reaches every value-producing token",
+            expand("{argument name=\"A\"}", encoding: .percentEncoding, arguments: ["A": "x y"]).text
+                == "x%20y")
+        check("snippets ask for no encoding, so their expansion is unchanged",
+            expand("{clipboard}").text == "a b&c")
+
+        // {selectedText} is an accepted spelling of {selection}.
+        check("selectedText resolves to the selection",
+            expand("{selectedText}").text == expand("{selection}").text)
+        check("the alias is case-insensitive like every other token name",
+            expand("{SelectedText}").text == "a b&c")
+        check("the alias takes the same modifier pipeline",
+            expand("{selectedText | trim | uppercase}").text == "A B&C")
+        check("the alias is encoded like the canonical spelling",
+            expand("{selectedText}", encoding: .percentEncoding).text == "a%20b%26c")
+        check("the alias rejects parameters, exactly as selection does",
+            expand("{selectedText offset=1}").text == "{selectedText offset=1}")
+        let aliasSnippet = record(
+            "/tmp/alias.md", Snippet(name: "Alias", text: "[{selectedText}]"))
+        check("a snippet may use the alias too — it is not quicklink-only",
+            SnippetTemplateEngine.expand(aliasSnippet, snippets: [], context: context).text
+                == "[a b&c]")
+
+        // usesSelection drives the selection-fallback setting.
+        check("usesSelection sees both spellings",
+            SnippetTemplateEngine.usesSelection("a {selection} b")
+                && SnippetTemplateEngine.usesSelection("a {selectedText} b"))
+        check("usesSelection is false for a template that reads no selection",
+            !SnippetTemplateEngine.usesSelection("{clipboard} {date}"))
+        check("usesSelection parses rather than searches, so a malformed token does not count",
+            !SnippetTemplateEngine.usesSelection("{selection offset=1}"))
     }
 
     private static func testKeywordPolicy() {

--- a/docs/development.md
+++ b/docs/development.md
@@ -117,6 +117,10 @@ swiftc -swift-version 6 Tinycast/Core/Uninstall/UninstallTarget.swift \
     Tinycast/Core/Uninstall/UninstallSearchRoot.swift Tinycast/Core/Uninstall/UninstallRules.swift \
     Tinycast/Core/Uninstall/UninstallProtection.swift Tinycast/Core/Uninstall/UninstallPlan.swift \
     Tools/uninstall-test.swift -o /tmp/uninstall-test && /tmp/uninstall-test  # uninstall attribution + locking
+swiftc -swift-version 6 Tinycast/Core/Quicklinks/Quicklink.swift \
+    Tinycast/Core/Quicklinks/QuicklinkDestination.swift \
+    Tinycast/Core/Quicklinks/QuicklinkStore.swift Tinycast/Core/Quicklinks/QuicklinkArchive.swift \
+    Tools/quicklink-test.swift -o /tmp/quicklink-test && /tmp/quicklink-test  # quicklink destinations + store
 ```
 
 `Tools/fuzz-test.swift` compiles the real `Tinycast/Core/SearchRelevance.swift`, which is why that
@@ -150,6 +154,13 @@ encrypted with `CCCrypt` — and feeds the mapper hand-written JSON, so no real 
 committed. Turning payload values into Tinycast's own types lives in `RaycastImportV1`, which needs
 AppKit and is covered by the app build instead. The format contract is in
 [raycast-import.md](raycast-import.md).
+
+The quicklink harness compiles the real model, destination detector, SQLite store and JSON archive,
+so those four must stay Foundation-only (plus SQLite3). Each store is rooted in a throwaway temp
+directory and every path rule is asked against an injected home, so a run can never reach a real
+library. One case deliberately corrupts a database file and asserts the store reports itself
+unavailable **and leaves the file byte-for-byte intact** — quicklinks are authored data, so unlike
+`ClipboardStore` this one never deletes and recreates.
 
 The window-command harness compiles the real catalog, geometry and action memory (Foundation +
 CoreGraphics — `CGRect`'s `Equatable` conformance lives in the CoreGraphics overlay, not Foundation).

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -17,14 +17,19 @@ the keycap rendering — only the *engine* differs.
 Bindings persist as JSON strings under `KeyboardShortcuts_<name>` UserDefaults keys — a **legacy
 format** from the removed KeyboardShortcuts package, kept so old bindings survive. The set of bound
 bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch. System Settings panes use
-`boundPaneBundleIDs`; custom commands use their stable UUIDs in `boundCustomCommandIDs`.
+`boundPaneBundleIDs`; custom commands and quicklinks use their stable UUIDs in
+`boundCustomCommandIDs` and `boundQuicklinkIDs`. Those two are the per-item case — unlike a fixed
+catalog, there is no `allCases` to walk — so each needs an index for `start()` to re-register from
+and to prune bindings whose record was deleted while Tinycast wasn't running. That prune is why
+`QuicklinkStore` loads at launch even when the feature is off
+(see [quicklinks.md](quicklinks.md#hotkeys)).
 
 A `.combo` writes the original `{"carbonKeyCode":N,"carbonModifiers":N}` record and
 `HotKeyBinding.init(from:)` tries that shape first, so nothing needs migrating. A `.doubleTap` writes
 `{"doubleTapModifier":"command"}` — a shape a pre-double-tap build fails to decode and therefore reads
 as *unbound*, which is the intended degradation. The same wrapper is what `SettingsBackup.HotkeyBackup`
 stores, so old backup files import unchanged; a backup containing a double-tap cannot be read by an
-older build, which is what the `version` 3 bump records.
+older build, which is what the `version` 3 bump records (`version` 4 adds the quicklinks array).
 
 System actions and window commands are the fixed-catalog case: they persist under
 `KeyboardShortcuts_systemActionHotkey.<raw-id>` and `KeyboardShortcuts_windowCommandHotkey.<raw-id>`

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -104,8 +104,8 @@ permission-aware failures. With the palette closed it targets the frontmost app,
 Quit All act on the same window a palette launch would have.
 
 System actions occupy their own launcher section and their own Settings pane. The empty-query publication
-order is applications, System Settings, snippets, system actions, window commands, custom commands,
-then built-in commands; the sectioned view filters in that same order so the visible rows remain
+order is applications, System Settings, quicklinks, snippets, system actions, window commands, custom
+commands, then built-in commands; the sectioned view filters in that same order so the visible rows remain
 identical to the flat selection index.
 Search, favorites, visibility and learned ranking work through the normal `AppEntry` path, and every
 action is bindable to a global shortcut from Settings › System Actions
@@ -159,6 +159,15 @@ so launcher rows render keycaps for them. Their per-command shortcut and visibil
 Settings › Window Management rather than a launcher-category pane of their own — the same call already
 made for snippets. The feature ships off. See
 [window-management.md](window-management.md).
+
+## Quicklinks
+
+`QuicklinkStore` supplies its slice the same way custom commands do, sorted pinned-first then
+alphabetically by `Quicklink.precedes`. Only the name is indexed — a URL is a subsequence of nearly
+any query — and a per-item "show in root search" flag filters the slice before it is published. The
+four Quicklinks commands are dropped from the built-in slice in the same publish while the feature is
+off, so a toggle can't leave the section and its commands out of step. See
+[quicklinks.md](quicklinks.md).
 
 ## Custom commands
 

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -13,10 +13,19 @@ UUID) so the SwiftUI search field re-focuses. `RootPaletteView` switches its con
 - `.clipboard` → `ClipboardList` + preview
 - `.calculatorHistory` → `CalculatorHistoryList`
 - `.uninstall` → `UninstallList` (see [uninstall.md](uninstall.md))
+- `.quicklinks` → `QuicklinkList`
+- `.quicklinkArguments` → `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt))
 
 Clipboard and Calculator History are sub-screens reached from the launcher (Tab, a command, or a
 hotkey) and back out to it. Uninstall is one too, but reached only from a launcher app's Actions menu
-and scoped to that app; like Calculator History it stays out of the Tab cycle.
+and scoped to that app; like Calculator History it stays out of the Tab cycle. So do both Quicklinks
+screens.
+
+The argument screen is the one mode where the search field is not a search field: it *is* the current
+argument's input, so its placeholder names that argument and ↵ submits rather than activating a row.
+Its own state lives on `AppCore.quicklinkArguments`, the way `.uninstall`'s target lives on
+`UninstallSession`, and leaving the mode cancels the pending open. A bare backspace steps back an
+argument before it falls through to the usual exit-to-launcher.
 
 The flat `selection` index is the single source of truth for highlight / activation and **must always
 match the visible row order**, including the inline calculator card at index 0 when present (see

--- a/docs/palette.md
+++ b/docs/palette.md
@@ -53,6 +53,26 @@ in the half-open interval `(minY, maxY]`: the topmost row is exactly `maxY`, whi
 while that same value is the `minY` of the display stacked above. `contains` would therefore hand a
 pointer parked at the top of one display to its neighbour. `NSMouseInRect` exists for precisely this.
 
+## The placeholder is Tinycast's, not the field's
+
+The search field is a SwiftUI `TextField` with **no `prompt`**; `RootPaletteView` draws the
+placeholder itself as a leading-aligned background `Text`.
+
+AppKit gives an `NSTextField` a field editor one point taller than the field (measured: a 24pt editor
+in a 23pt field), and a `prompt` is rendered by whichever of the cell and the editor currently owns
+the text. The same placeholder glyphs therefore sit **one point higher** once the field takes the
+panel's shared field editor. That editor is created lazily and then cached on the window for its
+lifetime, so the step was only ever visible on the first summon after launch — and only where the eye
+could track it, when the outgoing and incoming placeholders share a leading word.
+
+Drawing it in SwiftUI pins it to the layout instead: measured ink is identical in both focus states,
+against a two-backing-pixel step for the real prompt. It is a **background**, not an overlay, so the
+caret still draws over it, and it carries `allowsHitTesting(false)` so clicking the placeholder still
+lands the caret. `PaletteMode.placeholder` is still the one source of the strings; the field takes an
+explicit `accessibilityLabel` because the prompt used to supply it.
+
+This is the same class of bug as the freeze below — both come from the cell/field-editor swap.
+
 ## Menu-open input freeze
 
 While a footer popover menu (⌘K Actions / app menu) is open the search field reads as inert but

--- a/docs/quicklinks.md
+++ b/docs/quicklinks.md
@@ -1,0 +1,176 @@
+# Quicklinks
+
+A quicklink turns a URL, search, file, folder or deeplink into a first-class command: searchable in
+the launcher, bindable to a global shortcut, and openable in a chosen app. Dynamic placeholders let
+one quicklink adapt to typed input, the clipboard, the selection, or the date.
+
+The feature ships **off**. **Settings → Quicklinks** carries the switch and its launcher-visibility
+companion. Off is fully off: no launcher section, no `Create` / `Search` / `Import` / `Export`
+Quicklinks commands, and `AppCore.openQuicklink` — the single funnel palette activation and global
+shortcuts both reach — refuses to open anything. Bindings stay registered, so re-enabling restores
+every shortcut without re-registering.
+
+## Destinations
+
+`QuicklinkDestination.detect` decides what a link is from its shape alone — no filesystem or Launch
+Services read — which is what keeps it pure and covered by `Tools/quicklink-test.swift`. In order:
+
+| Shape | Result |
+| --- | --- |
+| `~/…`, `/…`, `file://…` | `.path`, tilde expanded against the injected home |
+| `http:` · `https:` | `.web` |
+| `smb:` · `afp:` · `nfs:` · `ftp:` · `sftp:` · `ftps:` | `.network` |
+| any other `scheme:` | `.deeplink` (`spotify://`, `slack://`, `shortcuts://`, `mailto:`) |
+| a bare host with a letter-led TLD (`github.com/a?b=c`) | `.web`, `https://` prepended |
+| anything else | nothing — the link is rejected |
+
+Two false positives are excluded deliberately, because both are commoner than the schemes they would
+shadow: a one-letter "scheme" is a Windows drive letter, and a `scheme:` whose remainder is all
+digits is a `host:port`. A literal space is rescued by encoding it; anything else illegal is a real
+error, since blanket re-encoding would corrupt the `%xx` the template engine already produced.
+
+The detected kind decides the icon a row draws when the quicklink has no icon of its own, and
+`usesURLEncoding` decides whether substituted values are percent-encoded. That question is answered
+from the link's **prefix**, not from a parsed destination, because the encoding has to be chosen
+before the placeholders are resolved.
+
+## Placeholders
+
+Quicklinks reuse Tinycast's one template engine — the same
+[`SnippetTemplateEngine`](snippets.md#template-tokens) snippets use, so every token and every modifier
+is available and there is no second parser to keep in sync. `{cursor}` and `{snippet:…}` are text
+concerns with nothing to resolve against in a destination, so they are left literal.
+
+```text
+https://google.com/search?q={argument}
+https://github.com/search?q={argument name="Repository"}
+https://translate.google.com/?text={selection}
+https://chat.openai.com/?q={clipboard}
+~/Notes/{date format="yyyy-MM-dd"}.md
+```
+
+**Values going into a URL or deeplink are percent-encoded automatically**, so a search term with a
+space or an `&` can't truncate the destination. Encoding is applied *after* the modifier pipeline, so
+`| uppercase` can't rewrite the `%xx` hex, and it is skipped when the template already spoke for
+itself — `| raw` opts out, `| percent-encode` has done it once already. A local path is never
+encoded: `%20` in a path is a literal, not a space.
+
+`{selectedText}` is accepted as an alias for `{selection}`, so a link pasted from Raycast's docs
+works unchanged. `{selection}` stays the canonical spelling and is the only one the editor's
+**Insert…** menu writes.
+
+## The argument prompt
+
+A quicklink whose placeholders still need values doesn't open — it collects them first, in the
+palette, as `PaletteMode.quicklinkArguments`.
+
+Arguments are collected **one at a time** because the palette has exactly one text field, and that
+field *is* the current argument's input. The screen above it lists every argument with its answer so
+far. ↵ commits and advances; on the last one it opens. Backspace on an empty field steps back to the
+previous argument and restores what was typed there, so a typo in the second of three fields costs
+one keypress rather than the whole flow. An argument declaring `options=` renders its choices as
+ordinary selectable rows, so the flat selection index behaves exactly as it does in every other list.
+
+`QuicklinkArgumentSession` captures the expansion context **once**, before the first prompt — the
+same rule snippet expansion follows — so `{clipboard}`, `{selection}` and `{date}` cannot drift while
+the form is open. Reached from a global shortcut with the palette closed too: `AppCore` records the
+frontmost app first, the way `runSystemAction` does, so the selection is read from the window the
+user was actually in.
+
+When a template reads the selection and the app in front exposes nothing readable, **Settings →
+Quicklinks** decides what happens: substitute the clipboard, or ask for it through the same prompt as
+any other argument (a synthetic "Selected Text" argument).
+
+## Opening
+
+`QuicklinkLauncher` owns every platform effect. A path destination is checked with `fileExists`
+first, so a deleted folder names itself instead of failing as a silent no-op. `Open With` resolves a
+stored bundle ID through Launch Services; an app that has since been uninstalled reports a failure
+with an **Open with Default** recovery button rather than silently falling back.
+
+"Open in a new window" passes `--new-window` to the handler. Chromium and Firefox accept it, Safari
+ignores it, and an app that doesn't understand an argument drops it — so the setting is honest about
+applying only to handlers that accept one. Off is plain `NSWorkspace.open`, which reuses the
+frontmost tab; that is what "prefer existing tabs" means, so it is the same switch rather than a
+second one.
+
+Every failure — unresolvable link, missing file, missing app, refused open — reports through
+Tinycast's own dialog and leaves no partial state.
+
+## Search and pinning
+
+Quicklinks are their own `AppEntry.Kind`, their own `AppIndex` slice and their own launcher section,
+between System Settings and Snippets. Only the **name** is indexed; the destination is not searchable
+(a URL is a subsequence of almost any query). Per-quicklink "Show in root search" filters the slice;
+the pane's "Show in launcher" hides the whole section.
+
+`Quicklink.precedes` is the one display order — pinned first in the order they were pinned, then the
+rest by name — and both the store and the launcher slice sort through it, so the two can never
+disagree. **Pinned means the top of the Quicklinks section**, not above Applications: a second
+position in root search would need a second `AppEntry.Kind`, which the kind invariant forbids for one
+feature. The Search Quicklinks screen gives pins their own section, like the clipboard's.
+
+## Search Quicklinks
+
+`PaletteMode.quicklinks` is a sub-screen reached from the `Search Quicklinks` command. Like
+Calculator History it stays out of the Tab cycle and exits via the back chevron or a bare backspace.
+Its ⌘K menu carries Open (`↵`), Open With Default App (`⌘↵`, only when a handler is saved), Edit,
+Duplicate, Pin/Unpin (`⌘P`), Hide/Show in Root Search, Show in Finder (`⌘F`, only for a resolved
+path), and Delete (`⌘⌫`).
+
+Choosing an *arbitrary* app belongs to the editor, which has a picker; `PopoverMenu` is a flat list
+with no nesting, so the palette offers the one alternative that always exists — bypass the saved app
+and use the system handler, once, without changing what is saved.
+
+## Storage
+
+```text
+~/Library/Application Support/<bundle-id>/quicklinks.sqlite3
+```
+
+Application Support, not Caches: quicklinks are **authored data, not a regenerable cache**. That one
+fact decides the two ways `QuicklinkStore` differs from `ClipboardStore`, which it otherwise mirrors
+(WAL, `PRAGMA table_info` column sniffing plus `ALTER TABLE` for migrations, prepared statements, an
+`isolated deinit`):
+
+- The database lives beside the snippets library rather than in the cache.
+- **A database that won't open is never deleted.** `ClipboardStore` discards and recreates a corrupt
+  file because history is regenerable; doing that here would destroy the user's library. The store
+  publishes `isAvailable == false`, every mutation refuses with `QuicklinkError.storageUnavailable`,
+  and the pane says so. `Tools/quicklink-test.swift` asserts the file survives byte-for-byte.
+
+Editing preserves the UUID, and with it the quicklink's shortcut, favorite slot, visibility and
+learned ranking. Deleting goes through `AppCore`, which unwinds all four before removing the row.
+Duplicating takes a **new** identity, so the copy can't inherit the original's shortcut.
+
+## Hotkeys
+
+`HotKeyAction.quicklink(id:)` persists under `KeyboardShortcuts_quicklinkHotkey.<uuid>` with a
+`boundQuicklinkIDs` index, the same shape custom commands use — both are per-item rather than
+per-catalog-entry, so both need an index for `start()` to re-register from. The store therefore loads
+**even while the feature is off** and before `hotKeys.start`: the stale-binding prune reads that
+list, and an unloaded store would look like "every quicklink was deleted" and throw the shortcuts
+away.
+
+## Import & export
+
+`QuicklinkArchive` is a versioned JSON document (`{"version": 1, "quicklinks": [...]}`), pretty-printed
+with ISO 8601 dates so it can be hand-edited; a bare array decodes too, and only `name` and `link` are
+required. Duplicate detection is by **name or destination** — either match means the user already has
+it — compared against the existing library *and* against the rest of the incoming file, so one file
+can't import its own duplicates. Skipped entries are counted and reported in the summary. An import
+takes a fresh identity for every entry, so it can never collide with a shortcut an existing quicklink
+owns.
+
+Quicklinks and their bindings also ride in native settings backups, and the settings flags with them.
+Unlike `snippetsEnabled`, `quicklinksEnabled` grants no permission class and enables no listening, so
+excluding it would be cargo-culting.
+
+## Standalone harness
+
+```sh
+swiftc -swift-version 6 Tinycast/Core/Quicklinks/Quicklink.swift \
+  Tinycast/Core/Quicklinks/QuicklinkDestination.swift \
+  Tinycast/Core/Quicklinks/QuicklinkStore.swift Tinycast/Core/Quicklinks/QuicklinkArchive.swift \
+  Tools/quicklink-test.swift -o /tmp/quicklink-test && /tmp/quicklink-test
+```

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -79,7 +79,9 @@ lines, CR/LF choices, Unicode, and later lines containing `---` are preserved ex
 
 ## Template tokens
 
-The template engine is Foundation-only and receives one captured expansion context: clipboard
+The template engine is **shared with [Quicklinks](quicklinks.md#placeholders)**, which expands a bare
+string rather than a snippet record and asks for automatic percent-encoding. It is Foundation-only and
+receives one captured expansion context: clipboard
 history, selected text, clock, calendar, locale, time zone, and a UUID source. Everything the engine
 needs is injected, so the whole placeholder surface is covered by the standalone harness. If arguments
 require a prompt, the same context is reused afterward, so nothing can drift while the prompt is open.
@@ -91,7 +93,7 @@ so a migrated snippet keeps working.
 | --- | --- |
 | `{clipboard}` | Captured plain-text clipboard value |
 | `{clipboard offset=1}` | Nth most recent clipboard text; `offset=1` is the one before the current |
-| `{selection}` | Captured selected text from the target app, when Accessibility can read it |
+| `{selection}` · `{selectedText}` | Captured selected text from the target app, when Accessibility can read it. `{selectedText}` is Raycast's spelling, accepted on the way in; `{selection}` is the canonical one and the only one **Insert…** writes |
 | `{date}` · `{time}` · `{datetime}` | Captured date / time / both, in the context locale |
 | `{day}` | Weekday name |
 | `{uuid}` | A fresh UUID per token |
@@ -110,8 +112,9 @@ The editor's **Insert…** menu lists every token above; parameters and modifier
 Any value-producing token accepts a modifier pipeline, applied left to right:
 `{clipboard | trim | uppercase}`. The modifiers are `uppercase`, `lowercase`, `trim`,
 `percent-encode` (escapes everything outside RFC 3986's unreserved set), `json-stringify` (escapes for
-use *inside* a JSON string, without adding the quotes), and `raw` — accepted for Raycast
-compatibility and doing nothing, since Tinycast applies no automatic formatting to opt out of.
+use *inside* a JSON string, without adding the quotes), and `raw`, which opts a value out of any
+automatic formatting the *result* asks for. A snippet asks for none, so `raw` is a no-op there; a
+quicklink expanding into a URL percent-encodes every value, and `raw` is how a template opts one out.
 `{cursor}` and snippet references are structural, so they take no modifiers.
 
 A token Tinycast cannot parse — an unknown name, an unknown modifier, a duplicated or unsupported

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -332,6 +332,13 @@ The calculator's inline `CalculatorCard` reuses this card language (`cardFill` +
 
 ---
 
+## The palette search field
+
+Its placeholder is drawn by Tinycast, not by the field's `prompt` — an `NSTextField` renders a prompt
+through either its cell or its (one point taller) field editor, so a real prompt steps vertically when
+focus moves. Don't reintroduce `prompt:` on that field. See
+[palette.md](palette.md#the-placeholder-is-tinycasts-not-the-fields).
+
 ## Rules for agents working on the UI
 
 - **Restyle from screenshots, not extracted CSS.** Pixel-matching Raycast from its bundle led to wrong results before; compare rendered screenshots over a light desktop instead. There's no screen-recording from the shell here — verify AppKit rendering with a `swiftc` harness that prints layer state, and let the user do visual sign-off.


### PR DESCRIPTION
## Related issue

Closes #131

## What changed

Quicklinks: a saved URL, search, file, folder or deeplink becomes a first-class command — searchable
in the launcher, bindable to a global shortcut, openable in a chosen app, with dynamic placeholders
resolved at open time. Ships **off** behind a Settings switch. Full contract in
[`docs/quicklinks.md`](docs/quicklinks.md).

**Pure core** — `Core/Quicklinks/`, Foundation (+ SQLite3) only, so `Tools/quicklink-test.swift`
compiles the shipped sources rather than a copy:

- `Quicklink.swift` — model, `QuicklinkError`, and `Quicklink.precedes`, the one display order
  (pinned first by pin time, then by name) that both the store and the `AppIndex` slice sort through.
- `QuicklinkDestination.swift` — destination detection from shape alone, home directory injected.
- `QuicklinkStore.swift` — SQLite with `pinned_at` stamps.
- `QuicklinkArchive.swift` — versioned JSON import/export with name-or-destination dedup.

`QuicklinkLauncher` (every `NSWorkspace` call) and `QuicklinkArgumentSession` (prompt state) sit
beside them and stay out of the harness — the same split `Core/Uninstall/` uses.

**Surfaces** — a `.quicklink` `AppEntry.Kind` with its own launcher section between System Settings
and Snippets; four `CommandID`s (Create / Search / Import / Export); `PaletteMode.quicklinks` with a
full ⌘K menu; `PaletteMode.quicklinkArguments`; a Settings pane and editor sheet; per-item hotkeys;
settings-backup coverage.

### Non-obvious things in the diff

- **One template engine, not two.** Quicklinks expand through `SnippetTemplateEngine` rather than a
  second parser, so they inherit every token and modifier. Three additions, all behaviour-preserving
  because the new parameter defaults to off: a `expand(text:…)` entry point that the existing record
  overload now delegates to, a `ValueEncoding` applied *after* the modifier pipeline (so `| uppercase`
  can't rewrite `%xx` hex) and skipped when the template already spoke for itself, and
  `usesSelection`. This is what finally gives `| raw` a meaning — it opts a value out of the automatic
  percent-encoding a URL destination asks for. `{selectedText}` is accepted as an alias for
  `{selection}`; nothing ever *writes* it, so saved data keeps one spelling.
- **`QuicklinkStore` deliberately diverges from `ClipboardStore` in two places**, both because
  quicklinks are authored data rather than a regenerable cache: the database lives in Application
  Support, not Caches, and **a database that won't open is reported, never discarded**. The
  delete-and-recreate in `ClipboardStore.init` is only sound because history can be rebuilt; doing it
  here would destroy the user's library. There's a harness case that corrupts a file and asserts it
  survives byte-for-byte.
- **`AppEntry` gains one stored property**, `symbolName`. Quicklinks are the only kind whose glyph is
  the user's choice rather than its kind's; every other kind's `symbolIconName` is unchanged.
- **`AppIndex.setQuicklinks(_:commandsVisible:)` is one call for two slices** — the section and the
  four Quicklinks commands — so a toggle can't leave them out of step.
- **`HotKeyManager`'s UUID index is now shared.** Custom commands and quicklinks are both per-item
  rather than per-catalog-entry, so rather than a third copy of the same block there's now one
  `boundIDs` / `index` / `prune` / `persist` set that both namespaces use. `start()` takes a second
  ID set. This is also why `QuicklinkStore.load()` runs even while the feature is off: the
  stale-binding prune reads that list, and an unloaded store would look like "every quicklink was
  deleted" and throw the user's shortcuts away.
- **`AppPickerPopover` was promoted** out of `ClipboardSettingsView` (where it was `private`) into its
  own file, plus `AppPresentation.resolve` for the bundle-ID → name/icon fallback chain. It's the only
  app picker in the repo and the quicklink editor needs it; copying it would have been the wrong move.
  It gained an optional `clearTitle` row, so its callback is now `(String?) -> Void`.
- **`BackupActions` grew two shared panel helpers** (`chooseSaveLocation(named:)`, `chooseJSONFile()`)
  and `exportSettings` / `importSettings` now go through them instead of building panels inline.
- **`SettingsBackup` is `version` 4** — a `quicklinks` array, the flags, and `HotkeyBackup.quicklinks`.
  Unlike `snippetsEnabled`, `quicklinksEnabled` grants no permission class and enables no listening, so
  it's carried; excluding it would have been cargo-culting.
- **`LauncherView.rows` needed an explicit `[(String, [AppEntry])]` annotation.** With a ninth section
  the type-checker times out on the literal. Annotated with a comment saying why.
- **`Tinycast.xcodeproj` is regenerated.** The committed `.pbxproj` lists files individually, so new
  files do need `xcodegen generate` — worth knowing, since it's easy to assume the `path: Tinycast`
  glob resolves at build time.

### Second commit: the search-field placeholder step

Unrelated to Quicklinks in cause, found while testing it. The palette's search field no longer takes a
`prompt`; the placeholder is drawn as a leading-aligned background `Text`.

AppKit renders a `prompt` through either the field's cell or its field editor, and the editor is one
point taller than the field (measured: 24pt editor, 23pt field) — so identical placeholder glyphs sat
1pt higher once the field took the panel's shared field editor. That editor is created lazily then
cached on the window, which is why it only ever fired once per launch, and it only *read* as a bug
when the outgoing and incoming placeholders shared a leading word ("Search quicklinks…" →
"Search for apps and commands…").

Measured with a throwaway rasterizing probe, ink bounding box in backing pixels:

| configuration | ink y-range | shift on focus |
| --- | --- | --- |
| native prompt, unfocused | 29…65 | — |
| native prompt, focused | 27…63 | **−2px = −1pt** |
| background prompt, unfocused | 28…64 | — |
| background prompt, focused | 28…64 | **0** |

Header layout itself was ruled out first — the field lands at `minY 20.5, height 23.0` in all six
modes, so neither the placeholder string nor the mode icon was involved. A background rather than an
overlay so the caret still draws on top; `allowsHitTesting(false)` so clicking the placeholder still
lands the caret; an explicit `accessibilityLabel` because the prompt used to supply it.
`PaletteMode.placeholder` is still the single source of the strings.

## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

<!-- TODO: side-by-side before/after for the placeholder step (cold start → Search Quicklinks → back),
     plus a pass over the new screens: launcher section, Search Quicklinks + ⌘K, the argument prompt,
     the Settings pane and editor. -->

## Drawbacks

Deliberate tradeoffs:

- **"Open in a new window" can't be fully honoured, and the UI says so.** `NSWorkspace` passes
  `arguments` only when it actually launches the app, so `--new-window` reaches Chromium and Firefox
  on a cold start and is dropped by Safari and by an already-running handler. Doing better needs
  per-browser AppleScript. The setting's subtitle states the limitation rather than implying it always
  works. It also absorbs "always create new tab" — off *is* prefer-existing-tabs, so two switches
  would have been one switch twice.
- **"Show website previews" was dropped.** A favicon fetch is a network read, and the invariant is that
  every networked feature ships off behind a consent dialog naming the provider, on an ephemeral
  cacheless session. That's its own feature, not a checkbox on this one. Rows use a local glyph.
- **"Pin to top" means the top of the Quicklinks section**, not above Applications. A second root-search
  position would need a second `AppEntry.Kind`, which the kind invariant forbids for one feature. Pins
  do get their own section inside Search Quicklinks.
- **The palette's ⌘K offers "Open With Default App", not an arbitrary app picker.** `PopoverMenu` is a
  flat list with no nesting or picker; choosing an arbitrary app belongs to the editor, which has one.
  What the palette can usefully offer is the one alternative that always exists.
- **`{snippet:Name}` isn't resolved inside a quicklink.** A quicklink is a destination, not a text
  template; the token stays literal and save-time validation rejects it. Avoids coupling quicklinks to
  whether snippets are enabled.
- **A templated link isn't validated at save.** You can't check a template's output — only the real
  value can be. Non-templated links are rejected at save; templated ones report at open time.

Worth a second opinion:

- **The store loads at launch even with the feature off** (one small SELECT), because the hotkey
  stale-binding prune reads that list. The alternative — skipping the prune for quicklinks — felt
  worse than one short read.
- **Typed text still steps that same 1pt on a focus change**; only the placeholder is pinned. The
  palette's invariant is that the field never resigns first responder, so there shouldn't be a moment
  where it's visible, but it's the same root cause left standing.
- **Two commits, not one.** The placeholder fix is genuinely separate from Quicklinks and reads better
  on its own; say the word and I'll squash.

## Tests & validation

**New:** `Tools/quicklink-test.swift` — 82 checks over the four pure sources. Destination-detection
table (https, bare host with path/query/port, multi-label host, `spotify://`, `shortcuts://`,
`mailto:`, `smb://`, `afp://`, literal space, already-encoded value, `~/`, bare `~`, `/tmp`,
`file://`, and the rejections: empty, whitespace, prose, leftover `{argument}`, `1.5`, `C:/Users`);
tilde expansion against an injected home; the encoding choice per link shape; `Quicklink.precedes`;
store CRUD, validation and pinning; **persistence across a close and reopen**; reading a database
written by the `sqlite3` CLI (proves the bind order matches the read order independently of our own
writer); **a corrupt database left byte-for-byte intact**; archive round-trip, merge counts, and a
hand-written JSON fixture. Registered in `docs/development.md` and `.github/workflows/ci.yml`.

**Extended:** `Tools/snippets-test.swift` — the `expand(text:)` entry point (including `{snippet:X}`
staying literal through it), `.percentEncoding` after the pipeline, `| raw` opting out,
`| percent-encode` not double-encoding, `.none` leaving snippet behaviour byte-identical, the
`{selectedText}` alias in every form (case, modifiers, parameter rejection, and through the record
overload so it isn't quicklink-only), and `usesSelection`.

**All 16 harnesses pass** (`docs/development.md` § Tests) and the app **builds clean** with no new
warnings — `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug build`.

**Docs updated:** new `docs/quicklinks.md`; `AGENTS.md` (invariant, layout, subsystem links);
`docs/snippets.md` (shared engine, the alias, `raw`'s new meaning); `docs/launcher.md` (publication
order, new section); `docs/palette.md` (the two modes, the argument flow, the placeholder rule);
`docs/hotkeys.md` (the per-item index); `docs/ui.md` (don't reintroduce `prompt:`);
`docs/development.md`.

**By hand:** _to fill in — the manual checklist is in `docs/quicklinks.md` and covers the argument
flow from a hotkey with the palette closed, the failure dialogs, import/export, and the feature
switch teardown._
