### PR TITLE
Add signpost instrumentation for the refactor baseline

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1A899FE562A7344918CE1B44 /* QuicklinkLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECAB8490328EA3DADD05D9D /* QuicklinkLauncher.swift */; };
 		1AF562E00FCB98B12076F01D /* SnippetKeywordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5051622CC6497E2151326CA /* SnippetKeywordListener.swift */; };
 		1B90AA42601E3AE7EEE3AD5D /* WindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388A58EDB35AB0CB30EE20DE /* WindowLayout.swift */; };
+		1C86B50DD6012B25DFEDE26D /* Signposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A206E48D7BE14B14F360CD5 /* Signposts.swift */; };
 		1D0C2F452B3801503B70EA9E /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F63A3610C275E4961D60C7E /* GeneralSettingsView.swift */; };
 		1F39D145DBE2290532C93614 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849FF3D93960B75F341D867C /* ClipboardSettingsView.swift */; };
 		1F555347D7CE8F37A2C37BAF /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C069647C67120EBAED14422 /* SnippetRepository.swift */; };
@@ -222,6 +223,7 @@
 		596ADD747B4546B1E3340094 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		59D08C3AEAFB224866F23C3E /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
 		5A002AC0DE601E1F65D20C4A /* SnippetTemplateEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplateEngine.swift; sourceTree = "<group>"; };
+		5A206E48D7BE14B14F360CD5 /* Signposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signposts.swift; sourceTree = "<group>"; };
 		5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLauncher.swift; sourceTree = "<group>"; };
 		5D3E4F8A2BCECFF0E11441BE /* RaycastSnippetImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastSnippetImport.swift; sourceTree = "<group>"; };
 		5D57B0AE44D21035163BD422 /* CommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRegistry.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 				9AA0E1FD530C764A021E6053 /* SearchScopes.swift */,
 				C722D73D270A3A6CED4023F7 /* SettingsPaneScanner.swift */,
 				286B7598B81017C746558C7C /* ShellCommandRunner.swift */,
+				5A206E48D7BE14B14F360CD5 /* Signposts.swift */,
 				8925E80B57FDCEAB9764C65F /* SpotlightNames.swift */,
 				5175A8F8FED58C0DAEA2AFD6 /* SymbolImage.swift */,
 				0D16E927986D415F5386CDCF /* SystemAction.swift */,
@@ -894,6 +897,7 @@
 				F9C1192D849B94E783D05568 /* ShortcutCaptureSession.swift in Sources */,
 				57AE40420A6A5349AD092878 /* ShortcutRecorder.swift in Sources */,
 				4006B894BE909BD067ED1E3A /* ShortcutRecorderPopover.swift in Sources */,
+				1C86B50DD6012B25DFEDE26D /* Signposts.swift in Sources */,
 				85A9ACCB19D9502A79F1A508 /* Snippet.swift in Sources */,
 				0674D8E1567253879EF50150 /* SnippetArgumentsPrompt.swift in Sources */,
 				1AF562E00FCB98B12076F01D /* SnippetKeywordListener.swift in Sources */,

