### PR TITLE
Settle the palette's pointer in the panel

### DIFF
--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -56,12 +56,44 @@ final class PalettePanel: NSPanel {
         editor.updateInsertionPointStateAndRestartTimer(!hidden)
     }
 
+    /// Every event either mechanism sets a cursor on, so neither gets the last word.
+    private static let cursorEvents: Set<NSEvent.EventType> = [
+        .mouseMoved, .mouseEntered, .mouseExited, .cursorUpdate,
+        .leftMouseDown, .leftMouseUp, .leftMouseDragged
+    ]
+
+    /// Two AppKit mechanisms disagree over the field — SwiftUI's clip view claims the arrow for
+    /// the whole window as a cursor rect, the field editor claims the I-beam from its tracking
+    /// area — so the panel settles it from the field's own frame, after `super` has had its say.
+    private func applyCursorPolicy(for event: NSEvent) {
+        guard Self.cursorEvents.contains(event.type) else { return }
+        // Outset: the field editor AppKit installs is a point taller than the field it serves.
+        let text = searchFieldRect.insetBy(dx: -Self.fieldEditorSlack, dy: -Self.fieldEditorSlack)
+        let cursor: NSCursor =
+            text.contains(convertPoint(fromScreen: NSEvent.mouseLocation)) ? .iBeam : .arrow
+        guard NSCursor.current !== cursor else { return }
+        cursor.set()
+    }
+
+    /// docs/features/palette.md: a 24pt editor in a 23pt field, so its I-beam overhangs.
+    private static let fieldEditorSlack: CGFloat = 2
+
+    /// SwiftUI reports the field top-left down; AppKit reads the window bottom-left up.
+    private var searchFieldRect: CGRect {
+        guard let frame = paletteState?.searchFieldFrame, !frame.isEmpty,
+            let height = contentView?.bounds.height
+        else { return .zero }
+        return CGRect(
+            x: frame.minX, y: height - frame.maxY, width: frame.width, height: frame.height)
+    }
+
     override func sendEvent(_ event: NSEvent) {
         switch event.type {
         case .mouseMoved: paletteState?.hoverHighlightArmed = true
         case .keyDown: paletteState?.hoverHighlightArmed = false
         default: break
         }
+        defer { applyCursorPolicy(for: event) }
         // Before every other rule, so the arrows' own policies apply to the chords too.
         if event.type == .keyDown, let arrow = Self.emacsArrow(for: event) {
             sendEvent(arrow)

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -19,6 +19,9 @@ final class PaletteState {
     var pasteTarget: PasteTarget?
     /// True only while the pointer physically moves; untracked, so it never re-renders.
     @ObservationIgnored var hoverHighlightArmed = false
+    /// The search field's frame, published by the view that owns it. The panel's cursor policy
+    /// is a containment test against this: hit-testing a rebuilding hierarchy misses the field.
+    @ObservationIgnored var searchFieldFrame: CGRect = .zero
     /// True while a footer menu is open. See docs/features/palette.md#menu-open-input-freeze.
     @ObservationIgnored var menuOpen = false { didSet { onMenuOpenChanged?(menuOpen) } }
     /// Fired when `menuOpen` flips, so the panel can hide the caret without a focus swap.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -454,6 +454,10 @@ struct RootPaletteView: View {
                         onBegan: beginDrag, onEnded: endDrag)
                 }
             }
+            // The panel resolves the pointer against this rather than hit-testing for the field.
+            .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: {
+                vm.searchFieldFrame = $0
+            }
     }
 
     /// The Uninstall screen's primary action is destructive, so its pill isn't white.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -166,6 +166,35 @@ explicit `accessibilityLabel` because the prompt used to supply it.
 
 This is the same class of bug as the freeze below — both come from the cell/field-editor swap.
 
+## The panel settles the pointer itself
+
+`PalettePanel.applyCursorPolicy` sets the cursor after every mouse event: the I-beam inside the search
+field's frame, the arrow everywhere else. Without it the palette's pointer sticks as an I-beam over the
+whole window and flickers along the field's edge — the two AppKit mechanisms that claim a cursor here
+disagree, and neither yields.
+
+- SwiftUI's `HostingClipView` claims the **arrow** across the entire window as a *cursor rect*.
+- The field editor claims the **I-beam** from its own *tracking area*.
+
+Both fire on the same crossings, so the cursor alternates while the pointer is over the field, and the
+last claim simply stays put once it leaves — nothing re-evaluates a cursor rect until the pointer
+crosses one, and the arrow rect spans the window, so leaving the field crosses nothing.
+
+Two measured details the policy depends on:
+
+- **The field publishes its own frame.** `RootPaletteView` reports it into `PaletteState.searchFieldFrame`
+  via `onGeometryChange`, and the panel does a containment test against that. Hit-testing for the field
+  instead does not work: SwiftUI rebuilds it as it re-renders, and a hit test taken mid-rebuild misses
+  it and reads as *the pointer left the field*. The frame only moves on layout, so it never lies.
+  It arrives top-left-down and is flipped into AppKit's bottom-left-up window space.
+- **The rect is outset by 2pt.** AppKit's field editor is a point taller than the field it serves — the
+  same measurement the placeholder section above rests on — so its I-beam overhangs the published
+  frame. Without the slack that 1pt band is a disagreement, and it flickers.
+
+The policy runs after `super.sendEvent`, so it has the last word, and it writes only when the cursor
+actually differs. It must stay **symmetric**: an earlier version left the field alone and only forced
+the arrow outside it, and AppKit's own alternation over the field came straight back.
+
 ## Menu-open input freeze
 
 While a footer popover menu (⌘K Actions / app menu) is open the search field reads as inert but


