### PR TITLE
support palette panel draggable

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -73,6 +73,8 @@ run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \
                            Tinycast/Features/Emoji/Model/EmojiData.generated.swift
 run palette-selection-test Tinycast/Features/PaletteRowIndex.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift
+run palette-placement-test Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/Palette/PalettePlacement.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
                            Tinycast/Features/HotKeys/Model/HyperKey.swift \

--- a/Tests/palette-placement-test.swift
+++ b/Tests/palette-placement-test.swift
@@ -1,0 +1,166 @@
+import CoreGraphics
+import Foundation
+
+/// Drives `PalettePlacement` against the real `Theme` (compiled in, not copied), so retuning a token
+/// can't leave the palette restoring to a position no display still shows.
+@main
+@MainActor
+struct PalettePlacementTests {
+    static var failures = 0
+    static var passes = 0
+
+    // Exactly what `PaletteWindowController` passes.
+    static let width = Theme.Size.panelWidth
+    static let graspable = CGSize(width: width, height: Theme.Size.compactHeight)
+    static let minimumVisible = Theme.Size.paletteMinimumVisible
+    static let snap = Theme.Size.paletteSnapDistance
+    static let topFraction = Theme.Size.paletteTopMarginFraction
+
+    /// A 1440p display with the menu bar taken off the top.
+    static let laptop = CGRect(x: 0, y: 0, width: 2560, height: 1415)
+    /// A second display stacked to the right, as `NSScreen.screens` would report it.
+    static let external = CGRect(x: 2560, y: 0, width: 1920, height: 1055)
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func expect(_ actual: CGFloat, _ expected: CGFloat, _ message: String) {
+        expect(abs(actual - expected) < 0.001, "\(message) — got \(actual), want \(expected)")
+    }
+
+    static func home(_ screen: CGRect) -> CGPoint {
+        PalettePlacement.defaultAnchor(
+            in: screen, width: width, topMarginFraction: topFraction)
+    }
+
+    static func restored(_ stored: CGPoint, screens: [CGRect]) -> CGPoint? {
+        PalettePlacement.restored(
+            stored, graspable: graspable, visibleFrames: screens, minimumVisible: minimumVisible)
+    }
+
+    static func main() {
+        theDefaultPlacement()
+        restoringAcrossDisplays()
+        restoringPartlyOffscreen()
+        snapping()
+        tokenGrammar()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - The untouched placement
+
+    static func theDefaultPlacement() {
+        let anchor = home(laptop)
+        expect(anchor.x, laptop.midX - width / 2, "the panel centres horizontally")
+        expect(anchor.x + width, laptop.midX + width / 2, "and its right edge mirrors its left")
+        expect(
+            anchor.y, laptop.maxY - laptop.height * topFraction,
+            "its top edge sits the margin fraction below the top of the visible area")
+        expect(anchor.y < laptop.maxY, "the top edge is inside the screen, not on its edge")
+
+        // The panel grows downward from the anchor, so a full-height list must still fit.
+        expect(
+            anchor.y - Theme.Size.panelHeight > laptop.minY,
+            "an expanded palette clears the bottom of the screen it opened on")
+
+        // A screen offset from the origin must not shift the panel off it.
+        let offset = home(external)
+        expect(offset.x, external.midX - width / 2, "a non-origin display centres the same way")
+        expect(
+            offset.y, external.maxY - external.height * topFraction,
+            "and its top edge is measured from its own maxY")
+    }
+
+    // MARK: - Restoring a stored position
+
+    static func restoringAcrossDisplays() {
+        let onExternal = CGPoint(x: 2700, y: 900)
+        expect(
+            restored(onExternal, screens: [laptop, external]) == onExternal,
+            "a position on a connected display comes back verbatim")
+        expect(
+            restored(onExternal, screens: [laptop]) == nil,
+            "the same position is dropped once that display is unplugged")
+
+        // The fallback has to be reachable, not merely different.
+        expect(
+            restored(home(laptop), screens: [laptop]) != nil,
+            "the default placement is always restorable on its own screen")
+        expect(
+            restored(CGPoint(x: -4000, y: 9000), screens: [laptop, external]) == nil,
+            "a position on no display at all is dropped")
+    }
+
+    static func restoringPartlyOffscreen() {
+        // Deliberately slid off to the right: still restorable while a grabbable sliver shows.
+        let sliver = CGPoint(x: laptop.maxX - minimumVisible, y: 900)
+        expect(
+            restored(sliver, screens: [laptop]) != nil,
+            "exactly the minimum sliver of the compact bar is still grabbable")
+        let tooFar = CGPoint(x: laptop.maxX - minimumVisible + 1, y: 900)
+        expect(
+            restored(tooFar, screens: [laptop]) == nil,
+            "one point less than that is not, and falls back to the default")
+
+        // Slid off the top, where the whole grab strip is what goes missing first.
+        let peeking = CGPoint(x: 800, y: laptop.maxY + graspable.height - minimumVisible)
+        expect(
+            restored(peeking, screens: [laptop]) != nil,
+            "a bar hanging off the top edge is grabbable while the minimum still shows")
+        let gone = CGPoint(x: 800, y: laptop.maxY + graspable.height - minimumVisible + 1)
+        expect(
+            restored(gone, screens: [laptop]) == nil,
+            "pushed one point further up it is dropped")
+    }
+
+    // MARK: - Snapping home
+
+    static func snapping() {
+        let target = home(laptop)
+        expect(
+            PalettePlacement.isSnapping(target, to: target, within: snap),
+            "sitting exactly on the default placement snaps")
+
+        for offset in [CGPoint(x: snap, y: 0), CGPoint(x: 0, y: -snap), CGPoint(x: snap, y: snap)] {
+            let anchor = CGPoint(x: target.x + offset.x, y: target.y + offset.y)
+            expect(
+                PalettePlacement.isSnapping(anchor, to: target, within: snap),
+                "exactly the snap distance away on \(offset) still snaps")
+        }
+
+        // Both axes have to be inside: near in x but far in y is not a snap.
+        expect(
+            !PalettePlacement.isSnapping(
+                CGPoint(x: target.x, y: target.y + snap + 1), to: target, within: snap),
+            "one point beyond the threshold in y does not snap")
+        expect(
+            !PalettePlacement.isSnapping(
+                CGPoint(x: target.x + snap + 1, y: target.y), to: target, within: snap),
+            "nor does one point beyond it in x")
+        expect(
+            !PalettePlacement.isSnapping(
+                CGPoint(x: target.x + 300, y: target.y - 300), to: target, within: snap),
+            "and a panel dragged properly aside stays where it was dropped")
+    }
+
+    // MARK: - The tokens these rules depend on
+
+    static func tokenGrammar() {
+        // Raise it past the bar's own height and no stored position is ever restorable again.
+        expect(
+            minimumVisible <= graspable.height,
+            "the minimum visible sliver fits inside the compact bar")
+        expect(
+            snap * 2 < width,
+            "the snap zone is narrower than the panel, so it can't swallow every drop")
+        expect(topFraction > 0 && topFraction < 1, "the top margin is a real fraction of the screen")
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		19317D6C8A55E3F85BB7AE1F /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BCAB1F3B6930FE0B819F6D /* OnboardingState.swift */; };
 		19B0314193376FD1E4AC11A5 /* WindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E779B6EF738591CB935F3F95 /* WindowLayout.swift */; };
 		1BC16048EE05A1FD25739CB4 /* PaletteState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188A6D3C5B6BC67716F15F83 /* PaletteState.swift */; };
+		1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802BD2F4CC057228F2528217 /* PalettePlacement.swift */; };
 		1CA10DE219BAB97BFC29E54A /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */; };
 		1F1AD34A26931AF6E11E13F7 /* VolumeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B962318915EF7AEAC4996D /* VolumeState.swift */; };
 		208FFC22E116E53E7BF3D147 /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF9F16C3F5567240FF03122 /* CalcQuantity.swift */; };
@@ -119,6 +120,7 @@
 		8CC7A4A5D4205843219A81C8 /* CustomCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0880635E294D9DF55BAADA /* CustomCommand.swift */; };
 		8CFF2D2BF36F60659C8570A3 /* SettingsPaneScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F7C8CBD0AA75D016DBFC06 /* SettingsPaneScanner.swift */; };
 		8D529C8F3AB579941067FE98 /* MessageHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976A1F05AD82DB8A04B3C3F9 /* MessageHUDView.swift */; };