--- a/Tinycast/Core/AppCore.swift
+++ b/Tinycast/Core/AppCore.swift
@@ -157,113 +157,117 @@ final class AppCore: ObservableObject {
     }
 
     func start() {
-        // AppKit's default tooltip delay is ~2–3s; shorten it (in ms) so the compact-bar favorite tooltips appear promptly. Registration domain — never overrides a user default.
-        UserDefaults.standard.register(defaults: ["NSInitialToolTipDelay": 250])
-        NSApp.setActivationPolicy(.accessory)
-        // Force dark: the Liquid Glass material is tuned for a deep dark surface and renders washed-out in Light mode.
-        NSApp.appearance = NSAppearance(named: .darkAqua)
+        Signposts.interval("AppCore.start") {
+            // AppKit's default tooltip delay is ~2–3s; shorten it (in ms) so the compact-bar favorite tooltips appear promptly. Registration domain — never overrides a user default.
+            UserDefaults.standard.register(defaults: ["NSInitialToolTipDelay": 250])
+            NSApp.setActivationPolicy(.accessory)
+            // Force dark: the Liquid Glass material is tuned for a deep dark surface and renders washed-out in Light mode.
+            NSApp.appearance = NSAppearance(named: .darkAqua)
 
-        clipboardStore.maxAge = settings.clipboardRetention.maxAge
-        // Defer the initial SQLite read + stale-image prune off the synchronous launch path so the menu bar is interactive immediately; `items` is @Published, so the palette fills in when it lands.
-        Task { clipboardStore.load() }
-        clipboardManager.start()
+            clipboardStore.maxAge = settings.clipboardRetention.maxAge
+            // Defer the initial SQLite read + stale-image prune off the synchronous launch path so the menu bar is interactive immediately; `items` is @Published, so the palette fills in when it lands.
+            Task { clipboardStore.load() }
+            clipboardManager.start()
 
-        appIndex.start(settings: settings)
-        customCommands.onChange = { [weak self] _ in
-            self?.applyCustomCommandsPresence()
-        }
-        applyCustomCommandsPresence()
-        applyWindowCommandsPresence()
-        quicklinks.onChange = { [weak self] _ in
-            self?.applyQuicklinksPresence()
-        }
-        // Loaded even while the feature is off, and before `hotKeys.start`: its stale-binding prune
-        // reads this list, so an unloaded store would look like "every quicklink was deleted" and
-        // throw away the user's shortcuts. The library is small, so this is one short read.
-        quicklinks.load()
-        applyQuicklinksPresence()
-        Task { await appIndex.refresh() }
-        Task { await emojiIndex.load() }
-        currencyRates.start()
-
-        hotKeys.onTogglePalette = { [weak self] in self?.togglePalette() }
-        hotKeys.onToggleClipboard = { [weak self] in self?.toggleClipboard() }
-        hotKeys.onToggleEmoji = { [weak self] in self?.toggleEmoji() }
-        hotKeys.onRunCustomCommand = { [weak self] id in self?.runCustomCommand(id: id) }
-        hotKeys.onRunSystemAction = { [weak self] id in self?.runSystemAction(id: id) }
-        hotKeys.onRunWindowCommand = { [weak self] id in self?.runWindowCommand(id: id) }
-        hotKeys.onOpenQuicklink = { [weak self] id in self?.openQuicklink(id: id) }
-        hotKeys.start(
-            customCommandIDs: Set(customCommands.commands.map(\.id)),
-            quicklinkIDs: Set(quicklinks.quicklinks.map(\.id)))
-        // Deliberately keeps running while `hotKeys.recordingAction` pauses Carbon: the recorder relies on the tap's rewritten flags to capture Hyper shortcuts.
-        hyperKeyTap.start(settings: settings)
-
-        snippetsStore.onSnapshot = { [weak self] snapshot in
-            guard let self else { return }
-            self.applySnippetsLauncherPresence()
-            self.snippetListener.update(snapshot.records)
-        }
-        // Off out of the box, so a user who never enables snippets pays for no load, no watcher and no tap.
-        if settings.snippetsEnabled {
-            Task { await snippetsStore.start() }
-            startSnippetKeywordListener()
-        }
-
-        // @Published emits synchronously before the property is written (as in `AppIndex.start`), so every re-projection defers to a task that reads the settled value.
-        for publisher in [
-            settings.$windowManagementEnabled, settings.$windowManagementShowInLauncher
-        ] {
-            publisher.dropFirst()
-                .sink { [weak self] _ in
-                    MainActor.assumeIsolated {
-                        guard let self else { return }
-                        Task { self.applyWindowCommandsPresence() }
-                    }
-                }
-                .store(in: &cancellables)
-        }
-        for publisher in [settings.$customCommandsEnabled, settings.$customCommandsShowInLauncher] {
-            publisher.dropFirst()
-                .sink { [weak self] _ in
-                    MainActor.assumeIsolated {
-                        guard let self else { return }
-                        Task { self.applyCustomCommandsPresence() }
-                    }
-                }
-                .store(in: &cancellables)
-        }
-        for publisher in [settings.$quicklinksEnabled, settings.$quicklinksShowInLauncher] {
-            publisher.dropFirst()
-                .sink { [weak self] _ in
-                    MainActor.assumeIsolated {
-                        guard let self else { return }
-                        Task { self.applyQuicklinksPresence() }
-                    }
-                }
-                .store(in: &cancellables)
-        }
-        settings.$snippetsEnabled.dropFirst()
-            .sink { [weak self] _ in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    Task { self.applySnippetsEnabled() }
-                }
+            appIndex.start(settings: settings)
+            customCommands.onChange = { [weak self] _ in
+                self?.applyCustomCommandsPresence()
             }
-            .store(in: &cancellables)
-        settings.$snippetsShowInLauncher.dropFirst()
-            .sink { [weak self] _ in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    Task { self.applySnippetsLauncherPresence() }
-                }
+            applyCustomCommandsPresence()
+            applyWindowCommandsPresence()
+            quicklinks.onChange = { [weak self] _ in
+                self?.applyQuicklinksPresence()
             }
-            .store(in: &cancellables)
+            // Loaded even while the feature is off, and before `hotKeys.start`: its stale-binding prune
+            // reads this list, so an unloaded store would look like "every quicklink was deleted" and
+            // throw away the user's shortcuts. The library is small, so this is one short read.
+            quicklinks.load()
+            applyQuicklinksPresence()
+            Task { await appIndex.refresh() }
+            Task { await emojiIndex.load() }
+            currencyRates.start()
 
-        // First launch has no palette hotkey bound and shows nothing but the menu-bar icon; guide the user once. Marker is written at show-time so it stays one-time even if they Cmd-Q mid-flow.
-        if !OnboardingState.hasOnboarded {
-            OnboardingState.markShown()
-            showOnboarding()
+            hotKeys.onTogglePalette = { [weak self] in self?.togglePalette() }
+            hotKeys.onToggleClipboard = { [weak self] in self?.toggleClipboard() }
+            hotKeys.onToggleEmoji = { [weak self] in self?.toggleEmoji() }
+            hotKeys.onRunCustomCommand = { [weak self] id in self?.runCustomCommand(id: id) }
+            hotKeys.onRunSystemAction = { [weak self] id in self?.runSystemAction(id: id) }
+            hotKeys.onRunWindowCommand = { [weak self] id in self?.runWindowCommand(id: id) }
+            hotKeys.onOpenQuicklink = { [weak self] id in self?.openQuicklink(id: id) }
+            hotKeys.start(
+                customCommandIDs: Set(customCommands.commands.map(\.id)),
+                quicklinkIDs: Set(quicklinks.quicklinks.map(\.id)))
+            // Deliberately keeps running while `hotKeys.recordingAction` pauses Carbon: the recorder relies on the tap's rewritten flags to capture Hyper shortcuts.
+            hyperKeyTap.start(settings: settings)
+
+            snippetsStore.onSnapshot = { [weak self] snapshot in
+                guard let self else { return }
+                self.applySnippetsLauncherPresence()
+                self.snippetListener.update(snapshot.records)
+            }
+            // Off out of the box, so a user who never enables snippets pays for no load, no watcher and no tap.
+            if settings.snippetsEnabled {
+                Task { await snippetsStore.start() }
+                startSnippetKeywordListener()
+            }
+
+            // @Published emits synchronously before the property is written (as in `AppIndex.start`), so every re-projection defers to a task that reads the settled value.
+            for publisher in [
+                settings.$windowManagementEnabled, settings.$windowManagementShowInLauncher
+            ] {
+                publisher.dropFirst()
+                    .sink { [weak self] _ in
+                        MainActor.assumeIsolated {
+                            guard let self else { return }
+                            Task { self.applyWindowCommandsPresence() }
+                        }
+                    }
+                    .store(in: &cancellables)
+            }
+            for publisher in [
+                settings.$customCommandsEnabled, settings.$customCommandsShowInLauncher
+            ] {
+                publisher.dropFirst()
+                    .sink { [weak self] _ in
+                        MainActor.assumeIsolated {
+                            guard let self else { return }
+                            Task { self.applyCustomCommandsPresence() }
+                        }
+                    }
+                    .store(in: &cancellables)
+            }
+            for publisher in [settings.$quicklinksEnabled, settings.$quicklinksShowInLauncher] {
+                publisher.dropFirst()
+                    .sink { [weak self] _ in
+                        MainActor.assumeIsolated {
+                            guard let self else { return }
+                            Task { self.applyQuicklinksPresence() }
+                        }
+                    }
+                    .store(in: &cancellables)
+            }
+            settings.$snippetsEnabled.dropFirst()
+                .sink { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        guard let self else { return }
+                        Task { self.applySnippetsEnabled() }
+                    }
+                }
+                .store(in: &cancellables)
+            settings.$snippetsShowInLauncher.dropFirst()
+                .sink { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        guard let self else { return }
+                        Task { self.applySnippetsLauncherPresence() }
+                    }
+                }
+                .store(in: &cancellables)
+
+            // First launch has no palette hotkey bound and shows nothing but the menu-bar icon; guide the user once. Marker is written at show-time so it stays one-time even if they Cmd-Q mid-flow.
+            if !OnboardingState.hasOnboarded {
+                OnboardingState.markShown()
+                showOnboarding()
+            }
         }
     }
 

