### PR TITLE
Stop overloading Coordinator in SnippetRepository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,8 +312,10 @@ Exceptions, each earning its own word:
 - `Center` (`HotKeyCenter`) — the Carbon registration layer specifically.
 - `Presenter` (`HUDPresenter`) — owns the one-at-a-time / auto-dismiss / fade policy for both HUDs.
 - Domain terms with no better alternative: `SnippetTextInjector`, `WindowMover`, `HyperKeyTap`.
-- `Registry` is retired as a top-level suffix — a static table is a `Catalog`. It survives only on
-  `SnippetRepository`'s private nested `CoordinatorRegistry`, which really does register: it interns
-  one lock per canonical channel-directory path.
+- `Registry` and `ViewModel` are retired — a static table is a `Catalog`, and shared app state is a
+  `State`. Neither suffix appears anywhere in `Tinycast/`.
+- `Coordinator` means the action surface above and nothing else. `SnippetRepository`'s per-directory
+  mutex is a `DirectoryLock` held in a `DirectoryLockTable`, so the word is not overloaded against
+  `NSFileCoordinator` in the one file that uses both.
 - SwiftUI-layer suffixes (`View`, `Screen`, `Card`, `Row`, `Sheet`) are a separate vocabulary and are
   not governed by this table.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,10 +312,6 @@ Exceptions, each earning its own word:
 - `Center` (`HotKeyCenter`) — the Carbon registration layer specifically.
 - `Presenter` (`HUDPresenter`) — owns the one-at-a-time / auto-dismiss / fade policy for both HUDs.
 - Domain terms with no better alternative: `SnippetTextInjector`, `WindowMover`, `HyperKeyTap`.
-- `Registry` and `ViewModel` are retired — a static table is a `Catalog`, and shared app state is a
-  `State`. Neither suffix appears anywhere in `Tinycast/`.
-- `Coordinator` means the action surface above and nothing else. `SnippetRepository`'s per-directory
-  mutex is a `DirectoryLock` held in a `DirectoryLockTable`, so the word is not overloaded against
-  `NSFileCoordinator` in the one file that uses both.
+- `Registry` and `ViewModel` are retired: a static table is a `Catalog`, shared app state is a `State`.
 - SwiftUI-layer suffixes (`View`, `Screen`, `Card`, `Row`, `Sheet`) are a separate vocabulary and are
   not governed by this table.