### PR DESCRIPTION
Fixes the palette cursor sticking as an I-beam over the entire window once the pointer touched the search field, and the flicker along the field's edge.

## Root cause

Nothing in Tinycast ever set a cursor — the bug is two AppKit mechanisms claiming one in the same window and disagreeing. Instrumenting `PalettePanel.sendEvent` to sample the cursor before and after `super` caught them alternating, 292 times in one short session:

```
cursorUpdate  I-BEAM->arrow  CHANGED  owner=none                        <- a cursor rect sets arrow
entered       arrow->I-BEAM  CHANGED  owner=_SystemTextFieldFieldEditor <- a tracking area sets I-beam
cursorUpdate  I-BEAM->arrow  CHANGED  owner=none
entered       arrow->I-BEAM  CHANGED  owner=_SystemTextFieldFieldEditor
```

Dumping every view in the panel that overrides `resetCursorRects`, with each rect in window space, names the two claimants:

```
PaletteHostingView@y0-475          <- the panel
HostingClipView@y0-475             <- SwiftUI: ARROW across the whole window (cursor rect)
_SystemTextFieldFieldEditor@y431-455  <- the field editor: I-BEAM (tracking area)
```

- Over the field the two fire on the same crossings and alternate. That is the flicker.
- Off the field nothing re-evaluates. Cursor rects are only consulted when the pointer crosses one, and SwiftUI's arrow rect spans the whole window — so walking from the field down into the results crosses no boundary at all, and whichever claim landed last simply stays. That is the stuck I-beam.

The field editor's own rect is correctly scoped to `y431-455`, so nothing declared an I-beam at `y=39` where one was still displayed.

## Fix

`PalettePanel` settles it, after `super.sendEvent` so it has the last word:

```swift
private func applyCursorPolicy(for event: NSEvent) {
    guard Self.cursorEvents.contains(event.type) else { return }
    // Outset: the field editor AppKit installs is a point taller than the field it serves.
    let text = searchFieldRect.insetBy(dx: -Self.fieldEditorSlack, dy: -Self.fieldEditorSlack)
    let cursor: NSCursor =
        text.contains(convertPoint(fromScreen: NSEvent.mouseLocation)) ? .iBeam : .arrow
    guard NSCursor.current !== cursor else { return }
    cursor.set()
}
```

Two details it depends on, both measured rather than assumed:

- **The field publishes its own frame** (`RootPaletteView` -> `PaletteState.searchFieldFrame` via `onGeometryChange`). Hit-testing for the field instead does not work: SwiftUI rebuilds it as it re-renders, and a hit test taken mid-rebuild misses it and reads as *the pointer left the field*. Caught directly — the same stationary pointer resolving two ways:

  ```
  FLIP -> arrow   livePoint=(395,454)  hit=HostingScrollView
  FLIP -> I-BEAM  livePoint=(395,454)  hit=_SystemTextFieldFieldEditor
  ```

  The frame only moves on layout, so it never lies. It arrives top-left-down and is flipped into AppKit's bottom-left-up window space.

- **The rect is outset 2pt.** AppKit's field editor is a point taller than the field it serves (`y431-454` published vs `y431-455` actual) — the same measurement `docs/features/palette.md` already documents for the placeholder. That 1pt band was a disagreement, and it flickered.

The policy must stay **symmetric**. An intermediate version left the field alone and only forced the arrow outside it; AppKit's own alternation over the field came straight back.

## Rejected along the way

- `pointerStyle(.default)` on the panel with `.horizontalText` on the field — SwiftUI's pointer regions lose to the field editor's AppKit cursor rect. No effect.
- An arrow cursor rect on the hosting view via `resetCursorRects` — installs correctly, but spans the whole window, so leaving the field still crosses no boundary.
- Forcing the arrow while a menu is open — made the panel contradict AppKit while the pointer was genuinely over a text field, which flashed at event rate.

## Testing

`./Scripts/run-tests.sh` (19 harnesses), Debug build with no new warnings, `./Scripts/lint.sh` clean, `Features/*/Model/` import check clean. Behaviour verified by hand in a Dev build: field still and moving, both field edges, the results list, and with the Cmd-K Actions menu open and closed.

Closes #224