--- a/Tinycast/Core/AppIndex.swift
+++ b/Tinycast/Core/AppIndex.swift
@@ -449,36 +449,39 @@ final class AppIndex: ObservableObject {
     nonisolated private static func scan(
         scopes: [String], cache: SpotlightNames.Cache
     ) -> ([AppEntry], SpotlightNames.Cache) {
-        var cache = cache
-        var seenBundleIDs = Set<String>()
-        var result: [AppEntry] = []
-        for url in SearchScopes.appBundles(in: scopes) {
-            let bundle = Bundle(url: url)
-            let bundleID = bundle?.bundleIdentifier
-            // Dedup by bundle id; the earliest scope wins.
-            if let bundleID, !seenBundleIDs.insert(bundleID).inserted { continue }
+        Signposts.interval("AppIndex.scan") {
+            var cache = cache
+            var seenBundleIDs = Set<String>()
+            var result: [AppEntry] = []
+            for url in SearchScopes.appBundles(in: scopes) {
+                let bundle = Bundle(url: url)
+                let bundleID = bundle?.bundleIdentifier
+                // Dedup by bundle id; the earliest scope wins.
+                if let bundleID, !seenBundleIDs.insert(bundleID).inserted { continue }
 
-            let name =
-                (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
-                ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)
-                ?? url.deletingPathExtension().lastPathComponent
-            let executable = bundle?.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
-            result.append(
-                AppEntry(
-                    id: url.path, name: name, url: url, bundleID: bundleID,
-                    kind: .application,
-                    alternateNames: cache.alternateNames(for: url, displayName: name),
-                    // A binary named after the app adds nothing the display name doesn't already cover.
-                    executableName: executable.flatMap {
-                        $0.caseInsensitiveCompare(name) == .orderedSame ? nil : $0
-                    }))
+                let name =
+                    (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+                    ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)
+                    ?? url.deletingPathExtension().lastPathComponent
+                let executable =
+                    bundle?.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
+                result.append(
+                    AppEntry(
+                        id: url.path, name: name, url: url, bundleID: bundleID,
+                        kind: .application,
+                        alternateNames: cache.alternateNames(for: url, displayName: name),
+                        // A binary named after the app adds nothing the display name doesn't already cover.
+                        executableName: executable.flatMap {
+                            $0.caseInsensitiveCompare(name) == .orderedSame ? nil : $0
+                        }))
+            }
+            // `publishEntries` appends snippets, custom commands and built-in commands after apps and Settings panes so the sectioned flat selection maps 1:1 onto rows.
+            let apps = result.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            // Settings panes are `.appex` bundles, which carry no Spotlight alternate names.
+            return (apps + SettingsPaneScanner.scan(), cache)
         }
-        // `publishEntries` appends snippets, custom commands and built-in commands after apps and Settings panes so the sectioned flat selection maps 1:1 onto rows.
-        let apps = result.sorted {
-            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-        }
-        // Settings panes are `.appex` bundles, which carry no Spotlight alternate names.
-        return (apps + SettingsPaneScanner.scan(), cache)
     }
 
     private func publishEntries() {
@@ -505,22 +508,24 @@ final class AppIndex: ObservableObject {
     }
 
     private func rank(_ q: String, limit: Int) -> [AppEntry] {
-        let learned = ranking.boosts(query: q)
-        let scored = apps.compactMap { app -> (AppEntry, Int)? in
-            // Base relevance comes from the entry's strongest matching field; the learned boost is added after and never knows which field that was.
-            guard let score = SearchRelevance.score(query: q, fields: app.searchFields) else {
-                return nil
+        Signposts.interval("AppIndex.rank") {
+            let learned = ranking.boosts(query: q)
+            let scored = apps.compactMap { app -> (AppEntry, Int)? in
+                // Base relevance comes from the entry's strongest matching field; the learned boost is added after and never knows which field that was.
+                guard let score = SearchRelevance.score(query: q, fields: app.searchFields) else {
+                    return nil
+                }
+                return (app, score + (learned[app.preferenceKey] ?? 0))
             }
-            return (app, score + (learned[app.preferenceKey] ?? 0))
+            return
+                scored
+                .sorted {
+                    $0.1 != $1.1
+                        ? $0.1 > $1.1
+                        : $0.0.name.localizedCaseInsensitiveCompare($1.0.name) == .orderedAscending
+                }
+                .prefix(limit)
+                .map(\.0)
         }
-        return
-            scored
-            .sorted {
-                $0.1 != $1.1
-                    ? $0.1 > $1.1
-                    : $0.0.name.localizedCaseInsensitiveCompare($1.0.name) == .orderedAscending
-            }
-            .prefix(limit)
-            .map(\.0)
     }
 }

--- a/Tinycast/Core/PaletteWindowController.swift
+++ b/Tinycast/Core/PaletteWindowController.swift
@@ -18,29 +18,31 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     var isVisible: Bool { panel?.isVisible ?? false }
 
     func show() {
-        // Ignore ourselves as the "previous" app (e.g. summoned while Settings/About/Onboarding is frontmost) so paste/focus-restore always targets the user's real app, never Tinycast's own field.
-        let frontmost = NSWorkspace.shared.frontmostApplication
-        if frontmost?.processIdentifier != NSRunningApplication.current.processIdentifier {
-            previousApp = frontmost
-        }
-        // Resolve the name/icon path once per summon rather than per render; reading `previousApp` (not `frontmost`) keeps the label naming the same app paste will actually target.
-        core.palette.pasteTarget = PasteTarget(app: previousApp)
-        let panel = ensurePanel()
-        // Open disarmed: the pointer may already sit over a row, but nothing should be highlighted until the user actually moves it.
-        core.palette.hoverHighlightArmed = false
-        // Re-resolve the anchor for wherever the user is summoning now, then hold it for the whole session so compact↔expanded resizes never move the window.
-        anchor = nil
-        // Size + place the panel to the current collapsed state before ordering front, so a compact summon never flashes at full size.
-        positionPanel(panel, collapsed: core.paletteIsCollapsed)
-        // Flush the hosting view's first-mount layout while still off-screen, so the one-time safe-area settle of the `safeAreaInset` header doesn't nudge the search placeholder on the first visible frame.
-        panel.contentView?.layoutSubtreeIfNeeded()
-        // The `.nonactivatingPanel` takes key focus without activating the app, so summoning the palette never raises the app's Settings/onboarding windows behind it.
-        panel.makeKeyAndOrderFront(nil)
-        panel.orderFrontRegardless()
-        // A never-activated login-item process can drop the first key request before the window is registered with the window server; re-assert next turn once it is (same pattern as AuxWindowController).
-        DispatchQueue.main.async { [weak panel] in
-            guard let panel, panel.isVisible, !panel.isKeyWindow else { return }
+        Signposts.interval("PaletteWindowController.show") {
+            // Ignore ourselves as the "previous" app (e.g. summoned while Settings/About/Onboarding is frontmost) so paste/focus-restore always targets the user's real app, never Tinycast's own field.
+            let frontmost = NSWorkspace.shared.frontmostApplication
+            if frontmost?.processIdentifier != NSRunningApplication.current.processIdentifier {
+                previousApp = frontmost
+            }
+            // Resolve the name/icon path once per summon rather than per render; reading `previousApp` (not `frontmost`) keeps the label naming the same app paste will actually target.
+            core.palette.pasteTarget = PasteTarget(app: previousApp)
+            let panel = ensurePanel()
+            // Open disarmed: the pointer may already sit over a row, but nothing should be highlighted until the user actually moves it.
+            core.palette.hoverHighlightArmed = false
+            // Re-resolve the anchor for wherever the user is summoning now, then hold it for the whole session so compact↔expanded resizes never move the window.
+            anchor = nil
+            // Size + place the panel to the current collapsed state before ordering front, so a compact summon never flashes at full size.
+            positionPanel(panel, collapsed: core.paletteIsCollapsed)
+            // Flush the hosting view's first-mount layout while still off-screen, so the one-time safe-area settle of the `safeAreaInset` header doesn't nudge the search placeholder on the first visible frame.
+            panel.contentView?.layoutSubtreeIfNeeded()
+            // The `.nonactivatingPanel` takes key focus without activating the app, so summoning the palette never raises the app's Settings/onboarding windows behind it.
             panel.makeKeyAndOrderFront(nil)
+            panel.orderFrontRegardless()
+            // A never-activated login-item process can drop the first key request before the window is registered with the window server; re-assert next turn once it is (same pattern as AuxWindowController).
+            DispatchQueue.main.async { [weak panel] in
+                guard let panel, panel.isVisible, !panel.isKeyWindow else { return }
+                panel.makeKeyAndOrderFront(nil)
+            }
         }
     }
 

--- a/Tinycast/Core/Signposts.swift
+++ b/Tinycast/Core/Signposts.swift
@@ -1,0 +1,14 @@
+import os
+
+/// Coarse permanent intervals; free at runtime unless an Instruments session is attached.
+enum Signposts {
+    private static let signposter = OSSignposter(
+        subsystem: "com.tinycast.perf", category: "Performance")
+
+    /// Own the `defer`: `withIntervalSignpost` skips its end event when the wrapped work throws.
+    static func interval<T>(_ name: StaticString, around work: () throws -> T) rethrows -> T {
+        let state = signposter.beginInterval(name)
+        defer { signposter.endInterval(name, state) }
+        return try work()
+    }
+}

--- a/Tinycast/Core/Uninstall/UninstallScanner.swift
+++ b/Tinycast/Core/Uninstall/UninstallScanner.swift
@@ -27,71 +27,76 @@ enum UninstallScanner {
         isTargetRunning: Bool, roots: [UninstallSearchRoot] = UninstallSearchRoot.all,
         budget: SizeBudget = .default
     ) throws -> UninstallPlan {
-        let home = NSHomeDirectory()
-        let environment = UninstallEnvironment(
-            home: home, hasFullDiskAccess: detectFullDiskAccess(home: home))
-        guard
-            let identity = UninstallIdentity.make(
-                target: target, otherAppNames: otherAppNames, otherBundleIDs: otherBundleIDs,
-                ownBundleID: Bundle.main.bundleIdentifier, ownBundleURL: Bundle.main.bundleURL)
-        else { throw Failure.refused }
+        try Signposts.interval("UninstallScanner.scan") {
+            let home = NSHomeDirectory()
+            let environment = UninstallEnvironment(
+                home: home, hasFullDiskAccess: detectFullDiskAccess(home: home))
+            guard
+                let identity = UninstallIdentity.make(
+                    target: target, otherAppNames: otherAppNames, otherBundleIDs: otherBundleIDs,
+                    ownBundleID: Bundle.main.bundleIdentifier, ownBundleURL: Bundle.main.bundleURL)
+            else { throw Failure.refused }
 
-        let bundlePath = target.bundleURL.standardizedFileURL.path
-        var candidates: [UninstallCandidate] = [
-            candidate(
-                path: bundlePath, evidence: .bundle, environment: environment, budget: budget,
-                displayName: target.bundleURL.deletingPathExtension().lastPathComponent)
-        ].compactMap { $0 }
+            let bundlePath = target.bundleURL.standardizedFileURL.path
+            var candidates: [UninstallCandidate] = [
+                candidate(
+                    path: bundlePath, evidence: .bundle, environment: environment, budget: budget,
+                    displayName: target.bundleURL.deletingPathExtension().lastPathComponent)
+            ].compactMap { $0 }
 
-        var seen = Set(candidates.map(\.path))
-        for root in roots {
-            try Task.checkCancellation()
-            let rootPath = root.path(home: home)
-            guard let names = childNames(of: rootPath) else { continue }
-            // One stat per root, not per row.
-            let parent = parentFacts(of: rootPath)
-            for match in UninstallRules.matches(childNames: names, in: root, identity: identity) {
-                let path = (rootPath + "/" + match.name as NSString).standardizingPath
-                guard
-                    UninstallRules.isAcceptableCandidate(
-                        path: path, rootPath: rootPath, home: home, bundlePath: bundlePath),
-                    seen.insert(path).inserted,
-                    let candidate = candidate(
-                        path: path, evidence: match.evidence, environment: environment,
-                        budget: budget, parent: parent)
-                else { continue }
-                candidates.append(candidate)
+            var seen = Set(candidates.map(\.path))
+            for root in roots {
+                try Task.checkCancellation()
+                let rootPath = root.path(home: home)
+                guard let names = childNames(of: rootPath) else { continue }
+                // One stat per root, not per row.
+                let parent = parentFacts(of: rootPath)
+                for match in UninstallRules.matches(childNames: names, in: root, identity: identity)
+                {
+                    let path = (rootPath + "/" + match.name as NSString).standardizingPath
+                    guard
+                        UninstallRules.isAcceptableCandidate(
+                            path: path, rootPath: rootPath, home: home, bundlePath: bundlePath),
+                        seen.insert(path).inserted,
+                        let candidate = candidate(
+                            path: path, evidence: match.evidence, environment: environment,
+                            budget: budget, parent: parent)
+                    else { continue }
+                    candidates.append(candidate)
+                }
             }
-        }
 
-        for directory in UninstallSearchRoot.binDirectories {
-            try Task.checkCancellation()
-            let rootPath = (directory as NSString).expandingTildeInPath
-            guard let names = childNames(of: rootPath) else { continue }
-            let parent = parentFacts(of: rootPath)
-            for name in names {
-                let path = (rootPath + "/" + name as NSString).standardizingPath
-                guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: path)
-                else { continue }
-                // A relative link resolves against its own directory, not the cwd.
-                let resolved =
-                    target.hasPrefix("/")
-                    ? target : (rootPath as NSString).appendingPathComponent(target)
-                guard UninstallRules.isBundleSymlink(target: resolved, bundlePath: bundlePath),
-                    seen.insert(path).inserted,
-                    let candidate = candidate(
-                        path: path, evidence: .binSymlink, environment: environment, budget: budget,
-                        parent: parent)
-                else { continue }
-                candidates.append(candidate)
+            for directory in UninstallSearchRoot.binDirectories {
+                try Task.checkCancellation()
+                let rootPath = (directory as NSString).expandingTildeInPath
+                guard let names = childNames(of: rootPath) else { continue }
+                let parent = parentFacts(of: rootPath)
+                for name in names {
+                    let path = (rootPath + "/" + name as NSString).standardizingPath
+                    guard
+                        let target = try? FileManager.default.destinationOfSymbolicLink(
+                            atPath: path)
+                    else { continue }
+                    // A relative link resolves against its own directory, not the cwd.
+                    let resolved =
+                        target.hasPrefix("/")
+                        ? target : (rootPath as NSString).appendingPathComponent(target)
+                    guard UninstallRules.isBundleSymlink(target: resolved, bundlePath: bundlePath),
+                        seen.insert(path).inserted,
+                        let candidate = candidate(
+                            path: path, evidence: .binSymlink, environment: environment,
+                            budget: budget, parent: parent)
+                    else { continue }
+                    candidates.append(candidate)
+                }
             }
-        }
 
-        // Bundle pinned first; the rest by path, which is the order the list shows.
-        let leftovers = candidates.filter { $0.evidence != .bundle }.sorted { $0.path < $1.path }
-        return UninstallPlan(
-            target: target, candidates: candidates.filter { $0.evidence == .bundle } + leftovers,
-            isTargetRunning: isTargetRunning)
+            // Bundle pinned first; the rest by path, which is the order the list shows.
+            let leftovers = candidates.filter { $0.evidence != .bundle }.sorted { $0.path < $1.path }
+            return UninstallPlan(
+                target: target, candidates: candidates.filter { $0.evidence == .bundle } + leftovers,
+                isTargetRunning: isTargetRunning)
+        }
     }
 
     // MARK: - Private

--- a/docs/refactor/ROADMAP.md
+++ b/docs/refactor/ROADMAP.md
@@ -176,7 +176,7 @@ Update this table as phases land. `Blocked` requires a note in the phase's progr
 
 | #   | Status      | Branch / commit | Date | Notes |
 | --- | ----------- | --------------- | ---- | ----- |
-| 01  | Not started |                 |      |       |
+| 01  | In progress | `refactor/01-instrumentation-and-baselines` | 2026-08-05 | PR open. Build + harnesses pass; Core regression sweep and Instruments baselines outstanding. |
 | 02  | Not started |                 |      |       |
 | 03  | Not started |                 |      |       |
 | 04  | Not started |                 |      |       |

--- a/docs/refactor/progress/01-instrumentation-and-baselines.md
+++ b/docs/refactor/progress/01-instrumentation-and-baselines.md
@@ -1,0 +1,133 @@
+# Phase 01 — Instrumentation and baselines
+
+---
+
+## Status
+
+| Field                         | Value                                    |
+| ----------------------------- | ---------------------------------------- |
+| **Status**                    | In progress                              |
+| **Started**                   | 2026-08-05                               |
+| **Completed**                 | —                                        |
+| **Operator**                  | abue-ammar                               |
+| **Branch**                    | `refactor/01-instrumentation-and-baselines` |
+| **Commit**                    | filled in on merge                       |
+| **Claude conversations used** | 1                                        |
+| **Actual effort**             | ~1h vs. estimate of S                    |
+
+---
+
+## Completed tasks
+
+- [x] Objective 1 — a single `Signposts` helper exposing one `OSSignposter` on `com.tinycast.perf`
+- [x] Objective 2 — the five intervals: `AppIndex.scan`, `AppIndex.rank`,
+      `PaletteWindowController.show`, `UninstallScanner.scan`, `AppCore.start`
+- [ ] Objective 3 — record the baseline measurements (operator, needs Instruments; see below)
+
+## Acceptance criteria
+
+- [x] AC1 — one `OSSignposter` on subsystem `com.tinycast.perf` — verified by: `Signposts.swift` is the
+      only file importing `os`; one `OSSignposter` literal in the repo
+- [x] AC2 — all five emit begin/end including early-return and throw paths — verified by: the helper
+      uses `defer`, and a standalone build of the same helper streamed to `log stream --signpost` gave
+      27 begins / 27 ends with half the calls throwing
+- [x] AC3 — zero behaviour change — verified by: `git diff -w` reduces the whole diff to the five
+      wrapper lines, their closing braces and four indent-forced line re-wraps
+- [x] AC4 — Release builds, binary growth < 0.5 % — verified by: 3,471,592 → 3,473,448 bytes (+0.053 %)
+      against a clean HEAD build in a throwaway worktree
+- [x] AC5 — no new import in a harness-compiled file — verified by: `git diff -U0 | grep '^+import'` is
+      empty; all 16 harness commands compile and pass
+- [x] AC6 — net comment lines ≤ 5, zero stacked blocks — verified by: 2 added, non-consecutive, both
+      under 100 characters
+
+---
+
+## Verification
+
+| Checklist                  | Result  | Notes                                                                     |
+| -------------------------- | ------- | ------------------------------------------------------------------------- |
+| `checklists/build.md`      | PASS    | Debug + Release, zero new warnings; binary +1,856 B (+0.053 %)            |
+| `checklists/testing.md`    | PASS    | Harnesses run: all 16 in `docs/development.md`                            |
+| `checklists/regression.md` | PENDING | Core sweep is a manual UI pass — not run; see Issues                       |
+| `checklists/review.md`     | PASS    | Caught one overlong new comment line, fixed before commit                 |
+
+### Measurements
+
+| Metric                     | Before    | After     | Δ                 |
+| -------------------------- | --------- | --------- | ----------------- |
+| Binary size (Release)      | 3,471,592 | 3,473,448 | +1,856 B (+0.053 %) |
+| Clean install verified?    | —         | n-a       | phase persists nothing |
+| Cold launch, median of 3   | —         | —         | operator, Instruments |
+| RSS after 10 palette opens | —         | —         | operator          |
+| Phase-specific signpost    | —         | —         | operator, Instruments |
+
+### Baselines still to capture (operator)
+
+The phase document assigns these to the operator, and they need Instruments and Activity Monitor:
+`AppCore.start` duration · `AppIndex.scan` cold vs. warm (first open vs. tenth) ·
+`PaletteWindowController.show` · `UninstallScanner.scan` on an app with a large support folder ·
+cold launch median of 3 · RSS after 10 palette opens · RSS after browsing 50 clipboard images ·
+the four comment-density `grep` figures from review H-1.
+
+Every later phase compares against these, so capture them before starting phase 02.
+
+---
+
+## Failed tasks
+
+| What | Why it failed | Decision |
+| ---- | ------------- | -------- |
+| none |               |          |
+
+---
+
+## Issues encountered
+
+- **`withIntervalSignpost` leaks its interval when the wrapped work throws.** The SDK's
+  `callSignpostAroundTask` is `let result = try task()` with no `defer`, so the `.end` emit is skipped
+  on the throw path. Measured before relying on it: a standalone build where half the calls threw
+  emitted 26 begins against 13 ends. The helper therefore owns an explicit `defer` around
+  `beginInterval`/`endInterval`; the same test then gave 27/27. This matters for
+  `UninstallScanner.scan`, which throws on `Failure.refused` and on `Task.checkCancellation()`.
+- The Core regression sweep in `checklists/regression.md` was not run — it is a manual keyboard and
+  visual pass. The diff is instrumentation-only (`git diff -w` is five wrapper lines), so the risk is
+  low, but the sweep is still owed before this merges.
+
+---
+
+## Deviations from the phase document
+
+- The phase names `withIntervalSignpost` first; the helper uses `beginInterval` + `defer` instead, for
+  the reason above. AC2 explicitly permits `defer`, and no call site is affected — every one is a
+  single `Signposts.interval("…") { … }` wrapper.
+- Four statements were re-wrapped because the added indent level pushed them past 100 columns. No
+  statement was reordered and no comment text was edited.
+
+---
+
+## Follow-up work
+
+| Observation                                                                                                    | Where                                     | Suggested phase |
+| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------- |
+| AC2 and the Regression-risks table both treat `withIntervalSignpost` as leak-proof on throw. It is not.        | `phases/01-instrumentation-and-baselines.md` | doc fix, no phase |
+
+---
+
+## Rollback notes
+
+- **Revert command:** `git revert <sha>`
+- **Is a plain revert sufficient?** Yes — nothing persists, nothing migrates, no later phase reads this
+  code (only the operator reads its output).
+- **Dependent phases that must also be reverted:** none
+- **Data risk on revert:** none
+
+---
+
+## Sign-off
+
+- [x] All acceptance criteria met
+- [ ] All four checklists passed — regression sweep outstanding
+- [x] `ROADMAP.md` status table updated
+- [x] Follow-ups recorded above, not fixed in this phase
+- [ ] Merged to `main`
+- [ ] **Stopped.** Next phase is a separate session.


### PR DESCRIPTION
Refactor **phase 01 — Instrumentation and baselines** (`docs/refactor/phases/01-instrumentation-and-baselines.md`).

Five permanent `os_signpost` intervals so the roadmap's later performance claims are falsifiable. Instrumentation only — no logic change.

## What changed

`Tinycast/Core/Signposts.swift` (new, 14 lines) holds one `OSSignposter` on subsystem `com.tinycast.perf` and one `interval(_:around:)` helper. Five call sites wrap their existing bodies in it:

| Interval | Site |
| --- | --- |
| `AppIndex.scan` | the detached app + settings-pane scan |
| `AppIndex.rank` | the scoring pass |
| `PaletteWindowController.show` | summon to ordered-front |
| `UninstallScanner.scan` | the full uninstall scan |
| `AppCore.start` | the synchronous launch path |

`import os` appears only in `Signposts.swift`. No harness-compiled file gained an import, so the purity invariant holds.

## One deviation from the phase document

The phase names `withIntervalSignpost` first. **It does not satisfy AC2.** The SDK's `callSignpostAroundTask` is `let result = try task()` with no `defer`, so a throw propagates and the `.end` event is never emitted. Measured before relying on it — a standalone build with half the calls throwing emitted **26 begins / 13 ends**. The helper therefore owns an explicit `defer` around `beginInterval`/`endInterval`; the same test then gave **27 / 27**.

This is load-bearing for `UninstallScanner.scan`, which throws on `Failure.refused` and on `Task.checkCancellation()`. AC2 explicitly permits `defer`, and no call site is affected.

`AC2` and the Regression-risks table in the phase doc both describe `withIntervalSignpost` as leak-proof on throw; that's recorded as a doc fix in the progress file's Follow-up work.

## Verification

- `xcodebuild` Debug **and** Release: BUILD SUCCEEDED, zero new warnings
- All **16** harness commands from `docs/development.md`: pass
- Release binary 3,471,592 → 3,473,448 bytes, **+0.053 %** (budget: < 0.5 %), measured against a clean `HEAD` build in a throwaway worktree
- `git diff -w` reduces the entire diff to the five wrapper lines, their closing braces, and four line re-wraps forced by the added indent — no statement reordered, no condition altered, no comment text edited

## Reviewer notes

- The large `+/-` counts are indentation. Read this with **`git diff -w`** — it collapses to ~26 lines.
- `checklists/regression.md` (Core sweep) has **not** been run — it is a manual keyboard and visual pass.
- The Instruments baselines the phase assigns to the operator are **not** captured yet; `docs/refactor/progress/01-instrumentation-and-baselines.md` lists exactly which numbers are outstanding. They should be recorded before phase 02 starts, since every later phase compares against them.