+		8DCF330D30E59FFEE8C8E8CF /* PaletteDropGuideController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */; };
 		8F66949F8518CF6F1878AEEF /* QuicklinkDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */; };
 		903FFCACE52FFA25958AD832 /* SnippetArgumentsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80495AE6BF7CE22BD6B20EE /* SnippetArgumentsPrompt.swift */; };
 		906C261B36E9E0B597198E3D /* UninstallRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7DAF3FFEE6CAB656B0FA8A /* UninstallRules.swift */; };
@@ -137,6 +139,7 @@
 		A1F267E9D9914DB60DEEE0AD /* DoubleTapDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C54F3A609CD1C2CDF304FB /* DoubleTapDetector.swift */; };
 		A2073E8EBBAAB620E27F0BD5 /* SnippetTextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725A38B32FDAA64D4A4A88DF /* SnippetTextInjector.swift */; };
 		A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B89168050723B7221F04A2 /* ClipboardCoordinator.swift */; };
+		A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */; };
 		A500AF3BF8910B335A7A936C /* HUDPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1752929BA1ACC0BC54865C /* HUDPanel.swift */; };
 		A5354210CDCB796D2D988B82 /* RaycastImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F474B4E9FD7738D97AB65E /* RaycastImport.swift */; };
 		A54766FEEBC9A4E7BE546226 /* AppPickerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E1BEE80A3B75140D10D740 /* AppPickerPopover.swift */; };
@@ -247,6 +250,7 @@
 		28B962318915EF7AEAC4996D /* VolumeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeState.swift; sourceTree = "<group>"; };
 		28D150930C930F1FB5E2A31B /* DialogRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogRequest.swift; sourceTree = "<group>"; };
 		296F67E23BF91CFBC6D66385 /* SystemActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionCoordinator.swift; sourceTree = "<group>"; };
+		29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideController.swift; sourceTree = "<group>"; };
 		2AEDBB526AB2C0406D8226D5 /* SystemActionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionRunner.swift; sourceTree = "<group>"; };
 		2B0F5891A80B604FBE21897B /* CalcCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcCurrency.swift; sourceTree = "<group>"; };
 		2B2CB71671625A1F446316A1 /* MessageHUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageHUDController.swift; sourceTree = "<group>"; };
@@ -272,6 +276,7 @@
 		3C504229760FFFFA9D8A7799 /* SettingsHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHistory.swift; sourceTree = "<group>"; };
 		3E16AEF81320A101E384098E /* KeyShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyShortcut.swift; sourceTree = "<group>"; };
 		3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
+		418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideView.swift; sourceTree = "<group>"; };
 		418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyAction.swift; sourceTree = "<group>"; };
 		445B0374FD5D74DBE23243CD /* PaletteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteScreen.swift; sourceTree = "<group>"; };
@@ -318,6 +323,7 @@
 		7E7DAF3FFEE6CAB656B0FA8A /* UninstallRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRules.swift; sourceTree = "<group>"; };
 		7EBAD0766FF9BFC6A4396474 /* UninstallTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallTarget.swift; sourceTree = "<group>"; };
 		7F64F4362989516482853CDB /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		802BD2F4CC057228F2528217 /* PalettePlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePlacement.swift; sourceTree = "<group>"; };
 		83C54F3A609CD1C2CDF304FB /* DoubleTapDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapDetector.swift; sourceTree = "<group>"; };
 		83CD7B0E866AEF486F9EC5E9 /* QuicklinkCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkCoordinator.swift; sourceTree = "<group>"; };
 		856F65245B10433A230194E6 /* QuicklinkListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkListView.swift; sourceTree = "<group>"; };
@@ -1014,8 +1020,11 @@
 			isa = PBXGroup;
 			children = (
 				C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */,
+				29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */,
+				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
+				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
 				445B0374FD5D74DBE23243CD /* PaletteScreen.swift */,
 				188A6D3C5B6BC67716F15F83 /* PaletteState.swift */,
 				209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */,
@@ -1362,8 +1371,11 @@
 				19317D6C8A55E3F85BB7AE1F /* OnboardingState.swift in Sources */,
 				0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */,
 				86C36C0885D5820E70184CF6 /* PaletteCoordinator.swift in Sources */,
+				8DCF330D30E59FFEE8C8E8CF /* PaletteDropGuideController.swift in Sources */,
+				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
+				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,
 				9F8806D46EBAF7058FC2EAEC /* PaletteRowIndex.swift in Sources */,
 				DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */,
 				1BC16048EE05A1FD25739CB4 /* PaletteState.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		D9113113F828FD6983715D6B /* UninstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */; };
 		DA1EE0A8933EADD357FCE32C /* QuicklinkArgumentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E48A8D5E2BC00E9E1CD5BF /* QuicklinkArgumentSession.swift */; };
 		DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B0374FD5D74DBE23243CD /* PaletteScreen.swift */; };
+		DD25D0E22E5729CF612FA1AE /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1545635C1E94D5E7DFECF1 /* WindowDragHandle.swift */; };
 		DDFA439EA7942183414375DC /* AppPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A96350EBE68EC79497FA2D /* AppPaths.swift */; };
 		DEBCF434AB244DAD43DB8A6A /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */; };
 		DFB25A4CDD35071B745F2EF9 /* DoubleTapModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */; };
@@ -326,6 +327,7 @@
 		8AFD491421DFE25892C0FC37 /* RaycastV1Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastV1Decoder.swift; sourceTree = "<group>"; };
 		8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		8E58EBB08450BA3426DF0565 /* AppIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIndex.swift; sourceTree = "<group>"; };
+		8F1545635C1E94D5E7DFECF1 /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
 		8F6F59F3C88C49BDED945F25 /* EdgeDissolve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeDissolve.swift; sourceTree = "<group>"; };
 		8FEAC591704D983A2C31188F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
 		90E23F92F4B4DEEE55077C7C /* AppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconView.swift; sourceTree = "<group>"; };
@@ -728,6 +730,7 @@
 			children = (
 				73E25B87C692D5FEE1FBF994 /* PanelTransition.swift */,
 				F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */,
+				8F1545635C1E94D5E7DFECF1 /* WindowDragHandle.swift */,
 			);
 			path = Interaction;
 			sourceTree = "<group>";
@@ -1460,6 +1463,7 @@
 				4E5F73461C417BE2B3472E6E /* WindowChrome.swift in Sources */,
 				2C788DCDF146ED245150EF82 /* WindowCommand.swift in Sources */,
 				43885792945F28AF3CDE30BC /* WindowCommandCoordinator.swift in Sources */,
+				DD25D0E22E5729CF612FA1AE /* WindowDragHandle.swift in Sources */,
 				19B0314193376FD1E4AC11A5 /* WindowLayout.swift in Sources */,
 				0360C7038877B9CB656DB697 /* WindowManagementSettingsView.swift in Sources */,
 				A6A8CD2B71A15625F47498EA /* WindowMover.swift in Sources */,

--- a/Tinycast/DesignSystem/Interaction/WindowDragHandle.swift
+++ b/Tinycast/DesignSystem/Interaction/WindowDragHandle.swift
@@ -13,8 +13,38 @@ struct WindowDragHandle: NSViewRepresentable {
 }
 
 extension View {
-    /// Marks a region as a drag handle for a borderless, title-bar-less window.
+    /// Marks a region as a window-drag handle; an overlay, so it wins the hit-test race.
     func windowDraggable() -> some View {
-        background(WindowDragHandle())
+        overlay(WindowDragHandle())
+    }
+}
+
+/// Drags past the visible text; declines over it, so a click there edits/selects normally.
+struct TextTrailingDragHandle: NSViewRepresentable {
+    var text: String
+    var font: NSFont
+
+    func makeNSView(context: Context) -> CatcherView { CatcherView() }
+
+    func updateNSView(_ nsView: CatcherView, context: Context) {
+        nsView.text = text
+        nsView.font = font
+    }
+
+    final class CatcherView: NSView {
+        var text = ""
+        var font: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
+        /// Slack so a click right at the text's trailing edge still edits rather than drags.
+        private static let edgeSlack: CGFloat = 4
+
+        override func mouseDown(with event: NSEvent) {
+            window?.performDrag(with: event)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            guard bounds.contains(point) else { return nil }
+            let textWidth = (text as NSString).size(withAttributes: [.font: font]).width
+            return point.x > textWidth + Self.edgeSlack ? self : nil
+        }
     }
 }

