### PR TITLE
Chords for the Actions rows that had none: ⌃X, ⌃⇧X and ⌥↵

### DIFF
--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -79,12 +79,12 @@ final class AppCore {
         snippetExpansion: snippetExpansion, core: self)
     @ObservationIgnored private(set) lazy var clipboardCoordinator = ClipboardCoordinator(
         clipboardStore: clipboardStore, palette: palette, windowController: windowController,
-        paletteCoordinator: paletteCoordinator)
+        paletteCoordinator: paletteCoordinator, core: self)
     @ObservationIgnored private(set) lazy var emojiCoordinator = EmojiCoordinator(
         frequentEmoji: frequentEmoji, settings: settings, windowController: windowController,
         paletteCoordinator: paletteCoordinator)
     @ObservationIgnored private(set) lazy var calculatorCoordinator = CalculatorCoordinator(
-        calcHistory: calcHistory, paletteCoordinator: paletteCoordinator)
+        calcHistory: calcHistory, paletteCoordinator: paletteCoordinator, core: self)
 
     @ObservationIgnored private lazy var windowController = PaletteWindowController(core: self)
     @ObservationIgnored private lazy var messageHUD = MessageHUDController(settings: settings)

--- a/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
+++ b/Tinycast/DesignSystem/Scrolling/ScrollIntent.swift
@@ -24,7 +24,9 @@ extension View {
 
     /// Restores the origin when the header's safe-area inset settles after a scroll view mounts.
     func pinOriginOnInsetSettle(_ scroll: ScrollIntent, proxy: ScrollViewProxy) -> some View {
-        onScrollGeometryChange(for: CGFloat.self) { $0.contentInsets.top } action: { _, _ in
+        onScrollGeometryChange(for: CGFloat.self) {
+            $0.contentInsets.top
+        } action: { _, _ in
             // A settle during keyboard nav must not yank the list back, hence the `.top` guard.
             guard scroll.kind == .top else { return }
             proxy.scrollToOrigin()

--- a/Tinycast/Features/Calculator/UI/CalculatorCoordinator.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorCoordinator.swift
@@ -5,10 +5,26 @@ import AppKit
 final class CalculatorCoordinator {
     private let calcHistory: CalculatorHistoryStore
     private let paletteCoordinator: PaletteCoordinator
+    /// Dialogs, for the one action here that can't be undone.
+    private unowned let core: AppCore
 
-    init(calcHistory: CalculatorHistoryStore, paletteCoordinator: PaletteCoordinator) {
+    init(
+        calcHistory: CalculatorHistoryStore, paletteCoordinator: PaletteCoordinator, core: AppCore
+    ) {
         self.calcHistory = calcHistory
         self.paletteCoordinator = paletteCoordinator
+        self.core = core
+    }
+
+    /// Both the ⌃⇧X chord and the menu row land here, so neither can skip the confirmation.
+    func deleteAllHistory() async {
+        guard
+            await core.confirm(
+                title: "Clear calculation history?",
+                message: "Every past calculation goes. This can't be undone.",
+                symbol: PaletteMode.calculatorHistory.systemImage, confirmTitle: "Clear History")
+        else { return }
+        calcHistory.clearAll()
     }
 
     /// Enter on the inline calculator card: copy the answer, remember the calculation, dismiss.

--- a/Tinycast/Features/Calculator/UI/CalculatorHistoryScreen.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorHistoryScreen.swift
@@ -80,10 +80,15 @@ struct CalculatorHistoryScreen: PaletteScreen {
         return true
     }
 
-    /// ⌘⌫ — the screen owns the chord, but the inline card can't be deleted.
+    /// ⌘⌫ / ⌃X — the screen owns the chord, but the inline card can't be deleted.
     func delete(at selection: Int) {
         guard let entry = entry(at: selection) else { return }
         history.remove(entry)
+    }
+
+    /// ⌃⇧X — mirrors the Actions row; the inline card survives, being a live answer, not history.
+    func deleteAll() {
+        history.clearAll()
     }
 
     func body(selection: Int, scroll: ScrollIntent) -> AnyView {
@@ -145,11 +150,14 @@ enum CalcHistoryActionsMenu {
                 ) {
                     core.calculatorCoordinator.copyHistoryExpression(entry)
                 },
-                PopoverMenuItem(title: "Delete Entry", systemImage: "trash", isDestructive: true) {
+                PopoverMenuItem(
+                    title: "Delete Entry", systemImage: "trash", shortcut: "⌃X", isDestructive: true
+                ) {
                     calcHistory.remove(entry)
                 },
                 PopoverMenuItem(
-                    title: "Delete All Entries", systemImage: "trash.fill", isDestructive: true
+                    title: "Delete All Entries", systemImage: "trash", shortcut: "⌃⇧X",
+                    isDestructive: true
                 ) {
                     calcHistory.clearAll()
                 }

--- a/Tinycast/Features/Calculator/UI/CalculatorHistoryScreen.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorHistoryScreen.swift
@@ -86,9 +86,9 @@ struct CalculatorHistoryScreen: PaletteScreen {
         history.remove(entry)
     }
 
-    /// ⌃⇧X — mirrors the Actions row; the inline card survives, being a live answer, not history.
+    /// ⌃⇧X — mirrors the Actions row, confirmation included; the live inline card isn't history.
     func deleteAll() {
-        history.clearAll()
+        Task { await core.calculatorCoordinator.deleteAllHistory() }
     }
 
     func body(selection: Int, scroll: ScrollIntent) -> AnyView {
@@ -159,7 +159,7 @@ enum CalcHistoryActionsMenu {
                     title: "Delete All Entries", systemImage: "trash", shortcut: "⌃⇧X",
                     isDestructive: true
                 ) {
-                    calcHistory.clearAll()
+                    Task { await core.calculatorCoordinator.deleteAllHistory() }
                 }
             ]
         )

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -7,17 +7,21 @@ final class ClipboardCoordinator {
     private let palette: PaletteState
     private let windowController: PaletteWindowController
     private let paletteCoordinator: PaletteCoordinator
+    /// Dialogs, for the one action here that can't be undone.
+    private unowned let core: AppCore
 
     init(
         clipboardStore: ClipboardStore,
         palette: PaletteState,
         windowController: PaletteWindowController,
-        paletteCoordinator: PaletteCoordinator
+        paletteCoordinator: PaletteCoordinator,
+        core: AppCore
     ) {
         self.clipboardStore = clipboardStore
         self.palette = palette
         self.windowController = windowController
         self.paletteCoordinator = paletteCoordinator
+        self.core = core
     }
 
     /// The setting names an age, the store enforces it; a shortened window culls straight away.
@@ -39,6 +43,17 @@ final class ClipboardCoordinator {
         if windowController.pasteKeepingWindowOpen(item, store: clipboardStore) {
             selectClip(item)
         }
+    }
+
+    /// Both the ⌃⇧X chord and the menu row land here, so neither can skip the confirmation.
+    func deleteAllClips() async {
+        guard
+            await core.confirm(
+                title: "Clear clipboard history?",
+                message: "Every entry goes, pinned ones included. This can't be undone.",
+                symbol: PaletteMode.clipboard.systemImage, confirmTitle: "Clear History")
+        else { return }
+        clipboardStore.clearAll()
     }
 
     func copyToClipboard(_ item: ClipboardItem) {

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -55,9 +55,9 @@ struct ClipboardScreen: PaletteScreen {
         store.remove(item)
     }
 
-    /// ⌃⇧X — mirrors the Actions row; pinned entries go with the rest, as the row does.
+    /// ⌃⇧X — mirrors the Actions row, confirmation included; pinned entries go with the rest.
     func deleteAll() {
-        store.clearAll()
+        Task { await core.clipboardCoordinator.deleteAllClips() }
     }
 
     /// Follow a row the store moved; with a query typed the highlight stays put.
@@ -170,7 +170,7 @@ enum ClipboardActionsMenu {
                 title: "Delete All Entries", systemImage: "trash", shortcut: "⌃⇧X",
                 isDestructive: true
             ) {
-                store.clearAll()
+                Task { await core.clipboardCoordinator.deleteAllClips() }
             })
         return PopoverMenuContent(header: headerText(item), items: items)
     }

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -42,10 +42,15 @@ struct ClipboardScreen: PaletteScreen {
         return true
     }
 
-    /// ⌘⌫ — the screen owns the chord whether or not a row sits under the selection.
+    /// ⌘⌫ / ⌃X — the screen owns the chord whether or not a row sits under the selection.
     func delete(at selection: Int) {
         guard let item = item(at: selection) else { return }
         store.remove(item)
+    }
+
+    /// ⌃⇧X — mirrors the Actions row; pinned entries go with the rest, as the row does.
+    func deleteAll() {
+        store.clearAll()
     }
 
     /// Follow a row the store moved; with a query typed the highlight stays put.
@@ -147,12 +152,15 @@ enum ClipboardActionsMenu {
                 })
         }
         items.append(
-            PopoverMenuItem(title: "Delete Entry", systemImage: "trash", isDestructive: true) {
+            PopoverMenuItem(
+                title: "Delete Entry", systemImage: "trash", shortcut: "⌃X", isDestructive: true
+            ) {
                 store.remove(item)
             })
         items.append(
             PopoverMenuItem(
-                title: "Delete All Entries", systemImage: "trash.fill", isDestructive: true
+                title: "Delete All Entries", systemImage: "trash", shortcut: "⌃⇧X",
+                isDestructive: true
             ) {
                 store.clearAll()
             })

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -35,6 +35,13 @@ struct ClipboardScreen: PaletteScreen {
         return true
     }
 
+    /// ⌥↵ — the palette stays up, so a run of entries goes over without re-summoning it.
+    func pasteKeepingWindowOpen(at selection: Int) -> Bool {
+        guard let item = item(at: selection) else { return false }
+        core.clipboardCoordinator.pasteKeepingWindowOpen(item)
+        return true
+    }
+
     /// ⌘P — mirrors the Actions menu row; pinning lifts the row into the Pinned section.
     func pin(at selection: Int) -> Bool {
         guard let item = item(at: selection) else { return false }
@@ -129,7 +136,8 @@ enum ClipboardActionsMenu {
                 core.clipboardCoordinator.copyToClipboard(item)
             },
             PopoverMenuItem(
-                title: "Paste & Keep Window Open", icon: .paste(target, fallback: "macwindow")
+                title: "Paste and Keep Window Open", icon: .paste(target, fallback: "macwindow"),
+                shortcut: "⌥↵"
             ) {
                 core.clipboardCoordinator.pasteKeepingWindowOpen(item)
             }

--- a/Tinycast/Features/Emoji/UI/EmojiScreen.swift
+++ b/Tinycast/Features/Emoji/UI/EmojiScreen.swift
@@ -39,7 +39,7 @@ struct EmojiScreen: PaletteScreen {
         return true
     }
 
-    /// ⌥↵, the one chord that leaves the palette up, so emoji can be pasted in a run.
+    /// ⌥↵ — the palette stays up, so a run of emoji goes over without re-summoning it.
     func pasteKeepingWindowOpen(at selection: Int) -> Bool {
         guard let entry = entry(at: selection) else { return false }
         core.emojiCoordinator.pasteEmojiKeepingWindowOpen(entry)
@@ -112,7 +112,8 @@ enum EmojiActionsMenu {
                     core.emojiCoordinator.copyEmoji(entry)
                 },
                 PopoverMenuItem(
-                    title: "Paste & Keep Window Open", icon: .paste(target, fallback: "macwindow")
+                    title: "Paste and Keep Window Open",
+                    icon: .paste(target, fallback: "macwindow"), shortcut: "⌥↵"
                 ) {
                     core.emojiCoordinator.pasteEmojiKeepingWindowOpen(entry)
                 }

--- a/Tinycast/Palette/PaletteScreen.swift
+++ b/Tinycast/Palette/PaletteScreen.swift
@@ -19,6 +19,8 @@ enum PaletteAxis {
     func activate(at selection: Int)
     /// ⌘↵. False when the selection has no secondary action, leaving the key unhandled.
     func secondary(at selection: Int) -> Bool
+    /// ⌥↵. False on every screen with nothing to paste, which is most of them.
+    func pasteKeepingWindowOpen(at selection: Int) -> Bool
     /// The selection an arrow key lands on, or nil to leave the key to the palette's own default.
     func move(_ delta: Int, axis: PaletteAxis, from selection: Int) -> Int?
     @ViewBuilder func body(selection: Int, scroll: ScrollIntent) -> AnyView
@@ -26,5 +28,6 @@ enum PaletteAxis {
 
 extension PaletteScreen {
     func hasPrimaryAction(at selection: Int) -> Bool { true }
+    func pasteKeepingWindowOpen(at selection: Int) -> Bool { false }
     func move(_ delta: Int, axis: PaletteAxis, from selection: Int) -> Int? { nil }
 }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -262,8 +262,7 @@ struct RootPaletteView: View {
             let screen = screen
             let selection = selection(in: screen)
             if command { return screen.secondary(at: selection) ? .handled : .ignored }
-            guard let emoji = screen as? EmojiScreen else { return .ignored }
-            return emoji.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
+            return screen.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
         }
         .onKeyPress(.escape) {
             if showActions || showAppMenu {

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -309,6 +309,23 @@ struct RootPaletteView: View {
             }
             return .ignored
         }
+        // ⌃X / ⌃⇧X mirror the delete rows — both cases, Shift uppercasing — and close an open menu.
+        .onKeyPress(keys: ["x", "X"], phases: .down) { press in
+            guard press.modifiers.contains(.control) else { return .ignored }
+            let screen = screen
+            let selection = selection(in: screen)
+            let all = press.modifiers.contains(.shift)
+            switch screen {
+            case let clipboard as ClipboardScreen:
+                if all { clipboard.deleteAll() } else { clipboard.delete(at: selection) }
+            case let history as CalculatorHistoryScreen:
+                if all { history.deleteAll() } else { history.delete(at: selection) }
+            default:
+                return .ignored
+            }
+            if menuOpen { closeMenus() }
+            return .handled
+        }
         // ⌘P mirrors the Actions row, and works while that menu is open like the rest.
         .onKeyPress(keys: ["p"], phases: .down) { press in
             guard press.modifiers.contains(.command) else { return .ignored }

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -122,8 +122,8 @@ frozen instead:
 
 - `RootPaletteView` mirrors the open state into `PaletteState.menuOpen`, whose `didSet` fires
   `onMenuOpenChanged`.
-- `PalettePanel.sendEvent` then swallows text-editing keystrokes while `menuOpen` (letting ⌘/⌥ chords
-  and menu-nav keys through to SwiftUI `onKeyPress`).
+- `PalettePanel.sendEvent` then swallows text-editing keystrokes while `menuOpen` (letting ⌘/⌃ chords
+  and menu-nav keys through to SwiftUI `onKeyPress`), which is how ⌘P and ⌃X still reach their rows.
 - The caret is hidden by clearing SwiftUI's **own** live field editor's `insertionPointColor`. SwiftUI
   force-casts its field editor to a private subclass, so vending a custom one crashes — only the
   existing one can be tuned.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -184,6 +184,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Search is correct both under and over three characters
 - ⌘P pins and the highlight follows the row into Pinned; ⌘⌫ deletes; ⌘↵ copies without pasting
 - ⌃X deletes the selected entry and ⌃⇧X clears the history, from the list and from an open ⌘K menu
+- ⌃⇧X asks first, through Tinycast's own dialog; Cancel and Esc both leave every entry in place
 - ↵ pastes into the previous app; ⌥↵ pastes without closing the palette
 - A copy from an excluded app (Settings ▸ Clipboard ▸ Disabled Applications) is **not** recorded
 - Password-manager copies are still not recorded
@@ -229,6 +230,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 ### Calculator and currency
 
 - `2+2` shows a card; ↵ copies and records to history; unit and date conversions work
+- In Calculator History, ⌃X deletes a row and ⌃⇧X clears the history behind a confirmation
 - With currency conversion **off**, a currency query produces no card and **no network request**
 - Turning it on shows the consent sheet, naming the provider, first
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -183,6 +183,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - A copy appears at the top within about a second; an image copy records a thumbnail
 - Search is correct both under and over three characters
 - ⌘P pins and the highlight follows the row into Pinned; ⌘⌫ deletes; ⌘↵ copies without pasting
+- ⌃X deletes the selected entry and ⌃⇧X clears the history, from the list and from an open ⌘K menu
 - ↵ pastes into the previous app; ⌥↵ pastes without closing the palette
 - A copy from an excluded app (Settings ▸ Clipboard ▸ Disabled Applications) is **not** recorded
 - Password-manager copies are still not recorded


### PR DESCRIPTION
## Related issue

Closes #151

The feature request's own list is already shipped — pinning and the per-app allow/block list exist,
and type filters were declined. The one thing left open in the thread was a keyboard shortcut for
**Delete Entry**, which is what the first commit adds. The second gives the same treatment to
**Paste and Keep Window Open**, the other Actions row that had no chord.

## What changed

### ⌃X / ⌃⇧X — delete

Both Actions menus that carry these rows — Clipboard and Calculator History — now show and honour a
chord, and **Delete All Entries** drops `trash.fill` for the same `trash` glyph its sibling uses.

- **⌃X** deletes the selected entry, **⌃⇧X** clears the whole history.
- Each screen gained a `deleteAll()` beside its existing `delete(at:)`, so the chord and the menu row
  run the same store call rather than a second spelling of it.
- One `onKeyPress` in `RootPaletteView` owns both chords, shaped like the existing ⌃⇧Q handler: both
  key cases registered, Shift selecting the clear-all path. It closes an open Actions menu afterwards,
  which is what activating the row itself does.
- **⌃⇧X asks first**, through Tinycast's own dialog — the same `AppCore.confirm` the quicklink delete
  uses, not a system alert. The confirmation lives on the coordinator (`deleteAllClips()` /
  `deleteAllHistory()`), as the quicklink delete does, so the chord and the Actions row share one path
  and neither can skip it. The row asks now too, which it didn't before.
- `⌘⌫` is untouched, and deleting a *single* entry stays instant on every path.

Both coordinators took an `unowned let core: AppCore` to reach the dialogs, matching
`QuicklinkCoordinator`. Note the dialog takes key status, so the palette dismisses behind it — same as
confirming a quicklink delete from the palette today.

Non-obvious bit: the chords work from an open ⌘K menu, not just the list. Two things make that hold,
and both are load-bearing — the menu-open input freeze in `PalettePanel.sendEvent` lets ⌃ chords
through, and `^x` has no entry in AppKit's `StandardKeyBinding.dict`, so the field editor never
swallows it before SwiftUI sees it. That is the same path ⌃⇧Q already relies on.

### ⌥↵ — paste and keep window open

The row existed in both paste menus, but only the emoji grid was wired to a chord; ⌥↵ on the clipboard
fell through unhandled — something `docs/testing.md` already claimed worked.

- `pasteKeepingWindowOpen(at:)` joins the `PaletteScreen` protocol beside `secondary(at:)`, defaulting
  to `false` for the screens with nothing to paste. That removes the `as? EmojiScreen` downcast from
  the ↵ handler, so ⌘↵ and ⌥↵ now route identically instead of one of them being a special case.
- `ClipboardScreen` implements it against the coordinator call the menu row already used.
- Both rows show ⌥↵ and now read **"Paste and Keep Window Open"** — the ampersand was the odd one out
  among the menu titles. Shout if you'd rather keep `&` and I'll revert just that.

### Docs

The Clipboard and Calculator rows of the manual checklist in `docs/testing.md` gained the delete chords and the confirmation. Its ⌥↵ line
needed no edit — it described behaviour that only now exists. `docs/features/palette.md` said the
menu-open freeze passes `⌘/⌥` chords where the code passes `⌘/⌃`; corrected, since that sentence is
load-bearing for the delete chords.

## Memory footprint

Not measured — neither change allocates, stores state or extends an object's lifetime. One
`onKeyPress` modifier and one protocol method, both calling store and coordinator methods that already
existed. Happy to run the table if you want it on the record anyway.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: n/a — nothing captured or retained.

## Demo

No before/after clip. The visible change is keycap chips on three menu rows, one swapped glyph and one
reworded title; the screenshots in #151 are the target and the rows now match them.

## Drawbacks

- The chords aren't customisable, per your call in the thread.
- ⌃⇧X on the clipboard takes pinned entries with it, matching the row; the dialog says so.
- The confirmation isn't behind a setting, unlike quicklinks' `quicklinkConfirmsBeforeDelete`. Easy to
  add if you want the escape hatch — I didn't invent a preference nobody asked for.
- The palette dismisses when the dialog takes key, so confirming a wipe also closes the palette. That
  is what a quicklink delete from the palette already does, so I left it alone rather than special-case
  this one.
- Adding `pasteKeepingWindowOpen(at:)` to `PaletteScreen` puts a paste-flavoured name on a protocol
  most of whose conformers can't paste. The alternative was a second downcast in the ↵ handler; I took
  the protocol method since it's the same shape `secondary(at:)` already has.

## Tests & validation

- `./Scripts/run-tests.sh` — all 19 harnesses pass.
- Debug build via `xcodebuild` succeeds with no new warnings.
- `./Scripts/lint.sh` clean; `Features/*/Model/` still free of AppKit/SwiftUI imports.
- `plutil -p StandardKeyBinding.dict` confirms no `^x` / `^X` binding, so nothing upstream eats that chord.

Not exercised in a running app — no harness drives palette key handling or dialog presentation, and I
can't send synthetic keystrokes here. Worth a manual pass:

- ⌃X and ⌃⇧X from the list and from an open ⌘K menu, on both Clipboard and Calculator History.
- The ⌃⇧X dialog: Delete clears, Cancel and Esc leave everything in place, and click-away cancels.
- ⌥↵ on the clipboard — needs Accessibility, should leave the palette frontmost with the pasted row
  selected — plus a check that the emoji grid's ⌥↵ still behaves.
