### PR TITLE
Emacs navigation chords in the palette

### DIFF
--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -21,6 +21,33 @@ final class PalettePanel: NSPanel {
         kVK_Return, kVK_ANSI_KeypadEnter, kVK_Escape, kVK_Tab
     ]
 
+    /// ⌃N/⌃P/⌃F/⌃B respelled as their arrow, so the arrow handlers serve both spellings.
+    private static func emacsArrow(for event: NSEvent) -> NSEvent? {
+        guard event.modifierFlags.intersection([.command, .option, .control, .shift]) == .control
+        else { return nil }
+        let arrow: (key: KeyEquivalent, code: Int)
+        // Character chords, not key codes: Dvorak transposes the two.
+        switch event.charactersIgnoringModifiers?.lowercased() {
+        case "n": arrow = (.downArrow, kVK_DownArrow)
+        case "p": arrow = (.upArrow, kVK_UpArrow)
+        case "f": arrow = (.rightArrow, kVK_RightArrow)
+        case "b": arrow = (.leftArrow, kVK_LeftArrow)
+        default: return nil
+        }
+        let characters = String(arrow.key.character)
+        return NSEvent.keyEvent(
+            with: .keyDown,
+            location: event.locationInWindow,
+            modifierFlags: [.function, .numericPad],
+            timestamp: event.timestamp,
+            windowNumber: event.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: event.isARepeat,
+            keyCode: UInt16(arrow.code))
+    }
+
     /// Caret hiding on SwiftUI's own field editor. docs/features/palette.md#menu-open-input-freeze
     private func setSearchCaretHidden(_ hidden: Bool) {
         guard let editor = firstResponder as? NSTextView else { return }
@@ -34,6 +61,11 @@ final class PalettePanel: NSPanel {
         case .mouseMoved: paletteState?.hoverHighlightArmed = true
         case .keyDown: paletteState?.hoverHighlightArmed = false
         default: break
+        }
+        // Before every other rule, so the arrows' own policies apply to the chords too.
+        if event.type == .keyDown, let arrow = Self.emacsArrow(for: event) {
+            sendEvent(arrow)
+            return
         }
         // A footer menu owns the keyboard. See docs/features/palette.md#menu-open-input-freeze.
         if event.type == .keyDown,

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -128,6 +128,23 @@ frozen instead:
   force-casts its field editor to a private subclass, so vending a custom one crashes — only the
   existing one can be tuned.
 
+## Emacs navigation chords
+
+⌃N/⌃P and ⌃F/⌃B navigate exactly as ↓/↑ and →/← do — on the emoji grid all four step the selection,
+and everywhere else the horizontal pair falls through to the caret, which is what a native search field
+does.
+
+None of them reach `onKeyPress` on their own: AppKit's key-binding table hands the field editor
+`moveDown:` / `moveUp:` / `moveForward:` / `moveBackward:` first, and in a one-line field the vertical
+pair walks the caret to the end or the start rather than moving anything.
+
+`PalettePanel.sendEvent` therefore rewrites each chord into its arrow and re-dispatches, ahead of every
+other rule it applies. Nothing else changes: the arrow handlers in `RootPaletteView` are the only
+navigation code, so the compact bar's expand-on-↓, the grid's row and column steps, menu highlight
+movement and the scroll-into-view intent all follow for free. The caret keeps ⌃F/⌃B off the grid
+because `moveHorizontally` leaves →/← `.ignored` there, and the field editor then moves by a character
+exactly as the chord natively would. A chord carrying any modifier beyond ⌃ — ⌃⇧Q, say — is left alone.
+
 ## Focus restoration (load-bearing)
 
 `PaletteWindowController` records `previousApp` (the frontmost app) on show. Paste then targets that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -166,6 +166,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Reopening focuses the search field with an empty query, in the same position and at the same size
 - Compact mode: typing expands it, and the search bar does **not** shift vertically during the swap
 - Typing filters instantly; ↑/↓ move the highlight and scroll it into view without yanking the list
+- ⌃N/⌃P move the highlight as ↓/↑ do; ⌃F/⌃B step the emoji grid's selection, and the caret elsewhere
 - The highlight always sits on the row the footer pill describes
 - With a calculation typed, the calculator card is first and is selected first
 - Section headers appear in order: Favorites, Applications, System Settings, Quicklinks, Snippets,


### PR DESCRIPTION
⌃N/⌃P and ⌃F/⌃B navigate exactly as ↓/↑ and →/← do. On the emoji grid all four step the selection; everywhere else the horizontal pair falls through to the caret, which is what a native search field does (the Emoji & Symbols panel included).

## Why it needs code at all

None of the four reach `onKeyPress` on their own. AppKit's standard key-binding table hands the field editor `moveDown:` / `moveUp:` / `moveForward:` / `moveBackward:` first, and in a one-line field the vertical pair walks the caret to the end or the start rather than moving anything.

`PalettePanel.sendEvent` therefore rewrites each chord into its arrow and re-dispatches, ahead of every other rule it applies. That keeps the arrow handlers in `RootPaletteView` the only navigation code, so the compact bar's expand-on-↓, the grid's row and column steps, menu highlight movement, the empty/single-result clamping and the scroll-into-view intent all follow for free.

Two details that fall out of reusing the arrows rather than branching:

- The caret keeps ⌃F/⌃B off the grid because `moveHorizontally` leaves →/← `.ignored` there — `EmojiScreen` is the only screen implementing `move(axis: .horizontal)`.
- A chord carrying any modifier beyond ⌃ is untouched, so ⌃⇧Q on a launcher row still quits the app, and ⌘ shortcuts are unaffected.

Matching on `charactersIgnoringModifiers` rather than key codes follows the existing chord handling — Dvorak transposes the two.

## Verification

`./Scripts/run-tests.sh` (19 harnesses), `./Scripts/lint.sh`, the purity grep and a clean Debug build all pass with no new warnings.

Keystrokes can't be driven into the real app from a shell here, so the behaviour was checked with a throwaway AppKit harness — an `NSPanel` carrying the same remap, hosting a focused SwiftUI `TextField`:

| Input | Result |
| --- | --- |
| ⌃N / ⌃P | `downArrow` / `upArrow` handlers fire, same as a real arrow |
| real ↓ | unchanged |
| plain `n` | still types |
| ⌘N | reaches the key handler with `.command` intact |
| ⌃B / ⌃F, no horizontal move | caret 4 → 3 → 4, as the chords natively do |
| ⌃B / ⌃F, screen consumes →/← | `leftArrow` / `rightArrow` fire and the caret stays put |

Still worth a manual pass on real hardware: held key repeat (`isARepeat` is carried through to the synthetic event) and the grid feel.

# Closes #152 

## Docs

`docs/features/palette.md` gains an **Emacs navigation chords** section next to the other two `sendEvent` interceptions, and the core manual sweep in `docs/testing.md` gains a line for the chords.