### PR TITLE
Release File Search icons after dismissal

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -87,6 +87,7 @@ run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swi
                            Tinycast/Features/HotKeys/Service/KeyShortcut.swift
 run callout-test           Tinycast/DesignSystem/Theme.swift \
                            Tinycast/Features/HotKeys/UI/CalloutPlacement.swift
+run icon-cache-test        Tinycast/Platform/Images/IconCache.swift
 run system-action-test     Tinycast/Features/SystemActions/Model/SystemAction.swift
 run volume-test            Tinycast/Features/SystemActions/Model/VolumeLevel.swift
 run window-command-test    Tinycast/Features/WindowManagement/WindowCommand.swift \

--- a/Tests/file-search-session-test.swift
+++ b/Tests/file-search-session-test.swift
@@ -4,12 +4,26 @@ actor FileSearchProbe {
     private var active = 0
     private var calls: [String] = []
     private var maximumActive = 0
+    private let pausedQuery: String?
+    private var pauseEnabled: Bool
+    private var pausedContinuation: CheckedContinuation<Void, Never>?
+
+    init(pausing query: String? = nil) {
+        pausedQuery = query
+        pauseEnabled = query != nil
+    }
 
     func search(query: String, policy: FileSearchPolicy) async -> [FileSearchResult] {
         active += 1
         calls.append(query)
         maximumActive = max(maximumActive, active)
-        try? await Task.sleep(for: .milliseconds(80))
+        if pauseEnabled, query == pausedQuery {
+            await withCheckedContinuation { continuation in
+                pausedContinuation = continuation
+            }
+        } else {
+            try? await Task.sleep(for: .milliseconds(80))
+        }
         active -= 1
         return [
             FileSearchResult(
@@ -20,6 +34,24 @@ actor FileSearchProbe {
 
     func snapshot() -> (calls: [String], maximumActive: Int) {
         (calls, maximumActive)
+    }
+
+    func waitUntilPaused() async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while pausedContinuation == nil, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        guard pausedContinuation != nil else {
+            pauseEnabled = false
+            return false
+        }
+        return true
+    }
+
+    func resumePausedSearch() {
+        pauseEnabled = false
+        pausedContinuation?.resume()
+        pausedContinuation = nil
     }
 }
 
@@ -51,7 +83,6 @@ struct FileSearchSessionTests {
         let probe = FileSearchProbe()
         let session = makeSession(probe: probe, debounce: .milliseconds(30))
         session.search("annual")
-        try? await Task.sleep(for: .milliseconds(10))
         session.search("annual report")
         await waitUntil { session.state == .ready }
 
@@ -61,11 +92,14 @@ struct FileSearchSessionTests {
     }
 
     static func serializesRunningQueries() async {
-        let probe = FileSearchProbe()
+        let probe = FileSearchProbe(pausing: "first")
         let session = makeSession(probe: probe, debounce: .milliseconds(10))
         session.search("first")
-        try? await Task.sleep(for: .milliseconds(25))
+        let firstStarted = await probe.waitUntilPaused()
+        expect(firstStarted, "the first query starts")
+        guard firstStarted else { return }
         session.search("second")
+        await probe.resumePausedSearch()
         await waitUntil { session.state == .ready && session.results.first?.name == "second" }
 
         let snapshot = await probe.snapshot()

--- a/Tests/icon-cache-test.swift
+++ b/Tests/icon-cache-test.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@main
+@MainActor
+struct IconCacheTests {
+    static var failures = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func main() {
+        var generation = IconCacheGeneration()
+        let captured = generation.value
+        var stored: [Int] = []
+
+        let current = generation.publish(1, capturedAt: captured) { stored.append($0) }
+        expect(current == 1, "a current decode reaches its caller")
+        expect(stored == [1], "a current decode populates the cache")
+
+        generation.invalidate()
+        let stale = generation.publish(2, capturedAt: captured) { stored.append($0) }
+        expect(stale == 2, "a stale decode still reaches its active caller")
+        expect(stored == [1], "a stale decode cannot repopulate the cache")
+
+        print(failures == 0 ? "Icon cache tests passed" : "\(failures) tests failed")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tinycast/Features/FileSearch/UI/FileSearchList.swift
+++ b/Tinycast/Features/FileSearch/UI/FileSearchList.swift
@@ -45,6 +45,7 @@ struct FileSearchList: View {
                 }
             }
         }
+        .onDisappear { IconCache.purgeFitted() }
     }
 }
 

--- a/Tinycast/Features/Uninstall/UI/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallView.swift
@@ -64,6 +64,7 @@ struct UninstallList: View {
                 }
             }
         }
+        .onDisappear { IconCache.purgeFitted() }
     }
 }
 

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -75,6 +75,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         dropGuides.hide()
         // Drop the multi-MB preview bitmaps, so idle RAM returns near baseline.
         ImageThumbnail.purgePreviews()
