### PR TITLE
Cut launcher per-keystroke work and idle timer cost (4.0x per arrow key, 1.35ms off each launch)

### DIFF
--- a/Tests/ranking-test.swift
+++ b/Tests/ranking-test.swift
@@ -3,7 +3,7 @@ import Foundation
 @main
 struct RankingTest {
     @MainActor
-    static func main() {
+    static func main() async {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("tinycast-ranking-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: fileURL) }
@@ -92,6 +92,8 @@ struct RankingTest {
             Set(table.keys) == [whatsApp, wick])
 
         let persistedWickBoost = boost(store, wick, "w")
+        // Persisting is off-main, so the reload has to meet it before it can read the file.
+        await store.flush()
         let reloaded = LauncherRankingStore(fileURL: fileURL) { clock }
         check(
             "records persist across store instances",

--- a/Tinycast/Features/Launcher/Model/LauncherRankingStore.swift
+++ b/Tinycast/Features/Launcher/Model/LauncherRankingStore.swift
@@ -25,6 +25,8 @@ final class LauncherRankingStore {
 
     /// `boosts(query:)` builds this from a launcher render; tracked, the write lands mid-body.
     @ObservationIgnored private var lookup: [String: [String: LauncherRankingRecord]]?
+    /// The in-flight persist, awaited by the next one so a burst can't land out of order.
+    @ObservationIgnored private var writeTask: Task<Void, Never>?
 
     init(fileURL: URL? = nil, now: @escaping () -> Date = Date.init) {
         self.fileURL = fileURL ?? Self.defaultFileURL()
@@ -41,6 +43,11 @@ final class LauncherRankingStore {
     }
 
     var isEmpty: Bool { records.isEmpty }
+
+    /// Awaits the pending persist. The launcher never needs it; reading the file back does.
+    func flush() async {
+        await writeTask?.value
+    }
 
     /// Records every prefix, so the preferred result surfaces for shorter input too.
     func record(itemKey: String, query: String) {
@@ -136,7 +143,13 @@ final class LauncherRankingStore {
     private func didMutate() {
         lookup = nil
         revision &+= 1
-        if let data = try? JSONEncoder().encode(records) {
+        // Off-main: this lands on ↵, in front of the launch. Chained, so writes stay ordered.
+        let snapshot = records
+        let fileURL = fileURL
+        let previous = writeTask
+        writeTask = Task.detached(priority: .utility) {
+            await previous?.value
+            guard let data = try? JSONEncoder().encode(snapshot) else { return }
             try? data.write(to: fileURL, options: .atomic)
         }
     }

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -49,23 +49,20 @@ struct LauncherList: View {
         var rows: [Row] = calcRows
         let favorites = results.prefix(favoriteCount)
         let rest = results.dropFirst(favoriteCount)
-        func section(_ kind: AppEntry.Kind) -> (String, [AppEntry]) {
-            (kind.descriptor.sectionTitle, rest.filter { $0.kind == kind })
+        var grouped: [AppEntry.Kind: [AppEntry]] = [:]
+        for app in rest { grouped[app.kind, default: []].append(app) }
+        if !favorites.isEmpty {
+            rows.append(.header("Favorites"))
+            rows.append(contentsOf: favorites.map(Row.app))
         }
-        // Publication order, so rows match the flat index; annotated, or inference times out.
-        let sections: [(String, [AppEntry])] = [
-            ("Favorites", Array(favorites)),
-            section(.application),
-            section(.systemSettings),
-            section(.quicklink),
-            section(.snippet),
-            section(.systemAction),
-            section(.windowCommand),
-            section(.customCommand),
-            section(.command)
+        // Publication order, so rows match the flat index.
+        let kinds: [AppEntry.Kind] = [
+            .application, .systemSettings, .quicklink, .snippet,
+            .systemAction, .windowCommand, .customCommand, .command
         ]
-        for (title, group) in sections where !group.isEmpty {
-            rows.append(.header(title))
+        for kind in kinds {
+            guard let group = grouped[kind], !group.isEmpty else { continue }
+            rows.append(.header(kind.descriptor.sectionTitle))
             rows.append(contentsOf: group.map(Row.app))
         }
         return rows

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -5,12 +5,39 @@ struct LauncherScreen: PaletteScreen {
     let appIndex: AppIndex
     let favorites: FavoritesStore
     let visibility: VisibilityStore
-    let currencyRates: CurrencyRateStore
     let core: AppCore
     let vm: PaletteState
     /// Sampled by `openActions`, so the Quit row can't appear or vanish while the menu is up.
     let running: Bool
     let openActions: () -> Void
+
+    /// The one ordered result list; an empty query pins favorites above the ranked matches.
+    private let results: [AppEntry]
+    private let calc: CalcResult?
+    /// Resolved in `init`: the palette indexes this several times per event, so it can't recompute.
+    let rows: [Row]
+
+    init(
+        appIndex: AppIndex, favorites: FavoritesStore, visibility: VisibilityStore,
+        currencyRates: CurrencyRateStore, core: AppCore, vm: PaletteState, running: Bool,
+        openActions: @escaping () -> Void
+    ) {
+        self.appIndex = appIndex
+        self.favorites = favorites
+        self.visibility = visibility
+        self.core = core
+        self.vm = vm
+        self.running = running
+        self.openActions = openActions
+
+        let results = appIndex.orderedResults(
+            query: vm.query, visibility: visibility, favorites: favorites)
+        let calc = CalcMemo.evaluate(vm.query, currency: currencyRates.source)
+        let entries = results.map(Row.entry)
+        self.results = results
+        self.calc = calc
+        self.rows = calc.map { [.calc($0)] + entries } ?? entries
+    }
 
     /// The card is a row like any other, so the flat selection indexes `rows` with no offset.
     enum Row: Equatable, Identifiable {
@@ -23,18 +50,6 @@ struct LauncherScreen: PaletteScreen {
             case .entry(let app): return app.id
             }
         }
-    }
-
-    /// The one ordered result list; an empty query pins favorites above the ranked matches.
-    private var results: [AppEntry] {
-        appIndex.orderedResults(query: vm.query, visibility: visibility, favorites: favorites)
-    }
-    private var calc: CalcResult? { CalcMemo.evaluate(vm.query, currency: currencyRates.source) }
-
-    var rows: [Row] {
-        let entries = results.map(Row.entry)
-        guard let calc else { return entries }
-        return [.calc(calc)] + entries
     }
 
     /// The pill carries no selection, so the screen applies the clamp the palette applies.
@@ -52,8 +67,7 @@ struct LauncherScreen: PaletteScreen {
     }
 
     private func row(at selection: Int) -> Row? {
-        let rows = rows
-        return rows.indices.contains(selection) ? rows[selection] : nil
+        rows.indices.contains(selection) ? rows[selection] : nil
     }
 
     private func entry(at selection: Int) -> AppEntry? {
@@ -135,8 +149,6 @@ struct LauncherScreen: PaletteScreen {
 
     @ViewBuilder
     private func content(selection: Int, scroll: ScrollIntent) -> some View {
-        let rows = rows
-        let results = results
         // Sections stand in for the ranked Results list, which a typed query collapses to.
         let showSections = vm.query.trimmingCharacters(in: .whitespaces).isEmpty
         LauncherList(

--- a/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
+++ b/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
@@ -224,8 +224,10 @@ final class SnippetKeywordListener: HealthCheckable {
     private func syncTapPresence() {
         let decision = lifecycleDecision()
         switch decision.tapAction {
+        // Nothing moved, so the decision still describes the tap: don't pay for a second one.
         case .none:
-            break
+            status = decision.status
+            return
         case .install:
             installTapIfNeeded()
         case .reenable:

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -62,16 +62,25 @@ struct RootPaletteView: View {
         }
     }
 
-    private var resultCount: Int { screen.rows.count }
     /// Selection clamped into the results: one source for highlight, preview and activation.
-    private var selection: Int { resultCount == 0 ? 0 : min(max(vm.selection, 0), resultCount - 1) }
+    private func selection(count: Int) -> Int {
+        count == 0 ? 0 : min(max(vm.selection, 0), count - 1)
+    }
+
+    /// Takes a resolved screen — reaching `rows` costs a list build, so callers resolve it once.
+    private func selection(in screen: any PaletteScreen) -> Int {
+        selection(count: screen.rows.count)
+    }
 
     private var menuOpen: Bool { showActions || showAppMenu }
 
     // MARK: - Popover menu content
 
     /// The Actions menu for the current selection, or nil when it has no actions.
-    private var actionsContent: PopoverMenuContent? { screen.actions(at: selection) }
+    private var actionsContent: PopoverMenuContent? {
+        let screen = screen
+        return screen.actions(at: selection(in: screen))
+    }
 
     /// The bottom-left app menu content (About / Settings).
     private var appMenuContent: PopoverMenuContent {
@@ -96,7 +105,7 @@ struct RootPaletteView: View {
         // Resolve the screen once per render, so the flat index can't drift from the rows.
         let screen = screen
         let count = screen.rows.count
-        let sel = count == 0 ? 0 : min(max(vm.selection, 0), count - 1)
+        let sel = selection(count: count)
         // The argument form has no rows to count, but ↵ still does something.
         let showActionGroup =
             (count > 0 || vm.mode == .quicklinkArguments) && screen.hasPrimaryAction(at: sel)
@@ -250,6 +259,8 @@ struct RootPaletteView: View {
                 return .handled
             }
             guard command || option else { return .ignored }
+            let screen = screen
+            let selection = selection(in: screen)
             if command { return screen.secondary(at: selection) ? .handled : .ignored }
             guard let emoji = screen as? EmojiScreen else { return .ignored }
             return emoji.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
@@ -272,9 +283,10 @@ struct RootPaletteView: View {
             guard press.modifiers.contains(.command) else { return .ignored }
             // The Actions menu has no anchor in the compact bar, so swallow ⌘K there.
             guard !isCollapsed else { return .handled }
-            guard resultCount > 0 else { return .handled }
+            let screen = screen
+            guard !screen.rows.isEmpty else { return .handled }
             // An error calc card is the selection but has no actions — don't open an empty panel.
-            guard screen.hasPrimaryAction(at: selection) else { return .handled }
+            guard screen.hasPrimaryAction(at: selection(in: screen)) else { return .handled }
             toggleActions()
             return .handled
         }
@@ -282,6 +294,8 @@ struct RootPaletteView: View {
         .onKeyPress(keys: [.delete, .deleteForward], phases: .down) { press in
             if menuOpen { return .handled }
             guard press.modifiers.contains(.command) else { return .ignored }
+            let screen = screen
+            let selection = selection(in: screen)
             if let quicklinks = screen as? QuicklinkListScreen {
                 return quicklinks.delete(at: selection) ? .handled : .ignored
             }
@@ -298,6 +312,8 @@ struct RootPaletteView: View {
         // ⌘P mirrors the Actions row, and works while that menu is open like the rest.
         .onKeyPress(keys: ["p"], phases: .down) { press in
             guard press.modifiers.contains(.command) else { return .ignored }
+            let screen = screen
+            let selection = selection(in: screen)
             if let clipboard = screen as? ClipboardScreen {
                 return clipboard.pin(at: selection) ? .handled : .ignored
             }
@@ -311,7 +327,7 @@ struct RootPaletteView: View {
             guard press.modifiers.contains(.control), press.modifiers.contains(.shift),
                 !isCollapsed, let launcher = screen as? LauncherScreen
             else { return .ignored }
-            return launcher.quit(at: selection) ? .handled : .ignored
+            return launcher.quit(at: selection(in: launcher)) ? .handled : .ignored
         }
     }
 
@@ -437,7 +453,8 @@ struct RootPaletteView: View {
 
     /// The one path opening the Actions menu, sampling the state its rows depend on.
     private func openActions() {
-        selectionIsRunning = (screen as? LauncherScreen)?.isRunning(at: selection) ?? false
+        let launcher = screen as? LauncherScreen
+        selectionIsRunning = launcher.map { $0.isRunning(at: selection(in: $0)) } ?? false
         withAnimation(Self.menuAnimation) { showActions = true }
     }
 
@@ -466,16 +483,18 @@ struct RootPaletteView: View {
 
     // MARK: - Actions
 
-    private func move(_ delta: Int) {
-        guard resultCount > 0 else { return }
-        vm.selection = min(max(selection + delta, 0), resultCount - 1)
+    private func move(_ delta: Int, in screen: any PaletteScreen) {
+        let count = screen.rows.count
+        guard count > 0 else { return }
+        vm.selection = min(max(selection(count: count) + delta, 0), count - 1)
         scroll = ScrollIntent(kind: .follow)
     }
 
     /// ↑/↓: the screen's own move where it has one, else a linear step through the rows.
     private func moveVertically(_ delta: Int) {
-        guard let next = screen.move(delta, axis: .vertical, from: selection) else {
-            move(delta)
+        let screen = screen
+        guard let next = screen.move(delta, axis: .vertical, from: selection(in: screen)) else {
+            move(delta, in: screen)
             return
         }
         vm.selection = next
@@ -484,7 +503,8 @@ struct RootPaletteView: View {
 
     /// ←/→: consumed only by a horizontally navigating screen, else the caret keeps them.
     private func moveHorizontally(_ delta: Int) -> Bool {
-        guard let next = screen.move(delta, axis: .horizontal, from: selection) else {
+        let screen = screen
+        guard let next = screen.move(delta, axis: .horizontal, from: selection(in: screen)) else {
             return false
         }
         vm.selection = next
@@ -518,7 +538,8 @@ struct RootPaletteView: View {
     private func activateSelection() {
         // Nothing is visibly selected when collapsed, so launch via ⌘1–⌘5 or typing.
         guard !isCollapsed else { return }
-        screen.activate(at: selection)
+        let screen = screen
+        screen.activate(at: selection(in: screen))
     }
 }
 

--- a/Tinycast/Platform/HealthTicker.swift
+++ b/Tinycast/Platform/HealthTicker.swift
@@ -21,6 +21,8 @@ final class HealthTicker {
         let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated { self?.tick() }
         }
+        // Recovery, not latency: tolerance lets the kernel coalesce the idle wakeup.
+        timer.tolerance = 0.2
         RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
     }


### PR DESCRIPTION
A CPU/memory audit of the palette, launcher, timers, event taps, startup graph and persistence layer. Five findings survived the filter; all five are fixed here. **No UI, UX, behavior, settings, animation or startup change** — every fix is either a caching change, a pass reduction, or moving already-required work off the main actor.

Most of the codebase needed no work and was left alone: the fuzzy scorer is already allocation-tuned, `IconCache`/`ImageThumbnail` cache with byte-accurate cost limits and decode off-main, `AppIndex.scan` is `nonisolated` on `Task.detached`, and the `Memo` layer is correctly `@ObservationIgnored`.

---

## Results

Measured against the **real shipped sources** (`AppIndex`, `AppEntry`, `LauncherRankingStore`, `FavoritesStore`, `VisibilityStore` compiled directly), on a 169-entry index — the empty-query launcher, i.e. the default view on every summon.

| Path | Before | After | Δ |
| --- | ---: | ---: | ---: |
| `rows` materialization per event | 167.2 µs | 12.0 µs | **13.8× faster** |
| `LauncherList` section building per render | 107.8 µs | 55.5 µs | **1.9× faster** |
| **Combined, one arrow key / keystroke** | **275.2 µs** | **68.6 µs** | **4.0× faster** |
| Blocking main-actor work per app launch | 1346.4 µs | ~0 µs | **1.35 ms removed** |

Transient heap traffic per event (exact, from `MemoryLayout`):

```
MemoryLayout<AppEntry>.stride      120 bytes
MemoryLayout<Row>.stride           128 bytes
one rows array (169 entries)     21,632 bytes
BEFORE: 14 arrays               302,848 bytes, 14 allocations
AFTER:   1 array                 21,632 bytes,  1 allocation
=> 281,216 bytes and 13 allocations avoided per event
```

The combined saving is ~1.24% of a 16.6 ms frame per keystroke, and it **scales linearly with index size** — this machine has 169 entries, so a larger app collection sees proportionally more.

A Time Profiler trace (`xctrace record --template 'Time Profiler'`) over the same run corroborates the shape — `JSONEncoder.wrapGeneric` dominates the persist path, and `oldSectionRows` carries more samples than `newSectionRows` once its outlined `section` closure is included. At 1 ms sampling it is too coarse for the per-event numbers, so the table above comes from in-process `DispatchTime` measurement, which is what those figures should be read as.

---

## The five findings

### 1. The launcher's `rows` array was rebuilt ~14× per keystroke and per arrow key

`LauncherScreen.rows` was a computed property with no storage — `results.map(Row.entry)` allocated a fresh array on every access, and `row(at:)` rebuilt the whole array to read one index.

`RootPaletteView` compounded it. `resultCount` and `selection` were computed properties that each re-entered `screen.rows`. Tracing one ↓ through `moveVertically` → `move`: **7 full materializations before the render even starts**, then 7 more inside `body` (`rows.count`, `hasPrimaryAction`, `screen.body`, `entry(at:)`, `isCardSelected`, `primaryActionTitle` → `clampedSelection` + `row(at:)`).

The existing comment *"Resolve the screen once per render"* hoisted the screen **value** but not the `rows` array, so it bought correctness, not work avoidance.

**Fix:** `LauncherScreen` computes `results`, `calc` and `rows` once in an explicit `init` and stores them. `RootPaletteView`'s `resultCount`/`selection` became functions taking an already-resolved screen, and all ~10 call sites hoist `let screen = screen` first. The old computed properties are deleted, so the compiler enforced finding every caller. **14 → 1.**

Worth noting: the empty query is the *largest* case, not the smallest. `AppIndex.matches` short-circuits with `return apps` and no limit; the `.prefix(limit)` only applies to typed queries. So the default view was mapping the entire index 14 times.

### 2. `LauncherList` did 8 full filter passes to build sections

Eight `rest.filter` calls, each a complete pass with its own array allocation, then a ninth to concatenate. Replaced with one pass into a kind-keyed dictionary emitted in the same fixed order.

### 3. Every launcher activation blocked the main actor on a JSON encode + atomic write

`LauncherCoordinator.launch` calls `ranking.record(...)` **first**, synchronously, before dispatching the entry or hiding the palette. That ran a 1,000-record `JSONEncoder` pass plus an atomic write on the main actor, directly in front of the app launch — **measured at 1.35 ms**.

This matters more than the raw number suggests: the process holds three system-wide event taps and `HyperKeyTap` uses `options: .defaultTap`, so any main-thread stall here sits in the system-wide keyboard input path.

**Fix:** the in-memory mutation and `revision` bump stay exactly where they were — those are what the UI observes. Only the encode + write moved to a chained `Task.detached`, so writes stay ordered and the file converges to the same bytes.

**Durability note:** a crash within ~1 ms of ↵ could now lose the last learned visit. The store was already best-effort (`try?` on both encode and write, Caches directory, filtered on load), so this widens an existing window rather than creating a new failure mode. This was an explicit call, not an accident.

### 4. The 1 Hz watchdog timer set no tolerance

`HealthTicker`'s timer had no `tolerance`, forcing an exact-time wakeup the kernel cannot coalesce — the classic cause of a menu-bar app showing energy impact. `ClipboardManager.startPolling()` already sets one; this site just missed it. Added `timer.tolerance = 0.2`. It is a tap-recovery watchdog, not a latency-sensitive path.

### 5. The snippet listener evaluated its lifecycle decision twice per second

`syncTapPresence()` called `lifecycleDecision()` twice, each doing an `AXIsProcessTrusted()` XPC call plus `CGEvent.tapIsEnabled`. The steady-state `.none` branch now reuses the first decision; the action branches still re-read so the reported status reflects the post-action tap state.

**Honest scoping:** I estimated this as more expensive than it is. Measured, `AXIsProcessTrusted()` costs **0.40 µs**, so this saves ~0.4 µs/s. It is correct and free, but it is not a performance win worth claiming — it is dead work removal.

---

## Examined and deliberately not changed

| Area | Why |
| --- | --- |
| `ClipboardManager` 0.5 s pasteboard poll | Only permanent unconditional wakeup, but the fast path is a single `changeCount` compare and it already sets `tolerance = 0.1`. No public pasteboard-change notification exists; lowering the rate or gating on visibility would drop clips. |
| `EmojiIndex.load()` eager at launch | ~2,055 entries in three collections held for the session (~0.5–1 MB) even if the picker is never opened. The parse is already off-main. Making it lazy would introduce a first-open delay. |
| `AppEntry.searchFields` allocating `[name] + matchAliases` | ~169 one-element allocations per uncached rank, an order of magnitude below Finding 1. Micro-optimization. |
| Three sync JSON reads during `AppCore.shared` construction | ~2–5 ms at `applicationDidFinishLaunching` on a login item with no window. Not user-visible. |
| `FavoritesStore.isFavorite` linear `contains` | `keys` is a handful of favorites and `prefix(while:)` stops at the first miss. |
| `AppEntry.Kind.descriptor` rebuilt per call | Swift string literals live in the binary's constant data — no heap allocation. |

---

## Correctness

`LauncherList.rows` is **not** covered by any harness — no harness compiles that file. Rather than assume the rewrite was equivalent, I ran a differential check replicating both the old 8-filter builder and the new grouping pass over **200,012 randomized inputs**, including interleaved kinds (the case a naive run-boundary pass would get wrong):

```
200012 cases checked, 0 mismatches
```

The dictionary approach is equivalent by construction regardless of input ordering, so it does not depend on `publishEntries`' slice ordering staying stable.

### `ranking-test` needed a real change

The harness reloads the store from disk immediately after `record()`, which the async write broke. I fixed the cause rather than the assertion: `LauncherRankingStore.flush()` awaits the pending persist, and the harness awaits it before reloading. The test still checks genuinely round-tripped file content.

## Checks

- `./Scripts/run-tests.sh` — all 18 harnesses pass
- Debug build — succeeds, no new warnings
- `./Scripts/lint.sh` — clean
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` — empty

## What has not been verified

The measurements come from a benchmark compiled against the shipped sources, not from driving the real app's UI. Behavioral equivalence in the running app — section order, headers, flat-index mapping for ⌘↵ / ⌃⇧Q / ⌘K / ⌘1–⌘5, compact collapse, footer pill label — is argued from the code and the differential check, and still wants a manual pass before merge.
