### PR TITLE
Fix initial palette scroll after mounted screens

### DIFF
--- a/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
+++ b/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
@@ -21,6 +21,69 @@ extension View {
             Color.clear.frame(height: 0).id(ScrollOrigin.id)
         }
     }
+
+    /// Applies top intents once the header inset is usable; screens still own follow behavior.
+    func applyTopScrollIntent(_ scroll: ScrollIntent, proxy: ScrollViewProxy) -> some View {
+        modifier(TopScrollIntentModifier(scroll: scroll, proxy: proxy))
+    }
+}
+
+private struct MountScrollGeometry: Equatable {
+    let topInset: CGFloat
+    let contentOffsetY: CGFloat
+}
+
+private struct TopScrollIntentModifier: ViewModifier {
+    let scroll: ScrollIntent
+    let proxy: ScrollViewProxy
+    @State private var pendingTopNonce: UUID?
+    @State private var topInset: CGFloat = 0
+
+    private static let geometryTolerance: CGFloat = 0.5
+
+    init(scroll: ScrollIntent, proxy: ScrollViewProxy) {
+        self.scroll = scroll
+        self.proxy = proxy
+        _pendingTopNonce = State(initialValue: scroll.kind == .top ? scroll.nonce : nil)
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: scroll.nonce) {
+                guard scroll.kind == .top else {
+                    pendingTopNonce = nil
+                    return
+                }
+                guard topInset > 0 else {
+                    pendingTopNonce = scroll.nonce
+                    return
+                }
+                pendingTopNonce = nil
+                proxy.scrollToOrigin()
+            }
+            .onScrollPhaseChange { _, phase in
+                guard phase == .interacting else { return }
+                pendingTopNonce = nil
+            }
+            .onScrollGeometryChange(for: MountScrollGeometry.self) { geometry in
+                MountScrollGeometry(
+                    topInset: geometry.contentInsets.top,
+                    contentOffsetY: geometry.contentOffset.y)
+            } action: { oldGeometry, newGeometry in
+                let offsetDelta = newGeometry.contentOffsetY - oldGeometry.contentOffsetY
+                let insetDelta = newGeometry.topInset - oldGeometry.topInset
+                let offsetChanged = abs(offsetDelta) > Self.geometryTolerance
+                let followsInset = abs(offsetDelta + insetDelta) <= Self.geometryTolerance
+                if oldGeometry.topInset <= 0, offsetChanged, !followsInset {
+                    pendingTopNonce = nil
+                }
+                topInset = newGeometry.topInset
+                guard newGeometry.topInset > 0 else { return }
+                guard scroll.kind == .top, pendingTopNonce == scroll.nonce else { return }
+                pendingTopNonce = nil
+                proxy.scrollToOrigin()
+            }
+    }
 }
 
 private enum ScrollOrigin {

--- a/Tinycast/Features/Calculator/UI/CalculatorHistoryView.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorHistoryView.swift
@@ -93,17 +93,14 @@ struct CalculatorHistoryList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .applyTopScrollIntent(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
-                switch scroll.kind {
-                case .top:
+                guard scroll.kind == .follow else { return }
+                // Snap to the origin on the first row so its section header shows too.
+                if firstRowSelected {
                     proxy.scrollToOrigin()
-                case .follow:
-                    // Snap to the origin on the first row so its section header shows too.
-                    if firstRowSelected {
-                        proxy.scrollToOrigin()
-                    } else if let selectedRowID {
-                        proxy.reveal(selectedRowID)
-                    }
+                } else if let selectedRowID {
+                    proxy.reveal(selectedRowID)
                 }
             }
         }

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -77,17 +77,14 @@ struct ClipboardList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .applyTopScrollIntent(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
-                switch scroll.kind {
-                case .top:
+                guard scroll.kind == .follow else { return }
+                // Snap to the origin on the first row so its section header shows too.
+                if firstRowSelected {
                     proxy.scrollToOrigin()
-                case .follow:
-                    // Snap to the origin on the first row so its section header shows too.
-                    if firstRowSelected {
-                        proxy.scrollToOrigin()
-                    } else if let selectedID {
-                        proxy.reveal(selectedID.uuidString)
-                    }
+                } else if let selectedID {
+                    proxy.reveal(selectedID.uuidString)
                 }
             }
         }

--- a/Tinycast/Features/Emoji/UI/EmojiGridView.swift
+++ b/Tinycast/Features/Emoji/UI/EmojiGridView.swift
@@ -125,18 +125,14 @@ struct EmojiGridView: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .applyTopScrollIntent(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
-                switch scroll.kind {
-                case .top:
+                guard scroll.kind == .follow, let selectedRowID else { return }
+                // Snap to the origin on the first row so its header shows too.
+                if selectedRowID == firstRowID {
                     proxy.scrollToOrigin()
-                case .follow:
-                    guard let selectedRowID else { return }
-                    // Snap to the origin on the first row so its header shows too.
-                    if selectedRowID == firstRowID {
-                        proxy.scrollToOrigin()
-                    } else {
-                        proxy.reveal(selectedRowID)
-                    }
+                } else {
+                    proxy.reveal(selectedRowID)
                 }
             }
         }

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -107,17 +107,14 @@ struct LauncherList: View {
                     }
                     .edgeDissolve()
                     .thinScrollbar()
+                    .applyTopScrollIntent(scroll, proxy: proxy)
                     .onChange(of: scroll) { _, scroll in
-                        switch scroll.kind {
-                        case .top:
+                        guard scroll.kind == .follow else { return }
+                        // Snap to the origin on the first row so its header shows too.
+                        if firstRowSelected {
                             proxy.scrollToOrigin()
-                        case .follow:
-                            // Snap to the origin on the first row so its header shows too.
-                            if firstRowSelected {
-                                proxy.scrollToOrigin()
-                            } else if let selectedRowID {
-                                proxy.reveal(selectedRowID)
-                            }
+                        } else if let selectedRowID {
+                            proxy.reveal(selectedRowID)
                         }
                     }
                 }

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsView.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsView.swift
@@ -79,11 +79,10 @@ struct QuicklinkArgumentsView: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .applyTopScrollIntent(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
-                switch scroll.kind {
-                case .top: proxy.scrollToOrigin()
-                case .follow: proxy.reveal(String(selection))
-                }
+                guard scroll.kind == .follow else { return }
+                proxy.reveal(String(selection))
             }
         }
     }

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListView.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListView.swift
@@ -75,16 +75,13 @@ struct QuicklinkList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .applyTopScrollIntent(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
-                switch scroll.kind {
-                case .top:
+                guard scroll.kind == .follow else { return }
+                if firstRowSelected {
                     proxy.scrollToOrigin()
-                case .follow:
-                    if firstRowSelected {
-                        proxy.scrollToOrigin()
-                    } else if let selectedID {
-                        proxy.reveal(selectedID.uuidString)
-                    }
+                } else if let selectedID {
+                    proxy.reveal(selectedID.uuidString)
                 }
             }
         }

