### PR TITLE
Name snippets and window commands correctly in the footer pill

### DIFF
--- a/Tinycast/Features/Launcher/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/LauncherScreen.swift
@@ -51,14 +51,17 @@ struct LauncherScreen: PaletteScreen {
         }
     }
 
+    /// The pill's verb; must match `AppActionsMenu.openTitle` — same row, same action, same words.
     private static func pillTitle(_ kind: AppEntry.Kind) -> String {
         switch kind {
+        case .application: return "Open Application"
         case .systemSettings: return "Open System Setting"
         case .command: return "Run Command"
         case .customCommand: return "Run Custom Command"
+        case .snippet: return "Paste Snippet"
         case .systemAction: return "Run System Action"
+        case .windowCommand: return "Move Window"
         case .quicklink: return "Open Quicklink"
-        default: return "Open Application"
         }
     }
 


### PR DESCRIPTION
The pill's kind switch ended in `default: "Open Application"`, so a snippet row and a window-management row both advertised themselves as an application while the Actions menu on the same row said "Paste Snippet" and "Move Window". The switch is now exhaustive and its eight cases are byte-identical to AppActionsMenu.openTitle, so the two can no longer disagree and a new Kind fails to build instead of falling through.

Only the wording was wrong; every row already ran the right action.

## Related issue

Closes #

## What changed

<!-- What it does and how it works. Call out anything non-obvious in the diff. -->

## Memory footprint

<!-- Required. Under 100 MB always, and back to baseline after the palette closes. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

<!-- Visual change → side-by-side before/after video. Same window size, same actions.
     "After"-only clips and stills don't count. Delete this section if nothing visual changed. -->

## Drawbacks

<!-- Tradeoffs made on purpose, and anything you're unsure about. "None" is a valid answer. -->

## Tests & validation

<!-- Which Tools/ harnesses you ran and any cases you added, plus what you exercised by hand.
     Commands: docs/development.md § Tests. -->
