### PR TITLE
Make ✦ the notation, and let Include Shift re-point recorded chords

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -78,7 +78,9 @@ run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \
 run palette-selection-test Tinycast/Features/PaletteRowIndex.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
-                           Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift
+                           Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
+                           Tinycast/Features/HotKeys/Model/HyperKey.swift \
+                           Tinycast/Features/HotKeys/Service/KeyShortcut.swift
 run callout-test           Tinycast/DesignSystem/Theme.swift \
                            Tinycast/Features/HotKeys/UI/CalloutPlacement.swift
 run system-action-test     Tinycast/Features/SystemActions/Model/SystemAction.swift

--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Carbon.HIToolbox
 import Foundation
 
 /// Drives `DoubleTapDetector` on a virtual clock, so every window boundary is exact rather than timed.
@@ -52,6 +54,8 @@ struct DoubleTapDetectorTests {
 
     static func main() {
         modifierGlyphs()
+        hyperChord()
+        hyperRetargeting()
         firing()
         timing()
         chords()
@@ -77,6 +81,96 @@ struct DoubleTapDetectorTests {
             DoubleTapModifier.allCases.map(\.rawValue)
                 == ["control", "option", "shift", "command"],
             "raw values are the persisted spelling and stay in canonical ⌃⌥⇧⌘ order")
+    }
+
+    // MARK: - The Hyper chord
+
+    /// A combo on the G key, spelled in Carbon like the on-disk shape.
+    private static func combo(_ flags: NSEvent.ModifierFlags) -> KeyShortcut {
+        KeyShortcut(
+            carbonKeyCode: kVK_ANSI_G, carbonModifiers: KeyShortcut.carbonModifiers(from: flags))
+    }
+
+    private static func caps(_ flags: NSEvent.ModifierFlags, includesShift: Bool?) -> [String] {
+        KeyShortcut.collapsedModifierSymbols(
+            from: flags,
+            hyperChord: includesShift.map { KeyShortcut.hyperChord(includesShift: $0) })
+    }
+
+    static func hyperChord() {
+        expect(
+            KeyShortcut.hyperChord(includesShift: false) == [.control, .option, .command],
+            "Hyper without Include Shift is exactly ⌃⌥⌘")
+        expect(
+            KeyShortcut.hyperChord(includesShift: true) == [.control, .option, .shift, .command],
+            "Include Shift adds ⇧ and nothing else")
+
+        for includesShift in [false, true] {
+            let chord = KeyShortcut.hyperChord(includesShift: includesShift)
+            expect(
+                caps(chord, includesShift: includesShift) == ["✦"],
+                "the chord itself collapses to a lone ✦ (shift \(includesShift))")
+            expect(
+                caps(chord.union(.capsLock), includesShift: includesShift) == ["✦"],
+                "a stray non-shortcut flag doesn't defeat the collapse (shift \(includesShift))")
+            expect(
+                caps(chord, includesShift: nil) == KeyShortcut.modifierSymbols(from: chord),
+                "with no Hyper key configured the chord renders literally (shift \(includesShift))")
+        }
+
+        // ⌃⌥⌘ is a subset of ⌃⌥⇧⌘, so only the shift-off chord can collapse under the wider set.
+        expect(
+            caps([.control, .option, .command], includesShift: true) == ["⌃", "⌥", "⌘"],
+            "the narrower chord doesn't collapse while Include Shift is on")
+        expect(
+            caps([.control, .option, .shift, .command], includesShift: false) == ["✦", "⇧"],
+            "an extra modifier trails ✦ in canonical order")
+        expect(
+            caps([.command, .shift], includesShift: false) == ["⇧", "⌘"],
+            "an ordinary combo is untouched, and stays in ⌃⌥⇧⌘ order rather than press order")
+
+        expect(
+            KeyShortcut(keyCode: kVK_ANSI_G, modifierFlags: KeyShortcut.hyperChord(
+                includesShift: true))?.carbonModifiers
+                == combo([.control, .option, .shift, .command]).carbonModifiers,
+            "recording while Hyper is held captures exactly the chord")
+    }
+
+    static func hyperRetargeting() {
+        let narrow = combo([.control, .option, .command])
+        let wide = combo([.control, .option, .shift, .command])
+
+        expect(narrow.retargetingHyper(includesShift: true) == wide, "⌃⌥⌘G follows ⇧ going on")
+        expect(wide.retargetingHyper(includesShift: false) == narrow, "⌃⌥⇧⌘G follows ⇧ going off")
+        expect(
+            narrow.retargetingHyper(includesShift: true).retargetingHyper(includesShift: false)
+                == narrow,
+            "the chord round-trips across a flip and back")
+        for includesShift in [false, true] {
+            let target = includesShift ? wide : narrow
+            expect(
+                target.retargetingHyper(includesShift: includesShift) == target,
+                "retargeting is idempotent, so an import can't corrupt a matching chord")
+        }
+
+        expect(
+            narrow.retargetingHyper(includesShift: true).carbonKeyCode == kVK_ANSI_G,
+            "only the modifiers move; the key is preserved")
+        expect(
+            combo([.control, .option, .command, .capsLock]).retargetingHyper(includesShift: true)
+                == wide,
+            "the masking initializer keeps a stray flag out of the retargeted chord")
+
+        // Anything that isn't the other chord is left exactly as recorded.
+        for flags in [[.command, .shift], [.option], [.control, .option], []] as [NSEvent
+            .ModifierFlags] {
+            let shortcut = combo(flags)
+            for includesShift in [false, true] {
+                expect(
+                    shortcut.retargetingHyper(includesShift: includesShift) == shortcut,
+                    "\(KeyShortcut.modifierSymbols(from: flags).joined()) is not a Hyper chord")
+            }
+        }
     }
 
     // MARK: - Firing

--- a/Tests/raycast-test.swift
+++ b/Tests/raycast-test.swift
@@ -209,7 +209,6 @@ enum RaycastTests {
                 "preferencesAdvanced": {
                   "popToRootTimeout": 90,
                   "emojiSkinTone": "medium",
-                  "useHyperKeyIcon": true,
                   "raycast_hyperKey_state": {
                     "enabled": true, "keyCode": 57, "includeShiftKey": true
                   }
@@ -244,7 +243,6 @@ enum RaycastTests {
 
         expect(parsed.popToRootTimeout == 90, "popToRootTimeout")
         expect(parsed.emojiSkinTone == "medium", "emojiSkinTone")
-        expect(parsed.useHyperKeyIcon == true, "useHyperKeyIcon")
         expect(parsed.hyperKey?.enabled == true, "hyper key enabled")
         expect(parsed.hyperKey?.keyCode == 57, "hyper key is a Carbon code, not a name")
         expect(parsed.hyperKey?.includesShift == true, "hyper key includes shift")

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */; };
 		48AE2C9989F8FA2AA99D2D61 /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B4495E56754B05B5F3551D /* CalcPercent.swift */; };
 		4F938D799099931DDA1D1876 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC8371BCD366F2549E0B01B /* SectionHeader.swift */; };
+		507D6A26EA5451465B1BE5AF /* HotKeyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */; };
 		5194FB6B47E004217CFD1ABB /* UninstallSearchRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54932083F6BC197453EA0C8 /* UninstallSearchRoot.swift */; };
 		52C4F57BB26F420CCD22C1D7 /* PaletteWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */; };
 		5332040ADB923832DCA06E5C /* CalculatorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518429EDBFBEA0B866CCAA81 /* CalculatorCoordinator.swift */; };