--- a/Tinycast/Features/Uninstall/UI/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallView.swift
@@ -49,17 +49,14 @@ struct UninstallList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .applyTopScrollIntent(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
-                switch scroll.kind {
-                case .top:
+                guard scroll.kind == .follow else { return }
+                // On the first row, snap to the origin so the summary header shows too.
+                if firstRowSelected {
                     proxy.scrollToOrigin()
-                case .follow:
-                    // On the first row, snap to the origin so the summary header shows too.
-                    if firstRowSelected {
-                        proxy.scrollToOrigin()
-                    } else if let selectedID {
-                        proxy.reveal(selectedID)
-                    }
+                } else if let selectedID {
+                    proxy.reveal(selectedID)
                 }
             }
         }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -25,7 +25,6 @@ struct RootPaletteView: View {
     @State private var menuSelection = 0
     /// The pending scroll request; modes are exclusive, so one piece of state serves all.
     @State private var scroll = ScrollIntent(kind: .top)
-    @State private var mountScrollResetTask: Task<Void, Never>?
 
     /// Compact vs. full; the source of truth is on `AppCore`, so the two can't disagree.
     private var isCollapsed: Bool { core.paletteCoordinator.paletteIsCollapsed }
@@ -44,7 +43,7 @@ struct RootPaletteView: View {
         case .quicklinkArguments:
             return QuicklinkArgumentsScreen(
                 session: quicklinkArguments, core: core, vm: vm,
-                scrollToTop: { sendScrollIntent(.top) })
+                scrollToTop: { scroll = ScrollIntent(kind: .top) })
         case .quicklinks:
             return QuicklinkListScreen(
                 store: quicklinks, core: core, vm: vm, openActions: openActions)
@@ -55,7 +54,7 @@ struct RootPaletteView: View {
         case .clipboard:
             return ClipboardScreen(
                 store: store, core: core, vm: vm, openActions: openActions,
-                scrollToFollow: { sendScrollIntent(.follow) })
+                scrollToFollow: { scroll = ScrollIntent(kind: .follow) })
         case .calculatorHistory:
             return CalculatorHistoryScreen(
                 history: calcHistory, currencyRates: currencyRates, core: core, vm: vm,
@@ -168,12 +167,12 @@ struct RootPaletteView: View {
         }
         .onChange(of: vm.query) {
             vm.selection = 0
-            sendScrollIntent(.top)
+            scroll = ScrollIntent(kind: .top)
         }
         .onChange(of: vm.mode) {
             vm.selection = 0
             showActions = false
-            resetScrollAfterMount(in: vm.mode)
+            scroll = ScrollIntent(kind: .top)
             // Every way out of the Uninstall screen: back chevron, bare backspace, a fresh summon.
             if vm.mode != .uninstall { uninstall.cancel() }
             // Same for a half-filled argument form: leaving the screen abandons the pending open.
@@ -181,7 +180,7 @@ struct RootPaletteView: View {
         }
         // `prepare` may change nothing, so this intent still snaps the scroll to the origin.
         .onChange(of: vm.resetToken) {
-            resetScrollAfterMount(in: vm.mode)
+            scroll = ScrollIntent(kind: .top)
         }
         // Opening either menu closes the other, so exactly one is open and highlighted.
         .onChange(of: showActions) {
@@ -203,7 +202,7 @@ struct RootPaletteView: View {
         .onChange(of: core.paletteCoordinator.paletteIsCollapsed) {
             core.paletteCoordinator.syncPaletteSize()
             guard !core.paletteCoordinator.paletteIsCollapsed else { return }
-            resetScrollAfterMount(in: vm.mode)
+            scroll = ScrollIntent(kind: .top)
         }
         // ⌘1–⌘5 launch the compact bar's favorite slots, or expand for the overflow.
         .onKeyPress(keys: ["1", "2", "3", "4", "5"], phases: .down) { press in
@@ -487,27 +486,11 @@ struct RootPaletteView: View {
 
     // MARK: - Actions
 
-    private func sendScrollIntent(_ kind: ScrollIntent.Kind) {
-        mountScrollResetTask?.cancel()
-        mountScrollResetTask = nil
-        scroll = ScrollIntent(kind: kind)
-    }
-
-    private func resetScrollAfterMount(in mode: PaletteMode) {
-        sendScrollIntent(.top)
-        mountScrollResetTask = Task { @MainActor in
-            await Task.yield()
-            guard !Task.isCancelled, vm.mode == mode, !isCollapsed else { return }
-            scroll = ScrollIntent(kind: .top)
-            mountScrollResetTask = nil
-        }
-    }
-
     private func move(_ delta: Int, in screen: any PaletteScreen) {
         let count = screen.rows.count
         guard count > 0 else { return }
         vm.selection = min(max(selection(count: count) + delta, 0), count - 1)
-        sendScrollIntent(.follow)
+        scroll = ScrollIntent(kind: .follow)
     }
 
     /// ↑/↓: the screen's own move where it has one, else a linear step through the rows.
@@ -518,7 +501,7 @@ struct RootPaletteView: View {
             return
         }
         vm.selection = next
-        sendScrollIntent(.follow)
+        scroll = ScrollIntent(kind: .follow)
     }
 
     /// ←/→: consumed only by a horizontally navigating screen, else the caret keeps them.
@@ -528,7 +511,7 @@ struct RootPaletteView: View {
             return false
         }
         vm.selection = next
-        sendScrollIntent(.follow)
+        scroll = ScrollIntent(kind: .follow)
         return true
     }
 

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -25,6 +25,7 @@ struct RootPaletteView: View {
     @State private var menuSelection = 0
     /// The pending scroll request; modes are exclusive, so one piece of state serves all.
     @State private var scroll = ScrollIntent(kind: .top)
+    @State private var mountScrollResetTask: Task<Void, Never>?
 
     /// Compact vs. full; the source of truth is on `AppCore`, so the two can't disagree.
     private var isCollapsed: Bool { core.paletteCoordinator.paletteIsCollapsed }
@@ -43,7 +44,7 @@ struct RootPaletteView: View {
         case .quicklinkArguments:
             return QuicklinkArgumentsScreen(
                 session: quicklinkArguments, core: core, vm: vm,
-                scrollToTop: { scroll = ScrollIntent(kind: .top) })
+                scrollToTop: { sendScrollIntent(.top) })
         case .quicklinks:
             return QuicklinkListScreen(
                 store: quicklinks, core: core, vm: vm, openActions: openActions)
@@ -54,7 +55,7 @@ struct RootPaletteView: View {
         case .clipboard:
             return ClipboardScreen(
                 store: store, core: core, vm: vm, openActions: openActions,
-                scrollToFollow: { scroll = ScrollIntent(kind: .follow) })
+                scrollToFollow: { sendScrollIntent(.follow) })
         case .calculatorHistory:
             return CalculatorHistoryScreen(
                 history: calcHistory, currencyRates: currencyRates, core: core, vm: vm,
@@ -167,12 +168,12 @@ struct RootPaletteView: View {
         }
         .onChange(of: vm.query) {
             vm.selection = 0
-            scroll = ScrollIntent(kind: .top)
+            sendScrollIntent(.top)
         }
         .onChange(of: vm.mode) {
             vm.selection = 0
             showActions = false
-            scroll = ScrollIntent(kind: .top)
+            resetScrollAfterMount(in: vm.mode)
             // Every way out of the Uninstall screen: back chevron, bare backspace, a fresh summon.
             if vm.mode != .uninstall { uninstall.cancel() }
             // Same for a half-filled argument form: leaving the screen abandons the pending open.
@@ -180,7 +181,7 @@ struct RootPaletteView: View {
         }
         // `prepare` may change nothing, so this intent still snaps the scroll to the origin.
         .onChange(of: vm.resetToken) {
-            scroll = ScrollIntent(kind: .top)
+            resetScrollAfterMount(in: vm.mode)
         }
         // Opening either menu closes the other, so exactly one is open and highlighted.
         .onChange(of: showActions) {
@@ -201,6 +202,8 @@ struct RootPaletteView: View {
         // Several paths flip `paletteIsCollapsed`, so resize the window to match.
         .onChange(of: core.paletteCoordinator.paletteIsCollapsed) {
             core.paletteCoordinator.syncPaletteSize()
+            guard !core.paletteCoordinator.paletteIsCollapsed else { return }
+            resetScrollAfterMount(in: vm.mode)
         }
         // ⌘1–⌘5 launch the compact bar's favorite slots, or expand for the overflow.
         .onKeyPress(keys: ["1", "2", "3", "4", "5"], phases: .down) { press in
@@ -484,11 +487,27 @@ struct RootPaletteView: View {
 
     // MARK: - Actions
 
+    private func sendScrollIntent(_ kind: ScrollIntent.Kind) {
+        mountScrollResetTask?.cancel()
+        mountScrollResetTask = nil
+        scroll = ScrollIntent(kind: kind)
+    }
+
+    private func resetScrollAfterMount(in mode: PaletteMode) {
+        sendScrollIntent(.top)
+        mountScrollResetTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled, vm.mode == mode, !isCollapsed else { return }
+            scroll = ScrollIntent(kind: .top)
+            mountScrollResetTask = nil
+        }
+    }
+
     private func move(_ delta: Int, in screen: any PaletteScreen) {
         let count = screen.rows.count
         guard count > 0 else { return }
         vm.selection = min(max(selection(count: count) + delta, 0), count - 1)
-        scroll = ScrollIntent(kind: .follow)
+        sendScrollIntent(.follow)
     }
 
     /// ↑/↓: the screen's own move where it has one, else a linear step through the rows.
@@ -499,7 +518,7 @@ struct RootPaletteView: View {
             return
         }
         vm.selection = next
-        scroll = ScrollIntent(kind: .follow)
+        sendScrollIntent(.follow)
     }
 
     /// ←/→: consumed only by a horizontally navigating screen, else the caret keeps them.
@@ -509,7 +528,7 @@ struct RootPaletteView: View {
             return false
         }
         vm.selection = next
-        scroll = ScrollIntent(kind: .follow)
+        sendScrollIntent(.follow)
         return true
     }
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -17,6 +17,9 @@ The command palette is a borderless floating `NSPanel` hosting SwiftUI; see
   instead; resigning shifts the text a point or two.
 - **Focus restoration is load-bearing.** Paste targets the recorded `previousApp` and requires the
   Accessibility permission (`Permissions.ensureAccessibility()`).
+- **A mount-time top scroll is consumed once, after the header inset settles.** Later scroll intents
+  cancel that pending correction, so keyboard or mouse navigation cannot be pulled back to the
+  origin.
 
 ## Summoning
 


### PR DESCRIPTION
## Related issues

Addresses #212 and generalizes the mount-timing fix discussed in #142.

## What changed

The previous revision retried the top-scroll intent after `Task.yield()`. That fixed the missed mount event but could produce the visible second snap shown in the review recording, and a scheduler yield was not tied to safe-area inset settlement.

This revision makes each scroll view consume `.top` only after its header inset is usable. The shared handler owns all top scrolling; the seven screens retain only selection-follow behavior. Pending mount resets are cancelled when a newer `.follow`, wheel/trackpad interaction, or direct custom-scrollbar offset wins. Coalesced inset and offset changes distinguish the system origin adjustment from user movement, so no standing `.top` policy can repin a list later.

## Validation

- All 19 standalone harnesses pass
- Debug build succeeds targeting macOS 26 (`CODE_SIGNING_ALLOWED=NO`)
- SwiftLint passes with only pre-existing warnings
- Format check, purity check, and `git diff --check` pass
- macOS 27 UI smoke covered first-letter search, launcher to emoji with immediate keyboard navigation, and compact-to-expanded search
- Earlier 60 fps captures showed no second visible snap after removing the yield retry
- Independent final review: APPROVE, no blockers

## Limitation

The available host runs macOS 27, so the macOS 26-specific visual result still needs confirmation on an affected machine.