### PR TITLE
Add AppPaths for the per-channel storage directories

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		A0C1BAEE55481326EEE81471 /* RaycastImportV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE385AAF41C4CB276025211 /* RaycastImportV1.swift */; };
 		A0DB31CA35D9A980CA984EDE /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D045D032498C2294A99890E /* LaunchAtLogin.swift */; };
 		A2EA931B8B8078A1D1162B53 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB20A38DA4C5603DF7430B3C /* VisualEffectView.swift */; };
+		A32BEBD97EBF2BD911516733 /* AppPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC80C1AD8E37995B77272F3 /* AppPaths.swift */; };
 		A3855695DA55ADA137630DCE /* QuicklinkArgumentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031271DE1EEF68A443713D32 /* QuicklinkArgumentSession.swift */; };
 		A41C0DCB2DEBCCA46F6C4B10 /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB750D045194AE34D39D792 /* FavoritesStore.swift */; };
 		A9D8B54D88A60DE9FC1F43BF /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D3EBB9D877817D10D120A8 /* CalcDateTime.swift */; };
@@ -177,6 +178,7 @@
 		0D16E927986D415F5386CDCF /* SystemAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAction.swift; sourceTree = "<group>"; };
 		0F50886DC766B9923C3875A5 /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
 		1A4B045F847659544FA182D4 /* DoubleTapModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapModifier.swift; sourceTree = "<group>"; };
+		1AC80C1AD8E37995B77272F3 /* AppPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPaths.swift; sourceTree = "<group>"; };
 		1BCCED95A78DC5BED117E960 /* RaycastImportSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportSelection.swift; sourceTree = "<group>"; };
 		1C6D4DFAC1D761ECC2DE1112 /* QuicklinksSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinksSettingsView.swift; sourceTree = "<group>"; };
 		1DB0D6E17E2B2D6F2CB47E0D /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				3A64EF5A07D459753998F78C /* AppCore.swift */,
 				BA7CE23482F7DF563A268806 /* AppIndex.swift */,
 				5A2EF9C70F8BC9571089D5EB /* AppLauncher.swift */,
+				1AC80C1AD8E37995B77272F3 /* AppPaths.swift */,
 				B275099E59BD2531A838F7D8 /* AppSettings.swift */,
 				D3FA43AD7C6FB00F555C52C2 /* Bundle+AppName.swift */,
 				F793A92DD4DC73CF1D87F3FD /* CalculatorHistoryStore.swift */,
@@ -789,6 +792,7 @@
 				C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */,
 				D322804853973E1C19F2A408 /* AppIndex.swift in Sources */,
 				DA2EBB18F026BD055E0270CD /* AppLauncher.swift in Sources */,
+				A32BEBD97EBF2BD911516733 /* AppPaths.swift in Sources */,
 				BE9EE0864C315080A4E4780F /* AppPickerPopover.swift in Sources */,
 				FEA05585E8AA58506D378CAF /* AppSettings.swift in Sources */,
 				CDBB4E26FCABEEE8817D12B2 /* ApplicationsSettingsView.swift in Sources */,