+        IconCache.purgeFitted()
         schedulePopToRoot()
         guard restoreFocus else { return }
         // Our own window first: it is still open, and activating another app would bury it.

--- a/Tinycast/Platform/Images/IconCache.swift
+++ b/Tinycast/Platform/Images/IconCache.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Synchronization
 
 /// App icons by path, downsampled and byte-bounded, so rows don't re-hit `NSWorkspace`.
 enum IconCache {
@@ -14,6 +15,14 @@ enum IconCache {
         return cache
     }()
 
+    // One 200-row result set fits; unlike launcher icons, these are discarded with the list.
+    private static let fittedCache: Cache = {
+        let cache = Cache()
+        cache.totalCostLimit = 8 * 1024 * 1024
+        return cache
+    }()
+    private static let fittedGeneration = Mutex(0)
+
     /// Cache-only lookups (never decode) so a row can paint an already-warm icon on the same frame.
     static func cached(forFile path: String) -> NSImage? { cache.object(forKey: path as NSString) }
     static func cachedSymbol(named name: String) -> NSImage? {
@@ -21,7 +30,15 @@ enum IconCache {
     }
 
     /// A freshly-decoded, thereafter-immutable `NSImage` is safe to move across the actor boundary.
-    private struct Decoded: @unchecked Sendable { let image: NSImage? }
+    private struct Decoded: @unchecked Sendable {
+        let image: NSImage?
+        let cost: Int
+
+        init(image: NSImage?, cost: Int = 0) {
+            self.image = image
+            self.cost = cost
+        }
+    }
 
     /// Returns the decode directly, so a purge mid-decode can't strand a placeholder.
     static func loadAsync(forFile path: String) async -> NSImage? {
@@ -97,23 +114,40 @@ enum IconCache {
 
     /// Cache-only lookup for `loadFittedAsync`.
     static func cachedFitted(forFile path: String) -> NSImage? {
-        cache.object(forKey: fittedKey(path))
+        fittedCache.object(forKey: fittedKey(path))
     }
 
     /// Like `loadAsync`, normalized so every file type paints to the same visual size.
     static func loadFittedAsync(forFile path: String) async -> NSImage? {
         if let cached = cachedFitted(forFile: path) { return cached }
-        return await Task.detached(priority: .userInitiated) { () -> Decoded in
-            guard FileManager.default.fileExists(atPath: path) else { return Decoded(image: nil) }
-            return Decoded(image: fittedIcon(forFile: path))
-        }.value.image
+        let generation = fittedGeneration.withLock { $0 }
+        let decoded = await Task.detached(
+            priority: .userInitiated,
+            operation: { () -> Decoded in
+                guard FileManager.default.fileExists(atPath: path) else {
+                    return Decoded(image: nil)
+                }
+                return fittedIcon(forFile: path)
+            }
+        ).value
+        guard let image = decoded.image, !Task.isCancelled else { return nil }
+        return fittedGeneration.withLock { current in
+            guard current == generation else { return nil }
+            fittedCache.setObject(image, forKey: fittedKey(path), cost: decoded.cost)
+            return image
+        }
+    }
+
+    static func purgeFitted() {
+        fittedGeneration.withLock { generation in
+            generation &+= 1
+            fittedCache.removeAllObjects()
+        }
     }
 
     private static func fittedKey(_ path: String) -> NSString { ("fit:" + path) as NSString }
 
-    private static func fittedIcon(forFile path: String) -> NSImage {
-        let key = fittedKey(path)
-        if let cached = cache.object(forKey: key) { return cached }
+    private static func fittedIcon(forFile path: String) -> Decoded {
         let source = NSWorkspace.shared.icon(forFile: path)
         // Solving `side * extent == displayPixel * artworkExtent` leaves an app icon as-is.
         let extent = paintedExtent(source) ?? artworkExtent
@@ -121,8 +155,7 @@ enum IconCache {
         let inset = (displayPixel - side) / 2
         let (icon, cost) = rasterized(
             source, into: NSRect(x: inset, y: inset, width: side, height: side))
-        cache.setObject(icon, forKey: key, cost: cost)
-        return icon
+        return Decoded(image: icon, cost: cost)
     }
 
     /// The artwork's larger dimension, measured at 2×: a 1× grid over-reads the extent.

--- a/Tinycast/Platform/Images/IconCache.swift
+++ b/Tinycast/Platform/Images/IconCache.swift
@@ -1,6 +1,19 @@
 import AppKit
 import Synchronization
 
+struct IconCacheGeneration {
+    private(set) var value = 0
+
+    mutating func invalidate() {
+        value &+= 1
+    }
+
+    func publish<Value>(_ item: Value, capturedAt generation: Int, store: (Value) -> Void) -> Value {
+        if value == generation { store(item) }
+        return item
+    }
+}
+
 /// App icons by path, downsampled and byte-bounded, so rows don't re-hit `NSWorkspace`.
 enum IconCache {
     /// `NSCache` is thread-safe but not `Sendable`, so assert the guarantee once here.
@@ -21,7 +34,7 @@ enum IconCache {
         cache.totalCostLimit = 8 * 1024 * 1024
         return cache
     }()
-    private static let fittedGeneration = Mutex(0)
+    private static let fittedGeneration = Mutex(IconCacheGeneration())
 
     /// Cache-only lookups (never decode) so a row can paint an already-warm icon on the same frame.
     static func cached(forFile path: String) -> NSImage? { cache.object(forKey: path as NSString) }
@@ -120,7 +133,7 @@ enum IconCache {
     /// Like `loadAsync`, normalized so every file type paints to the same visual size.
     static func loadFittedAsync(forFile path: String) async -> NSImage? {
         if let cached = cachedFitted(forFile: path) { return cached }
-        let generation = fittedGeneration.withLock { $0 }
+        let generation = fittedGeneration.withLock { $0.value }
         let decoded = await Task.detached(
             priority: .userInitiated,
             operation: { () -> Decoded in
@@ -132,15 +145,15 @@ enum IconCache {
         ).value
         guard let image = decoded.image, !Task.isCancelled else { return nil }
         return fittedGeneration.withLock { current in
-            guard current == generation else { return nil }
-            fittedCache.setObject(image, forKey: fittedKey(path), cost: decoded.cost)
-            return image
+            current.publish(image, capturedAt: generation) { image in
+                fittedCache.setObject(image, forKey: fittedKey(path), cost: decoded.cost)
+            }
         }
     }
 
     static func purgeFitted() {
         fittedGeneration.withLock { generation in
-            generation &+= 1
+            generation.invalidate()
             fittedCache.removeAllObjects()
         }
     }

--- a/docs/features/file-search.md
+++ b/docs/features/file-search.md
@@ -14,7 +14,7 @@ feature is enabled in Settings.
 - **Everything under `Model/` stays Foundation-only and pure**, `FileSearchIgnoreList`'s `import Darwin`
   included. `file-search-test` compiles the shipped files together with the existing pure fuzzy scorer.
 - **Search is filename-only and on demand.** An empty query does no work and Tinycast creates no
-  content index, history, cache, watcher or search data.
+  content index, history, query cache, watcher or search data.
 - **Hidden paths and application-bundle contents are structural, not patterns.** They are what keeps
   the feature permission-free, so no user setting can re-admit them. Everything else that is dropped
   comes from the ignore list.
@@ -106,6 +106,10 @@ orders of magnitude, not budgets; rerun the benchmark after query-policy work.
 `FileSearchScreen.rows` is the exact flat selection order rendered by `FileSearchList`. The list uses
 the shared Results header, row metrics, edge dissolve, thin scrollbar and scroll intent. A row shows a
 fitted native file icon, the full filename, and its tilde-abbreviated parent path.
+
+Fitted row icons use a separate 8 MB transient cache. Leaving the list or hiding the palette purges it
+and invalidates in-flight decodes, so scrolling stays warm within one result set without retaining its
+icons after File Search closes. Persistent launcher icons remain in their own cache.
 
 - Return calls `FileSearchCoordinator.open`, hides the palette without restoring focus, and uses the
   asynchronous `NSWorkspace` configuration API. A failure goes through Tinycast's dialog controller.

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -209,7 +209,8 @@ execution semantics.
 The ranking harness covers prefix learning, frequency/recency scoring, persistence, and both reset
 paths; see the command in `development.md`.
 
-Icons go through a count-capped `NSCache` (`IconCache`).
+Launcher icons use a persistent 32 MB cost-capped `NSCache`. Fitted file-row icons use a separate
+transient 8 MB cache that is purged when its palette list disappears (`IconCache`).
 
 ## Reveal in Finder
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -248,6 +248,8 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Visible custom top-level home folders and cloud-drive files remain searchable
 - Return opens, Command-Return reveals in Finder, and Copy Path keeps the palette open with a HUD
 - Replacing a query quickly never lets an older result list overwrite the current query
+- A broad `.` search can be scrolled end to end; leaving it releases its fitted icons, and repeating the
+  cycle does not raise the post-close memory floor
 - Removing home and adding one folder narrows results to it; restoring the default brings them back
 - A cleared scope list returns nothing rather than falling back to home, and never hangs
 - A missing scope shows the warning triangle without failing the rest of the search

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -229,6 +229,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Locked rows cannot be checked; filtering by name works
 - Confirming moves items to the Trash and they are **recoverable from it**
 - Escaping mid-scan cancels promptly with no spinner left behind
+- Hiding and immediately restoring the screen never strands an in-flight file icon as a placeholder
 
 ### Quicklinks
 


### PR DESCRIPTION
## Summary

Follow-up to #222 that fixes retained icon memory after leaving File Search.

Scrolling through a broad result set materializes fitted native file icons. Those icons were stored in
the shared persistent `IconCache`, so closing File Search left most of that memory resident.

This change:

- gives fitted file-row icons their own cost-bounded 8 MB cache
- purges that cache when File Search or Uninstall disappears, or when the palette closes
- invalidates in-flight loads so a late decode cannot repopulate a purged cache
- still returns an in-flight decode to its active row, preventing it from getting stuck on a placeholder
- leaves the existing persistent launcher-icon cache unchanged

Uninstall is included because it is the other consumer of the fitted-icon API. Purging when its list
disappears keeps the shared cache lifecycle consistent when the user backs out without closing the
palette.

## Measurements

Measured with a broad `.` search, scrolling through the complete result list, then closing File Search:

| | Idle | Peak while visible | After closing |
| --- | ---: | ---: | ---: |
| Physical footprint before | 21 MB | 78 MB | 77 MB |
| Physical footprint after | 20 MB | 78 MB | 52 MB |
| RSS before | 86 MB | 168.7 MB | 168.5 MB |
| RSS after | 86.6 MB | 169 MB | 142.8 MB |

The peak is expected while the rows and icons are visible. After closing, CG image residency falls to
2.2 MB and CoreAnimation residency to 2.7 MB instead of keeping the icon-heavy peak alive.

`leaks` reported only about 14 KB in Apple framework/XPC cycles, so this was retained cache lifetime
rather than unreachable objects.

## Testing

- Added a deterministic harness covering cache invalidation during an in-flight decode
- Added manual regression coverage for leaving and immediately restoring Uninstall without stranding an
  in-flight icon on its placeholder
- All 23 standalone harnesses pass
- Debug build succeeds with no new source warnings
- `./Scripts/lint.sh` is clean with existing warnings only
- Model-layer purity check passes
- `git diff --check` passes
- Manually verified with a broad search and full scroll