--- a/Tinycast/Features/Snippets/Model/SnippetRepository.swift
+++ b/Tinycast/Features/Snippets/Model/SnippetRepository.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct SnippetRepository: Sendable {
-    private final class Coordinator: @unchecked Sendable {
+    private final class DirectoryLock: @unchecked Sendable {
         private let lock = NSLock()
 
         func withLock<Value>(
@@ -13,17 +13,17 @@ struct SnippetRepository: Sendable {
         }
     }
 
-    private final class CoordinatorRegistry: @unchecked Sendable {
+    private final class DirectoryLockTable: @unchecked Sendable {
         private let lock = NSLock()
-        private var coordinators: [String: Coordinator] = [:]
+        private var locks: [String: DirectoryLock] = [:]
 
-        func coordinator(for channelDirectory: URL) -> Coordinator {
+        func directoryLock(for channelDirectory: URL) -> DirectoryLock {
             let identity = canonicalIdentity(for: channelDirectory)
             return lock.withLock {
-                if let coordinator = coordinators[identity] { return coordinator }
-                let coordinator = Coordinator()
-                coordinators[identity] = coordinator
-                return coordinator
+                if let existing = locks[identity] { return existing }
+                let directoryLock = DirectoryLock()
+                locks[identity] = directoryLock
+                return directoryLock
             }
         }
 
@@ -47,7 +47,7 @@ struct SnippetRepository: Sendable {
         }
     }
 
-    private static let coordinatorRegistry = CoordinatorRegistry()
+    private static let directoryLocks = DirectoryLockTable()
 
     enum Mutation: Sendable {
         case save
@@ -99,7 +99,7 @@ struct SnippetRepository: Sendable {
     let channelDirectory: URL
     let snippetsDirectory: URL
 
-    private let coordinator: Coordinator
+    private let directoryLock: DirectoryLock
     private let mutationHooks: MutationHooks
 
     init(
@@ -115,13 +115,13 @@ struct SnippetRepository: Sendable {
             bundleIdentifier,
             isDirectory: true)
         self.channelDirectory = channelDirectory
-        coordinator = Self.coordinatorRegistry.coordinator(for: channelDirectory)
+        directoryLock = Self.directoryLocks.directoryLock(for: channelDirectory)
         self.mutationHooks = mutationHooks
         snippetsDirectory = channelDirectory.appendingPathComponent("Snippets", isDirectory: true)
     }
 
     func load() throws(RepositoryError) -> Snapshot {
-        try coordinator.withLock { () throws(RepositoryError) -> Snapshot in
+        try directoryLock.withLock { () throws(RepositoryError) -> Snapshot in
             try mappedError(at: snippetsDirectory) {
                 try ensureSnippetsDirectory()
                 let files = try markdownFiles(in: snippetsDirectory)
@@ -151,7 +151,7 @@ struct SnippetRepository: Sendable {
     }
 
     func create(_ snippet: Snippet) throws(RepositoryError) -> StoredSnippet {
-        try coordinator.withLock { () throws(RepositoryError) -> StoredSnippet in
+        try directoryLock.withLock { () throws(RepositoryError) -> StoredSnippet in
             try mappedError(at: snippetsDirectory) {
                 try ensureSnippetsDirectory()
                 return try createUnlocked(snippet)
@@ -160,7 +160,7 @@ struct SnippetRepository: Sendable {
     }
 
     func create(_ snippets: [Snippet]) throws(RepositoryError) -> [StoredSnippet] {
-        try coordinator.withLock { () throws(RepositoryError) -> [StoredSnippet] in
+        try directoryLock.withLock { () throws(RepositoryError) -> [StoredSnippet] in
             try mappedError(at: snippetsDirectory) {
                 try ensureSnippetsDirectory()
                 var created: [StoredSnippet] = []
@@ -184,7 +184,7 @@ struct SnippetRepository: Sendable {
         fileURL: URL,
         expectedRevision: SnippetSourceRevision
     ) throws(RepositoryError) -> StoredSnippet {
-        try coordinator.withLock { () throws(RepositoryError) -> StoredSnippet in
+        try directoryLock.withLock { () throws(RepositoryError) -> StoredSnippet in
             try mappedError(at: fileURL) {
                 let fileURL = try validatedFileURL(fileURL)
                 let content = SnippetMarkdownSerializer.serialize(snippet)
@@ -213,7 +213,7 @@ struct SnippetRepository: Sendable {
         fileURL: URL,
         expectedRevision: SnippetSourceRevision
     ) throws(RepositoryError) {
-        try coordinator.withLock { () throws(RepositoryError) in
+        try directoryLock.withLock { () throws(RepositoryError) in
             try mappedError(at: fileURL) {
                 let fileURL = try validatedFileURL(fileURL)
                 try coordinatedMutation(at: fileURL, options: .forDeleting) { coordinatedURL in


### PR DESCRIPTION
The file carried three meanings of one word: the vocabulary's ten feature action surfaces, NSFileCoordinator at line 342, and a private NSLock wrapper. The mutex is now a DirectoryLock interned by canonical channel-directory path in a DirectoryLockTable, so Coordinator means the action surface and nothing else.

Four private identifiers, no API surface, no logic: normalising the rename pairs makes both sides of the diff identical. Registry and ViewModel are now absent from Tinycast/ entirely, so the AGENTS.md exception that carved out CoordinatorRegistry is gone with it.

## Related issue

Closes #

## What changed

<!-- What it does and how it works. Call out anything non-obvious in the diff. -->

## Memory footprint

<!-- Required. Under 100 MB always, and back to baseline after the palette closes. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

<!-- Visual change → side-by-side before/after video. Same window size, same actions.
     "After"-only clips and stills don't count. Delete this section if nothing visual changed. -->

## Drawbacks

<!-- Tradeoffs made on purpose, and anything you're unsure about. "None" is a valid answer. -->

## Tests & validation

<!-- Which Tools/ harnesses you ran and any cases you added, plus what you exercised by hand.
     Commands: docs/development.md § Tests. -->
