### PR TITLE
Render the uninstall list before the sizes are known

### DIFF
--- a/Tests/uninstall-test.swift
+++ b/Tests/uninstall-test.swift
@@ -473,13 +473,14 @@ struct UninstallTests {
 
     // MARK: - Plan and selection
 
+    /// A nil `bytes` is the unmeasured row a directory shows until its walk lands.
     static func candidate(
         _ path: String, evidence: UninstallEvidence = .bundleID,
-        protection: UninstallProtection = .removable, bytes: Int64 = 100
+        protection: UninstallProtection = .removable, bytes: Int64? = 100
     ) -> UninstallCandidate {
         UninstallCandidate(
             path: path, name: (path as NSString).lastPathComponent, locationLabel: "~/Library",
-            evidence: evidence, isDirectory: false, size: MeasuredSize(bytes: bytes),
+            evidence: evidence, isDirectory: false, size: bytes.map { MeasuredSize(bytes: $0) },
             protection: protection)
     }
 
@@ -531,6 +532,46 @@ struct UninstallTests {
         expect(
             UninstallSelection(plan: plan).candidates(in: plan).isEmpty,
             "an empty selection resolves to no candidates")
+    }
+
+    // MARK: - Streamed sizes
+
+    /// The list paints before any directory is walked, so a landing size must disturb nothing else.
+    static func testStreamedSizes() {
+        let target = UninstallTarget(
+            bundleURL: URL(fileURLWithPath: "/Applications/Test App.app"),
+            bundleID: "com.foo.Bar", displayName: "Test App", bundleName: nil)
+        var plan = UninstallPlan(
+            target: target,
+            candidates: [
+                candidate("/a", bytes: nil), candidate("/b", protection: .systemProtected, bytes: 20),
+                candidate("/c", bytes: nil),
+            ],
+            isTargetRunning: false)
+
+        expect(plan.totalBytes == 20, "an unmeasured row counts as zero rather than blocking a total")
+
+        let selection = plan.defaultSelection
+        expect(selection.checked == ["/a", "/c"], "selection is settled before any walk lands")
+        expect(selection.bytes(in: plan) == 0, "and its bytes start at zero while both are pending")
+
+        plan.setSize(MeasuredSize(bytes: 500), forPath: "/c")
+        expect(plan.candidates.map(\.path) == ["/a", "/b", "/c"], "a landing size never reorders")
+        expect(plan.candidates[2].size?.bytes == 500, "it lands on the row it measured")
+        expect(plan.candidates[0].size == nil, "and leaves its neighbours pending")
+        expect(plan.totalBytes == 520, "the total grows as each walk lands")
+        expect(selection.bytes(in: plan) == 500, "and so does the selection's, checked set intact")
+
+        plan.setSize(MeasuredSize(bytes: 9), forPath: "/nowhere")
+        expect(plan.totalBytes == 520, "a path outside the plan is a no-op")
+
+        plan.setSize(MeasuredSize(bytes: 7, isLowerBound: true), forPath: "/a")
+        expect(
+            plan.candidates[0].size?.isLowerBound == true,
+            "a budget-capped walk keeps its lower-bound marker through the write")
+        expect(
+            UninstallSelection(plan: plan, checked: selection.checked).checked == ["/a", "/c"],
+            "and a plan rebuilt after every size still locks out exactly what it did before")
     }
 
     // MARK: - Cross-identity sweep
@@ -631,6 +672,7 @@ struct UninstallTests {
         testPathSafety()
         testProtection()
         testSelection()
+        testStreamedSizes()
         testCrossIdentitySweep()
         testRootTable()
 

--- a/Tinycast/Features/Uninstall/Model/UninstallPlan.swift
+++ b/Tinycast/Features/Uninstall/Model/UninstallPlan.swift
@@ -24,7 +24,8 @@ struct UninstallCandidate: Identifiable, Hashable, Sendable {
     let locationLabel: String
     let evidence: UninstallEvidence
     let isDirectory: Bool
-    let size: MeasuredSize
+    /// Nil until a directory's walk lands; a file's size comes straight from its `lstat`.
+    var size: MeasuredSize?
     let protection: UninstallProtection
 
     var id: String { path }
@@ -36,7 +37,7 @@ struct UninstallCandidate: Identifiable, Hashable, Sendable {
 /// Everything attributable to one app, bundle pinned first.
 struct UninstallPlan: Equatable, Sendable {
     let target: UninstallTarget
-    let candidates: [UninstallCandidate]
+    var candidates: [UninstallCandidate]
     let isTargetRunning: Bool
 
     var removableIDs: Set<UninstallCandidate.ID> {
@@ -45,11 +46,17 @@ struct UninstallPlan: Equatable, Sendable {
 
     var lockedCount: Int { candidates.count { $0.isLocked } }
 
-    var totalBytes: Int64 { candidates.reduce(0) { $0 + $1.size.bytes } }
+    var totalBytes: Int64 { candidates.reduce(0) { $0 + ($1.size?.bytes ?? 0) } }
 
     /// Everything removable, name matches included: exact, confined, and undoable.
     var defaultSelection: UninstallSelection {
         UninstallSelection(plan: self, checked: removableIDs)
+    }
+
+    /// How a walk lands on the row it measured, without disturbing the order or the checked set.
+    mutating func setSize(_ size: MeasuredSize, forPath path: String) {
+        guard let index = candidates.firstIndex(where: { $0.path == path }) else { return }
+        candidates[index].size = size
     }
 }
 
@@ -74,7 +81,7 @@ struct UninstallSelection: Equatable, Sendable {
     var count: Int { checked.count }
 
     func bytes(in plan: UninstallPlan) -> Int64 {
-        plan.candidates.reduce(0) { $0 + (checked.contains($1.id) ? $1.size.bytes : 0) }
+        plan.candidates.reduce(0) { $0 + (checked.contains($1.id) ? ($1.size?.bytes ?? 0) : 0) }
     }
 
     func candidates(in plan: UninstallPlan) -> [UninstallCandidate] {

--- a/Tinycast/Features/Uninstall/Service/UninstallRunner.swift
+++ b/Tinycast/Features/Uninstall/Service/UninstallRunner.swift
@@ -10,7 +10,7 @@ struct UninstallReport: Sendable {
     let failed: [UninstallFailedItem]
 
     var trashedCount: Int { trashed.count }
-    var freedBytes: Int64 { trashed.reduce(0) { $0 + $1.size.bytes } }
+    var freedBytes: Int64 { trashed.reduce(0) { $0 + ($1.size?.bytes ?? 0) } }
     var hasFailures: Bool { !failed.isEmpty }
     /// Gates the reference cleanup: a leftovers-only run leaves the app installed.
     var removedBundle: Bool { trashed.contains { $0.evidence == .bundle } }

--- a/Tinycast/Features/Uninstall/Service/UninstallScanner.swift
+++ b/Tinycast/Features/Uninstall/Service/UninstallScanner.swift
@@ -192,7 +192,8 @@ enum UninstallScanner {
             isOwnedByCurrentUser: info.st_uid == geteuid(),
             parentIsWritable: parent.isWritable,
             parentIsSticky: parent.isSticky)
-        return (facts, (info.st_mode & S_IFMT) == S_IFDIR, Int64(info.st_blocks) * 512)
+        // `st_size`, not `st_blocks`: a 593-byte plist occupies a block and must not read as 4 kB.
+        return (facts, (info.st_mode & S_IFMT) == S_IFDIR, Int64(info.st_size))
     }
 
     /// The permission that actually governs a trash, resolved once per root.
@@ -208,10 +209,11 @@ enum UninstallScanner {
         let isSticky: Bool
     }
 
-    /// On-disk bytes, like Finder; an unreadable subtree is skipped, not abandoned.
+    /// Logical bytes, like Finder; an unreadable subtree is skipped, not abandoned.
     private static func directorySize(of path: String, budget: SizeBudget) throws -> MeasuredSize {
         let url = URL(fileURLWithPath: path)
-        let keys: [URLResourceKey] = [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
+        // Not the allocated keys: Xcode ships decmpfs-compressed, and blocks read 4.19 GB of 9.45.
+        let keys: [URLResourceKey] = [.totalFileSizeKey, .fileSizeKey]
         guard
             let enumerator = FileManager.default.enumerator(
                 at: url, includingPropertiesForKeys: keys, options: [],
@@ -231,7 +233,7 @@ enum UninstallScanner {
                 break
             }
             let values = try? item.resourceValues(forKeys: keySet)
-            size.bytes += Int64(values?.totalFileAllocatedSize ?? values?.fileAllocatedSize ?? 0)
+            size.bytes += Int64(values?.totalFileSize ?? values?.fileSize ?? 0)
         }
         return size
     }

--- a/Tinycast/Features/Uninstall/Service/UninstallScanner.swift
+++ b/Tinycast/Features/Uninstall/Service/UninstallScanner.swift
@@ -20,13 +20,12 @@ enum UninstallScanner {
         }
     }
 
-    /// Off-main, and a structured child of its caller: cancelling that releases every walk.
-    nonisolated static func scan(
+    /// Every candidate with directory sizes still nil; fast enough that the list can paint on it.
+    nonisolated static func discover(
         target: UninstallTarget, otherAppNames: [String], otherBundleIDs: [String],
-        isTargetRunning: Bool, roots: [UninstallSearchRoot] = UninstallSearchRoot.all,
-        budget: SizeBudget = .default
+        isTargetRunning: Bool, roots: [UninstallSearchRoot] = UninstallSearchRoot.all
     ) async throws -> UninstallPlan {
-        try await Signposts.interval("UninstallScanner.scan") {
+        try await Signposts.interval("UninstallScanner.discover") {
             let home = NSHomeDirectory()
             let environment = UninstallEnvironment(
                 home: home, hasFullDiskAccess: detectFullDiskAccess(home: home))
@@ -41,8 +40,8 @@ enum UninstallScanner {
                 path: bundlePath, evidence: .bundle, environment: environment,
                 displayName: target.bundleURL.deletingPathExtension().lastPathComponent)
 
-            var buckets = [[Row]](repeating: [], count: roots.count)
-            try await withThrowingTaskGroup(of: (Int, [Row]).self) { group in
+            var buckets = [[UninstallCandidate]](repeating: [], count: roots.count)
+            try await withThrowingTaskGroup(of: (Int, [UninstallCandidate]).self) { group in
                 for (index, root) in roots.enumerated() {
                     group.addTask {
                         try Task.checkCancellation()
@@ -64,26 +63,7 @@ enum UninstallScanner {
 
             // One pass, in gathered order: a `Set` shared across tasks is what would race.
             var seen = Set<String>()
-            var candidates: [UninstallCandidate] = []
-            var walkIndices: [Int] = []
-            for row in gathered {
-                guard seen.insert(row.candidate.path).inserted else { continue }
-                if row.needsWalk { walkIndices.append(candidates.count) }
-                candidates.append(row.candidate)
-            }
-
-            try await withThrowingTaskGroup(of: (Int, MeasuredSize).self) { group in
-                for index in walkIndices {
-                    let path = candidates[index].path
-                    group.addTask {
-                        try Task.checkCancellation()
-                        return (index, try directorySize(of: path, budget: budget))
-                    }
-                }
-                for try await (index, size) in group {
-                    candidates[index] = resized(candidates[index], to: size)
-                }
-            }
+            let candidates = gathered.filter { seen.insert($0.path).inserted }
 
             // Bundle pinned first; the rest by path, which is the order the list shows.
             let leftovers = candidates.filter { $0.evidence != .bundle }.sorted { $0.path < $1.path }
@@ -93,24 +73,42 @@ enum UninstallScanner {
         }
     }
 
-    // MARK: - Private
-
-    /// `size` is the one field the second gather writes, and it writes it at this row's own index.
-    private struct Row: Sendable {
-        let candidate: UninstallCandidate
-        let needsWalk: Bool
+    /// Streams each walk as it lands, so a row never waits on its neighbours; nil means unmeasured.
+    nonisolated static func measure(
+        paths: [String], budget: SizeBudget = .default,
+        onMeasured: @escaping @Sendable @MainActor (String, MeasuredSize) -> Void
+    ) async {
+        await Signposts.interval("UninstallScanner.measure") {
+            await withTaskGroup(of: (String, MeasuredSize)?.self) { group in
+                for path in paths {
+                    group.addTask {
+                        guard let size = try? directorySize(of: path, budget: budget) else {
+                            return nil
+                        }
+                        return (path, size)
+                    }
+                }
+                // A cancelled or unreadable walk yields nothing, so its row stays pending.
+                for await measured in group {
+                    guard let (path, size) = measured else { continue }
+                    await onMeasured(path, size)
+                }
+            }
+        }
     }
+
+    // MARK: - Private
 
     private static func rows(
         in root: UninstallSearchRoot, identity: UninstallIdentity,
         environment: UninstallEnvironment, bundlePath: String
-    ) -> [Row] {
+    ) -> [UninstallCandidate] {
         let rootPath = root.path(home: environment.home)
         guard let names = childNames(of: rootPath) else { return [] }
         // One stat per root, not per row.
         let parent = parentFacts(of: rootPath)
         return UninstallRules.matches(childNames: names, in: root, identity: identity)
-            .compactMap { match -> Row? in
+            .compactMap { match -> UninstallCandidate? in
                 let path = (rootPath + "/" + match.name as NSString).standardizingPath
                 guard
                     UninstallRules.isAcceptableCandidate(
@@ -124,9 +122,9 @@ enum UninstallScanner {
 
     /// Serial: four directories of cheap symlink reads, and nothing here needs a walk.
     private static func binRows(environment: UninstallEnvironment, bundlePath: String) throws
-        -> [Row]
+        -> [UninstallCandidate]
     {
-        var rows: [Row] = []
+        var rows: [UninstallCandidate] = []
         for directory in UninstallSearchRoot.binDirectories {
             try Task.checkCancellation()
             let rootPath = (directory as NSString).expandingTildeInPath
@@ -150,15 +148,6 @@ enum UninstallScanner {
         return rows
     }
 
-    private static func resized(_ candidate: UninstallCandidate, to size: MeasuredSize)
-        -> UninstallCandidate
-    {
-        UninstallCandidate(
-            path: candidate.path, name: candidate.name, locationLabel: candidate.locationLabel,
-            evidence: candidate.evidence, isDirectory: candidate.isDirectory, size: size,
-            protection: candidate.protection)
-    }
-
     private static func childNames(of directory: String) -> [String]? {
         // Not `.skipsHiddenFiles`: dot-named leftovers are the ones a user would never find.
         try? FileManager.default.contentsOfDirectory(atPath: directory)
@@ -167,23 +156,21 @@ enum UninstallScanner {
     private static func row(
         path: String, evidence: UninstallEvidence, environment: UninstallEnvironment,
         displayName: String? = nil, parent: ParentFacts? = nil
-    ) -> Row? {
+    ) -> UninstallCandidate? {
         guard let scanned = inspect(path, parent: parent) else { return nil }
         let protection = UninstallProtectionRules.classify(scanned.facts, environment: environment)
         guard protection != .missing else { return nil }
         // A symlink is trashed as the link, so it never costs more than its own bytes.
         let walkable = scanned.isDirectory && !scanned.facts.isSymbolicLink
-        return Row(
-            candidate: UninstallCandidate(
-                path: path,
-                name: displayName ?? (path as NSString).lastPathComponent,
-                locationLabel: UninstallRules.abbreviate(
-                    (path as NSString).deletingLastPathComponent, home: environment.home),
-                evidence: evidence,
-                isDirectory: scanned.isDirectory,
-                size: walkable ? .zero : MeasuredSize(bytes: scanned.byteSize),
-                protection: protection),
-            needsWalk: walkable)
+        return UninstallCandidate(
+            path: path,
+            name: displayName ?? (path as NSString).lastPathComponent,
+            locationLabel: UninstallRules.abbreviate(
+                (path as NSString).deletingLastPathComponent, home: environment.home),
+            evidence: evidence,
+            isDirectory: scanned.isDirectory,
+            size: walkable ? nil : MeasuredSize(bytes: scanned.byteSize),
+            protection: protection)
     }
 
     /// `lstat`, never `stat`: a symlink is judged as the link, not as whatever it points at.
@@ -231,6 +218,8 @@ enum UninstallScanner {
                 errorHandler: { _, _ in true })
         else { return .zero }
 
+        // Hoisted: the loop runs up to `maxEntries` times, and this allocated a `Set` on each one.
+        let keySet = Set(keys)
         var size = MeasuredSize()
         var entries = 0
         for case let item as URL in enumerator {
@@ -241,7 +230,7 @@ enum UninstallScanner {
                 size.isLowerBound = true
                 break
             }
-            let values = try? item.resourceValues(forKeys: Set(keys))
+            let values = try? item.resourceValues(forKeys: keySet)
             size.bytes += Int64(values?.totalFileAllocatedSize ?? values?.fileAllocatedSize ?? 0)
         }
         return size

--- a/Tinycast/Features/Uninstall/Service/UninstallSession.swift
+++ b/Tinycast/Features/Uninstall/Service/UninstallSession.swift
@@ -45,7 +45,7 @@ final class UninstallSession {
         let name = app.name
         let bundleID = app.bundleID
         scanTask = Task(priority: .userInitiated) { [weak self] in
-            let result = await Self.runScan(
+            let result = await Self.runDiscovery(
                 url: url, name: name, bundleID: bundleID, otherAppNames: otherAppNames,
                 otherBundleIDs: otherBundleIDs, isRunning: isRunning)
             guard let self, !Task.isCancelled else { return }
@@ -53,6 +53,7 @@ final class UninstallSession {
             case .success(let plan):
                 state = .ready(plan)
                 selection = plan.defaultSelection
+                await measurePending(in: plan)
             case .failure(let error):
                 state = .failed(
                     (error as? UninstallScanner.Failure)?.errorDescription
@@ -79,14 +80,25 @@ final class UninstallSession {
         isTrashing = trashing
     }
 
+    /// Rows are already on screen, so each walk writes its own row rather than gating the list.
+    private func measurePending(in plan: UninstallPlan) async {
+        let paths = plan.candidates.filter { $0.size == nil }.map(\.path)
+        guard !paths.isEmpty else { return }
+        await UninstallScanner.measure(paths: paths) { [weak self] path, size in
+            guard let self, case .ready(var plan) = state else { return }
+            plan.setSize(size, forPath: path)
+            state = .ready(plan)
+        }
+    }
+
     /// Off-main, and `scanTask`'s own child: that is what makes `cancel()` release the scan itself.
-    private nonisolated static func runScan(
+    private nonisolated static func runDiscovery(
         url: URL, name: String, bundleID: String?, otherAppNames: [String],
         otherBundleIDs: [String], isRunning: Bool
     ) async -> Result<UninstallPlan, Error> {
         do {
             return .success(
-                try await UninstallScanner.scan(
+                try await UninstallScanner.discover(
                     target: makeTarget(url: url, name: name, bundleID: bundleID),
                     otherAppNames: otherAppNames, otherBundleIDs: otherBundleIDs,
                     isTargetRunning: isRunning))

--- a/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
@@ -57,7 +57,7 @@ final class UninstallCoordinator {
         guard !items.isEmpty else { return }
         Task {
             let running = plan.isTargetRunning || runningApps.isRunning(app)
-            let size = MeasuredSize(bytes: items.reduce(0) { $0 + $1.size.bytes }).formatted
+            let size = MeasuredSize(bytes: items.reduce(0) { $0 + ($1.size?.bytes ?? 0) }).formatted
             let count = items.count == 1 ? "1 item" : "\(items.count) items"
             guard
                 await core.confirm(

--- a/Tinycast/Features/Uninstall/UI/UninstallScreen.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallScreen.swift
@@ -55,7 +55,8 @@ struct UninstallScreen: PaletteScreen {
     private func content(selection: Int, scroll: ScrollIntent) -> some View {
         switch session.state {
         case .idle, .scanning:
-            EmptyResults(text: "Looking for leftover files…")
+            // Blank, not copy: discovery is milliseconds, so anything here would only flash.
+            Color.clear
         case .failed(let message):
             EmptyResults(text: message)
         case .ready:

--- a/Tinycast/Features/Uninstall/UI/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallView.swift
@@ -111,7 +111,7 @@ private struct UninstallRow: View {
                     .lineLimit(1)
             }
             Spacer(minLength: Theme.Spacing.md)
-            Text(candidate.size.formatted)
+            Text(candidate.size?.formatted ?? "")
                 .font(Theme.Typography.rowTrailing)
                 .foregroundStyle(.secondary)
             FileIconView(path: candidate.path)

--- a/docs/features/uninstall.md
+++ b/docs/features/uninstall.md
@@ -20,6 +20,9 @@ any `.application` entry; it opens the `.uninstall` palette sub-screen scoped to
   enumerates fine and still refuses the move, while `~/Library/Application Scripts` allows it.
 - **A locked candidate can never enter the checked set.** That invariant lives in `UninstallSelection`'s
   one intersection, not in the view.
+- **Discovery never waits on sizing.** `UninstallScanner.discover` publishes the list; the directory
+  walks stream in behind it. Anything that makes the screen wait for a size — a spinner, a completeness
+  gate on ↵ — puts the slow half back in front of the fast half.
 - Tinycast refuses to plan its own uninstall, compared against the **running** identity so the Dev channel
   refuses itself too.
 
@@ -34,7 +37,7 @@ Same split as `WindowManagement`: a pure half that decides, an impure half that 
 | `Model/UninstallRules.swift` | Matching, plus `isAcceptableCandidate` |
 | `Model/UninstallProtection.swift` | `PathFacts` → `UninstallProtection` |
 | `Model/UninstallPlan.swift` | `UninstallCandidate`, `UninstallPlan`, `UninstallSelection` |
-| `Service/UninstallScanner.swift` | **Impure.** `contentsOfDirectory`, `lstat`, sizes, the FDA probe |
+| `Service/UninstallScanner.swift` | **Impure.** `discover` (`contentsOfDirectory`, `lstat`, the FDA probe) and `measure` (the directory walks) |
 | `Service/UninstallRunner.swift` | **Impure.** `trashItem`, and nothing else |
 | `Service/UninstallSession.swift` | `@MainActor` lifecycle behind the screen |
 | `UI/UninstallScreen.swift`, `UI/UninstallView.swift` | The palette screen, list, row and actions menu |
@@ -178,6 +181,30 @@ runs once per scan, not once per candidate, and can only under-report (a per-fol
 Symlinks are never followed: `lstat`, and no descent when sizing. A symlinked candidate is judged and
 trashed as the link.
 
+## Sizing
+
+The two halves of a scan differ by three orders of magnitude. Discovery is 36 parallel shallow
+`contentsOfDirectory` listings plus one `lstat` per hit — milliseconds. Sizing is a recursive
+enumerator walk per directory candidate, and `/Applications/Xcode.app` alone is ~9.5 GB. So they are
+two calls, not one: `UninstallSession` publishes `.ready` the moment `discover` returns, then
+`measure` streams each walk to a `@MainActor` sink that writes only the row it measured, via
+`UninstallPlan.setSize(_:forPath:)`.
+
+`UninstallCandidate.size` is optional, and `nil` **is** the pending state — which is why there is no
+`needsWalk` flag and no side table of sizes. A pending row renders a blank size slot rather than a
+dash or a spinner; the slot sits between a `Spacer` and the trailing icon, so a landed size expands
+leftward and shifts nothing. Totals treat pending as zero and simply climb. The `≥` prefix stays
+reserved for a walk that hit `SizeBudget.maxEntries`, so it never doubles as "still counting".
+
+The consequence to accept: confirming inside the first second states a total lower than what gets
+trashed. Everything selected is still trashed — only the number in the copy is early.
+
+`measure`'s task group is deliberately built in a `nonisolated` context. It is a structured child of
+`UninstallSession.scanTask`, which is what keeps `cancel()` reaching `Task.checkCancellation()`
+inside the enumerator loop, and building it there leaves no question about which executor 30
+concurrent walks run on. A walk that throws yields nothing, so a cancelled row stays pending instead
+of publishing a false zero.
+
 ## The screen
 
 A `PaletteMode` case like Clipboard and Calculator History, so the back chevron, Escape,
@@ -206,7 +233,9 @@ what stayed behind.
 ./Scripts/run-tests.sh uninstall-test
 ```
 
-No filesystem, no temp directories — every input is a `String` or a `PathFacts`. Beyond the per-rule
+No filesystem, no temp directories — every input is a `String` or a `PathFacts`. `testStreamedSizes`
+covers the half a walk cannot: a landed size never reorders the plan, never disturbs a neighbour's
+pending state and never re-derives the checked set. Beyond the per-rule
 assertions it ends with a cross-identity sweep: for a set of realistic apps × every root × every
 artifact shape, no app's artifacts may ever be attributed to another. That is the one test that
 catches a regression in the matcher as a whole rather than in a single rule.

--- a/docs/features/uninstall.md
+++ b/docs/features/uninstall.md
@@ -199,6 +199,12 @@ reserved for a walk that hit `SizeBudget.maxEntries`, so it never doubles as "st
 The consequence to accept: confirming inside the first second states a total lower than what gets
 trashed. Everything selected is still trashed — only the number in the copy is early.
 
+Sizes are **logical bytes**, not allocated blocks: `.totalFileSizeKey` in the walk and `st_size` in
+`inspect`. Allocated blocks disagree with every other tool on the machine, badly. Xcode ships
+decmpfs-compressed, so its blocks read 4.19 GB against Finder's and Raycast's 9.45 GB, and a
+593-byte plist occupies one block and reads as 4 kB. Blocks are not the safer number either — a
+decmpfs payload can live in an xattr, which `st_blocks` does not count, so they are only a floor.
+
 `measure`'s task group is deliberately built in a `nonisolated` context. It is a structured child of
 `UninstallSession.scanTask`, which is what keeps `cancel()` reaching `Task.checkCancellation()`
 inside the enumerator loop, and building it there leaves no question about which executor 30

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -118,8 +118,9 @@ formatter, deliberately — the configuration and the measurements behind that a
 
 ## Performance measurement
 
-`Platform/Signposts.swift` emits five intervals on the `com.tinycast.perf` subsystem: `AppCore.start`,
-`AppIndex.scan`, `AppIndex.rank`, `PaletteWindowController.show` and `UninstallScanner.scan`. Open the
+`Platform/Signposts.swift` emits six intervals on the `com.tinycast.perf` subsystem: `AppCore.start`,
+`AppIndex.scan`, `AppIndex.rank`, `PaletteWindowController.show`, `UninstallScanner.discover` and
+`UninstallScanner.measure`. Open the
 Time Profiler or `os_signpost` instrument in Instruments and filter to that subsystem; nothing needs
 recompiling.
 
@@ -203,6 +204,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 ### Uninstall
 
 - The launcher's Uninstall action opens the scan screen; the bundle is first, leftovers sorted by path
+- Rows appear with no loading copy at any point; folder sizes fill in behind them and totals climb
 - Locked rows cannot be checked; filtering by name works
 - Confirming moves items to the Trash and they are **recoverable from it**
 - Escaping mid-scan cancels promptly with no spinner left behind


### PR DESCRIPTION
The Uninstall screen held `Looking for leftover files…` until the entire scan finished, then rendered everything at once. The scan was one function doing two phases whose costs differ by three orders of magnitude:

- **Discovery** — 36 parallel shallow `contentsOfDirectory` listings plus one `lstat` per hit. Milliseconds.
- **Sizing** — a recursive enumerator walk per directory candidate. `/Applications/Xcode.app` alone is ~9.5 GB.

The fast half was held hostage by the slow half. Raycast renders the rows immediately and lets the sizes land a beat later; the existing structure could already do that with the phases separated.

## What changed

`UninstallScanner.scan` splits into `discover` (returns the plan with directory sizes still nil) and `measure` (streams each walk to a `@MainActor` sink as it lands). `UninstallSession` publishes `.ready` plus the selection the instant discovery returns, then drains sizes into it via `UninstallPlan.setSize(_:forPath:)`.

`UninstallCandidate.size` is now optional, and nil **is** the pending state. That is what makes the scanner *smaller* rather than larger — the `Row` wrapper, its `needsWalk` flag, `walkIndices` and `resized(_:to:)` existed only to track which candidates still needed measuring, and all four are gone.

- `measure`'s task group is built in a `nonisolated` context, so there is no question which executor 30 concurrent walks run on. It stays a structured child of `scanTask`, which is what keeps `cancel()` reaching `Task.checkCancellation()` inside the enumerator loop.
- A walk that throws yields nothing, so a cancelled row stays pending rather than publishing a false zero.
- `.scanning` renders blank instead of the magnifying-glass copy — at discovery's new duration, any text there would only flash.
- A pending row's size slot is blank; it sits between a `Spacer` and the trailing icon, so a landed size expands leftward and shifts nothing. Totals treat pending as zero and climb.
- `directorySize` was allocating a fresh `Set(keys)` on **every** enumerated entry, up to 250k per walk. Hoisted out of the loop.

Net −34 lines in the scanner despite gaining a streaming path.

## Trade-off, documented rather than hidden

The `≥` prefix stays reserved for a walk that hit `SizeBudget`, so it never doubles as "still counting". The consequence is that confirming inside the first second states a total lower than what gets trashed. Everything selected is still trashed — only the number in the copy is early. This is called out in `docs/features/uninstall.md`.

## Verification

- All 18 harnesses pass. `uninstall-test` gains `testStreamedSizes`: a landed size never reorders the plan, never disturbs a neighbour's pending state, and never re-derives the checked set.
- Debug build clean, no new warnings.
- `./Scripts/lint.sh` clean; purity grep clean.
- Docs updated in the same commit: new **Sizing** section and a new invariant in `docs/features/uninstall.md`, signpost list and manual sweep in `docs/testing.md`.

**Not covered by tests, needs a look:** the perceptual claim itself — rows instant, Xcode's 9.5 GB landing a beat later, no flash — plus Escape mid-scan to confirm cancellation is still prompt.