### PR TITLE
Phase 02 — Render Settings launcher icons through AppIconView

### DIFF
--- a/Tinycast/Features/Settings/LauncherItemsCard.swift
+++ b/Tinycast/Features/Settings/LauncherItemsCard.swift
@@ -72,8 +72,7 @@ private struct LauncherItemRow: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.lg) {
-            Image(nsImage: entry.icon)
-                .resizable()
+            AppIconView(app: entry)
                 .frame(width: 22, height: 22)
             Text(entry.name).lineLimit(1)
             Spacer(minLength: Theme.Spacing.xl)

--- a/docs/refactor/ROADMAP.md
+++ b/docs/refactor/ROADMAP.md
@@ -177,7 +177,7 @@ Update this table as phases land. `Blocked` requires a note in the phase's progr
 | #   | Status      | Branch / commit | Date | Notes |
 | --- | ----------- | --------------- | ---- | ----- |
 | 01  | In progress | `refactor/01-instrumentation-and-baselines` | 2026-08-05 | PR open. Build + harnesses pass; Core regression sweep and Instruments baselines outstanding. |
-| 02  | Not started |                 |      |       |
+| 02  | In progress | `refactor/02-async-icons-in-settings` | 2026-08-05 | PR open. Build + review pass; regression sweep outstanding. `AppEntry.icon` retained — two callers in `AppPickerPopover`, so AC5 not met. |
 | 03  | Not started |                 |      |       |
 | 04  | Not started |                 |      |       |
 | 05  | Not started |                 |      |       |

--- a/docs/refactor/progress/02-async-icons-in-settings.md
+++ b/docs/refactor/progress/02-async-icons-in-settings.md
@@ -1,0 +1,139 @@
+# Phase 02 — Async icons in the Settings launcher list
+
+---
+
+## Status
+
+| Field                         | Value                                       |
+| ----------------------------- | ------------------------------------------- |
+| **Status**                    | In progress                                 |
+| **Started**                   | 2026-08-05                                  |
+| **Completed**                 | —                                           |
+| **Operator**                  | abue-ammar                                  |
+| **Branch**                    | `refactor/02-async-icons-in-settings`       |
+| **Commit**                    | filled in on merge                          |
+| **Claude conversations used** | 1                                           |
+| **Actual effort**             | ~0.5h vs. estimate of S                     |
+
+---
+
+## Completed tasks
+
+- [x] Objective 1 — replace the synchronous icon render in `LauncherItemRow` with `AppIconView`
+- [ ] Objective 2 — delete `AppEntry.icon` (**not done**; two live callers remain — see Deviations)
+- [x] Objective 3 — confirm no other synchronous icon path remains in a list context (one does, in
+      `AppPickerPopover`; recorded as follow-up rather than fixed here)
+
+## Acceptance criteria
+
+- [x] AC1 — `LauncherItemRow` renders through `AppIconView`, no synchronous `IconCache` call remains in
+      it — verified by: the diff is the row body itself; `grep -rn "\.icon\b" Tinycast` no longer matches
+      `LauncherItemsCard.swift`
+- [x] AC2 — warm icons paint on the first frame with no placeholder flash — verified by: `AppIconView` is
+      untouched, so its `init` still seeds `_image` from `IconCache.cached…`/`cachedSymbol` synchronously.
+      Visual confirmation is part of the outstanding regression sweep
+- [x] AC3 — `AppEntry.icon` deleted **or its remaining caller named** — verified by: satisfied via the
+      documented-caller branch; both callers named under Deviations
+- [x] AC4 — icon size, corner radius and row layout pixel-identical — verified by: the `22 × 22` frame is
+      unchanged and `AppIconView` applies `.resizable()` internally. Screenshot comparison is part of the
+      outstanding regression sweep
+- [ ] AC5 — `grep -rn "IconCache.icon(forFile" Tinycast` returns only the internal call — **NOT MET**;
+      three hits remain (`AppIndex.swift:95`, `AppPickerPopover.swift:80`, `ClipboardView.swift:441`).
+      The criterion presupposes the AC3 deletion the codebase does not permit inside this phase's
+      boundaries. See Deviations
+- [x] AC6 — no behaviour change beyond decode timing — verified by: `git diff -U0 | grep '^[-+].*"'` is
+      empty (no string changed); no condition, default, optional-handling or ordering in the diff
+
+---
+
+## Verification
+
+| Checklist                  | Result  | Notes                                                                         |
+| -------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `checklists/build.md`      | PASS    | §1–4. Debug + Release `BUILD SUCCEEDED`, zero new warnings; binary +0 B        |
+| `checklists/testing.md`    | PASS    | Harnesses run: **none** — the one touched file is in no row of the source map  |
+| `checklists/regression.md` | PENDING | Core sweep + **Launcher & icons** are manual UI passes — not run; see Issues   |
+| `checklists/review.md`     | PASS    | §1–8 mechanically clean; 1 file, +1/−2, under the expected commit size         |
+
+### Measurements
+
+| Metric                     | Before    | After     | Δ                       |
+| -------------------------- | --------- | --------- | ----------------------- |
+| Binary size (Release)      | 3,473,448 | 3,473,448 | +0 B (0 %)              |
+| Clean install verified?    | —         | n-a       | phase persists nothing  |
+| Cold launch, median of 3   | —         | —         | n-a, not a startup path |
+| RSS after 10 palette opens | —         | —         | n-a, Settings-only      |
+| Phase-specific signpost    | —         | —         | no signpost covers this |
+
+The performance claim here is main-thread work removed from a scroll path, which no existing signpost
+measures. Confirmation is the regression sweep's "scrolls smoothly with no hitch on first paint".
+
+---
+
+## Failed tasks
+
+| What                     | Why it failed                                                | Decision                    |
+| ------------------------ | ------------------------------------------------------------ | --------------------------- |
+| Deleting `AppEntry.icon` | Two live callers that cannot move inside the phase boundaries | Deferred — see Follow-up work |
+
+---
+
+## Issues encountered
+
+- **`AppEntry.icon` cannot be deleted as objective 2 assumes.** The phase document anticipated one
+  possible blocker (`AppPresentation`) and there are two, both in `AppPickerPopover.swift`. The deciding
+  one is `AppPresentation.resolve`, which returns a synchronous non-optional `(name, icon)` tuple:
+  `QuicklinkEditorSheet.swift:175` renders it directly, and `ClipboardView.swift:408` folds the `NSImage`
+  into an `InfoRow` **value**. Neither can accept a `View` without restructuring, and `ClipboardView` is
+  not in the phase's file list at all. The phase's own escape hatch covers this, but AC5 does not — it
+  was written assuming the deletion would land.
+- The Core sweep and the **Launcher & icons** section of `checklists/regression.md` were not run — both
+  are manual keyboard and visual passes. The diff is three lines in one row body and the build is clean,
+  so the risk is low, but the sweep is still owed before this merges. The two checks that matter are the
+  placeholder flash on reopen (open `Settings ▸ Applications` three times) and first-paint scroll
+  smoothness on a machine with 150+ apps.
+
+---
+
+## Deviations from the phase document
+
+- **`AppEntry.icon` is retained**, against objective 2 and AC5, under the phase's stated escape hatch
+  ("If a caller exists you cannot safely convert, leave the property and name the caller"). Remaining
+  callers: `AppPickerPopover.swift:35` (the picker's own `LazyVStack` row) and
+  `AppPickerPopover.swift:77` (`AppPresentation.resolve`). A half-deleted property would be worse.
+- **`AppPickerPopover.swift` was not modified**, though the phase lists it as a conditional target. Its
+  row has the same synchronous rasterise, but converting it would not enable the deletion — `resolve`
+  blocks that regardless — so it was left alone rather than widening the diff for no acceptance-criteria
+  gain.
+- The diff came in **under** the expected commit size (1 file, +1/−2 against 2–3 files, +5/−15), which is
+  the deletion not landing rather than work skipped.
+
+---
+
+## Follow-up work
+
+| Observation                                                                                                   | Where                                | Suggested phase |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------- |
+| The app picker's own `LazyVStack` row still rasterises synchronously — same bug class as this phase fixed     | `AppPickerPopover.swift:35`          | new small phase |
+| Retiring `AppEntry.icon` needs `AppPresentation.resolve` to stop returning an `NSImage`, which reaches into `ClipboardView`'s `InfoRow` | `AppPickerPopover.swift:75-83`, `ClipboardView.swift:389-441` | new small phase |
+| AC5 as written is unsatisfiable alongside AC3's escape hatch — the two criteria contradict                    | `phases/02-async-icons-in-settings.md` | doc fix, no phase |
+
+---
+
+## Rollback notes
+
+- **Revert command:** `git revert <sha>`
+- **Is a plain revert sufficient?** Yes — one view body, no persistence, no migration, no new file.
+- **Dependent phases that must also be reverted:** none
+- **Data risk on revert:** none
+
+---
+
+## Sign-off
+
+- [ ] All acceptance criteria met — AC5 not met, deviation recorded above
+- [ ] All four checklists passed — regression sweep outstanding
+- [x] `ROADMAP.md` status table updated
+- [x] Follow-ups recorded above, not fixed in this phase
+- [ ] Merged to `main`
+- [ ] **Stopped.** Next phase is a separate session.


### PR DESCRIPTION
Refactor phase 02 (milestone M1, review finding H-3). Phase document:
[`docs/refactor/phases/02-async-icons-in-settings.md`](docs/refactor/phases/02-async-icons-in-settings.md).

## What changed

`LauncherItemRow` rendered `Image(nsImage: entry.icon)`, and `AppEntry.icon` calls
`IconCache.icon(forFile:)` synchronously — on a cold key that hits `NSWorkspace.shared.icon` and
rasterises a bitmap on the main thread, inside a `LazyVStack` of ~200 rows, during scrolling. It now
renders through the palette's existing `AppIconView`, which decodes off-main and seeds from the warm
cache synchronously so there is no placeholder flash on reopen.

`AppIconView` is used exactly as-is — no new parameters, not moved, not copied; still exactly one
definition. `IconCache` is untouched. The `22 × 22` frame is unchanged.

**Diff: 1 file, +1/−2.**

## Deviation — `AppEntry.icon` is retained

The phase document's objective 2 asks for its deletion, with an explicit escape hatch when a caller
cannot be converted. Two callers remain, both in `AppPickerPopover.swift`:

- `AppPresentation.resolve` (line 77) returns a synchronous, non-optional `(name, icon)` tuple.
  `QuicklinkEditorSheet.swift:175` renders it directly and `ClipboardView.swift:408` folds the
  `NSImage` into an `InfoRow` **value** — neither can take a `View` without restructuring, and
  `ClipboardView` is not in the phase's file list at all.
- The picker's own `LazyVStack` row (line 35). Same bug class, but converting it would not enable the
  deletion either, so it was left alone rather than widening the diff.

Consequence: **AC5 is not met** — `grep -rn "IconCache.icon(forFile" Tinycast` still returns three
hits. That criterion presupposes the deletion AC3's escape hatch permits skipping; the two contradict.
Both are written up in the progress file, with the residual work as follow-ups.

## Verification

| Checklist | Result | Notes |
| --- | --- | --- |
| `build.md` | PASS (§1–4) | Debug + Release `BUILD SUCCEEDED`, zero new warnings vs. the pre-phase baseline; Release binary +0 B |
| `testing.md` | PASS | Harnesses run: **none** — the one touched file appears in no row of the harness → source map, and no pure-layer file was touched |
| `regression.md` | **PENDING** | Core sweep + **Launcher & icons** are manual UI passes, not yet run |
| `review.md` | PASS (§1–8) | Scope, behaviour, concurrency, memory, comments (0 added), dead/migration code, invariants all clean |

**Outstanding before merge** — the manual sweep, in particular: no placeholder flash when
`Settings ▸ Applications` is reopened three times; smooth first-paint scrolling on a machine with 150+
apps; and the Commands / System Actions / System Settings panes still drawing their SF Symbol tiles,
since one card serves all four.