--- a/Tinycast/Core/AppPaths.swift
+++ b/Tinycast/Core/AppPaths.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// The per-channel storage roots. Keyed by bundle id so a Dev build never shares a stable's dirs.
+enum AppPaths {
+    static func caches(
+        bundleID: String = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
+    ) -> URL {
+        root(.cachesDirectory, bundleID: bundleID)
+    }
+
+    static func applicationSupport(
+        bundleID: String = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
+    ) -> URL {
+        root(.applicationSupportDirectory, bundleID: bundleID)
+    }
+
+    private static func root(
+        _ directory: FileManager.SearchPathDirectory, bundleID: String
+    ) -> URL {
+        let url = FileManager.default
+            .urls(for: directory, in: .userDomainMask)[0]
+            .appendingPathComponent(bundleID, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Tinycast/Core/CalculatorHistoryStore.swift
+++ b/Tinycast/Core/CalculatorHistoryStore.swift
@@ -21,12 +21,7 @@ final class CalculatorHistoryStore: ObservableObject {
     private var searchCache: (query: String, result: [CalcHistoryEntry])?
 
     init() {
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
-        let base = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent(bundleID, isDirectory: true)
-        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
-        fileURL = base.appendingPathComponent("calculator-history.json")
+        fileURL = AppPaths.caches().appendingPathComponent("calculator-history.json")
 
         if let data = try? Data(contentsOf: fileURL),
             let decoded = try? JSONDecoder().decode([CalcHistoryEntry].self, from: data) {

--- a/Tinycast/Core/CurrencyRateStore.swift
+++ b/Tinycast/Core/CurrencyRateStore.swift
@@ -39,12 +39,7 @@ final class CurrencyRateStore: ObservableObject {
     init() {
         // Absent reads as false, which is the only safe default for a network feature.
         isEnabled = defaults.bool(forKey: Self.consentKey)
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
-        let base = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent(bundleID, isDirectory: true)
-        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
-        fileURL = base.appendingPathComponent("currency-rates.json")
+        fileURL = AppPaths.caches().appendingPathComponent("currency-rates.json")
 
         // Guard 1 — a disabled feature doesn't even read back a snapshot left on disk.
         guard isEnabled, let data = try? Data(contentsOf: fileURL) else { return }

--- a/Tinycast/Core/Emoji/FrequentEmojiStore.swift
+++ b/Tinycast/Core/Emoji/FrequentEmojiStore.swift
@@ -20,12 +20,7 @@ final class FrequentEmojiStore: ObservableObject {
     private var sortedGlyphs: [String]?
 
     init() {
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
-        let base = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent(bundleID, isDirectory: true)
-        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
-        fileURL = base.appendingPathComponent("emoji-frequency.json")
+        fileURL = AppPaths.caches().appendingPathComponent("emoji-frequency.json")
 
         if let data = try? Data(contentsOf: fileURL),
             let decoded = try? JSONDecoder().decode([FrequentEmoji].self, from: data) {

--- a/Tinycast/Core/OnboardingState.swift
+++ b/Tinycast/Core/OnboardingState.swift
@@ -2,13 +2,8 @@ import Foundation
 
 /// First-run marker stored as a file in Application Support (not UserDefaults) so a full uninstall — including leftover/`--zap` cleanup — clears it and a reinstall re-runs onboarding; a UserDefaults flag gets resurrected by cfprefsd and survives removal.
 enum OnboardingState {
-    private static let markerURL: URL = {
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
-        return FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent(bundleID, isDirectory: true)
-            .appendingPathComponent("onboarded")
-    }()
+    private static let markerURL = AppPaths.applicationSupport()
+        .appendingPathComponent("onboarded")
 
     /// True once onboarding has been shown.
     static var hasOnboarded: Bool {
@@ -17,8 +12,6 @@ enum OnboardingState {
 
     /// Records that onboarding has been shown; called at show-time so it stays one-time even if the user quits mid-flow.
     static func markShown() {
-        let dir = markerURL.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try? Data().write(to: markerURL)
     }
 }

--- a/docs/refactor/ROADMAP.md
+++ b/docs/refactor/ROADMAP.md
@@ -181,7 +181,7 @@ Update this table as phases land. `Blocked` requires a note in the phase's progr
 | 02  | Complete    | `40bab1f` (#158) | 2026-08-05 | Merged. `AppEntry.icon` retained — two callers in `AppPickerPopover`, so AC5 not met; follow-ups in `progress/02`. |
 | 03  | Complete    | `refactor/03-named-paste-timing-constants` | 2026-08-05 | Two constants, four call sites (doc said three). Values unchanged; paste verified into fast and slow apps. |
 | 04  | Complete    | `refactor/04-retire-the-last-nsalert` | 2026-08-05 | One call site converted; text and consent→persist→permission ordering unchanged. **AC1 not met** — a second `NSAlert` remains in `SnippetArgumentsPrompt`, outside this phase's files; see `progress/04`. |
-| 05  | Not started |                 |      |       |
+| 05  | Complete    | `refactor/05-app-paths` | 2026-08-05 | `AppPaths` adopted in the four non-harness stores; the four harness-compiled ones keep their injected parameter. No resolved path changed. |
 | 06  | Not started |                 |      |       |
 | 07  | Not started |                 |      |       |
 | 08  | Not started |                 |      |       |

--- a/docs/refactor/progress/05-app-paths.md
+++ b/docs/refactor/progress/05-app-paths.md
@@ -1,0 +1,151 @@
+# Phase 05 — `AppPaths`, one channel-directory helper
+
+---
+
+## Status
+
+| Field                         | Value                        |
+| ----------------------------- | ---------------------------- |
+| **Status**                    | Complete                     |
+| **Started**                   | 2026-08-05                   |
+| **Completed**                 | 2026-08-05                   |
+| **Operator**                  | abue-ammar                   |
+| **Branch**                    | `refactor/05-app-paths`      |
+| **Commit**                    | single commit on the branch  |
+| **Claude conversations used** | 1                            |
+| **Actual effort**             | ~0.5h vs. estimate of S      |
+
+---
+
+## Completed tasks
+
+- [x] Objective 1 — `Tinycast/Core/AppPaths.swift` added with `caches(bundleID:)` and
+      `applicationSupport(bundleID:)`, both defaulting to `Bundle.main.bundleIdentifier ?? "com.tinycast.app"`
+- [x] Objective 2 — adopted in exactly the four non-harness-compiled call sites
+- [x] Objective 3 — channel isolation kept; every resolved path is still keyed by the bundle identifier
+
+## Acceptance criteria
+
+- [x] AC1 — `AppPaths.swift` exists, is Foundation-only, no dependency on any other app type — verified by:
+      it imports only `Foundation`, and it compiles **standalone** under
+      `swiftc -swift-version 6 Tinycast/Core/AppPaths.swift <driver>` with no other app source on the
+      command line. Directory creation stayed inside the helper, as the phase requires
+- [x] AC2 — adopted in exactly the four non-harness types — verified by: `git diff --name-only` lists
+      `CalculatorHistoryStore`, `CurrencyRateStore`, `Emoji/FrequentEmojiStore`, `OnboardingState` and
+      nothing else under `Tinycast/`
+- [x] AC3 — the four harness-compiled types are untouched — verified by:
+      `git diff --name-only HEAD | grep -E "ClipboardStore|QuicklinkStore|LauncherRankingStore|SnippetRepository"`
+      returns nothing. Each keeps its own inline fallback and its injectable parameter
+- [x] AC4 — every path keyed by `Bundle.main.bundleIdentifier` — verified two ways: the default argument is
+      literally `Bundle.main.bundleIdentifier ?? "com.tinycast.app"` at both entry points, and a standalone
+      driver confirmed `caches(bundleID:)` / `applicationSupport(bundleID:)` append the id as the last path
+      component, create the directory, and are idempotent. Resolved paths are byte-identical to the
+      pre-phase ones (table below)
+- [x] AC5 — all harnesses pass with **no command-line change** — verified by: every `swiftc` line copied
+      verbatim from `docs/development.md`; all 16 built and reported `ALL PASSED`
+- [x] AC6 — `AGENTS.md` and `docs/development.md` unchanged — verified by: neither appears in
+      `git diff --name-only`; no harness command line was edited or added to
+- [x] AC7 — clean install works — **verified at runtime by the operator.** All four stores initialise from
+      nothing, nothing crashes on an absent file
+
+### Resolved paths (AC4 evidence)
+
+| Type                      | Resolved path                                                       | Changed? |
+| ------------------------- | ------------------------------------------------------------------- | -------- |
+| `CalculatorHistoryStore`  | `~/Library/Caches/<bundle-id>/calculator-history.json`              | no       |
+| `FrequentEmojiStore`      | `~/Library/Caches/<bundle-id>/emoji-frequency.json`                 | no       |
+| `CurrencyRateStore`       | `~/Library/Caches/<bundle-id>/currency-rates.json`                  | no       |
+| `OnboardingState`         | `~/Library/Application Support/<bundle-id>/onboarded`               | no       |
+
+`<bundle-id>` is `Bundle.main.bundleIdentifier`, i.e. `com.tinycast.app.dev` for a Debug build and
+`com.tinycast.app` for a release one. No path string changed, which `POLICY.md` would have permitted but
+the phase discourages as diff noise.
+
+---
+
+## Verification
+
+| Checklist                  | Result | Notes                                                                     |
+| -------------------------- | ------ | ------------------------------------------------------------------------- |
+| `checklists/build.md`      | PASS   | Debug `BUILD SUCCEEDED`, zero Swift warnings and zero errors. **No pre-phase baseline was captured** (operator elected to skip it), so "zero *new* warnings" is asserted from an absolute zero rather than a diff against a baseline |
+| `checklists/testing.md`    | PASS   | All 16 harnesses in `docs/development.md` run with unmodified command lines: `fuzz`, `ranking`, `calc`, `clipboard`, `scopes`, `raycast`, `emoji`, `custom-command`, `snippets`, `hotkey`, `callout`, `system-action`, `volume`, `window-command`, `uninstall`, `quicklink` — all `ALL PASSED`. The four harness-compiled stores were deliberately not touched, which is what keeps `clipboard`, `quicklink`, `ranking` and `snippets` green |
+| `checklists/regression.md` | PASS   | Core sweep + **Clean install**, run by the operator, who confirmed the app works |
+| `checklists/review.md`     | PASS   | 5 files, +25/−27 against an expected 5 files, +35/−25. Under on additions because the helper is shared rather than restated |
+
+### Measurements
+
+| Metric                     | Before | After | Δ                                     |
+| -------------------------- | ------ | ----- | ------------------------------------- |
+| Binary size (Release)      | —      | —     | not measured; no Release build run    |
+| Clean install verified?    | —      | yes   | operator-verified                     |
+| Cold launch, median of 3   | —      | —     | n-a, no startup work added or removed |
+| RSS after 10 palette opens | —      | —     | n-a, no allocation change             |
+| Phase-specific signpost    | —      | —     | no signpost covers this               |
+
+This phase claims no performance effect: the same `FileManager` calls run the same number of times, just
+from one place instead of four.
+
+---
+
+## Failed tasks
+
+None.
+
+---
+
+## Issues encountered
+
+- **`OnboardingState` was the only adopter whose directory creation moved.** It alone created its directory
+  in `markShown()` rather than when computing the URL, so adopting `AppPaths` — which creates on demand —
+  made those two lines redundant and they were deleted. Observably a no-op: `QuicklinkStore.init` already
+  creates that exact Application Support directory unconditionally at launch, before either
+  `OnboardingState.hasOnboarded` or `markShown()` is reached.
+- **`kill` is blocked in this environment**, so the already-running Dev instance could not be quit from the
+  agent side. The clean-install run was done by the operator instead. The Dev channel's Caches and
+  Application Support directories were snapshotted to the session scratchpad before any wipe was
+  attempted; nothing was deleted.
+- **`docs/development.md` lists 16 harnesses, not 17.** The phase document, `ROADMAP.md` and
+  `checklists/testing.md` all say "all 17 harnesses". Counting the `swiftc` invocations in
+  `docs/development.md` gives 16. All 16 were run; the 17th does not exist. Recorded as a doc fix below.
+
+---
+
+## Deviations from the phase document
+
+- **`Tinycast.xcodeproj/project.pbxproj` also changed.** It is a committed generated file and `xcodegen
+  generate` registers the new source. Not listed in the phase's file table, but unavoidable and mechanical.
+- **Diff is +25/−27 rather than the expected +35/−25**, i.e. net negative. Four five-line blocks collapsed
+  to four one-line calls, and the helper is 26 lines including its signature wrapping.
+- **No pre-phase warning baseline.** `checklists/build.md` scores new warnings against a baseline; the
+  operator skipped capturing one. Mitigated by the build reporting zero Swift warnings outright.
+
+---
+
+## Follow-up work
+
+| Observation                                                                             | Where                                       | Suggested phase   |
+| --------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------- |
+| The refactor docs say "all 17 harnesses" but `docs/development.md` defines 16. Every phase that gates on the count inherits the error | `ROADMAP.md`, `checklists/testing.md`, several phase docs | doc fix, no phase |
+| `ClipboardStore`, `QuicklinkStore`, `LauncherRankingStore` and `SnippetRepository` still each carry their own copy of the bundle-id fallback. Consolidating them needs an `AGENTS.md` invariant change to let `AppPaths.swift` join four harness command lines — deliberately out of scope here | those four files | new phase, if ever |
+| `QuicklinkStore` and `SnippetRepository` both compute the Application Support root independently, and `QuicklinkStore.defaultDirectory` documents the shared root in a comment rather than in code | `Core/Quicklinks/QuicklinkStore.swift:52` | same as above |
+
+---
+
+## Rollback notes
+
+- **Revert command:** `git revert <sha>`
+- **Is a plain revert sufficient?** Yes — five files, no persistence shape change, no path string change.
+- **Dependent phases that must also be reverted:** none. No later phase depends on 05.
+- **Data risk on revert:** none. The reverted code resolves the same paths the new code does, so a store
+  written before the revert is read after it.
+
+---
+
+## Sign-off
+
+- [x] All acceptance criteria met
+- [x] All four checklists passed
+- [x] `ROADMAP.md` status table updated
+- [x] Follow-ups recorded above, not fixed in this phase
+- [ ] Merged to `main`
+- [x] **Stopped.** Next phase is a separate session.


### PR DESCRIPTION
Four stores computed the same caches/app-support path with the same bundle-id fallback. One helper, one place to audit the channel-isolation invariant. The harness-compiled stores keep their injected directory parameter and are untouched.

## Related issue

Closes #

## What changed

<!-- What it does and how it works. Call out anything non-obvious in the diff. -->

## Memory footprint

<!-- Required. Under 100 MB always, and back to baseline after the palette closes. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

<!-- Visual change → side-by-side before/after video. Same window size, same actions.
     "After"-only clips and stills don't count. Delete this section if nothing visual changed. -->

## Drawbacks

<!-- Tradeoffs made on purpose, and anything you're unsure about. "None" is a valid answer. -->

## Tests & validation

<!-- Which Tools/ harnesses you ran and any cases you added, plus what you exercised by hand.
     Commands: docs/development.md § Tests. -->
