### PR TITLE
Act on the verified subset of the architectural audit

### DIFF
--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -174,8 +174,7 @@ extension SettingsBackup {
         var count = 0
         if let days = s.clipboardRetentionDays, let retention = ClipboardRetention(rawValue: days) {
             settings.clipboardRetention = retention
-            core.clipboardStore.maxAge = retention.maxAge
-            core.clipboardStore.enforceLimits()
+            core.clipboardCoordinator.applyRetention(retention)
             count += 1
         }
         if let apps = s.clipboardDisabledApps {

--- a/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
@@ -39,9 +39,7 @@ struct ClipboardSettingsView: View {
                     .labelsHidden()
                     .fixedSize()
                     .onChange(of: settings.clipboardRetention) {
-                        let store = core.clipboardStore
-                        store.maxAge = settings.clipboardRetention.maxAge
-                        store.enforceLimits()
+                        core.clipboardCoordinator.applyRetention(settings.clipboardRetention)
                     }
                 }
             }

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -20,6 +20,12 @@ final class ClipboardCoordinator {
         self.paletteCoordinator = paletteCoordinator
     }
 
+    /// The setting names an age, the store enforces it; a shortened window culls straight away.
+    func applyRetention(_ retention: ClipboardRetention) {
+        clipboardStore.maxAge = retention.maxAge
+        clipboardStore.enforceLimits()
+    }
+
     func paste(_ item: ClipboardItem) {
         let previous = windowController.previousApp
         paletteCoordinator.hidePalette(restoreFocus: false)

--- a/Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
+++ b/Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
@@ -60,6 +60,7 @@ enum ShellCommandRunner {
         return .success
     }
 
+    /// Immutable, confined to one `execute` on `queue`, and only read after `waitUntilExit`.
     private final class StderrCapture: @unchecked Sendable {
         let url: URL
         let handle: FileHandle

--- a/Tinycast/Features/Launcher/Service/AppLauncher.swift
+++ b/Tinycast/Features/Launcher/Service/AppLauncher.swift
@@ -12,19 +12,20 @@ enum AppLauncher {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
-    /// No AppKit route for Get Info, so this drives Finder over Apple events.
-    @MainActor
-    static func showInfoInFinder(_ url: URL) -> Bool {
+    /// No AppKit route for Get Info, so this drives Finder over Apple events — seconds when cold.
+    static func showInfoInFinder(_ url: URL) async -> Bool {
         let source = """
             tell application "Finder"
                 activate
                 open information window of (POSIX file "\(url.path)" as alias)
             end tell
             """
-        guard let script = NSAppleScript(source: source) else { return false }
-        var errorInfo: NSDictionary?
-        script.executeAndReturnError(&errorInfo)
-        return errorInfo == nil
+        return await Task.detached(priority: .userInitiated) {
+            guard let script = NSAppleScript(source: source) else { return false }
+            var errorInfo: NSDictionary?
+            script.executeAndReturnError(&errorInfo)
+            return errorInfo == nil
+        }.value
     }
 
     /// Opens System Settings at the pane backed by the given extension bundle ID.

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
@@ -197,20 +197,37 @@ final class QuicklinkCoordinator {
                     symbol: quicklink.iconSymbol ?? Quicklink.sfSymbol, confirmTitle: "Delete")
             else { return }
         }
+        // Unwound only once the row is gone: a failed delete must not strand its references.
+        do {
+            try store.remove(id: id)
+        } catch {
+            await core.showNotice(
+                title: "Couldn’t Delete “\(quicklink.name)”", message: error.localizedDescription,
+                symbol: quicklink.iconSymbol ?? Quicklink.sfSymbol, tone: .danger)
+            return
+        }
         removeQuicklinkReferences(ids: [id], entryIDs: [quicklink.entryID])
-        try? store.remove(id: id)
     }
 
     func toggleQuicklinkPinned(id: UUID) {
-        try? store.togglePinned(id: id)
+        do { try store.togglePinned(id: id) } catch { report(error) }
     }
 
     func setQuicklinkShowsInRootSearch(_ shows: Bool, id: UUID) {
-        try? store.setShowsInRootSearch(shows, id: id)
+        do { try store.setShowsInRootSearch(shows, id: id) } catch { report(error) }
     }
 
     func duplicateQuicklink(id: UUID) {
-        _ = try? store.duplicate(id: id)
+        do { _ = try store.duplicate(id: id) } catch { report(error) }
+    }
+
+    /// Quicklinks are authored data, so a refused write says so rather than reading as a no-op.
+    private func report(_ error: QuicklinkError) {
+        Task {
+            await core.showNotice(
+                title: "Couldn’t Save the Change", message: error.localizedDescription,
+                symbol: Quicklink.sfSymbol, tone: .danger)
+        }
     }
 
     /// Opens the Quicklinks pane with the editor showing `quicklink`; nil is a new one.

--- a/Tinycast/Features/Snippets/Model/SnippetRepository.swift
+++ b/Tinycast/Features/Snippets/Model/SnippetRepository.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct SnippetRepository: Sendable {
+    /// Holds no state beyond the `NSLock` every access already goes through.
     private final class DirectoryLock: @unchecked Sendable {
         private let lock = NSLock()
 
@@ -13,6 +14,7 @@ struct SnippetRepository: Sendable {
         }
     }
 
+    /// `locks` is only ever read or written inside `lock.withLock`, which is the whole guarantee.
     private final class DirectoryLockTable: @unchecked Sendable {
         private let lock = NSLock()
         private var locks: [String: DirectoryLock] = [:]

--- a/Tinycast/Features/SystemActions/Service/SystemActionRunner.swift
+++ b/Tinycast/Features/SystemActions/Service/SystemActionRunner.swift
@@ -54,11 +54,11 @@ enum SystemActionRunner {
         case .sleepDisplays:
             try await runProcess("/usr/bin/pmset", arguments: ["displaysleepnow"])
         case .restart:
-            try runAppleScript("tell application \"System Events\" to restart")
+            try await runAppleScript("tell application \"System Events\" to restart")
         case .shutDown:
-            try runAppleScript("tell application \"System Events\" to shut down")
+            try await runAppleScript("tell application \"System Events\" to shut down")
         case .logOut:
-            try runAppleScript("tell application \"System Events\" to log out")
+            try await runAppleScript("tell application \"System Events\" to log out")
         case .showScreenSaver:
             let url = URL(fileURLWithPath: "/System/Library/CoreServices/ScreenSaverEngine.app")
             guard FileManager.default.fileExists(atPath: url.path) else {
@@ -102,9 +102,9 @@ enum SystemActionRunner {
                 arguments: ["1"])
         case .toggleAppearance:
             // The script returns the resulting state, so the confirmation can name it.
-            let result = try runAppleScript(
+            let result = try await runAppleScript(
                 "tell application \"System Events\" to tell appearance preferences to set dark mode to not dark mode")
-            let dark = result?.booleanValue ?? false
+            let dark = result.flag
             return SystemActionFeedback(dark ? "Dark Appearance" : "Light Appearance")
         case .toggleStageManager:
             let on = try await toggleDefault(
@@ -118,12 +118,12 @@ enum SystemActionRunner {
         case .emptyTrash:
             // Count first: Finder errors on an empty Trash, and `~/.Trash` is TCC-protected.
             let items =
-                try runAppleScript("tell application \"Finder\" to count items of trash")?
-                .int32Value ?? 0
+                try await runAppleScript("tell application \"Finder\" to count items of trash")
+                .number
             guard items > 0 else {
                 return SystemActionFeedback("Trash Is Already Empty", isNoOp: true)
             }
-            try runAppleScript("tell application \"Finder\" to empty trash")
+            try await runAppleScript("tell application \"Finder\" to empty trash")
             return SystemActionFeedback("Trash Emptied")
         case .ejectAllDisks:
             let ejected = try ejectAllDisks()
@@ -550,22 +550,34 @@ enum SystemActionRunner {
             settings: .bluetooth)
     }
 
+    /// `NSAppleEventDescriptor` isn't `Sendable`, so the two fields callers read cross instead.
+    private struct AppleScriptResult: Sendable {
+        let number: Int32
+        let flag: Bool
+    }
+
+    /// A cold Finder answers in seconds, so the send never happens on the main actor.
     @discardableResult
-    private static func runAppleScript(_ source: String) throws -> NSAppleEventDescriptor? {
-        guard let script = NSAppleScript(source: source) else {
-            throw SystemActionFailure("The system automation could not be prepared.")
-        }
-        var errorInfo: NSDictionary?
-        let result = script.executeAndReturnError(&errorInfo)
-        guard let errorInfo else { return result }
-        let number = errorInfo[NSAppleScript.errorNumber] as? Int
-        let detail = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown automation error."
-        if number == -1743 {
-            throw SystemActionFailure(
-                "Allow Tinycast to control the requested app in Automation settings, then try again.",
-                settings: .automation)
-        }
-        throw SystemActionFailure(detail)
+    private static func runAppleScript(_ source: String) async throws -> AppleScriptResult {
+        try await Task.detached(priority: .userInitiated) {
+            guard let script = NSAppleScript(source: source) else {
+                throw SystemActionFailure("The system automation could not be prepared.")
+            }
+            var errorInfo: NSDictionary?
+            let result = script.executeAndReturnError(&errorInfo)
+            guard let errorInfo else {
+                return AppleScriptResult(number: result.int32Value, flag: result.booleanValue)
+            }
+            let number = errorInfo[NSAppleScript.errorNumber] as? Int
+            let detail =
+                errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown automation error."
+            if number == -1743 {
+                throw SystemActionFailure(
+                    "Allow Tinycast to control the requested app in Automation settings, then try again.",
+                    settings: .automation)
+            }
+            throw SystemActionFailure(detail)
+        }.value
     }
 
     private static func runProcess(_ executable: String, arguments: [String]) async throws {

--- a/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
@@ -95,7 +95,7 @@ final class UninstallCoordinator {
     func showUninstallItemInfo(_ candidate: UninstallCandidate) {
         paletteCoordinator.hidePalette(restoreFocus: false)
         Task {
-            guard !AppLauncher.showInfoInFinder(candidate.url) else { return }
+            guard await !AppLauncher.showInfoInFinder(candidate.url) else { return }
             await core.showNotice(
                 title: "Couldn’t Open Get Info",
                 message: "Allow Tinycast to control Finder in System Settings › Privacy & Security "

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,11 +79,14 @@ coordinators, and the window controllers.
 `AppDelegate.applicationDidFinishLaunching` calls `AppCore.shared.start()` and nothing else. That is the
 one wiring point, and `start()` reads as the app's whole boot sequence in one screen.
 
-Views do **not** call `AppCore`. Feature actions live on that feature's coordinator, which a view reaches
-through `@Environment`; `AppCore` holds only the closure wiring that connects a hotkey to a coordinator.
-The exceptions are deliberate and narrow: `showNotice`, `confirm`, `reportFailure`, `showMessage` and
-`pickVolume` are forwarders that exist so `DialogController` and `MessageHUDController` stay
-single-owned.
+**Feature actions live on that feature's coordinator, and a view must never reach past a coordinator
+into a store to mutate it.** That is the rule; `AppCore` holds only the closure wiring that connects a
+hotkey to a coordinator. Views inject `AppCore` through `@Environment` and use it as the *locator* for
+those coordinators — `core.quicklinkCoordinator.deleteQuicklink(…)` is the shape, and the alternative
+is injecting eleven coordinators separately for no gain. Reading a store off `AppCore` to render it is
+fine too; deciding something with one is what the rule forbids. `showNotice`, `confirm`,
+`reportFailure`, `showMessage` and `pickVolume` are forwarders on `AppCore` itself, so
+`DialogController` and `MessageHUDController` stay single-owned.
 
 New long-lived state belongs on `AppCore`, wired in `start()`. Do not create a competing singleton — see
 [decisions.md](decisions.md) entry 1 for why this is a singleton and not a container.

--- a/docs/features/quicklinks.md
+++ b/docs/features/quicklinks.md
@@ -70,6 +70,12 @@ space or an `&` can't truncate the destination. Encoding is applied _after_ the 
 itself — `| raw` opts out, `| percent-encode` has done it once already. A local path is never
 encoded: `%20` in a path is a literal, not a space.
 
+`| raw` opts out of more than the escaping. Whether a link is a website, a path or a deeplink is
+decided by `QuicklinkDestination.detect` on the **expanded** text, so an unencoded substituted value
+that begins with a scheme picks the destination kind — a `{clipboard | raw}` holding `file:///…`
+resolves to a local path rather than to the web link the template looked like. Encoding is what
+normally prevents that, which is why `| raw` is a deliberate authoring choice and not a default.
+
 `{selectedText}` is accepted as an alias for `{selection}`, so a link pasted from Raycast's docs
 works unchanged. `{selection}` stays the canonical spelling and is the only one the editor's
 **Insert…** menu writes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,6 +143,9 @@ Measured at the end of the 2026 refactor, on `main`. Useful as orders of magnitu
 | Largest view / owner | `RootPaletteView` 662 lines, `AppCore` 284 lines |
 | Comment density | 1,653 of 27,289 source lines (6.1%) |
 | `palette-selection-test` | 111,684 assertions — a tripwire: a change in this count means the row-order model moved |
+| `SnippetKeywordPolicy` match | 7 µs/keystroke at 50 keywords, 59 µs at 1,000 — the `lowercased()` is 0.09 µs of it |
+| `ClipboardStore.pinnedItems` | 27–127 µs per uncached search, 1,000-row window — no cache earns its invalidation yet |
+| `count items of trash` | 5,000 ms against a cold Finder on an *empty* Trash, 110 ms warm — why AppleScript is detached |
 
 Launch time, allocation counts and RSS have never been captured as numbers. The signposts are in place,
 so any of them can be taken from `main` whenever a change makes it worth knowing.


### PR DESCRIPTION
An external audit raised nine findings. Each was checked against the code
before anything was changed: two held up as written, five were partly right
with the severity or the proposed fix wrong, and two were rejected as
documented design. This is the subset that survived.

## Fixed

**Quicklink references unwound before the delete landed.** `deleteQuicklink`
removed the hotkey binding, favorite slot and visibility entry, *then* ran
`try? store.remove`. A failed delete left a live row stripped of everything
that made it reachable. All four store mutations discarded a
`throws(QuicklinkError)` that exists because quicklinks are authored data
(decisions.md 14). The delete now runs first and reports through
`showNotice`.

**AppleScript blocked the main actor.** `count items of trash` measured
**5.0 s against a cold Finder on an empty Trash** (110 ms warm). For that
window the palette hotkey is dead and the menu bar item beachballs. The send
now happens off-main. `AppLauncher.showInfoInFinder` had the same defect and
is fixed with it — the audit missed that one.

**Three `@unchecked Sendable` types had no stated reason.** `DirectoryLock`,
`DirectoryLockTable`, `StderrCapture`. All three are correct; each gains the
line standards.md requires.

**Policy in a view body.** `ClipboardSettingsView.onChange` set
`clipboardStore.maxAge` and called `enforceLimits()`. Both move behind
`ClipboardCoordinator.applyRetention`, which `SettingsBackup` adopts too.

**Docs that were wrong.** `quicklinks.md` gains the `| raw` consequence —
destination detection runs on the expanded text, so an unencoded value
beginning with a scheme picks the destination kind. `architecture.md` said
"Views do not call `AppCore`" while eleven views inject it; nine use it only
to reach a coordinator, so the rule is restated as what it actually protects.

## Answered with a number instead of a change

standards.md asks for a measurement before optimising. Both baselines are now
recorded in testing.md.

| | Measured | Share of a 16.6 ms frame |
|---|---|---|
| Keyword scan, 50 keywords | 7 µs/keystroke | 0.04% |
| Keyword scan, 1,000 keywords | 59 µs/keystroke | 0.36% |
| `pinnedItems`, 1,000-row window | 27–127 µs/search | 0.2–0.8% |

The audit led with the `buffer.lowercased()` allocation; it is 0.09 µs, 0.15%
of the cost. Neither finding earns a cache or a bucket yet.

## Rejected

**Unbounded pinned-clipboard memory.** Documented, load-bearing design:
clipboard.md states pinned rows are matched in memory *because* every one is
resident, and that a pin outlives the retention window. Text is capped at
32,000 characters and images are stored as paths. The proposed remedy — cap
or prune pins — would silently delete curated data.

**A shared `JSONFileStore` helper.** The claim that no store-specific
behaviour rides along is false, and two of the four stores are harness-
compiled, so a shared helper is exactly the coupling decisions.md 19
declined.

## Notes for review

The audit's proposed fix for the AppleScript finding does not compile —
`NSAppleEventDescriptor` carries no `Sendable` conformance, so it cannot
leave a detached task. The two fields callers actually read cross as a small
`Sendable` struct instead. I also verified directly that `NSAppleScript` runs
correctly from a cooperative-pool thread with no run loop, rather than
assuming it.

## Verification

- `./Scripts/run-tests.sh` — 18/18 harnesses pass
- Debug build clean, no new warnings; `./Scripts/lint.sh` reports `lint-clean`
- Purity grep over `Features/*/Model/` returns nothing

**Restart, shut down and log out could not be exercised locally** — they end
the session. Those three now send their Apple event from a background thread;
the trash and appearance paths were tested, but log out is worth a manual run
before merge.