@@ -259,6 +260,7 @@
 		3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
 		418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		41A52665A3078BAAD151528C /* AuxWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuxWindowController.swift; sourceTree = "<group>"; };
+		43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyAction.swift; sourceTree = "<group>"; };
 		445B0374FD5D74DBE23243CD /* PaletteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteScreen.swift; sourceTree = "<group>"; };
 		45D4BA6E1BD8EB1F96A8927F /* Tinycast.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tinycast.entitlements; sourceTree = "<group>"; };
 		45EB979ECD44738BCD9E2F90 /* EmojiCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCoordinator.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 			children = (
 				83C54F3A609CD1C2CDF304FB /* DoubleTapDetector.swift */,
 				72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */,
+				43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */,
 				85B00A698366E83C7352BC1E /* HotKeyBinding.swift */,
 				95BFA41B0D7F369A8CF1E013 /* HyperKey.swift */,
 			);
@@ -1301,6 +1304,7 @@
 				A500AF3BF8910B335A7A936C /* HUDPanel.swift in Sources */,
 				68537C3544E4EBC40E3ACD39 /* HUDPresenter.swift in Sources */,
 				14D056C9DA105D9D89A9691E /* HealthTicker.swift in Sources */,
+				507D6A26EA5451465B1BE5AF /* HotKeyAction.swift in Sources */,
 				B2404EBFB52B8199DC2536F6 /* HotKeyBinding.swift in Sources */,
 				ACD8CAE659B1C49EC8652576 /* HotKeyCenter.swift in Sources */,
 				CC9A286B77E32C22B21A22BE /* HotKeyManager.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -148,8 +148,9 @@ final class AppCore {
                 self?.quicklinkCoordinator.openQuicklink(id: id)
             }
             hotKeys.displayName = { [weak self] action in self?.hotKeyDisplayName(for: action) }
-            KeyShortcut.hyperDisplay = { [settings] in
-                (settings.hyperKey, settings.hyperKeyReplacesGlyph, settings.hyperKeyIncludesShift)
+            KeyShortcut.displayedHyperChord = { [settings] in
+                guard settings.hyperKey != .none else { return nil }
+                return KeyShortcut.hyperChord(includesShift: settings.hyperKeyIncludesShift)
             }
             SystemActionRunner.onAsyncFailure = { [weak self] id, failure in
                 self?.systemActionCoordinator.presentSystemActionFailure(id: id, failure: failure)
@@ -222,6 +223,8 @@ final class AppCore {
             _ = $0.quicklinksShowInLauncher
         }, reproject: { $0.quicklinkCoordinator.applyQuicklinksPresence() })
         track({ _ = $0.snippetsEnabled }, reproject: { $0.snippetExpansion.applySnippetsEnabled() })
+        // Not a feature switch, but the same re-projection: a combo has the chord's ⇧ bit baked in.
+        track({ _ = $0.hyperKeyIncludesShift }, reproject: { $0.applyHyperChord() })
         track(
             { _ = $0.snippetsShowInLauncher },
             reproject: { $0.snippetExpansion.applySnippetsLauncherPresence() })
@@ -241,6 +244,12 @@ final class AppCore {
                 reproject(self)
             }
         }
+    }
+
+    /// Without a Hyper key the chord means nothing, so a literal ⌃⌥⌘ combo is left as recorded.
+    private func applyHyperChord() {
+        guard settings.hyperKey != .none else { return }
+        hotKeys.retargetHyperBindings(includesShift: settings.hyperKeyIncludesShift)
     }
 
     private func applyWindowCommandsPresence() {

--- a/Tinycast/Features/Backup/Model/RaycastImport.swift
+++ b/Tinycast/Features/Backup/Model/RaycastImport.swift
@@ -52,10 +52,6 @@ enum RaycastImport {
                     settings.hyperKey = key
                     hasSettings = true
                 }
-                if let glyph = backup.settings?.hyperKeyReplacesGlyph {
-                    settings.hyperKeyReplacesGlyph = glyph
-                    hasSettings = true
-                }
             }
 
             let keepClipboard = options.contains(.clipboardHistory)

--- a/Tinycast/Features/Backup/Model/RaycastImportV1.swift
+++ b/Tinycast/Features/Backup/Model/RaycastImportV1.swift
@@ -54,10 +54,6 @@ enum RaycastImportV1 {
                 mapped = true
             }
         }
-        if let useIcon = payload.useHyperKeyIcon {
-            data.hyperKeyReplacesGlyph = useIcon
-            mapped = true
-        }
         // Raycast's window mode is a string; we only have the compact toggle.
         if let mode = payload.windowMode {
             data.compactMode = (mode == "compact")

--- a/Tinycast/Features/Backup/Model/RaycastV1Decoder.swift
+++ b/Tinycast/Features/Backup/Model/RaycastV1Decoder.swift
@@ -26,7 +26,6 @@ struct RaycastV1Payload: Sendable, Equatable {
     var popToRootTimeout: Int?
     var emojiSkinTone: String?
     var hyperKey: HyperKeyState?
-    var useHyperKeyIcon: Bool?
     var windowMode: String?
     var showFavoritesInCompactMode: Bool?
     var statusBarIsVisible: Bool?
@@ -130,7 +129,6 @@ enum RaycastV1Decoder {
 
         payload.popToRootTimeout = advanced?["popToRootTimeout"] as? Int
         payload.emojiSkinTone = advanced?["emojiSkinTone"] as? String
-        payload.useHyperKeyIcon = advanced?["useHyperKeyIcon"] as? Bool
         if let state = advanced?["raycast_hyperKey_state"] as? [String: Any],
             let keyCode = state["keyCode"] as? Int {
             payload.hyperKey = .init(

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -20,7 +20,6 @@ struct SettingsBackup: Codable {
         var hyperKey: String?
         var hyperKeyIncludesShift: Bool?
         var hyperKeyQuickPress: String?
-        var hyperKeyReplacesGlyph: Bool?
         var emojiSkinTone: String?
         var showInMenuBar: Bool?
         var popToRootSeconds: Int?
@@ -83,7 +82,6 @@ extension SettingsBackup {
             hyperKey: s.hyperKey.rawValue,
             hyperKeyIncludesShift: s.hyperKeyIncludesShift,
             hyperKeyQuickPress: s.hyperKeyQuickPress.rawValue,
-            hyperKeyReplacesGlyph: s.hyperKeyReplacesGlyph,
             emojiSkinTone: s.emojiSkinTone.rawValue,
             showInMenuBar: UserDefaults.standard.object(forKey: SettingsKey.showInMenuBar) as? Bool
                 ?? true,
@@ -195,10 +193,6 @@ extension SettingsBackup {
         }
         if let raw = s.hyperKeyQuickPress, let quick = HyperKeyQuickPress(rawValue: raw) {
             settings.hyperKeyQuickPress = quick
-            count += 1
-        }
-        if let flag = s.hyperKeyReplacesGlyph {
-            settings.hyperKeyReplacesGlyph = flag
             count += 1
         }
         if let raw = s.emojiSkinTone, let tone = EmojiSkinTone(rawValue: raw) {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -9,7 +9,6 @@ enum SettingsBackupCoverage {
         "hyperKey": .hyperKey,
         "hyperKeyIncludesShift": .hyperKeyIncludesShift,
         "hyperKeyQuickPress": .hyperKeyQuickPress,
-        "hyperKeyReplacesGlyph": .hyperKeyReplacesGlyph,
         "emojiSkinTone": .emojiSkinTone,
         "popToRootSeconds": .popToRootTimeout,
         "compactMode": .compactMode,

--- a/Tinycast/Features/Backup/Service/RaycastImportV2.swift
+++ b/Tinycast/Features/Backup/Service/RaycastImportV2.swift
@@ -84,10 +84,6 @@ enum RaycastImportV2 {
             data.hyperKey = key.rawValue
             mapped = true
         }
-        if let display = general?["hyperKeyDisplayShortcut"] as? Bool {
-            data.hyperKeyReplacesGlyph = display
-            mapped = true
-        }
         if let showInMenuBar = general?["showInMenuBar"] as? Bool {
             data.showInMenuBar = showInMenuBar
             mapped = true

--- a/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
+++ b/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Everything in Tinycast a global shortcut can be bound to.
+enum HotKeyAction: Hashable, Sendable {
+    case togglePalette
+    case toggleClipboard
+    case toggleEmoji
+    case app(bundleID: String)
+    case settingsPane(bundleID: String)
+    case customCommand(id: UUID)
+    case systemAction(id: SystemAction.ID)
+    case windowCommand(id: WindowCommand.ID)
+    case quicklink(id: UUID)
+
+    /// The UserDefaults key, and the `HotKeyCenter` registration id: one per action.
+    var defaultsKey: String {
+        switch self {
+        case .togglePalette: "hotkey.togglePalette"
+        case .toggleClipboard: "hotkey.toggleClipboard"
+        case .toggleEmoji: "hotkey.toggleEmoji"
+        case .app(let bundleID): "hotkey.app." + bundleID
+        case .settingsPane(let bundleID): "hotkey.pane." + bundleID
+        case .customCommand(let id): "hotkey.customCommand." + id.uuidString.lowercased()
+        case .systemAction(let id): "hotkey.systemAction." + id.rawValue
+        case .windowCommand(let id): "hotkey.windowCommand." + id.rawValue
+        case .quicklink(let id): "hotkey.quicklink." + id.uuidString.lowercased()
+        }
+    }
+}

--- a/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
+++ b/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
@@ -130,6 +130,19 @@ final class HotKeyManager {
         }
     }
 
+    /// Include Shift redefines the chord, and a stored combo has the old one baked in.
+    func retargetHyperBindings(includesShift: Bool) {
+        for action in candidateActions {
+            guard let shortcut = bindings[action]?.shortcut else { continue }
+            let retargeted = shortcut.retargetingHyper(includesShift: includesShift)
+            guard retargeted != shortcut else { continue }
+            let binding = HotKeyBinding.combo(retargeted)
+            // Skip a collision rather than clobber it: the second registration would fail silently.
+            guard conflictOwner(of: binding, excluding: action) == nil else { continue }
+            setBinding(binding, for: action)
+        }
+    }
+
     /// What else holds `binding`, or nil. Whole-binding comparison covers both kinds alike.
     func conflictOwner(of binding: HotKeyBinding, excluding action: HotKeyAction) -> String? {
         for candidate in candidateActions

--- a/Tinycast/Features/HotKeys/Service/KeyShortcut.swift
+++ b/Tinycast/Features/HotKeys/Service/KeyShortcut.swift
@@ -20,22 +20,18 @@ struct KeyShortcut: Hashable, Sendable {
         self.init(carbonKeyCode: keyCode, carbonModifiers: Self.carbonModifiers(from: flags))
     }
 
-    /// Hyper display preference; a closure, not a value, so a Settings toggle re-renders keycaps.
-    @MainActor
-    static var hyperDisplay:
-        () -> (hyperKey: HyperKeyPhysicalKey, replacesGlyph: Bool, includesShift: Bool) = {
-            (.none, false, true)
-        }
+    /// The chord ✦ stands for, nil without a Hyper key; a closure, so a toggle re-renders keycaps.
+    @MainActor static var displayedHyperChord: () -> NSEvent.ModifierFlags? = { nil }
 
     /// One string per keycap in canonical order (⌃⌥⇧⌘), with the key glyph last.
     @MainActor var keycaps: [String] {
-        let hyper = Self.hyperDisplay()
-        return Self.collapsedModifierSymbols(
-            from: modifierFlags, hyperKey: hyper.hyperKey, replacesGlyph: hyper.replacesGlyph,
-            includesShift: hyper.includesShift) + [keyGlyph]
+        Self.collapsedModifierSymbols(from: modifierFlags, hyperChord: Self.displayedHyperChord())
+            + [keyGlyph]
     }
 
-    var modifierFlags: NSEvent.ModifierFlags {
+    var modifierFlags: NSEvent.ModifierFlags { Self.modifierFlags(from: carbonModifiers) }
+
+    static func modifierFlags(from carbonModifiers: Int) -> NSEvent.ModifierFlags {
         var flags: NSEvent.ModifierFlags = []
         if carbonModifiers & controlKey != 0 { flags.insert(.control) }
         if carbonModifiers & optionKey != 0 { flags.insert(.option) }
@@ -53,22 +49,31 @@ struct KeyShortcut: Hashable, Sendable {
         return carbon
     }
 
-    /// `modifierSymbols` with the Hyper set collapsed to "✦", keyed on configuration.
+    // MARK: - The Hyper chord
+
+    /// ⌃⌥⌘, plus ⇧ when Include Shift is on — the one place the chord is spelled out.
+    static func hyperChord(includesShift: Bool) -> NSEvent.ModifierFlags {
+        includesShift ? [.control, .option, .shift, .command] : [.control, .option, .command]
+    }
+
+    /// Re-points a chord recorded against the other Hyper set. docs/features/hotkeys.md
+    func retargetingHyper(includesShift: Bool) -> KeyShortcut {
+        let stale = Self.hyperChord(includesShift: !includesShift)
+        guard modifierFlags.isSuperset(of: stale) else { return self }
+        let retargeted =
+            modifierFlags.subtracting(stale).union(Self.hyperChord(includesShift: includesShift))
+        return KeyShortcut(
+            carbonKeyCode: carbonKeyCode, carbonModifiers: Self.carbonModifiers(from: retargeted))
+    }
+
+    /// `modifierSymbols` with the Hyper chord collapsed to "✦", when one is configured at all.
     static func collapsedModifierSymbols(
-        from flags: NSEvent.ModifierFlags,
-        hyperKey: HyperKeyPhysicalKey,
-        replacesGlyph: Bool,
-        includesShift: Bool
+        from flags: NSEvent.ModifierFlags, hyperChord: NSEvent.ModifierFlags?
     ) -> [String] {
-        guard hyperKey != .none, replacesGlyph else {
+        guard let hyperChord, flags.isSuperset(of: hyperChord) else {
             return modifierSymbols(from: flags)
         }
-        let hyperSet: NSEvent.ModifierFlags =
-            includesShift
-            ? [.control, .option, .shift, .command]
-            : [.control, .option, .command]
-        guard flags.isSuperset(of: hyperSet) else { return modifierSymbols(from: flags) }
-        return [HyperKeyPhysicalKey.hyperGlyph] + modifierSymbols(from: flags.subtracting(hyperSet))
+        return [HyperKeyPhysicalKey.hyperGlyph] + modifierSymbols(from: flags.subtracting(hyperChord))
     }
 
     /// Modifier symbols in the fixed ⌃⌥⇧⌘ order every macOS surface uses.
@@ -155,33 +160,5 @@ extension KeyShortcut: Codable {
             carbonKeyCode: try container.decode(Int.self, forKey: .carbonKeyCode),
             carbonModifiers: try container.decode(Int.self, forKey: .carbonModifiers)
         )
-    }
-}
-
-/// Everything in Tinycast a global shortcut can be bound to.
-enum HotKeyAction: Hashable, Sendable {
-    case togglePalette
-    case toggleClipboard
-    case toggleEmoji
-    case app(bundleID: String)
-    case settingsPane(bundleID: String)
-    case customCommand(id: UUID)
-    case systemAction(id: SystemAction.ID)
-    case windowCommand(id: WindowCommand.ID)
-    case quicklink(id: UUID)
-
-    /// The UserDefaults key, and the `HotKeyCenter` registration id: one per action.
-    var defaultsKey: String {
-        switch self {
-        case .togglePalette: "hotkey.togglePalette"
-        case .toggleClipboard: "hotkey.toggleClipboard"
-        case .toggleEmoji: "hotkey.toggleEmoji"
-        case .app(let bundleID): "hotkey.app." + bundleID
-        case .settingsPane(let bundleID): "hotkey.pane." + bundleID
-        case .customCommand(let id): "hotkey.customCommand." + id.uuidString.lowercased()
-        case .systemAction(let id): "hotkey.systemAction." + id.rawValue
-        case .windowCommand(let id): "hotkey.windowCommand." + id.rawValue
-        case .quicklink(let id): "hotkey.quicklink." + id.uuidString.lowercased()
-        }
     }
 }

--- a/Tinycast/Features/HotKeys/UI/ShortcutRecorderPopover.swift
+++ b/Tinycast/Features/HotKeys/UI/ShortcutRecorderPopover.swift
@@ -59,10 +59,8 @@ struct ShortcutRecorderPopover: View {
         if let conflict = capture.conflict {
             return State(caps: conflict.binding.keycaps, label: conflict.owner, tint: .orange)
         }
-        let hyper = KeyShortcut.hyperDisplay()
         let held = KeyShortcut.collapsedModifierSymbols(
-            from: capture.heldModifiers, hyperKey: hyper.hyperKey,
-            replacesGlyph: hyper.replacesGlyph, includesShift: hyper.includesShift)
+            from: capture.heldModifiers, hyperChord: KeyShortcut.displayedHyperChord())
         guard held.isEmpty else { return State(caps: held, label: "Add a key") }
         return State(
             caps: [DoubleTapModifier.option.glyph, "A"], label: "Type a shortcut", isExample: true)

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -66,11 +66,6 @@ final class AppSettings {
         }
     }
 
-    /// Collapse the Hyper modifier set to "✦" wherever shortcut keycaps render.
-    var hyperKeyReplacesGlyph: Bool {
-        didSet { defaults.set(hyperKeyReplacesGlyph, forKey: Key.hyperKeyReplacesGlyph.rawValue) }
-    }
-
     /// Preferred skin tone applied to modifier-capable emoji at render and copy time.
     var emojiSkinTone: EmojiSkinTone {
         didSet { defaults.set(emojiSkinTone.rawValue, forKey: Key.emojiSkinTone.rawValue) }
@@ -193,7 +188,7 @@ final class AppSettings {
         hyperKey =
             defaults.string(forKey: Key.hyperKey.rawValue).flatMap(HyperKeyPhysicalKey.init)
             ?? .none
-        // The two Bools default to true, so absence must be distinguished from stored `false`.
+        // Defaults to true, so absence must be distinguished from a stored `false`.
         hyperKeyIncludesShift =
             defaults.object(forKey: Key.hyperKeyIncludesShift.rawValue) == nil
             || defaults.bool(forKey: Key.hyperKeyIncludesShift.rawValue)
@@ -201,9 +196,6 @@ final class AppSettings {
             defaults.string(forKey: Key.hyperKeyQuickPress.rawValue)
             .flatMap(HyperKeyQuickPress.init)
             ?? .none
-        hyperKeyReplacesGlyph =
-            defaults.object(forKey: Key.hyperKeyReplacesGlyph.rawValue) == nil
-            || defaults.bool(forKey: Key.hyperKeyReplacesGlyph.rawValue)
         emojiSkinTone =
             defaults.string(forKey: Key.emojiSkinTone.rawValue).flatMap(EmojiSkinTone.init) ?? .none
         popToRootTimeout =

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -8,7 +8,6 @@ enum AppSettingsKey: String, CaseIterable {
     case hyperKey = "hyperKeyPhysicalKey"
     case hyperKeyIncludesShift = "hyperKeyIncludesShift"
     case hyperKeyQuickPress = "hyperKeyQuickPress"
-    case hyperKeyReplacesGlyph = "hyperKeyReplacesGlyph"
     case emojiSkinTone = "emojiSkinTone"
     case popToRootTimeout = "popToRootTimeout"
     case compactMode = "compactMode"

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -27,9 +27,7 @@ struct GeneralSettingsView: View {
         }
         var text =
             "Pressing \(settings.hyperKey.title) will trigger the left \(hyperGlyphs) modifier keys."
-        if settings.hyperKeyReplacesGlyph {
-            text += " Hyper Key shortcuts will be shown in Tinycast with ✦."
-        }
+            + " Hyper Key shortcuts are shown in Tinycast with ✦."
         if hyperTap.status == .needsAccessibility {
             text += " Tinycast needs Accessibility access to remap keys."
         }
@@ -125,19 +123,10 @@ struct GeneralSettingsView: View {
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                        // Flipping it re-points recorded chords, so it needs a chord to mean.
+                        .disabled(settings.hyperKey == .none)
                 }
-                SettingsDivider()
-                SettingsRow(
-                    title: "Replace occurrences of \(hyperGlyphs) with ✦",
-                    subtitle: "Shortcuts containing the Hyper Key modifiers are shown with ✦.",
-                    systemImage: "keyboard",
-                    tint: .gray
-                ) {
-                    Toggle("", isOn: $settings.hyperKeyReplacesGlyph)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
-                        .controlSize(.small)
-                }
+                .opacity(settings.hyperKey == .none ? 0.5 : 1)
             }
 
             SettingsCard(header: "Appearance") {

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -349,3 +349,19 @@ English-specific, so localizing the UI without them would ship a half-translated
 
 **What would change this:** shipping through a channel that requires a manifest, or a decision to localize
 the calculator grammars first.
+
+### 31 — Toggling Include Shift rewrites a chord the user may have typed by hand
+
+Flipping Include Shift re-points every stored combo whose modifiers contain the other Hyper chord. A combo
+recorded by physically holding ⌃⌥⌘ is byte-identical to one recorded from ✦, so it is re-pointed too — a
+hand-typed ⌃⌥⌘G becomes ⌃⌥⇧⌘G.
+
+**Why:** provenance is not recoverable. The tap rewrites flags before anything sees them, so the recorder
+cannot tell a real ⌃⌥⌘ from a synthesized one, and storing a "recorded from Hyper" bit would mean trusting
+a heuristic at capture time forever. Leaving the chord alone is the worse failure: the keycaps stop saying
+✦ *and* the shortcut stops firing, because Carbon stays registered for a chord the tap no longer emits.
+Re-pointing keeps what the keycaps say and what actually fires in agreement, which is the property users
+notice. See [hotkeys.md](features/hotkeys.md#include-shift-re-points-what-is-already-recorded).
+
+**What would change this:** a way to know at capture time that the flags came from the tap — the tap would
+have to mark its rewritten events in a field `NSEvent` still exposes.

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -26,6 +26,9 @@ the keycap rendering — only the _engine_ differs.
   with the clock injected as a parameter, for `hotkey-test`. Every `CGEvent` call lives in
   `Service/DoubleTapMonitor.swift`, which is listen-only, installs *only* while something is bound to a
   double-tap, and never prompts for Accessibility.
+- **`KeyShortcut.hyperChord(includesShift:)` is the only spelling of the Hyper chord**, read by both the
+  ✦ collapse and the re-point below. `HyperKeyTap` composes its own flags because it also needs the
+  left-side device bits, which no display path wants.
 - `LegacyHotKeyRecords` is scheduled for deletion and nothing new may depend on it — see
   [decisions.md](../decisions.md) entry 24.
 
@@ -142,6 +145,28 @@ flags do not always read as fully pressed. The Hyper key's own residue is scrubb
 Caps Lock's alpha-shift bit, or — for a key modifier outside the Hyper set — its generic mask and both
 device bits. Events the tap posts carry a `"TYCT"` marker in `.eventSourceUserData`, the same FourCC
 `HotKeyCenter` uses, so the tap never reacts to its own synthetics.
+
+### ✦ is the notation, not a preference
+
+Any combo whose modifiers are a superset of the chord renders with the Hyper set replaced by a single
+**✦** keycap — `✦G`, or `✦⇧G` when a modifier survives the subtraction. It is unconditional: there is
+no toggle, because collapsing the chord is what the feature *is*. The one condition is a Hyper key
+being configured at all — `AppCore` hands `KeyShortcut.displayedHyperChord` a `nil` chord otherwise, and a
+literal ⌃⌥⌘G renders as itself. That hook is a **closure rather than a value** so reading it inside a
+view body registers the `AppSettings` dependency, and every keycap re-renders the moment a toggle moves.
+
+### Include Shift re-points what is already recorded
+
+A `KeyShortcut` stores absolute Carbon modifiers, captured from the already-rewritten flags, so a chord
+recorded under one Include Shift setting is stale under the other: it would stop collapsing to ✦ *and*
+stop firing, because Carbon is registered for ⌃⌥⌘ while the tap has started emitting ⌃⌥⇧⌘. So flipping
+the toggle re-points every stored combo — `HotKeyManager.retargetHyperBindings`, driven by the same
+`AppCore.track` observation the feature switches use, swapping the stale chord for the current one
+through `setBinding` so persistence and re-registration stay on one path. A re-point that would land on
+a chord another action already holds is skipped rather than clobbering it; that row keeps its literal
+keycaps. `retargetingHyper` is idempotent, which is what makes a settings import a no-op rather than a
+corruption. Nothing is re-pointed while the Hyper key is `.none` — and the Settings row is disabled
+there, so the toggle cannot move without a chord to mean.
 
 ### Lifecycle
 

--- a/docs/features/raycast-import.md
+++ b/docs/features/raycast-import.md
@@ -59,7 +59,6 @@ v1 JSON is a set of `builtin_package_*` / `raycast_*` providers, with `raycast_v
 | `…raycastPreferences.preferencesAdvanced.popToRootTimeout`                          | `popToRootSeconds` (exact `PopToRootTimeout` match only)              |
 | `…preferencesAdvanced.emojiSkinTone`                                                | `emojiSkinTone` (`default` → none)                                    |
 | `…preferencesAdvanced.raycast_hyperKey_state` `{enabled, keyCode, includeShiftKey}` | `hyperKey` (a Carbon code — 57 is caps lock), `hyperKeyIncludesShift` |
-| `…preferencesAdvanced.useHyperKeyIcon`                                              | `hyperKeyReplacesGlyph`                                               |
 | `…preferencesAppearance.raycastPreferredWindowMode`                                 | `compactMode` (`== "compact"`)                                        |
 | `…preferencesAppearance.showFavoritesInCompactMode`                                 | same                                                                  |
 | `…preferencesAppearance.statusBarIsVisible`                                         | `showInMenuBar`                                                       |


### PR DESCRIPTION
## What

Two changes to the Hyper Key section of General settings.

**✦ is the notation, not a preference.** `hyperKeyReplacesGlyph` is deleted. It defaulted on, and collapsing the Hyper set to a single ✦ keycap is what the feature *is* rather than something to opt out of. Gone with it: the setting and its `AppSettingsKey` case, the `SettingsBackup` field and its coverage entry, both Raycast import mappings (`useHyperKeyIcon`, `hyperKeyDisplayShortcut`) and the parameter threaded through the keycap formatter. ✦ still renders only when a Hyper key is actually configured — `KeyShortcut.displayedHyperChord` hands the formatter a `nil` chord otherwise, and a literal ⌃⌥⌘G renders as itself.

**Include Shift now re-points what is already recorded.** This was the bug, and it was worse than a display glitch. A `KeyShortcut` stores absolute Carbon modifiers, captured from the tap's already-rewritten flags, and nothing ever re-pointed them — so a combo recorded under one Include Shift setting was stale under the other:

- it stopped collapsing to ✦, because `collapsedModifierSymbols` requires a superset of the current chord;
- **and it stopped firing at all**, because Carbon stayed registered for ⌃⌥⌘ while `HyperKeyTap` — which reads the preference live — had started emitting ⌃⌥⇧⌘.

`HotKeyManager.retargetHyperBindings` swaps the stale chord for the current one through the existing `setBinding`, so persistence, Carbon re-registration and the bound indexes stay on one path. It is driven by the same `AppCore.track` observation the feature switches use. The recorder field, the launcher row badge and the quicklinks row badge therefore stay in agreement with what actually fires.

## Details worth a look

- `KeyShortcut.hyperChord(includesShift:)` is now the only spelling of the chord. `HyperKeyTap` still composes its own flags because it also needs the left-side device bits, which no display path wants.
- `retargetingHyper` is **idempotent**, which is what makes a settings import a no-op rather than a corruption: the imported combos were exported against the imported shift setting, so they retarget to themselves.
- A re-point that would land on a chord another action already holds is **skipped** rather than clobbering it — the same rule `SettingsBackup.applyHotkeys` follows, since a second Carbon registration fails silently.
- Nothing is re-pointed while the Hyper key is `.none`, and the Include Shift row is now **disabled and dimmed** there (the pattern the compact-mode favorites row already uses), so a stored chord cannot drift out of sync.
- `HotKeyAction` moves out of the bottom of `KeyShortcut.swift` into its own `Model/` file — one type per file, and it lets `hotkey-test` compile the chord math without dragging in `SystemAction` and `WindowCommand`.
- The orphaned `hyperKeyReplacesGlyph` UserDefaults key is left where it lies. Nothing reads it, and clearing it would be migration scaffolding.

## Trade-off

Re-pointing also rewrites a chord the user typed *physically* as ⌃⌥⌘, which is byte-identical to one recorded from ✦. Provenance is not recoverable — the tap rewrites flags before the recorder sees them — and leaving it alone is the worse failure, since the keycaps and the firing would disagree. `docs/decisions.md` entry 31 records this so it doesn't get "fixed" later.

## Verification

- `./Scripts/run-tests.sh` — **all 18 harnesses pass**. `hotkey-test` gains 25 assertions covering the chord sets, the collapse (including the `nil`-chord and non-superset paths), and the re-point in both directions, idempotent, round-tripping, and a no-op for ordinary combos. `settings-backup-test` proves the coverage table still matches `AppSettingsKey`.
- Debug build succeeds with **no new warnings**; `./Scripts/lint.sh` reports no new violations (the two it prints predate this branch).
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` is empty.
- `xcodegen generate` re-run for the new file; both `project.yml`'s output and the source are committed.
- Docs updated in the same commit: `docs/features/hotkeys.md` (the ✦ collapse was previously undocumented), `docs/decisions.md`, `docs/features/raycast-import.md`.

Manual QA still worth doing on a machine with the Accessibility grant: record ✦G with Include Shift off, flip it on, and confirm the row still reads ✦G *and* the shortcut fires.