--- a/Tinycast/DesignSystem/Interaction/WindowDragHandle.swift
+++ b/Tinycast/DesignSystem/Interaction/WindowDragHandle.swift
@@ -2,20 +2,24 @@ import SwiftUI
 
 /// Starts a window drag on mouse-down — the hosting view otherwise eats the click first.
 struct WindowDragHandle: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView { DragView() }
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    var onBegan: () -> Void
+    var onEnded: () -> Void
 
-    private final class DragView: NSView {
-        override func mouseDown(with event: NSEvent) {
-            window?.performDrag(with: event)
-        }
+    func makeNSView(context: Context) -> NSView { DragView() }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        (nsView as? DragView)?.bind(onBegan: onBegan, onEnded: onEnded)
     }
 }
 
 extension View {
     /// Marks a region as a window-drag handle; an overlay, so it wins the hit-test race.
-    func windowDraggable() -> some View {
-        overlay(WindowDragHandle())
+    func windowDraggable(
+        _ enabled: Bool, onBegan: @escaping () -> Void, onEnded: @escaping () -> Void
+    ) -> some View {
+        overlay {
+            if enabled { WindowDragHandle(onBegan: onBegan, onEnded: onEnded) }
+        }
     }
 }
 
@@ -23,28 +27,64 @@ extension View {
 struct TextTrailingDragHandle: NSViewRepresentable {
     var text: String
     var font: NSFont
+    var onBegan: () -> Void
+    var onEnded: () -> Void
 
-    func makeNSView(context: Context) -> CatcherView { CatcherView() }
+    func makeNSView(context: Context) -> NSView { TextTailDragView() }
 
-    func updateNSView(_ nsView: CatcherView, context: Context) {
-        nsView.text = text
-        nsView.font = font
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let view = nsView as? TextTailDragView else { return }
+        view.text = text
+        view.font = font
+        view.bind(onBegan: onBegan, onEnded: onEnded)
+    }
+}
+
+/// Tracks the drag itself rather than calling `performDrag(with:)`, which hands the gesture to the
+/// window server and returns at once — leaving no way to know when the mouse actually comes up.
+private class DragView: NSView {
+    private var onBegan: (() -> Void)?
+    private var onEnded: (() -> Void)?
+
+    func bind(onBegan: @escaping () -> Void, onEnded: @escaping () -> Void) {
+        self.onBegan = onBegan
+        self.onEnded = onEnded
     }
 
-    final class CatcherView: NSView {
-        var text = ""
-        var font: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
-        /// Slack so a click right at the text's trailing edge still edits rather than drags.
-        private static let edgeSlack: CGFloat = 4
-
-        override func mouseDown(with event: NSEvent) {
-            window?.performDrag(with: event)
+    override func mouseDown(with event: NSEvent) {
+        guard let window else { return }
+        // Deltas off `mouseLocation`, so no view or window coordinate conversion can drift.
+        let origin = window.frame.origin
+        let start = NSEvent.mouseLocation
+        onBegan?()
+        window.trackEvents(
+            matching: [.leftMouseDragged, .leftMouseUp], timeout: NSEvent.foreverDuration,
+            mode: .eventTracking
+        ) { tracked, stop in
+            guard let tracked, tracked.type != .leftMouseUp else {
+                stop.pointee = true
+                return
+            }
+            let mouse = NSEvent.mouseLocation
+            window.setFrameOrigin(
+                CGPoint(x: origin.x + mouse.x - start.x, y: origin.y + mouse.y - start.y))
         }
+        onEnded?()
+    }
+}
 
-        override func hitTest(_ point: NSPoint) -> NSView? {
-            guard bounds.contains(point) else { return nil }
-            let textWidth = (text as NSString).size(withAttributes: [.font: font]).width
-            return point.x > textWidth + Self.edgeSlack ? self : nil
-        }
+/// Claims only the run of the field past its text, measured in the font the field draws with.
+private final class TextTailDragView: DragView {
+    var text = ""
+    var font: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
+    /// Slack so a click right at the text's trailing edge still edits rather than drags.
+    private static let edgeSlack: CGFloat = 4
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        // `point` is in the superview's coordinates; the text is measured from our own leading edge.
+        let local = convert(point, from: superview)
+        guard bounds.contains(local) else { return nil }
+        let textWidth = (text as NSString).size(withAttributes: [.font: font]).width
+        return local.x > textWidth + Self.edgeSlack ? super.hitTest(point) : nil
     }
 }

--- a/Tinycast/DesignSystem/Interaction/WindowDragHandle.swift
+++ b/Tinycast/DesignSystem/Interaction/WindowDragHandle.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Starts a window drag on mouse-down — the hosting view otherwise eats the click first.
+struct WindowDragHandle: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { DragView() }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class DragView: NSView {
+        override func mouseDown(with event: NSEvent) {
+            window?.performDrag(with: event)
+        }
+    }
+}
+
+extension View {
+    /// Marks a region as a drag handle for a borderless, title-bar-less window.
+    func windowDraggable() -> some View {
+        background(WindowDragHandle())
+    }
+}

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -46,6 +46,12 @@ enum Theme {
         static let headerPadding: CGFloat = 10
         /// Collapsed compact bar: the search row centered in symmetric `headerPadding` slack.
         static let compactHeight: CGFloat = headerHeight + headerPadding * 2
+        /// How near the default placement a drag has to land before it snaps home.
+        static let paletteSnapDistance: CGFloat = 24
+        /// A restored position needs this much of the compact bar on a display to still be grabbable.
+        static let paletteMinimumVisible: CGFloat = 44
+        /// Dash and gap of the drop guides, equal so the line reads evenly.
+        static let dropGuideDash: CGFloat = 4
         static let bottomBarHeight: CGFloat = 52
         static let rowIcon: CGFloat = 24
         static let keyCap: CGFloat = 18
@@ -118,7 +124,12 @@ enum Theme {
 
     /// System text styles (not hardcoded sizes) so the UI honors Dynamic Type.
     enum Typography {
-        static let searchField = Font.system(size: 20, weight: .regular)
+        /// One size, two frameworks: `TextTrailingDragHandle` measures what the field renders.
+        static let searchFieldSize: CGFloat = 20
+        static let searchField = Font.system(size: searchFieldSize, weight: .regular)
+        /// `NSFont` is not `Sendable`, hence the isolation; every reader is a view anyway.
+        @MainActor static let searchFieldNSFont = NSFont.systemFont(
+            ofSize: searchFieldSize, weight: .regular)
         static let headerIcon = Font.system(size: 18, weight: .medium)
         static let rowTitle = Font.body
         static let rowTrailing = Font.callout
@@ -157,6 +168,9 @@ enum Theme {
         static let glassFrost = Color.white.opacity(0.05)
         /// The violet of the app mark, used only to tint the About support callout.
         static let brand = Color(red: 0.525, green: 0.231, blue: 1.0)
+        /// The palette's drop guides while dragging, and once a release would snap it home.
+        static let dropGuide = Color.white.opacity(0.35)
+        static let dropGuideArmed = Color.blue
         /// Destructive tint: a destructive label, and a `.danger` dialog's glyph.
         static let destructive = Color.red
         /// Success tint: the leading glyph of a `.success` dialog.

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -52,6 +52,7 @@ enum Theme {
         static let paletteMinimumVisible: CGFloat = 44
         /// Dash and gap of the drop guides, equal so the line reads evenly.
         static let dropGuideDash: CGFloat = 4
+        static let dropGuideWidth: CGFloat = 2
         static let bottomBarHeight: CGFloat = 52
         static let rowIcon: CGFloat = 24
         static let keyCap: CGFloat = 18

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -27,6 +27,8 @@ struct SettingsBackup: Codable {
         var showFavoritesInCompactMode: Bool?
         var searchScopes: [String]?
         var openOnCursorScreen: Bool?
+        // Safe to carry: it grants no permission class, just repositions the window.
+        var paletteDraggable: Bool?
         // `snippetsEnabled` is absent: an import must not enable keystroke listening.
         var customCommandsEnabled: Bool?
         var customCommandsShowInLauncher: Bool?
@@ -90,6 +92,7 @@ extension SettingsBackup {
             showFavoritesInCompactMode: s.showFavoritesInCompactMode,
             searchScopes: s.searchScopes,
             openOnCursorScreen: s.openOnCursorScreen,
+            paletteDraggable: s.paletteDraggable,
             customCommandsEnabled: s.customCommandsEnabled,
             customCommandsShowInLauncher: s.customCommandsShowInLauncher,
             snippetsShowInLauncher: s.snippetsShowInLauncher,
@@ -221,6 +224,10 @@ extension SettingsBackup {
         }
         if let flag = s.openOnCursorScreen {
             settings.openOnCursorScreen = flag
+            count += 1
+        }
+        if let flag = s.paletteDraggable {
+            settings.paletteDraggable = flag
             count += 1
         }
         // Writing through AppSettings is enough; AppCore's sinks re-project the rest.

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -15,6 +15,7 @@ enum SettingsBackupCoverage {
         "showFavoritesInCompactMode": .showFavoritesInCompactMode,
         "searchScopes": .searchScopes,
         "openOnCursorScreen": .openOnCursorScreen,
+        "paletteDraggable": .paletteDraggable,
         "customCommandsEnabled": .customCommandsEnabled,
         "customCommandsShowInLauncher": .customCommandsShowInLauncher,
         "snippetsShowInLauncher": .snippetsShowInLauncher,

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -39,6 +39,8 @@ enum SettingsBackupCoverage {
     /// Keys kept out of a backup on purpose, each with the reason it has to stay out.
     static let deliberatelyExcluded: [String: String] = [
         AppSettingsKey.snippetsEnabled.rawValue:
-            "Doubles as keyword-expansion consent; an import must not enable keystroke listening."
+            "Doubles as keyword-expansion consent; an import must not enable keystroke listening.",
+        AppSettingsKey.palettePosition.rawValue:
+            "Machine-local geometry: a point restored onto another display layout lands nowhere."
     ]
 }

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -99,6 +99,18 @@ final class AppSettings {
         didSet { defaults.set(paletteDraggable, forKey: Key.paletteDraggable.rawValue) }
     }
 
+    /// Where a drag left the panel's top-left, in screen coordinates; nil means the default placement.
+    var palettePosition: CGPoint? {
+        didSet {
+            guard let palettePosition else {
+                defaults.removeObject(forKey: Key.palettePosition.rawValue)
+                return
+            }
+            defaults.set(
+                [palettePosition.x, palettePosition.y], forKey: Key.palettePosition.rawValue)
+        }
+    }
+
     // Feature switches, off out of the box, and off means fully off.
     var customCommandsEnabled: Bool {
         didSet { defaults.set(customCommandsEnabled, forKey: Key.customCommandsEnabled.rawValue) }
@@ -218,6 +230,9 @@ final class AppSettings {
             defaults.object(forKey: Key.openOnCursorScreen.rawValue) == nil
             || defaults.bool(forKey: Key.openOnCursorScreen.rawValue)
         paletteDraggable = defaults.bool(forKey: Key.paletteDraggable.rawValue)
+        // A half-written pair is no position at all, so both coordinates have to be there.
+        palettePosition = (defaults.array(forKey: Key.palettePosition.rawValue) as? [Double])
+            .flatMap { $0.count == 2 ? CGPoint(x: $0[0], y: $0[1]) : nil }
         // These default on, so absence must be distinguished from a stored `false`.
         customCommandsEnabled = defaults.bool(forKey: Key.customCommandsEnabled.rawValue)
         customCommandsShowInLauncher =

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -94,6 +94,11 @@ final class AppSettings {
         didSet { defaults.set(openOnCursorScreen, forKey: Key.openOnCursorScreen.rawValue) }
     }
 
+    /// Lets the panel be dragged by its top edge; off by default, so most launches never grab it.
+    var paletteDraggable: Bool {
+        didSet { defaults.set(paletteDraggable, forKey: Key.paletteDraggable.rawValue) }
+    }
+
     // Feature switches, off out of the box, and off means fully off.
     var customCommandsEnabled: Bool {
         didSet { defaults.set(customCommandsEnabled, forKey: Key.customCommandsEnabled.rawValue) }
@@ -212,6 +217,7 @@ final class AppSettings {
         openOnCursorScreen =
             defaults.object(forKey: Key.openOnCursorScreen.rawValue) == nil
             || defaults.bool(forKey: Key.openOnCursorScreen.rawValue)
+        paletteDraggable = defaults.bool(forKey: Key.paletteDraggable.rawValue)
         // These default on, so absence must be distinguished from a stored `false`.
         customCommandsEnabled = defaults.bool(forKey: Key.customCommandsEnabled.rawValue)
         customCommandsShowInLauncher =

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -14,6 +14,7 @@ enum AppSettingsKey: String, CaseIterable {
     case showFavoritesInCompactMode = "showFavoritesInCompactMode"
     case searchScopes = "launcherSearchScopes"
     case openOnCursorScreen = "openOnCursorScreen"
+    case paletteDraggable = "paletteDraggable"
     case customCommandsEnabled = "customCommandsEnabled"
     case customCommandsShowInLauncher = "customCommandsShowInLauncher"
     case snippetsEnabled = "snippetsEnabled"

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -15,6 +15,7 @@ enum AppSettingsKey: String, CaseIterable {
     case searchScopes = "launcherSearchScopes"
     case openOnCursorScreen = "openOnCursorScreen"
     case paletteDraggable = "paletteDraggable"
+    case palettePosition = "palettePosition"
     case customCommandsEnabled = "customCommandsEnabled"
     case customCommandsShowInLauncher = "customCommandsShowInLauncher"
     case snippetsEnabled = "snippetsEnabled"

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -125,6 +125,12 @@ struct GeneralSettingsView: View {
                         "Open the launcher on whichever display the pointer is on, rather than the one with the menu bar."
                     )
                 }
+                Toggle(isOn: $settings.paletteDraggable) {
+                    Text("Drag to reposition")
+                    Text(
+                        "Grab the thin strip just above the search field to move the launcher out of the way."
+                    )
+                }
             } header: {
                 Text("Appearance")
             }

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -86,4 +86,15 @@ final class PaletteCoordinator {
     func syncPaletteSize() {
         windowController.applyCollapsed(paletteIsCollapsed)
     }
+
+    // MARK: - Dragging
+
+    /// Bracket one drag gesture; the handle tracks it from mouse-down to mouse-up itself.
+    func beginPaletteDrag() {
+        windowController.beginDrag()
+    }
+
+    func endPaletteDrag() {
+        windowController.endDrag()
+    }
 }

--- a/Tinycast/Palette/PaletteDropGuideController.swift
+++ b/Tinycast/Palette/PaletteDropGuideController.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+
+/// Shows the drop guides over one screen for the length of a drag. The window controller drives it;
+/// nothing else may, since only a live drag has a home placement to point at.
+@MainActor
+final class PaletteDropGuideController {
+    private var panel: NSPanel?
+    private var host: NSHostingView<PaletteDropGuideView>?
+    private var screenFrame: CGRect = .zero
+    private var home: CGPoint = .zero
+    private var armed = false
+
+    /// Reveal the guides, with `home` the default placement's top-left in screen coordinates.
+    func show(home: CGPoint, screenFrame: CGRect, armed: Bool) {
+        self.home = home
+        self.screenFrame = screenFrame
+        self.armed = armed
+        let panel = ensurePanel()
+        panel.setFrame(screenFrame, display: false)
+        render()
+        panel.orderFrontRegardless()
+    }
+
+    /// Re-point mid-drag. `windowDidMove` fires continuously, so an unchanged move costs nothing.
+    func move(home: CGPoint, screenFrame: CGRect) {
+        guard self.home != home || self.screenFrame != screenFrame else { return }
+        let crossedScreens = self.screenFrame != screenFrame
+        self.home = home
+        self.screenFrame = screenFrame
+        if crossedScreens { panel?.setFrame(screenFrame, display: false) }
+        render()
+    }
+
+    func setArmed(_ armed: Bool) {
+        guard self.armed != armed else { return }
+        self.armed = armed
+        render()
+    }
+
+    func hide() {
+        panel?.orderOut(nil)
+    }
+
+    // MARK: - Private
+
+    /// One step under `.floating`, so the guides clear other apps but never the panel being dragged.
+    private static let level = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue - 1)
+
+    private func ensurePanel() -> NSPanel {
+        if let panel { return panel }
+        let host = NSHostingView(rootView: guides)
+        // The controller owns the frame; without this the hosting view would size the window.
+        host.sizingOptions = []
+        let panel = PaletteDropGuidePanel(level: Self.level)
+        panel.contentView = host
+        self.host = host
+        self.panel = panel
+        return panel
+    }
+
+    private func render() {
+        host?.rootView = guides
+    }
+
+    /// AppKit's y grows up from the screen's origin, SwiftUI's grows down from the window's top.
+    private var guides: PaletteDropGuideView {
+        PaletteDropGuideView(
+            topLeft: CGPoint(x: home.x - screenFrame.minX, y: screenFrame.maxY - home.y),
+            width: Theme.Size.panelWidth,
+            armed: armed)
+    }
+}
+
+/// Borderless, click-through, never key: the guides are a readout, not a surface.
+private final class PaletteDropGuidePanel: NSPanel {
+    init(level: NSWindow.Level) {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false)
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        self.level = level
+        ignoresMouseEvents = true
+        hidesOnDeactivate = false
+        animationBehavior = .none
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isReleasedWhenClosed = false
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}

--- a/Tinycast/Palette/PaletteDropGuideView.swift
+++ b/Tinycast/Palette/PaletteDropGuideView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Alignment guides marking the palette's default placement while a drag is in flight.
+struct PaletteDropGuideView: View {
+    /// The default placement's top-left, in the guide window's flipped coordinates.
+    let topLeft: CGPoint
+    let width: CGFloat
+    /// True once releasing would snap the panel home.
+    let armed: Bool
+
+    var body: some View {
+        DropGuidePath(topLeft: topLeft, width: width)
+            .stroke(
+                armed ? Theme.Colors.dropGuideArmed : Theme.Colors.dropGuide,
+                style: StrokeStyle(
+                    lineWidth: Theme.Size.dropGuideWidth,
+                    dash: [Theme.Size.dropGuideDash, Theme.Size.dropGuideDash]))
+            .animation(.easeInOut(duration: Theme.Duration.tooltip), value: armed)
+    }
+}
+
+/// Both panel edges run the full height, its top edge the full width — one path, one stroke.
+private struct DropGuidePath: Shape {
+    let topLeft: CGPoint
+    let width: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        for x in [topLeft.x, topLeft.x + width] {
+            path.move(to: CGPoint(x: x, y: rect.minY))
+            path.addLine(to: CGPoint(x: x, y: rect.maxY))
+        }
+        path.move(to: CGPoint(x: rect.minX, y: topLeft.y))
+        path.addLine(to: CGPoint(x: rect.maxX, y: topLeft.y))
+        return path
+    }
+}

--- a/Tinycast/Palette/PalettePlacement.swift
+++ b/Tinycast/Palette/PalettePlacement.swift
@@ -1,0 +1,34 @@
+import CoreGraphics
+
+/// Where the palette's top-left corner sits. Pure, with every screen fact injected, so the window
+/// controller holds no placement maths of its own and this stays testable off a display.
+enum PalettePlacement {
+    /// The untouched placement: centred, top edge a fraction of the way down, growing downward.
+    static func defaultAnchor(in visibleFrame: CGRect, width: CGFloat, topMarginFraction: CGFloat)
+        -> CGPoint
+    {
+        CGPoint(
+            x: visibleFrame.midX - width / 2,
+            y: visibleFrame.maxY - visibleFrame.height * topMarginFraction)
+    }
+
+    /// A stored anchor, or nil once no display shows enough of the compact bar to grab it back —
+    /// which is what a disconnected screen or a resolution change leaves behind.
+    static func restored(
+        _ stored: CGPoint, graspable: CGSize, visibleFrames: [CGRect], minimumVisible: CGFloat
+    ) -> CGPoint? {
+        let bar = CGRect(
+            x: stored.x, y: stored.y - graspable.height,
+            width: graspable.width, height: graspable.height)
+        let reachable = visibleFrames.contains { screen in
+            let shown = screen.intersection(bar)
+            return !shown.isNull && shown.width >= minimumVisible && shown.height >= minimumVisible
+        }
+        return reachable ? stored : nil
+    }
+
+    /// Near enough to the default placement that releasing the drag should drop it home.
+    static func isSnapping(_ anchor: CGPoint, to home: CGPoint, within distance: CGFloat) -> Bool {
+        abs(anchor.x - home.x) <= distance && abs(anchor.y - home.y) <= distance
+    }
+}

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -10,8 +10,21 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// Our key window at summon time, so hiding hands focus back to Settings, not a stale app.
     private weak var previousOwnWindow: NSWindow?
     private var popToRootTimer: Timer?
-    /// The session anchor, resolved once per show. See docs/features/palette.md#window-placement.
-    private var anchor: (x: CGFloat, topEdgeY: CGFloat)?
+    /// The session anchor — the panel's top-left, resolved once per show, the top edge being the
+    /// one that must not drift. See docs/features/palette.md#window-placement.
+    private var anchor: CGPoint?
+    /// Live only between mouse-down and mouse-up on a drag handle; nil means a move was ours.
+    private var drag: DragSession?
+    private let dropGuides = PaletteDropGuideController()
+
+    /// What a drag in flight needs: where home is, and whether releasing now would land there.
+    private struct DragSession {
+        var home: CGPoint
+        var screenFrame: CGRect
+        var armed = false
+        /// The guides wait for this, so a click that never moves the panel doesn't flash them.
+        var moved = false
+    }
 
     init(core: AppCore) {
         self.core = core
@@ -57,6 +70,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel?.orderOut(nil)
         // Drop the anchor, so the next summon re-resolves for the screen in use then.
         anchor = nil
+        // The guides must never outlive the panel they point at.
+        drag = nil
+        dropGuides.hide()
         // Drop the multi-MB preview bitmaps, so idle RAM returns near baseline.
         ImageThumbnail.purgePreviews()
         schedulePopToRoot()
@@ -123,7 +139,54 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// A drag re-anchors the session, so the next resize grows from where the user left it.
     func windowDidMove(_ notification: Notification) {
         guard let panel else { return }
-        anchor = (x: panel.frame.minX, topEdgeY: panel.frame.maxY)
+        let moved = CGPoint(x: panel.frame.minX, y: panel.frame.maxY)
+        anchor = moved
+        guard drag != nil else { return }
+        trackDrag(to: moved)
+    }
+
+    // MARK: - Dragging
+
+    /// A drag handle took the mouse down. Nothing shows yet — the guides wait for a real move.
+    func beginDrag() {
+        guard let screen = panel?.screen ?? targetScreen() else { return }
+        drag = DragSession(home: defaultAnchor(on: screen), screenFrame: screen.frame)
+    }
+
+    /// Release: snap home and forget the stored position, or remember where it was dropped.
+    func endDrag() {
+        let session = drag
+        // Cleared before the snap, so `positionPanel`'s own move isn't read as more dragging.
+        drag = nil
+        dropGuides.hide()
+        guard let panel, let session, session.moved else { return }
+        guard session.armed else {
+            core.settings.palettePosition = anchor
+            return
+        }
+        anchor = session.home
+        positionPanel(panel, collapsed: core.paletteCoordinator.paletteIsCollapsed)
+        core.settings.palettePosition = nil
+    }
+
+    /// Keep the guides on the panel's screen, armed only while a release would snap it home.
+    private func trackDrag(to moved: CGPoint) {
+        guard var session = drag else { return }
+        if let screen = panel?.screen, screen.frame != session.screenFrame {
+            session.screenFrame = screen.frame
+            session.home = defaultAnchor(on: screen)
+        }
+        session.armed = PalettePlacement.isSnapping(
+            moved, to: session.home, within: Theme.Size.paletteSnapDistance)
+        if session.moved {
+            dropGuides.move(home: session.home, screenFrame: session.screenFrame)
+            dropGuides.setArmed(session.armed)
+        } else {
+            session.moved = true
+            dropGuides.show(
+                home: session.home, screenFrame: session.screenFrame, armed: session.armed)
+        }
+        drag = session
     }
 
     // MARK: - Private
@@ -203,7 +266,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         guard let anchor = resolveAnchor() else { return }
         let height = collapsed ? Theme.Size.compactHeight : Theme.Size.panelHeight
         let frame = NSRect(
-            x: anchor.x, y: anchor.topEdgeY - height, width: Theme.Size.panelWidth, height: height)
+            x: anchor.x, y: anchor.y - height, width: Theme.Size.panelWidth, height: height)
         panel.setFrame(frame, display: true)
     }
 
@@ -215,16 +278,29 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
     }
 
-    /// The session anchor, cached until hide so both placements read one `visibleFrame`.
-    private func resolveAnchor() -> (x: CGFloat, topEdgeY: CGFloat)? {
+    /// The session anchor, cached until hide so both placements read one `visibleFrame`. A
+    /// remembered drag outranks the display setting; the default is what it falls back to.
+    private func resolveAnchor() -> CGPoint? {
         if let anchor { return anchor }
-        guard let screen = targetScreen() else { return nil }
-        let visible = screen.visibleFrame
-        let resolved = (
-            x: visible.midX - Theme.Size.panelWidth / 2,
-            topEdgeY: visible.maxY - visible.height * Theme.Size.paletteTopMarginFraction
-        )
+        let resolved = restoredAnchor() ?? targetScreen().map(defaultAnchor(on:))
         anchor = resolved
         return resolved
+    }
+
+    /// Where the last drag left it, unless no display still shows enough of the bar to grab.
+    private func restoredAnchor() -> CGPoint? {
+        guard let stored = core.settings.palettePosition else { return nil }
+        return PalettePlacement.restored(
+            stored,
+            graspable: CGSize(width: Theme.Size.panelWidth, height: Theme.Size.compactHeight),
+            visibleFrames: NSScreen.screens.map(\.visibleFrame),
+            minimumVisible: Theme.Size.paletteMinimumVisible)
+    }
+
+    /// The untouched placement on one display; the summon path and the drop guides share it.
+    private func defaultAnchor(on screen: NSScreen) -> CGPoint {
+        PalettePlacement.defaultAnchor(
+            in: screen.visibleFrame, width: Theme.Size.panelWidth,
+            topMarginFraction: Theme.Size.paletteTopMarginFraction)
     }
 }

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -120,6 +120,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         }
     }
 
+    /// A drag re-anchors the session, so the next resize grows from where the user left it.
+    func windowDidMove(_ notification: Notification) {
+        guard let panel else { return }
+        anchor = (x: panel.frame.minX, topEdgeY: panel.frame.maxY)
+    }
+
     // MARK: - Private
 
     private func ensurePanel() -> PalettePanel {

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -349,8 +349,7 @@ struct RootPaletteView: View {
         }
     }
 
-    /// A thin invisible strip along the top edge, for grabbing the window with no title bar.
-    /// Settings ▸ Appearance ▸ Drag to reposition gates it — most launches never touch it.
+    /// A thin strip along the top edge for grabbing the window; the Appearance setting gates it.
     @ViewBuilder
     private var topDragStrip: some View {
         let strip = Color.clear.frame(height: Theme.Size.headerPadding)
@@ -361,8 +360,21 @@ struct RootPaletteView: View {
         }
     }
 
+    /// A header sliver nothing occupies — safe to drag; the search field handles its own.
+    @ViewBuilder
+    private func headerGutter(width: CGFloat) -> some View {
+        let gutter = Color.clear.frame(width: width)
+        if settings.paletteDraggable {
+            gutter.windowDraggable()
+        } else {
+            gutter
+        }
+    }
+
     private var header: some View {
-        HStack(alignment: .center, spacing: Theme.Spacing.md) {
+        HStack(alignment: .center, spacing: 0) {
+            // Matches the list rows and section headers' own indent below.
+            headerGutter(width: Theme.Spacing.md * 2)
             // Sub-screens of the root search, so their header icon is a back chevron.
             if vm.mode != .launcher {
                 Button(action: exitToLauncher) {
@@ -381,6 +393,7 @@ struct RootPaletteView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: Theme.Size.headerIconSlot)
             }
+            headerGutter(width: Theme.Spacing.md)
             searchField
             // Compact pins favorites beside the field; expanded shows them as rows.
             if isCollapsed, settings.showFavoritesInCompactMode,
@@ -388,6 +401,7 @@ struct RootPaletteView: View {
             {
                 let slots = launcher.compactFavoriteSlots
                 if !slots.isEmpty {
+                    headerGutter(width: Theme.Spacing.md)
                     CompactFavoritesRow(
                         slots: slots,
                         onLaunch: { core.launcherCoordinator.launch($0) },
@@ -395,9 +409,8 @@ struct RootPaletteView: View {
                     )
                 }
             }
+            headerGutter(width: Theme.Spacing.md * 2)
         }
-        // Align the search icon with the list rows and section headers below.
-        .padding(.horizontal, Theme.Spacing.md * 2)
         // Identical metrics in both states, so typing can't move the search bar.
         .frame(height: Theme.Size.headerHeight)
         .padding(.top, Theme.Size.headerPadding)
@@ -409,7 +422,10 @@ struct RootPaletteView: View {
         vm.mode == .quicklinkArguments ? quicklinkArguments.prompt : vm.mode.placeholder
     }
 
-    /// The one search field, drawing its own placeholder. docs/features/palette.md#the-placeholder
+    /// Mirrors `Theme.Typography.searchField`; there's no NSFont-valued token to share it from.
+    private static let searchFieldNSFont = NSFont.systemFont(ofSize: 20, weight: .regular)
+
+    /// The one search field — past its text it's a drag handle, matching Spotlight.
     private var searchField: some View {
         @Bindable var vm = vm
         return TextField("", text: $vm.query)
@@ -418,6 +434,8 @@ struct RootPaletteView: View {
             .tint(.white)
             .focused($searchFocused)
             .onSubmit(activateSelection)
+            // Fills the row's height, so there's no gap above it for topDragStrip to meet.
+            .frame(maxHeight: .infinity)
             .background(alignment: .leading) {
                 if vm.query.isEmpty {
                     Text(searchPrompt)
@@ -430,6 +448,12 @@ struct RootPaletteView: View {
             }
             // The prompt used to carry this; without it the field would be unlabelled.
             .accessibilityLabel(Text(searchPrompt))
+            // Never branches on query — that tore down the field editor mid-keystroke once.
+            .overlay {
+                if settings.paletteDraggable {
+                    TextTrailingDragHandle(text: vm.query, font: Self.searchFieldNSFont)
+                }
+            }
     }
 
     /// The Uninstall screen's primary action is destructive, so its pill isn't white.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -350,26 +350,21 @@ struct RootPaletteView: View {
     }
 
     /// A thin strip along the top edge for grabbing the window; the Appearance setting gates it.
-    @ViewBuilder
     private var topDragStrip: some View {
-        let strip = Color.clear.frame(height: Theme.Size.headerPadding)
-        if settings.paletteDraggable {
-            strip.windowDraggable()
-        } else {
-            strip
-        }
+        Color.clear
+            .frame(height: Theme.Size.headerPadding)
+            .windowDraggable(settings.paletteDraggable, onBegan: beginDrag, onEnded: endDrag)
     }
 
     /// A header sliver nothing occupies — safe to drag; the search field handles its own.
-    @ViewBuilder
     private func headerGutter(width: CGFloat) -> some View {
-        let gutter = Color.clear.frame(width: width)
-        if settings.paletteDraggable {
-            gutter.windowDraggable()
-        } else {
-            gutter
-        }
+        Color.clear
+            .frame(width: width)
+            .windowDraggable(settings.paletteDraggable, onBegan: beginDrag, onEnded: endDrag)
     }
+
+    private func beginDrag() { core.paletteCoordinator.beginPaletteDrag() }
+    private func endDrag() { core.paletteCoordinator.endPaletteDrag() }
 
     private var header: some View {
         HStack(alignment: .center, spacing: 0) {
@@ -422,9 +417,6 @@ struct RootPaletteView: View {
         vm.mode == .quicklinkArguments ? quicklinkArguments.prompt : vm.mode.placeholder
     }
 
-    /// Mirrors `Theme.Typography.searchField`; there's no NSFont-valued token to share it from.
-    private static let searchFieldNSFont = NSFont.systemFont(ofSize: 20, weight: .regular)
-
     /// The one search field — past its text it's a drag handle, matching Spotlight.
     private var searchField: some View {
         @Bindable var vm = vm
@@ -451,7 +443,9 @@ struct RootPaletteView: View {
             // Never branches on query — that tore down the field editor mid-keystroke once.
             .overlay {
                 if settings.paletteDraggable {
-                    TextTrailingDragHandle(text: vm.query, font: Self.searchFieldNSFont)
+                    TextTrailingDragHandle(
+                        text: vm.query, font: Theme.Typography.searchFieldNSFont,
+                        onBegan: beginDrag, onEnded: endDrag)
                 }
             }
     }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -350,8 +350,15 @@ struct RootPaletteView: View {
     }
 
     /// A thin invisible strip along the top edge, for grabbing the window with no title bar.
+    /// Settings ▸ Appearance ▸ Drag to reposition gates it — most launches never touch it.
+    @ViewBuilder
     private var topDragStrip: some View {
-        Color.clear.frame(height: Theme.Size.headerPadding).windowDraggable()
+        let strip = Color.clear.frame(height: Theme.Size.headerPadding)
+        if settings.paletteDraggable {
+            strip.windowDraggable()
+        } else {
+            strip
+        }
     }
 
     private var header: some View {

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -125,6 +125,8 @@ struct RootPaletteView: View {
                     pillLabel: screen.primaryActionTitle, showActionGroup: showActionGroup)
             }
         }
+        // The panel has no title bar, so this thin top margin is the only place left to grab it.
+        .overlay(alignment: .top) { topDragStrip }
         // In-window overlays, so a menu stays clipped inside the panel.
         .overlay {
             if showAppMenu || showActions {
@@ -345,6 +347,11 @@ struct RootPaletteView: View {
             else { return .ignored }
             return launcher.quit(at: selection(in: launcher)) ? .handled : .ignored
         }
+    }
+
+    /// A thin invisible strip along the top edge, for grabbing the window with no title bar.
+    private var topDragStrip: some View {
+        Color.clear.frame(height: Theme.Size.headerPadding).windowDraggable()
     }
 
     private var header: some View {

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -49,14 +49,14 @@ Each `PaletteMode` maps to one type conforming to `PaletteScreen`, and the proto
 selection invariant honest: a screen exposes `rows` as its single source of visible order, and the
 palette indexes into it. Adding a mode means adding a conformer, not a branch in `RootPaletteView`.
 
-| Mode                  | Screen                     | Inner list                                                                        |
-| --------------------- | -------------------------- | --------------------------------------------------------------------------------- |
-| `.launcher`           | `LauncherScreen`           | `LauncherList`                                                                    |
-| `.clipboard`          | `ClipboardScreen`          | `ClipboardList` + preview                                                         |
-| `.calculatorHistory`  | `CalculatorHistoryScreen`  | `CalculatorHistoryList`                                                           |
-| `.emoji`              | `EmojiScreen`              | `EmojiGridView`                                                                   |
-| `.uninstall`          | `UninstallScreen`          | `UninstallList` (see [uninstall.md](uninstall.md))                                |
-| `.quicklinks`         | `QuicklinkListScreen`      | `QuicklinkList`                                                                   |
+| Mode | Screen | Inner list |
+| --- | --- | --- |
+| `.launcher` | `LauncherScreen` | `LauncherList` |
+| `.clipboard` | `ClipboardScreen` | `ClipboardList` + preview |
+| `.calculatorHistory` | `CalculatorHistoryScreen` | `CalculatorHistoryList` |
+| `.emoji` | `EmojiScreen` | `EmojiGridView` |
+| `.uninstall` | `UninstallScreen` | `UninstallList` (see [uninstall.md](uninstall.md)) |
+| `.quicklinks` | `QuicklinkListScreen` | `QuicklinkList` |
 | `.quicklinkArguments` | `QuicklinkArgumentsScreen` | `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt)) |
 
 Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab cycles launcher ↔
@@ -80,16 +80,12 @@ for every compact↔expanded resize, so only the height changes and the top edge
 anchor is dropped on hide, so the next summon re-resolves for wherever the user is then.
 
 **Drag to reposition** (`AppSettings.paletteDraggable`, off by default) is the only thing that moves a
-panel already on screen. `WindowDragHandle` hands mouse-down to `performDrag(with:)` from the top strip
-and the header's margins and inter-item gaps (`RootPaletteView.headerGutter`) — everywhere in the header
-no control occupies. The search field itself is also a handle past its visible text: `TextTrailingDragHandle`
-measures the query's rendered width and only claims the hit-test beyond it, so a click or drag on the
-text still edits or selects normally, matching Spotlight's own field. AppKit moves the frame without
-going through the controller, so `windowDidMove` writes the new top-left back into the anchor —
-otherwise the next compact↔expanded resize would snap the panel back to the position it was summoned
-at. That write is idempotent, since `positionPanel` places the frame at exactly the anchor and its own
-`setFrame` round-trips the same values. The anchor still dies on hide, so a dragged position lasts for
-that summon only.
+panel already on screen: `WindowDragHandle` hands mouse-down to `performDrag(with:)` from a strip along
+the top edge. AppKit moves the frame without going through the controller, so `windowDidMove` writes the
+new top-left back into the anchor — otherwise the next compact↔expanded resize would snap the panel back
+to the position it was summoned at. That write is idempotent, since `positionPanel` places the frame at
+exactly the anchor and its own `setFrame` round-trips the same values. The anchor still dies on hide, so
+a dragged position lasts for that summon only.
 
 Which display it anchors to depends on the **Follow the cursor across displays** setting
 (`AppSettings.openOnCursorScreen`, on by default):

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -49,14 +49,14 @@ Each `PaletteMode` maps to one type conforming to `PaletteScreen`, and the proto
 selection invariant honest: a screen exposes `rows` as its single source of visible order, and the
 palette indexes into it. Adding a mode means adding a conformer, not a branch in `RootPaletteView`.
 
-| Mode | Screen | Inner list |
-| --- | --- | --- |
-| `.launcher` | `LauncherScreen` | `LauncherList` |
-| `.clipboard` | `ClipboardScreen` | `ClipboardList` + preview |
-| `.calculatorHistory` | `CalculatorHistoryScreen` | `CalculatorHistoryList` |
-| `.emoji` | `EmojiScreen` | `EmojiGridView` |
-| `.uninstall` | `UninstallScreen` | `UninstallList` (see [uninstall.md](uninstall.md)) |
-| `.quicklinks` | `QuicklinkListScreen` | `QuicklinkList` |
+| Mode                  | Screen                     | Inner list                                                                        |
+| --------------------- | -------------------------- | --------------------------------------------------------------------------------- |
+| `.launcher`           | `LauncherScreen`           | `LauncherList`                                                                    |
+| `.clipboard`          | `ClipboardScreen`          | `ClipboardList` + preview                                                         |
+| `.calculatorHistory`  | `CalculatorHistoryScreen`  | `CalculatorHistoryList`                                                           |
+| `.emoji`              | `EmojiScreen`              | `EmojiGridView`                                                                   |
+| `.uninstall`          | `UninstallScreen`          | `UninstallList` (see [uninstall.md](uninstall.md))                                |
+| `.quicklinks`         | `QuicklinkListScreen`      | `QuicklinkList`                                                                   |
 | `.quicklinkArguments` | `QuicklinkArgumentsScreen` | `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt)) |
 
 Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab cycles launcher ↔
@@ -80,12 +80,16 @@ for every compact↔expanded resize, so only the height changes and the top edge
 anchor is dropped on hide, so the next summon re-resolves for wherever the user is then.
 
 **Drag to reposition** (`AppSettings.paletteDraggable`, off by default) is the only thing that moves a
-panel already on screen: `WindowDragHandle` hands mouse-down to `performDrag(with:)` from a strip along
-the top edge. AppKit moves the frame without going through the controller, so `windowDidMove` writes the
-new top-left back into the anchor — otherwise the next compact↔expanded resize would snap the panel back
-to the position it was summoned at. That write is idempotent, since `positionPanel` places the frame at
-exactly the anchor and its own `setFrame` round-trips the same values. The anchor still dies on hide, so
-a dragged position lasts for that summon only.
+panel already on screen. `WindowDragHandle` hands mouse-down to `performDrag(with:)` from the top strip
+and the header's margins and inter-item gaps (`RootPaletteView.headerGutter`) — everywhere in the header
+no control occupies. The search field itself is also a handle past its visible text: `TextTrailingDragHandle`
+measures the query's rendered width and only claims the hit-test beyond it, so a click or drag on the
+text still edits or selects normally, matching Spotlight's own field. AppKit moves the frame without
+going through the controller, so `windowDidMove` writes the new top-left back into the anchor —
+otherwise the next compact↔expanded resize would snap the panel back to the position it was summoned
+at. That write is idempotent, since `positionPanel` places the frame at exactly the anchor and its own
+`setFrame` round-trips the same values. The anchor still dies on hide, so a dragged position lasts for
+that summon only.
 
 Which display it anchors to depends on the **Follow the cursor across displays** setting
 (`AppSettings.openOnCursorScreen`, on by default):

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -79,16 +79,58 @@ match the visible row order**, including the inline calculator card at index 0 w
 for every compact↔expanded resize, so only the height changes and the top edge never drifts. The
 anchor is dropped on hide, so the next summon re-resolves for wherever the user is then.
 
-**Drag to reposition** (`AppSettings.paletteDraggable`, off by default) is the only thing that moves a
-panel already on screen: `WindowDragHandle` hands mouse-down to `performDrag(with:)` from a strip along
-the top edge. AppKit moves the frame without going through the controller, so `windowDidMove` writes the
-new top-left back into the anchor — otherwise the next compact↔expanded resize would snap the panel back
-to the position it was summoned at. That write is idempotent, since `positionPanel` places the frame at
-exactly the anchor and its own `setFrame` round-trips the same values. The anchor still dies on hide, so
-a dragged position lasts for that summon only.
+All of the arithmetic lives in `PalettePlacement`, which is CoreGraphics-only and takes every screen
+fact as a parameter, so `palette-placement-test` drives the shipped rules rather than a copy of them.
 
-Which display it anchors to depends on the **Follow the cursor across displays** setting
-(`AppSettings.openOnCursorScreen`, on by default):
+### Drag to reposition
+
+**Drag to reposition** (`AppSettings.paletteDraggable`, off by default) is the only thing that moves a
+panel already on screen. `WindowDragHandle` claims mouse-down on the top strip and on the header's
+margins and inter-item gaps (`RootPaletteView.headerGutter`) — everywhere in the header no control
+occupies. The search field is a handle too, but only past its visible text:
+`TextTrailingDragHandle` measures the query in `Theme.Typography.searchFieldNSFont` and claims the
+hit-test only beyond it, so clicking or dragging the text still edits and selects, matching Spotlight.
+
+AppKit moves the frame without going through the controller, so `windowDidMove` writes the new top-left
+back into the anchor — otherwise the next compact↔expanded resize would snap the panel back to the
+position it was summoned at. That write is idempotent, since `positionPanel` places the frame at exactly
+the anchor and its own `setFrame` round-trips the same values.
+
+**The handle tracks the gesture itself rather than calling `performDrag(with:)`.** That method hands the
+drag to the window server and returns immediately, so it can say when a drag *starts* but never when it
+ends — the mouse-up arrives long after it has returned. `DragView.mouseDown` instead runs
+`trackEvents(matching:timeout:mode:)` over `.leftMouseDragged` / `.leftMouseUp`, moving the window by
+the `NSEvent.mouseLocation` delta, which puts the whole gesture inside one call. It brackets that with
+`PaletteCoordinator.beginPaletteDrag()` / `endPaletteDrag()`, and the controller holds a `DragSession`
+for exactly that span. **Only a move inside a session is a user drag**; without that flag every
+programmatic resize would be recorded as one.
+
+### The drop guides
+
+While a drag is in flight, `PaletteDropGuideController` puts a click-through borderless panel over the
+display the panel is on, one level under `.floating` so it never covers the panel being dragged. It
+draws three dotted lines through the default placement — both panel edges full height, the top edge full
+width — which turn `Theme.Colors.dropGuideArmed` once the anchor is within `Theme.Size.paletteSnapDistance`
+of home. Releasing while armed snaps the panel there.
+
+The guides wait for the first `windowDidMove` of a session rather than appearing on mouse-down, so a
+bare click on a handle never flashes them. Crossing to another display re-points them at that display's
+default placement, which is what a snap would then land on.
+
+### Remembering where it was left
+
+A drop that isn't a snap writes the anchor to `AppSettings.palettePosition`, and the next summon reopens
+there — across relaunches, since it is a persisted setting. **A remembered position outranks the display
+setting below**; `PalettePlacement.restored` drops it only when no display still shows
+`Theme.Size.paletteMinimumVisible` of the compact bar, which is what a disconnected screen or a
+resolution change leaves behind. Snapping onto the guides clears the stored position, so the guides
+double as the way back to default behaviour.
+
+The position is deliberately **not** in a settings backup — it is machine-local geometry, the same
+reason the Settings window autosaves its frame instead ([backup.md](backup.md)).
+
+Which display an *unremembered* palette anchors to depends on the **Follow the cursor across displays**
+setting (`AppSettings.openOnCursorScreen`, on by default):
 
 - **On** — the screen holding `NSEvent.mouseLocation`, i.e. the display under the pointer.
 - **Off** — `NSScreen.main`.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -7,7 +7,9 @@ The command palette is a borderless floating `NSPanel` hosting SwiftUI; see
 
 - **`PaletteWindowController` solely owns the palette frame.** The hosting view sets
   `sizingOptions = []` so SwiftUI never drives the window size — otherwise the hosting view resizes the
-  panel to fit content and the top edge drifts on the compact↔expanded swap.
+  panel to fit content and the top edge drifts on the compact↔expanded swap. A user drag is the one
+  frame change that starts elsewhere, and `windowDidMove` folds it back into the anchor so the
+  controller stays the authority.
 - **The flat `selection` index must match the visible row order exactly**, including the inline
   calculator card at index 0 when present. Selection is the single source of truth for highlight and
   activation. `Features/PaletteRowIndex.swift` is that mapping and stays **Foundation-only and pure** —
@@ -76,6 +78,14 @@ match the visible row order**, including the inline calculator card at index 0 w
 `PaletteWindowController` resolves an anchor (left edge + top edge) **once per summon** and reuses it
 for every compact↔expanded resize, so only the height changes and the top edge never drifts. The
 anchor is dropped on hide, so the next summon re-resolves for wherever the user is then.
+
+**Drag to reposition** (`AppSettings.paletteDraggable`, off by default) is the only thing that moves a
+panel already on screen: `WindowDragHandle` hands mouse-down to `performDrag(with:)` from a strip along
+the top edge. AppKit moves the frame without going through the controller, so `windowDidMove` writes the
+new top-left back into the anchor — otherwise the next compact↔expanded resize would snap the panel back
+to the position it was summoned at. That write is idempotent, since `positionPanel` places the frame at
+exactly the anchor and its own `setFrame` round-trips the same values. The anchor still dies on hide, so
+a dragged position lasts for that summon only.
 
 Which display it anchors to depends on the **Follow the cursor across displays** setting
 (`AppSettings.openOnCursorScreen`, on by default):

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -52,6 +52,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `clipboard-test` | `Clipboard/Model/ClipboardStore.swift` |
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
+| `palette-placement-test` | `DesignSystem/Theme.swift`, `Palette/PalettePlacement.swift` |
 | `hotkey-test` | `HotKeys/Model/DoubleTapModifier.swift`, `DoubleTapDetector.swift` |
 | `callout-test` | `DesignSystem/Theme.swift`, `HotKeys/UI/CalloutPlacement.swift` |
 | `system-action-test` | `SystemActions/Model/SystemAction.swift` |


### PR DESCRIPTION

## Related issue

Closes #216 

## What changed

Let the palette panel be dragged by a strip along its top edge

The panel is borderless with no title bar, and isMovableByWindowBackground does nothing here: the whole content is one NSHostingView, which claims mouse-down for its own hit-testing before AppKit's background-drag shortcut ever sees it.

WindowDragHandle wraps a plain NSView that forwards mouseDown to window.performDrag(with:), and RootPaletteView applies it to a headerPadding-tall strip along the very top — the one region already free of the search field, header icon and favorites row.


## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |    42 MB    |
| Palette open            |     44 MB   |
| Feature in use (peak)   |    44 MB    |
| Palette closed, settled |    44 MB    |

Leak-tested: Yes.


## Demo

https://github.com/user-attachments/assets/6aeabee9-0a8c-4047-be9c-2d9ab4623934


## Drawbacks

None


## Tests

No `Tests/` harness applies to this change — everything touched (`WindowDragHandle.swift`, `RootPaletteView.swift`) is AppKit/SwiftUI interaction glue under `Palette/` and `DesignSystem/Interaction/`, not `Features/*/Model/` pure logic, so nothing in the harness table ([docs/testing.md](docs/testing.md)) guards it and none needed adding.

