### PR TITLE
Re-pin palette scroll views when the header's inset settles

### DIFF
--- a/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
+++ b/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
@@ -21,6 +21,14 @@ extension View {
             Color.clear.frame(height: 0).id(ScrollOrigin.id)
         }
     }
+
+    /// Restores the origin when the floating header's safe-area inset settles the frame after a scroll view mounts.
+    func pinOriginOnInsetSettle(_ scroll: ScrollIntent, proxy: ScrollViewProxy) -> some View {
+        onScrollGeometryChange(for: CGFloat.self) { $0.contentInsets.top } action: { _, _ in
+            guard scroll.kind == .top else { return }
+            proxy.scrollToOrigin()
+        }
+    }
 }
 
 private enum ScrollOrigin {

--- a/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
+++ b/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
@@ -22,9 +22,10 @@ extension View {
         }
     }
 
-    /// Restores the origin when the floating header's safe-area inset settles the frame after a scroll view mounts.
+    /// Restores the origin when the header's safe-area inset settles after a scroll view mounts.
     func pinOriginOnInsetSettle(_ scroll: ScrollIntent, proxy: ScrollViewProxy) -> some View {
         onScrollGeometryChange(for: CGFloat.self) { $0.contentInsets.top } action: { _, _ in
+            // A settle during keyboard nav must not yank the list back, hence the `.top` guard.
             guard scroll.kind == .top else { return }
             proxy.scrollToOrigin()
         }

--- a/Tinycast/Features/Calculator/UI/CalculatorHistoryView.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorHistoryView.swift
@@ -93,6 +93,7 @@ struct CalculatorHistoryList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .pinOriginOnInsetSettle(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
                 switch scroll.kind {
                 case .top:

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -77,6 +77,7 @@ struct ClipboardList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .pinOriginOnInsetSettle(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
                 switch scroll.kind {
                 case .top:

--- a/Tinycast/Features/Emoji/UI/EmojiGridView.swift
+++ b/Tinycast/Features/Emoji/UI/EmojiGridView.swift
@@ -125,6 +125,7 @@ struct EmojiGridView: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .pinOriginOnInsetSettle(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
                 switch scroll.kind {
                 case .top:

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -107,6 +107,7 @@ struct LauncherList: View {
                     }
                     .edgeDissolve()
                     .thinScrollbar()
+                    .pinOriginOnInsetSettle(scroll, proxy: proxy)
                     .onChange(of: scroll) { _, scroll in
                         switch scroll.kind {
                         case .top:

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsView.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsView.swift
@@ -79,6 +79,7 @@ struct QuicklinkArgumentsView: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .pinOriginOnInsetSettle(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
                 switch scroll.kind {
                 case .top: proxy.scrollToOrigin()

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListView.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListView.swift
@@ -75,6 +75,7 @@ struct QuicklinkList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .pinOriginOnInsetSettle(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
                 switch scroll.kind {
                 case .top:

--- a/Tinycast/Features/Uninstall/UI/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallView.swift
@@ -49,6 +49,7 @@ struct UninstallList: View {
             }
             .edgeDissolve()
             .thinScrollbar()
+            .pinOriginOnInsetSettle(scroll, proxy: proxy)
             .onChange(of: scroll) { _, scroll in
                 switch scroll.kind {
                 case .top:


### PR DESCRIPTION
## Related issue

Closes #142

Supersedes #215 — same fix, rebuilt against the current file layout (that branch predates the `DesignSystem/` + `Features/<Feature>/UI/` split and no longer merges).

## What changed

The palette header is attached with `safeAreaInset`, so a scroll view mounts before its top content inset is known. The inset landing a beat later shifts the content, and the list reads as though it opened already scrolled. The reproducible case in #142 is the first keystroke of a search.

- `pinOriginOnInsetSettle(_:proxy:)` in `DesignSystem/Scrolling/ScrollIntent.swift` watches `contentInsets.top` through `onScrollGeometryChange` and re-runs `scrollToOrigin()` whenever the standing `ScrollIntent` is `.top`. The `.top` guard is the whole point — a settle during keyboard navigation (`.follow`) must not yank the list back.
- Applied at all seven scroll surfaces that already pair a `ScrollViewReader` with a `ScrollIntent`: launcher, clipboard, emoji, calculator history, quicklink list, quicklink arguments, uninstall.

Non-obvious bit: this is a second path to the origin, not a replacement. The existing `onChange(of: scroll)` still handles every intent raised after the view is settled; this only covers the mount-time race where the intent is already `.top` before the geometry exists.

`EdgeDissolve.swift` and `ThinScrollbar.swift` are untouched.

Difference from #215: that branch also split `RootPaletteView.body` into two `let`s to stay inside the type-checker's budget. The refactor has since moved the per-mode bodies out behind `screen.body(selection:scroll:)`, so that expression is far smaller and the split is no longer needed. Dropped it rather than carry a workaround for a problem that no longer exists.

## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

## Drawbacks

`onScrollGeometryChange` fires on every inset change, not only the first. That is intentional — the compact↔expanded swap changes the inset too — but it does mean an inset animation while a `.top` intent stands will re-pin more than once. Cheap, and idempotent.

## Tests & validation

Not yet run — needs a macOS + Xcode 26 box. Pending:

- `./Scripts/format.sh`, `./Scripts/lint.sh`, and a build.
- Manual: #142's repro (type `s` into a cold palette), then the same on the clipboard, emoji, quicklink and uninstall lists; and arrow-key navigation to confirm the `.follow` path is unaffected.