### PR TITLE
Filter clipboard history by type

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -73,7 +73,8 @@ run file-search-session-test Tinycast/Platform/Signposts.swift \
 run ranking-test           $L/SearchRelevance.swift $L/LauncherRankingStore.swift
 run scopes-test            $L/SearchScopes.swift
 run calc-test              Tinycast/Features/Calculator/Model/*.swift
-run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
 run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift \
                            Tinycast/Features/Emoji/Model/EmojiData.generated.swift
@@ -85,6 +86,8 @@ run scroll-reveal-test     Tinycast/DesignSystem/Scrolling/SelectionReveal.swift
 run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Palette/PaletteState.swift \
                            Tinycast/Palette/PaletteMode.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
@@ -116,7 +119,8 @@ run snippets-test          Tinycast/Platform/NotificationToken.swift \
 run raycast-test           Tinycast/Features/Backup/Model/RaycastFormat.swift \
                            Tinycast/Features/Backup/Model/RaycastV1Decoder.swift \
                            Tinycast/Features/Backup/Service/Gunzip.swift \
-                           Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+                           Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
 run settings-backup-test   Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
 run settings-history-test  Tinycast/Features/Settings/SettingsTab.swift \

--- a/Tests/clipboard-test.swift
+++ b/Tests/clipboard-test.swift
@@ -13,6 +13,9 @@ struct ClipboardTests {
         pasteLeavesPinsAlone()
         pinsSurvivePruningAndTheWindow()
         pinsLeadFilteredSearches()
+        textFormClassification()
+        typeFilterSplitsTheHistory()
+        typeFilterJoinsTheSearchMemo()
         persistence()
         migrationFromShippedDatabase()
 
@@ -125,7 +128,7 @@ struct ClipboardTests {
             _ = store.importEntries(seed)
             store.togglePinned(item(store, "needle in the haystack"))
 
-            let results = store.search("haystack")
+            let results = store.search("haystack", filter: .all)
             expect(results.count > 200, "FTS results plus the pinned block")
             expect(
                 results.first?.text == "needle in the haystack",
@@ -133,10 +136,86 @@ struct ClipboardTests {
             expect(
                 results.filter(\.isPinned).count == 1, "the pinned row is not duplicated")
 
-            let short = store.search("ne")  // below the trigram threshold: the fallback path
+            // Below the trigram threshold: the fallback path.
+            let short = store.search("ne", filter: .all)
             expect(
                 short.first?.text == "needle in the haystack",
                 "the pinned match leads the fallback search too")
+        }
+    }
+
+    /// The link/address classifier, including the filenames that must not read as links.
+    static func textFormClassification() {
+        let links = [
+            "https://apple.com", "http://apple.com/path?q=1", "apple.com", "apple.com/store",
+            "www.Apple.com", "vscode://file/tmp/x", "docs.google.com", "bit.ly/abc"
+        ]
+        for text in links {
+            expect(form(text) == .link, "\(text) is a link")
+        }
+
+        let addresses = ["hi@apple.com", "mailto:hi@apple.com", "first.last@mail.example.co.uk"]
+        for text in addresses {
+            expect(form(text) == .email, "\(text) is an address")
+        }
+
+        let plain = [
+            // Extensions that collide with a real TLD are the whole reason for the TLD set.
+            "report.pdf", "index.html", "App.swift", "data.json", "Safari.app", "image.png",
+            "hello world", "visit apple.com today", "3.14", "", "   ", "no-dot-at-all",
+            "two@at@signs.com", "@apple.com", "hi@localhost", "line one\nline two"
+        ]
+        for text in plain {
+            expect(form(text) == .plain, "\(String(text.prefix(20))) is plain text")
+        }
+
+        // Past the scan cap, so a multi-MB copy is never walked looking for a scheme.
+        expect(
+            form("https://apple.com/" + String(repeating: "a", count: 4096)) == .plain,
+            "an over-long token is plain by definition")
+
+        expect(
+            ClipboardItem(imagePath: "/tmp/x.png", sourceBundleID: nil).textForm == nil,
+            "an image has no text form")
+    }
+
+    /// Each filter returns only its own kind, and a pin still leads the block.
+    static func typeFilterSplitsTheHistory() {
+        withStore { store, _ in
+            store.addText("just some prose", sourceBundleID: nil)
+            store.addText("https://apple.com", sourceBundleID: nil)
+            store.addText("hi@apple.com", sourceBundleID: nil)
+            store.addText("second.link.dev", sourceBundleID: nil)
+
+            expect(texts(store).count == 4, "every entry under All Types")
+            expect(texts(store, filter: .text) == ["just some prose"], "text excludes links")
+            expect(
+                texts(store, filter: .link) == ["second.link.dev", "https://apple.com"],
+                "links stay newest-first")
+            expect(texts(store, filter: .email) == ["hi@apple.com"], "addresses on their own")
+            expect(texts(store, filter: .image).isEmpty, "no images were captured")
+
+            store.togglePinned(item(store, "https://apple.com"))
+            expect(
+                texts(store, filter: .link) == ["https://apple.com", "second.link.dev"],
+                "a pinned link leads its filtered block")
+        }
+    }
+
+    /// The memo keys on the filter too: same query, new filter, different rows.
+    static func typeFilterJoinsTheSearchMemo() {
+        withStore { store, _ in
+            store.addText("shared token prose", sourceBundleID: nil)
+            store.addText("shared-token.com", sourceBundleID: nil)
+
+            expect(store.search("shared", filter: .all).count == 2, "both match the query")
+            expect(
+                store.search("shared", filter: .link).map(\.text) == ["shared-token.com"],
+                "the same query under a link filter is not served from the wider memo")
+            expect(
+                store.search("shared", filter: .text).map(\.text) == ["shared token prose"],
+                "and switching filters again re-runs rather than reusing")
+            expect(store.search("shared", filter: .all).count == 2, "back to both")
         }
     }
 
@@ -253,14 +332,18 @@ struct ClipboardTests {
         return Set(String(decoding: data, as: UTF8.self).split(separator: "\n").map(String.init))
     }
 
+    static func form(_ text: String) -> ClipboardItem.TextForm? {
+        ClipboardItem(text: text, sourceBundleID: nil).textForm
+    }
+
     static func entry(_ text: String, at date: Date) -> ClipboardItem {
         ClipboardItem(
             id: UUID(), kind: .text, text: text, imagePath: nil, createdAt: date,
             sourceBundleID: nil)
     }
 
-    static func texts(_ store: ClipboardStore) -> [String] {
-        store.search("").compactMap(\.text)
+    static func texts(_ store: ClipboardStore, filter: ClipboardFilter = .all) -> [String] {
+        store.search("", filter: filter).compactMap(\.text)
     }
 
     static func item(_ store: ClipboardStore, _ text: String) -> ClipboardItem {

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0360C7038877B9CB656DB697 /* WindowManagementSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21678BAD7BA4A4E300FDA2C /* WindowManagementSettingsView.swift */; };
 		03C41F6394089BAEC7E630D6 /* ClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF6EF3A2C35F45B82D40968 /* ClipboardView.swift */; };
 		07726F26DC68689F8984F467 /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D0784E49BC5899A585F285 /* Scrypt.swift */; };
+		0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395BACF833C810961A248F0 /* BarButton.swift */; };
 		089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ABE4AF80DD5F5F8E91F63E /* SpotlightNames.swift */; };
 		0B9C941402B85C69A33200C2 /* UninstallProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A48095F6487DEE76663F88 /* UninstallProtection.swift */; };
 		0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42664C60B760276FBAAD61 /* EmojiSettingsView.swift */; };
@@ -35,6 +36,7 @@
 		1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802BD2F4CC057228F2528217 /* PalettePlacement.swift */; };
 		1CA10DE219BAB97BFC29E54A /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */; };
 		1F1AD34A26931AF6E11E13F7 /* VolumeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B962318915EF7AEAC4996D /* VolumeState.swift */; };
+		1F8F2135470F74627A644ACC /* ClipboardFilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */; };
 		208FFC22E116E53E7BF3D147 /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF9F16C3F5567240FF03122 /* CalcQuantity.swift */; };
 		22420E8A41685143315904F5 /* RaycastImportSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B711492A6DA473E6DC9646C /* RaycastImportSelection.swift */; };
 		22EE4D5AFAAA12E649666019 /* PermissionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C7D17F97002FD58E8A5F53 /* PermissionsSettingsView.swift */; };
@@ -162,6 +164,7 @@
 		ACB45791BFE60896455293B4 /* FileSearchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC86115B040B8C574EAD0B5 /* FileSearchPolicy.swift */; };
 		ACD8CAE659B1C49EC8652576 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AD346C8FD5F2D4F00FF2B6 /* HotKeyCenter.swift */; };
 		ACE645630E536C93CA102050 /* VolumeHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90559D7DB9F6F3874CAFCDE /* VolumeHUDView.swift */; };
+		AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */; };
 		AD98F015439106F0E9D32015 /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */; };
 		ADE29D44A9504AC24FC17E72 /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A97022BE0F95B5D19F0C26 /* CalcDateTime.swift */; };
 		AE3144FCC55FADC48955D17A /* KeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E16AEF81320A101E384098E /* KeyShortcut.swift */; };
@@ -296,6 +299,7 @@
 		3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
 		418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideView.swift; sourceTree = "<group>"; };
 		418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
+		4395BACF833C810961A248F0 /* BarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarButton.swift; sourceTree = "<group>"; };
 		43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyAction.swift; sourceTree = "<group>"; };
 		445B0374FD5D74DBE23243CD /* PaletteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteScreen.swift; sourceTree = "<group>"; };
 		45D4BA6E1BD8EB1F96A8927F /* Tinycast.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tinycast.entitlements; sourceTree = "<group>"; };
@@ -325,6 +329,7 @@
 		658C57A4CE41C0FA80BBE41D /* RaycastImportV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV1.swift; sourceTree = "<group>"; };
 		6621A88681E993D49EEF07A3 /* tinycast.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = tinycast.icon; sourceTree = "<group>"; };
 		67B6CA2ED2DDD9A89C7EE874 /* EmojiScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiScreen.swift; sourceTree = "<group>"; };
+		682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardFilter.swift; sourceTree = "<group>"; };
 		685FB7FD7E4E5BE6606440D0 /* QuicklinkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkStore.swift; sourceTree = "<group>"; };
 		6C045C66BB654E4CB407A673 /* AppActionsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActionsMenu.swift; sourceTree = "<group>"; };
 		71B96B69CB4E52319BB3EC7D /* FileSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchService.swift; sourceTree = "<group>"; };
@@ -397,6 +402,7 @@
 		B235DFF451FF4D52A8E44D00 /* ShortcutCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureSession.swift; sourceTree = "<group>"; };
 		B3C7D17F97002FD58E8A5F53 /* PermissionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsSettingsView.swift; sourceTree = "<group>"; };
 		B40049CE320BEE3A4388CDFF /* CustomCommandEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandEditorSheet.swift; sourceTree = "<group>"; };
+		B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardFilterButton.swift; sourceTree = "<group>"; };
 		B6A6748260B2DF011CCAFCEF /* ThinScrollbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinScrollbar.swift; sourceTree = "<group>"; };
 		B6A96350EBE68EC79497FA2D /* AppPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPaths.swift; sourceTree = "<group>"; };
 		B6BE90FB09366A3518C2D4E5 /* EmojiData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiData.generated.swift; sourceTree = "<group>"; };
@@ -600,6 +606,7 @@
 			children = (
 				6F218021C90FC685A2DF21CE /* Interaction */,
 				16F1DA610F3D792F6B08AFE5 /* Scrolling */,
+				4395BACF833C810961A248F0 /* BarButton.swift */,
 				C5BA06E4CC7E8D40E3285F16 /* KeyCapChip.swift */,
 				4FAE24CC14F7DFECD1BD7FB1 /* PopoverMenu.swift */,
 				BEDDA8820165672AF8464E25 /* SettingsComponents.swift */,
@@ -647,6 +654,7 @@
 			isa = PBXGroup;
 			children = (
 				E5B89168050723B7221F04A2 /* ClipboardCoordinator.swift */,
+				B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */,
 				548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */,
 				FBF6EF3A2C35F45B82D40968 /* ClipboardView.swift */,
 			);
@@ -1280,6 +1288,7 @@
 		FE2191441B39CE41CC3052ED /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */,
 				201FCD08ACA933378876385B /* ClipboardStore.swift */,
 			);
 			path = Model;
@@ -1374,6 +1383,7 @@
 				BD45A99F26C015BF00AC77D5 /* ApplicationsSettingsView.swift in Sources */,
 				A0A247FFDB1EA278C0F6F813 /* BackupActions.swift in Sources */,
 				4549280508130B232069071E /* BackupSettingsView.swift in Sources */,
+				0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */,
 				B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */,
 				ADE29D44A9504AC24FC17E72 /* CalcDateTime.swift in Sources */,
 				309B1313B6B40D1342362492 /* CalcEngine.swift in Sources */,
@@ -1390,6 +1400,8 @@
 				279F586CC34205EBA8ACA892 /* CalloutPlacement.swift in Sources */,
 				80E77985425032856DEECDFD /* CalloutShape.swift in Sources */,
 				A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */,
+				AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */,
+				1F8F2135470F74627A644ACC /* ClipboardFilterButton.swift in Sources */,
 				A64891F5587F2C11E4A2E2D2 /* ClipboardManager.swift in Sources */,
 				935F7433BB0C0ECDE6FA3BF3 /* ClipboardScreen.swift in Sources */,
 				D4A45373662D6658706E4DA4 /* ClipboardSettingsView.swift in Sources */,

--- a/Tinycast/DesignSystem/BarButton.swift
+++ b/Tinycast/DesignSystem/BarButton.swift
@@ -1,19 +1,38 @@
 import SwiftUI
 
-/// A palette bar control: bare label at rest, a faint capsule fill on hover.
+/// A bar control's hover chrome. The footer's buttons are capsules; one that opens a menu takes
+/// that menu's own corner instead, so the control and what it opens read as one piece.
+enum BarButtonChrome {
+    case capsule
+    case menu
+
+    var shape: AnyShape {
+        switch self {
+        case .capsule:
+            return AnyShape(Capsule())
+        case .menu:
+            return AnyShape(
+                RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous))
+        }
+    }
+}
+
+/// A palette bar control: bare label at rest, a faint fill on hover.
 /// Hover lives here, so a sweep across one never re-renders the view that owns it.
 struct BarButton<Label: View>: View {
+    var chrome: BarButtonChrome = .capsule
     let action: () -> Void
     @ViewBuilder let label: Label
     @State private var hovered = false
 
     var body: some View {
-        Button(action: action) {
+        let shape = chrome.shape
+        return Button(action: action) {
             label
                 .padding(.horizontal, Theme.Spacing.md)
                 .frame(height: Theme.Size.barButtonHeight)
-                .contentShape(Capsule())
-                .background(Capsule().fill(hovered ? Theme.Colors.rowHover : Color.clear))
+                .contentShape(shape)
+                .background(shape.fill(hovered ? Theme.Colors.rowHover : Color.clear))
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }

--- a/Tinycast/DesignSystem/BarButton.swift
+++ b/Tinycast/DesignSystem/BarButton.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// A palette bar control: bare label at rest, a faint capsule fill on hover.
+/// Hover lives here, so a sweep across one never re-renders the view that owns it.
+struct BarButton<Label: View>: View {
+    let action: () -> Void
+    @ViewBuilder let label: Label
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            label
+                .padding(.horizontal, Theme.Spacing.md)
+                .frame(height: Theme.Size.barButtonHeight)
+                .contentShape(Capsule())
+                .background(Capsule().fill(hovered ? Theme.Colors.rowHover : Color.clear))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+    }
+}

--- a/Tinycast/DesignSystem/PopoverMenu.swift
+++ b/Tinycast/DesignSystem/PopoverMenu.swift
@@ -53,6 +53,8 @@ struct PopoverMenu: View {
     var header: String?
     let items: [PopoverMenuItem]
     @Binding var selection: Int
+    /// Fixed, never intrinsic: a menu whose width tracked its longest row would jitter as it changes.
+    var width: CGFloat = Theme.Size.menuWidth
     let onActivate: (Int) -> Void
 
     var body: some View {
@@ -78,7 +80,7 @@ struct PopoverMenu: View {
             }
         }
         .padding(Theme.Spacing.sm)
-        .frame(width: Theme.Size.menuWidth)
+        .frame(width: width)
         // Glass carries its own elevation, so a drop shadow on top reads heavy.
         .glassEffect(
             .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -54,6 +54,8 @@ enum Theme {
         static let dropGuideDash: CGFloat = 4
         static let dropGuideWidth: CGFloat = 2
         static let bottomBarHeight: CGFloat = 52
+        /// A `BarButton`'s hover capsule, shared by the footer group and the header's filter.
+        static let barButtonHeight: CGFloat = 28
         static let rowIcon: CGFloat = 24
         static let keyCap: CGFloat = 18
         /// Settings shortcut-recorder keycap — smaller than the palette's `keyCap` chip.
@@ -80,6 +82,8 @@ enum Theme {
         static let clipboardListWidth: CGFloat = 290
         static let emojiCell: CGFloat = 56
         static let menuWidth: CGFloat = 276
+        /// The clipboard type filter's menu; `menuWidth` is far too wide for five short rows.
+        static let clipboardFilterMenuWidth: CGFloat = 200
         /// A menu row's glyph slot, sized so symbol and app-icon rows read the same.
         static let menuIcon: CGFloat = 20
         /// Opening size and the resize floor; tall enough that the sidebar's rows never scroll.
@@ -142,6 +146,8 @@ enum Theme {
         static let compactKeyCap = Font.caption2
         static let heroKeyCap = Font.body
         static let bar = Font.callout.weight(.medium)
+        /// A dropdown control's trailing chevron, deliberately smaller than the label it follows.
+        static let disclosure = Font.caption.weight(.semibold)
         static let menuRow = Font.body
         static let menuShortcut = Font.callout
         static let menuIcon = Font.body

--- a/Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// The clipboard list's type filter. See docs/features/clipboard.md#type-filter.
+enum ClipboardFilter: CaseIterable, Sendable {
+    case all
+    case text
+    case image
+    case link
+    case email
+
+    var title: String {
+        switch self {
+        case .all: return "All Types"
+        case .text: return "Text Only"
+        case .image: return "Images Only"
+        case .link: return "Links Only"
+        case .email: return "Emails Only"
+        }
+    }
+
+    /// Also the header button's glyph, so it states the active filter without opening the menu.
+    var systemImage: String {
+        switch self {
+        case .all: return "list.bullet"
+        case .text: return "textformat"
+        case .image: return "photo"
+        case .link: return "link"
+        case .email: return "at"
+        }
+    }
+
+    /// What an empty list says, so a filter hiding every entry explains itself.
+    var emptyMessage: String {
+        switch self {
+        case .all: return "Clipboard history is empty"
+        case .text: return "No text in clipboard history"
+        case .image: return "No images in clipboard history"
+        case .link: return "No links in clipboard history"
+        case .email: return "No email addresses in clipboard history"
+        }
+    }
+
+    /// The five are exclusive: a copied URL is a link rather than a narrower kind of text.
+    func matches(_ item: ClipboardItem) -> Bool {
+        switch self {
+        case .all: return true
+        case .image: return item.kind == .image
+        case .text: return item.textForm == .plain
+        case .link: return item.textForm == .link
+        case .email: return item.textForm == .email
+        }
+    }
+
+    /// Identity for `all`, so an unfiltered list never pays for a copy.
+    func apply(to items: [ClipboardItem]) -> [ClipboardItem] {
+        self == .all ? items : items.filter(matches)
+    }
+}
+
+extension ClipboardItem {
+    /// What a text entry holds; `Kind` says how an entry is stored, this says what it is.
+    enum TextForm: Sendable {
+        case plain
+        case link
+        case email
+    }
+
+    /// Derived and never persisted, so reclassifying is a code change rather than a migration.
+    var textForm: TextForm? {
+        guard kind == .text, let text else { return nil }
+        return Self.classify(text)
+    }
+
+    /// A link or an address is one short token, so anything longer is prose by definition.
+    private static let detectionLimit = 2048
+
+    /// A scheme-less link needs a TLD people actually copy, or every `report.pdf` reads as one.
+    private static let commonTopLevelDomains: Set<String> = [
+        "com", "org", "net", "edu", "gov", "io", "co", "ai", "app", "dev", "me", "info", "biz",
+        "xyz", "tv", "ly", "gg", "to", "uk", "us", "eu", "de", "fr", "es", "it", "nl", "se", "no",
+        "fi", "dk", "ch", "at", "be", "ie", "cz", "ru", "ua", "tr", "cn", "jp", "kr", "hk", "sg",
+        "au", "nz", "ca", "mx", "br", "ar", "za"
+    ]
+
+    private static func classify(_ text: String) -> TextForm {
+        // `utf8.count` is O(1); `count` would walk graphemes across a multi-MB copy.
+        guard text.utf8.count <= detectionLimit else { return .plain }
+        let token = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty, !token.contains(where: \.isWhitespace) else { return .plain }
+        if let form = schemeForm(of: token) { return form }
+        if isAddress(token) { return .email }
+        return isBareDomain(token) ? .link : .plain
+    }
+
+    /// `mailto:` is an address; any other `scheme://` is a link, so `vscode://` needs no allowlist.
+    private static func schemeForm(of token: String) -> TextForm? {
+        if token.range(of: "mailto:", options: [.caseInsensitive, .anchored]) != nil {
+            return .email
+        }
+        guard let separator = token.range(of: "://") else { return nil }
+        let scheme = token[token.startIndex..<separator.lowerBound]
+        guard !scheme.isEmpty,
+            scheme.allSatisfy({ $0.isASCII && ($0.isLetter || $0 == "+" || $0 == "-" || $0 == ".") })
+        else { return nil }
+        return .link
+    }
+
+    /// `local@domain.tld`: one `@`, a non-empty local part, and a host-shaped domain.
+    private static func isAddress(_ token: String) -> Bool {
+        let parts = token.split(separator: "@", omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty else { return false }
+        return topLevelLabel(of: parts[1]) != nil
+    }
+
+    /// A heuristic, and deliberately so: its worst case files a row under the wrong type.
+    private static func isBareDomain(_ token: String) -> Bool {
+        let host = token.prefix { !"/?#:".contains($0) }
+        if host.range(of: "www.", options: [.caseInsensitive, .anchored]) != nil { return true }
+        // Hosts are canonically lower case, which is what keeps `Safari.app` out of the links.
+        guard !host.contains(where: \.isUppercase), let tld = topLevelLabel(of: host) else {
+            return false
+        }
+        return commonTopLevelDomains.contains(String(tld))
+    }
+
+    /// The last label of a host, or nil unless every label is one — which is what rejects
+    /// an address-shaped token like `@apple.com` before it can read as a bare domain.
+    private static func topLevelLabel(of host: Substring) -> Substring? {
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.count >= 2, labels.allSatisfy(isHostLabel), let tld = labels.last,
+            tld.count >= 2, tld.allSatisfy({ $0.isASCII && $0.isLetter })
+        else { return nil }
+        return tld
+    }
+
+    private static func isHostLabel(_ label: Substring) -> Bool {
+        !label.isEmpty && label.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+    }
+}

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -102,7 +102,8 @@ final class ClipboardStore {
     var maxAge: TimeInterval = ClipboardRetention.threeMonths.maxAge
 
     /// One-entry memo so repeated renders reuse the FTS result; cleared when `items` changes.
-    @ObservationIgnored private var searchCache: (query: String, result: [ClipboardItem])?
+    @ObservationIgnored private var searchCache:
+        (query: String, filter: ClipboardFilter, result: [ClipboardItem])?
     /// Same memo for the empty query, so the pinned split runs once per mutation.
     @ObservationIgnored private var orderedCache: [ClipboardItem]?
 
@@ -279,20 +280,28 @@ final class ClipboardStore {
         return URL(fileURLWithPath: path)
     }
 
-    /// Display order for `query`: pinned entries first, each block newest-first.
-    func search(_ query: String) -> [ClipboardItem] {
+    /// Display order for `query` under `filter`: pinned entries first, each block newest-first.
+    func search(_ query: String, filter: ClipboardFilter) -> [ClipboardItem] {
         let q = query.trimmingCharacters(in: .whitespaces)
-        guard !q.isEmpty else { return orderedItems }
-        if let searchCache, searchCache.query == q { return searchCache.result }
-        // Pins are matched in memory: all resident, and the LIMIT would otherwise drop one.
-        let result = pinnedItems.filter { $0.matches(q) } + runSearch(q).filter { !$0.isPinned }
-        searchCache = (q, result)
+        // The filter joins the key: `rows` rebuilds per render, so a query-only memo goes stale.
+        if let searchCache, searchCache.query == q, searchCache.filter == filter {
+            return searchCache.result
+        }
+        // Filtering after the split leaves a matching pin in the Pinned section, in pin order.
+        let result = filter.apply(to: unfiltered(q))
+        searchCache = (q, filter, result)
         return result
     }
 
-    /// Row index of `item` for `query`, so the palette can follow a row that moved.
-    func rowIndex(of item: ClipboardItem, in query: String) -> Int? {
-        search(query).firstIndex { $0.id == item.id }
+    /// Row index of `item` as currently listed, so the palette can follow a row that moved.
+    func rowIndex(of item: ClipboardItem, in query: String, filter: ClipboardFilter) -> Int? {
+        search(query, filter: filter).firstIndex { $0.id == item.id }
+    }
+
+    private func unfiltered(_ q: String) -> [ClipboardItem] {
+        guard !q.isEmpty else { return orderedItems }
+        // Pins are matched in memory: all resident, and the LIMIT would otherwise drop one.
+        return pinnedItems.filter { $0.matches(q) } + runSearch(q).filter { !$0.isPinned }
     }
 
     private func runSearch(_ q: String) -> [ClipboardItem] {

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -78,6 +78,8 @@ final class ClipboardCoordinator {
 
     /// Select `item`'s row as currently filtered; a moved row isn't always index 0.
     private func selectClip(_ item: ClipboardItem) {
-        palette.selection = clipboardStore.rowIndex(of: item, in: palette.query) ?? 0
+        palette.selection =
+            clipboardStore.rowIndex(
+                of: item, in: palette.query, filter: palette.clipboardFilter) ?? 0
     }
 }

--- a/Tinycast/Features/Clipboard/UI/ClipboardFilterButton.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardFilterButton.swift
@@ -7,7 +7,7 @@ struct ClipboardFilterButton: View {
     let action: () -> Void
 
     var body: some View {
-        BarButton(action: action) {
+        BarButton(chrome: .menu, action: action) {
             HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: filter.systemImage)
                     .font(Theme.Typography.bar)

--- a/Tinycast/Features/Clipboard/UI/ClipboardFilterButton.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardFilterButton.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// The clipboard header's type filter control: it states the active filter and toggles its menu.
+struct ClipboardFilterButton: View {
+    let filter: ClipboardFilter
+    let isOpen: Bool
+    let action: () -> Void
+
+    var body: some View {
+        BarButton(action: action) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: filter.systemImage)
+                    .font(Theme.Typography.bar)
+                    .symbolRenderingMode(.hierarchical)
+                Text(filter.title)
+                    .font(Theme.Typography.bar)
+                    .lineLimit(1)
+                // Points at the menu it opens, the way a native pop-up's chevron does.
+                Image(systemName: isOpen ? "chevron.up" : "chevron.down")
+                    .font(Theme.Typography.disclosure)
+            }
+            .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .help("Filter by type  ⌘P")
+    }
+}

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -8,7 +8,7 @@ struct ClipboardScreen: PaletteScreen {
     let openActions: () -> Void
     let scrollToFollow: () -> Void
 
-    var rows: [ClipboardItem] { store.search(vm.query) }
+    var rows: [ClipboardItem] { store.search(vm.query, filter: vm.clipboardFilter) }
 
     var primaryActionTitle: String { vm.pasteTarget?.pasteTitle ?? "Paste" }
 
@@ -42,7 +42,7 @@ struct ClipboardScreen: PaletteScreen {
         return true
     }
 
-    /// ⌘P — mirrors the Actions menu row; pinning lifts the row into the Pinned section.
+    /// ⌘. — mirrors the Actions menu row; pinning lifts the row into the Pinned section.
     func pin(at selection: Int) -> Bool {
         guard let item = item(at: selection) else { return false }
         core.clipboardCoordinator.togglePinnedClip(item)
@@ -88,7 +88,8 @@ struct ClipboardScreen: PaletteScreen {
         let rows = rows
         // Empty history: centre one message across the panel, not in the list column.
         if rows.isEmpty {
-            EmptyResults(text: "Clipboard history is empty")
+            // Names the filter, so one hiding every entry doesn't read as an empty history.
+            EmptyResults(text: vm.clipboardFilter.emptyMessage)
         } else {
             let selected = item(at: selection)
             HStack(spacing: 0) {
@@ -144,12 +145,12 @@ enum ClipboardActionsMenu {
         ]
         if item.isPinned {
             items.append(
-                PopoverMenuItem(title: "Unpin Entry", systemImage: "pin.slash", shortcut: "⌘P") {
+                PopoverMenuItem(title: "Unpin Entry", systemImage: "pin.slash", shortcut: "⌘.") {
                     core.clipboardCoordinator.togglePinnedClip(item)
                 })
         } else {
             items.append(
-                PopoverMenuItem(title: "Pin Entry", systemImage: "pin", shortcut: "⌘P") {
+                PopoverMenuItem(title: "Pin Entry", systemImage: "pin", shortcut: "⌘.") {
                     core.clipboardCoordinator.togglePinnedClip(item)
                 })
         }

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
@@ -39,7 +39,7 @@ struct QuicklinkListScreen: PaletteScreen {
         return true
     }
 
-    /// ⌘P — mirrors the Actions menu row; pinning lifts the row into the Pinned section.
+    /// ⌘. — mirrors the Actions menu row; pinning lifts the row into the Pinned section.
     func pin(at selection: Int) -> Bool {
         guard let quicklink = quicklink(at: selection) else { return false }
         core.quicklinkCoordinator.toggleQuicklinkPinned(id: quicklink.id)
@@ -111,10 +111,10 @@ enum QuicklinkActionsMenu {
             })
         items.append(
             quicklink.isPinned
-                ? PopoverMenuItem(title: "Unpin Quicklink", systemImage: "pin.slash", shortcut: "⌘P") {
+                ? PopoverMenuItem(title: "Unpin Quicklink", systemImage: "pin.slash", shortcut: "⌘.") {
                     core.quicklinkCoordinator.toggleQuicklinkPinned(id: quicklink.id)
                 }
-                : PopoverMenuItem(title: "Pin Quicklink", systemImage: "pin", shortcut: "⌘P") {
+                : PopoverMenuItem(title: "Pin Quicklink", systemImage: "pin", shortcut: "⌘.") {
                     core.quicklinkCoordinator.toggleQuicklinkPinned(id: quicklink.id)
                 })
         items.append(

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -7,6 +7,8 @@ final class PaletteState {
     var mode: PaletteMode = .launcher
     var query: String = ""
     var selection: Int = 0
+    /// The clipboard screen's type filter, reset with the rest of the screen state on each summon.
+    var clipboardFilter: ClipboardFilter = .all
     /// Changes every time the palette is shown so the search field can re-focus.
     var focusToken = UUID()
     /// Bumped only by `prepare`, so lists snap to the top even when nothing else changed.
@@ -35,6 +37,7 @@ final class PaletteState {
         self.mode = mode
         query = ""
         selection = 0
+        clipboardFilter = .all
         forceExpanded = false
         dropHoverHighlight()
         menuOpen = false

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -15,6 +15,9 @@ final class PaletteState {
     var resetToken = UUID()
     /// Bumped when an action reorders the list, so the highlight scrolls back into view.
     var followToken = UUID()
+    /// Bumped when the panel intercepts ⌘.. AppKit binds that chord to `cancelOperation:`, so the
+    /// field editor eats it before `onKeyPress`; the screen still owns which row it pins.
+    private(set) var pinChordToken = UUID()
     /// Set by the compact bar's overflow to expand without a query; cleared by `prepare`.
     var forceExpanded = false
     /// The paste target, mirrored on every show; `prepare` resets the screen, not this.
@@ -43,6 +46,10 @@ final class PaletteState {
         menuOpen = false
         focusToken = UUID()
         resetToken = UUID()
+    }
+
+    func notePinChord() {
+        pinChordToken = UUID()
     }
 
     /// The pointer moved, which re-lights the highlight once it has cleared the arming slop.

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -246,6 +246,10 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             case ",":
                 self.core.settingsCoordinator.showSettings()
                 return true
+            // Pin. Swallowed on every screen, since ⌘. only ever means cancel to a search field.
+            case ".":
+                self.core.palette.notePinChord()
+                return true
             case "w":
                 self.core.paletteCoordinator.hidePalette()
                 return true

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -18,11 +18,11 @@ struct RootPaletteView: View {
     @Environment(QuicklinkArgumentSession.self) private var quicklinkArguments
     @Environment(AppSettings.self) private var settings
     @FocusState private var searchFocused: Bool
-    @State private var showActions = false
-    @State private var showAppMenu = false
+    /// Which in-window menu is open; at most one, so the state cannot disagree with itself.
+    @State private var openMenu: OpenMenu?
     /// Sampled once by `openActions`, so the Quit row can't appear while the menu is up.
     @State private var selectionIsRunning = false
-    /// Highlighted row of whichever menu is open; reset to the first row on open.
+    /// Highlighted row of whichever menu is open; each open path sets where it starts.
     @State private var menuSelection = 0
     /// The pending scroll request; modes are exclusive, so one piece of state serves all.
     @State private var scroll = ScrollIntent(kind: .top)
@@ -76,7 +76,7 @@ struct RootPaletteView: View {
         selection(count: screen.rows.count)
     }
 
-    private var menuOpen: Bool { showActions || showAppMenu }
+    private var menuOpen: Bool { openMenu != nil }
 
     // MARK: - Popover menu content
 
@@ -84,6 +84,16 @@ struct RootPaletteView: View {
     private var actionsContent: PopoverMenuContent? {
         let screen = screen
         return screen.actions(at: selection(in: screen))
+    }
+
+    /// The clipboard type filter's rows; activating one is the only way the filter changes.
+    private var clipboardFilterContent: PopoverMenuContent {
+        PopoverMenuContent(
+            items: ClipboardFilter.allCases.map { filter in
+                PopoverMenuItem(title: filter.title, systemImage: filter.systemImage) {
+                    vm.clipboardFilter = filter
+                }
+            })
     }
 
     /// The bottom-left app menu content (About / Settings).
@@ -98,11 +108,14 @@ struct RootPaletteView: View {
         ])
     }
 
-    /// Whichever menu is open; the two are mutually exclusive, Actions taking precedence.
+    /// Whichever menu is open — the one source `moveMenu` and `activateMenuItem` address rows through.
     private var menuContent: PopoverMenuContent? {
-        if showActions { return actionsContent }
-        if showAppMenu { return appMenuContent }
-        return nil
+        switch openMenu {
+        case .actions: return actionsContent
+        case .app: return appMenuContent
+        case .clipboardFilter: return clipboardFilterContent
+        case nil: return nil
+        }
     }
 
     var body: some View {
@@ -133,14 +146,14 @@ struct RootPaletteView: View {
         .overlay(alignment: .top) { topDragStrip }
         // In-window overlays, so a menu stays clipped inside the panel.
         .overlay {
-            if showAppMenu || showActions {
+            if menuOpen {
                 Color.black.opacity(0.001)
                     .contentShape(Rectangle())
                     .onTapGesture(perform: closeMenus)
             }
         }
         .overlay(alignment: .bottomLeading) {
-            if showAppMenu {
+            if openMenu == .app {
                 let content = appMenuContent
                 PopoverMenu(
                     header: content.header, items: content.items, selection: $menuSelection,
@@ -151,13 +164,27 @@ struct RootPaletteView: View {
             }
         }
         .overlay(alignment: .bottomTrailing) {
-            if showActions, let content = actionsContent {
+            if openMenu == .actions, let content = actionsContent {
                 PopoverMenu(
                     header: content.header, items: content.items, selection: $menuSelection,
                     onActivate: activateMenuItem
                 )
                 .padding(Self.menuInset)
                 .transition(Self.menuTransition(.bottomTrailing))
+            }
+        }
+        // Hangs off the header's filter button rather than a corner, so it needs the header's metrics.
+        .overlay(alignment: .topTrailing) {
+            if openMenu == .clipboardFilter {
+                let content = clipboardFilterContent
+                PopoverMenu(
+                    items: content.items, selection: $menuSelection,
+                    width: Theme.Size.clipboardFilterMenuWidth, onActivate: activateMenuItem
+                )
+                .padding(.top, Theme.Size.headerPadding + Theme.Size.headerHeight)
+                // Right edges flush with the button's, which sits inside the same trailing gutter.
+                .padding(.trailing, Theme.Spacing.md * 2)
+                .transition(Self.menuTransition(.topTrailing))
             }
         }
         // The window's frame is the size source, so the glass and clip stay matched.
@@ -168,17 +195,22 @@ struct RootPaletteView: View {
         // Every show bumps focusToken: refocus search and drop any menu left open.
         .onChange(of: vm.focusToken) {
             searchFocused = true
-            showActions = false
-            showAppMenu = false
+            openMenu = nil
         }
         .onChange(of: vm.query) {
             vm.selection = 0
             scroll = ScrollIntent(kind: .top)
             if vm.mode == .fileSearch { fileSearch.search(vm.query) }
         }
+        // A narrower list means the old index points at a different row, or at none.
+        .onChange(of: vm.clipboardFilter) {
+            vm.selection = 0
+            scroll = ScrollIntent(kind: .top)
+        }
         .onChange(of: vm.mode) {
             vm.selection = 0
-            showActions = false
+            vm.clipboardFilter = .all
+            openMenu = nil
             scroll = ScrollIntent(kind: .top)
             // Every way out of the Uninstall screen: back chevron, bare backspace, a fresh summon.
             if vm.mode != .uninstall { uninstall.cancel() }
@@ -190,19 +222,8 @@ struct RootPaletteView: View {
         .onChange(of: vm.resetToken) {
             scroll = ScrollIntent(kind: .top)
         }
-        // Opening either menu closes the other, so exactly one is open and highlighted.
-        .onChange(of: showActions) {
-            if showActions {
-                showAppMenu = false
-                menuSelection = 0
-            }
-            vm.menuOpen = menuOpen
-        }
-        .onChange(of: showAppMenu) {
-            if showAppMenu {
-                showActions = false
-                menuSelection = 0
-            }
+        // One optional makes "exactly one menu" structural; this only mirrors it for the panel.
+        .onChange(of: openMenu) {
             vm.menuOpen = menuOpen
         }
         .onAppear { searchFocused = true }
@@ -273,7 +294,7 @@ struct RootPaletteView: View {
             return screen.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
         }
         .onKeyPress(.escape) {
-            if showActions || showAppMenu {
+            if menuOpen {
                 closeMenus()
                 return .handled
             }
@@ -333,8 +354,16 @@ struct RootPaletteView: View {
             if menuOpen { closeMenus() }
             return .handled
         }
-        // ⌘P mirrors the Actions row, and works while that menu is open like the rest.
+        // ⌘P toggles the clipboard's type filter; never gated on the rows, since an
+        // over-narrow filter empties them and this is the way back out.
         .onKeyPress(keys: ["p"], phases: .down) { press in
+            guard press.modifiers.contains(.command) else { return .ignored }
+            guard !isCollapsed, vm.mode == .clipboard else { return .ignored }
+            toggleClipboardFilter()
+            return .handled
+        }
+        // ⌘. mirrors the Actions row, and works while that menu is open like the rest.
+        .onKeyPress(keys: ["."], phases: .down) { press in
             guard press.modifiers.contains(.command) else { return .ignored }
             let screen = screen
             let selection = selection(in: screen)
@@ -396,6 +425,13 @@ struct RootPaletteView: View {
             }
             headerGutter(width: Theme.Spacing.md)
             searchField
+            // Keyed off the mode, which is what says which screen is up; the field just flexes narrower.
+            if !isCollapsed, vm.mode == .clipboard {
+                headerGutter(width: Theme.Spacing.md)
+                ClipboardFilterButton(
+                    filter: vm.clipboardFilter, isOpen: openMenu == .clipboardFilter,
+                    action: toggleClipboardFilter)
+            }
             // Compact pins favorites beside the field; expanded shows them as rows.
             if isCollapsed, settings.showFavoritesInCompactMode,
                 let launcher = screen as? LauncherScreen
@@ -479,7 +515,7 @@ struct RootPaletteView: View {
 
     private var appMenuButton: some View {
         MenuCircleButton {
-            withAnimation(Self.menuAnimation) { showAppMenu.toggle() }
+            if openMenu == .app { closeMenus() } else { open(.app, highlighting: 0) }
         }
     }
 
@@ -514,22 +550,35 @@ struct RootPaletteView: View {
     private func openActions() {
         let launcher = screen as? LauncherScreen
         selectionIsRunning = launcher.map { $0.isRunning(at: selection(in: $0)) } ?? false
-        withAnimation(Self.menuAnimation) { showActions = true }
+        open(.actions, highlighting: 0)
     }
 
     private func toggleActions() {
-        if showActions {
-            withAnimation(Self.menuAnimation) { showActions = false }
+        if openMenu == .actions {
+            closeMenus()
         } else {
             openActions()
         }
     }
 
-    private func closeMenus() {
-        withAnimation(Self.menuAnimation) {
-            showActions = false
-            showAppMenu = false
+    /// Opens on the active filter, so the current value is the highlighted row like a pop-up's.
+    private func toggleClipboardFilter() {
+        if openMenu == .clipboardFilter {
+            closeMenus()
+            return
         }
+        let active = ClipboardFilter.allCases.firstIndex(of: vm.clipboardFilter) ?? 0
+        open(.clipboardFilter, highlighting: active)
+    }
+
+    /// Every open path lands here, so the highlight is always stated rather than left behind.
+    private func open(_ menu: OpenMenu, highlighting row: Int) {
+        menuSelection = row
+        withAnimation(Self.menuAnimation) { openMenu = menu }
+    }
+
+    private func closeMenus() {
+        withAnimation(Self.menuAnimation) { openMenu = nil }
     }
 
     /// Inset from the bottom corners, so the menu's own corner isn't clipped.
@@ -602,6 +651,13 @@ struct RootPaletteView: View {
     }
 }
 
+/// The palette's in-window menus. One optional of these is the whole "only one is open" invariant.
+private enum OpenMenu {
+    case actions
+    case app
+    case clipboardFilter
+}
+
 /// The footer's menu circle; hover lives here, so a sweep never re-renders the body.
 private struct MenuCircleButton: View {
     let action: () -> Void
@@ -621,25 +677,6 @@ private struct MenuCircleButton: View {
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
         .frosted(in: Circle())
-    }
-}
-
-/// Footer button: bare label at rest, a faint capsule fill on hover.
-private struct BarButton<Label: View>: View {
-    let action: () -> Void
-    @ViewBuilder let label: Label
-    @State private var hovered = false
-
-    var body: some View {
-        Button(action: action) {
-            label
-                .padding(.horizontal, Theme.Spacing.md)
-                .frame(height: 28)
-                .contentShape(Capsule())
-                .background(Capsule().fill(hovered ? Theme.Colors.rowHover : Color.clear))
-        }
-        .buttonStyle(.plain)
-        .onHover { hovered = $0 }
     }
 }
 

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -222,6 +222,8 @@ struct RootPaletteView: View {
         .onChange(of: vm.resetToken) {
             scroll = ScrollIntent(kind: .top)
         }
+        // ⌘. arrives as a token rather than a key press. See `PaletteState.pinChordToken`.
+        .onChange(of: vm.pinChordToken) { pinSelection() }
         // One optional makes "exactly one menu" structural; this only mirrors it for the panel.
         .onChange(of: openMenu) {
             vm.menuOpen = menuOpen
@@ -361,19 +363,6 @@ struct RootPaletteView: View {
             guard !isCollapsed, vm.mode == .clipboard else { return .ignored }
             toggleClipboardFilter()
             return .handled
-        }
-        // ⌘. mirrors the Actions row, and works while that menu is open like the rest.
-        .onKeyPress(keys: ["."], phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
-            let screen = screen
-            let selection = selection(in: screen)
-            if let clipboard = screen as? ClipboardScreen {
-                return clipboard.pin(at: selection) ? .handled : .ignored
-            }
-            if let quicklinks = screen as? QuicklinkListScreen {
-                return quicklinks.pin(at: selection) ? .handled : .ignored
-            }
-            return .ignored
         }
         // Both cases, Shift uppercasing the key; the compact bar shows no target.
         .onKeyPress(keys: ["q", "Q"], phases: .down) { press in
@@ -631,6 +620,17 @@ struct RootPaletteView: View {
         guard let items = menuContent?.items, items.indices.contains(index) else { return }
         items[index].action()
         closeMenus()
+    }
+
+    /// ⌘. — mirrors the Actions row, and works while that menu is open like the rest.
+    private func pinSelection() {
+        let screen = screen
+        let selection = selection(in: screen)
+        if let clipboard = screen as? ClipboardScreen {
+            _ = clipboard.pin(at: selection)
+        } else if let quicklinks = screen as? QuicklinkListScreen {
+            _ = quicklinks.pin(at: selection)
+        }
     }
 
     /// Tab flips launcher↔clipboard; Calculator History exits rather than joining.

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -8,6 +8,9 @@
   `clipboard-test` can compile it standalone. It uses `isolated deinit` for its SQLite teardown.
 - A database that cannot be opened is deleted and recreated. That is only sound because history is
   regenerable — `QuicklinkStore` deliberately does the opposite.
+- **A link or an address is derived from the text, never persisted.** `ClipboardItem.Kind` stays
+  `text`/`image` — the two things capture can tell apart — so improving the classifier is a code
+  change rather than a database migration plus a backfill.
 
 ## Poll-based capture
 
@@ -45,9 +48,40 @@ references — an image imported from another app's cache — are left on disk w
 retention cut can strand hundreds of files, so those deletions run off the main actor to keep
 capture-time pruning from hitching.
 
+## Type filter
+
+The clipboard header carries a `ClipboardFilterButton` at the trailing edge of the search field —
+the only palette screen with a control up there. It toggles a `PopoverMenu` anchored `.topTrailing`
+under the button, so the ⌘K Actions menu, the app menu and this one are the same view on the same
+glass. **⌘P** toggles it; ↑/↓, ↵ and Esc come free from `RootPaletteView`'s one menu path, and the
+menu opens highlighting the *active* filter rather than the first row, the way a pop-up button does.
+The filter is not gated on the list having rows: an over-narrow filter empties it, and the button is
+the way back out.
+
+`ClipboardFilter` owns the five cases and everything the UI needs from them — title, glyph, and the
+`emptyMessage` that stops "Clipboard history is empty" from appearing over a history that only looks
+empty. The cases are **exclusive**: a copied URL is a link, not a narrower kind of text, so *Text
+Only* means prose.
+
+`ClipboardItem.textForm` derives `plain`/`link`/`email` from the text on demand — nil for an image.
+The classifier is guarded cheapest-first, because `rows` is rebuilt every render: anything over
+2048 UTF-8 bytes is plain by definition (`utf8.count` is O(1), `count` walks graphemes), then
+anything holding whitespace, then a `scheme://` or `mailto:` prefix, an address shape, and finally
+a bare domain. That last step is the only one needing judgement — `report.pdf` and `index.html` are
+domain-shaped — so a bare domain must be lower case (which is what keeps `Safari.app` out) and end
+in one of a compact set of TLDs people actually copy. It is a heuristic whose worst case files a row
+under the wrong type, and `clipboard-test` pins the cases that matter.
+
+`search(_:filter:)` filters **after** the pinned/rest split, so a matching pin still leads its block
+in pin order, and the filter joins the search memo's key — keying on the query alone would serve
+stale rows for a render or more, since the filter changes without the query moving. One consequence
+of filtering after the fact: the FTS statement's `LIMIT 200` applies to the *unfiltered* matches, so
+a narrow filter over a broad query can show fewer rows than the history holds.
+
 ## Pinned entries
 
-A row's ⌘K Actions menu carries **Pin Entry / Unpin Entry** (⌘P), persisted as a `pinned_at` column
+A row's ⌘K Actions menu carries **Pin Entry / Unpin Entry** (⌘., since ⌘P opens the type filter),
+persisted as a `pinned_at` column
 on `items` (added to existing databases by an `ALTER TABLE` migration, alongside `source_app`'s) —
 a stamp rather than a flag, because the Pinned section is ordered by _when you pinned_, not by
 recency.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -195,9 +195,19 @@ The policy runs after `super.sendEvent`, so it has the last word, and it writes 
 actually differs. It must stay **symmetric**: an earlier version left the field alone and only forced
 the arrow outside it, and AppKit's own alternation over the field came straight back.
 
+## One menu at a time
+
+`RootPaletteView` holds a single `OpenMenu?` rather than a flag per menu, so "at most one is open" is
+structural instead of a pair of `onChange` handlers pushing each other closed. Three cases today —
+the ⌘K Actions menu (`.bottomTrailing`), the app menu (`.bottomLeading`) and the clipboard type
+filter (`.topTrailing`, hung under its header button). `menuContent` resolves the open case to one
+`PopoverMenuContent`, which is what lets ↑/↓, plain ↵, Esc and the click-away catcher serve every
+menu without knowing which is up. Every open path goes through `open(_:highlighting:)` and states
+where the highlight starts: the first row, except the type filter, which opens on the active filter.
+
 ## Menu-open input freeze
 
-While a footer popover menu (⌘K Actions / app menu) is open the search field reads as inert but
+While a popover menu (⌘K Actions / app menu / clipboard type filter) is open the search field reads as inert but
 **never resigns first responder** — resigning makes the `NSTextField` swap between its field-editor
 and cell rendering, shifting the text / placeholder a point or two, so focus stays put. Input is
 frozen instead:
@@ -205,7 +215,7 @@ frozen instead:
 - `RootPaletteView` mirrors the open state into `PaletteState.menuOpen`, whose `didSet` fires
   `onMenuOpenChanged`.
 - `PalettePanel.sendEvent` then swallows text-editing keystrokes while `menuOpen` (letting ⌘/⌃ chords
-  and menu-nav keys through to SwiftUI `onKeyPress`), which is how ⌘P and ⌃X still reach their rows.
+  and menu-nav keys through to SwiftUI `onKeyPress`), which is how ⌘. and ⌃X still reach their rows.
 - The caret is hidden by clearing SwiftUI's **own** live field editor's `insertionPointColor`. SwiftUI
   force-casts its field editor to a private subclass, so vending a custom one crashes — only the
   existing one can be tuned.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -220,6 +220,22 @@ frozen instead:
   force-casts its field editor to a private subclass, so vending a custom one crashes — only the
   existing one can be tuned.
 
+## Chords `onKeyPress` never sees
+
+Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and all of them are handled in
+`PalettePanel.sendEvent` before `super` hands the event to the responder chain:
+
+- **A bare backspace** — the field editor consumes it as an edit (`onBareBackspace`).
+- **Chords with no main menu item** — ⌘, and ⌘w, which an app with a menu bar would never see here.
+- **Chords AppKit has already bound to a selector.** `⌘.` is the one that bites: AppKit binds it to
+  `cancelOperation:` alongside Escape, so `interpretKeyEvents` hands it to the field editor and
+  `onKeyPress(keys: ["."])` never fires. Pin (⌘.) therefore arrives through `onCommandShortcut`,
+  which bumps `PaletteState.pinChordToken`; `RootPaletteView` observes that and resolves the row
+  through the current screen, so **which** row gets pinned still comes from `screen.rows` alone.
+
+Adding a chord that "does nothing" is almost always one of these three — check `sendEvent` before
+assuming the handler is wrong.
+
 ## Emacs navigation chords
 
 ⌃N/⌃P and ⌃F/⌃B navigate exactly as ↓/↑ and →/← do — on the emoji grid all four step the selection,

--- a/docs/features/quicklinks.md
+++ b/docs/features/quicklinks.md
@@ -136,7 +136,7 @@ feature. The Search Quicklinks screen gives pins their own section, like the cli
 `PaletteMode.quicklinks` is a sub-screen reached from the `Search Quicklinks` command. Like
 Calculator History it stays out of the Tab cycle and exits via the back chevron or a bare backspace.
 Its ⌘K menu carries Open (`↵`), Open With Default App (`⌘↵`, only when a handler is saved), Edit,
-Duplicate, Pin/Unpin (`⌘P`), Hide/Show in Root Search, Show in Finder (`⌘F`, only for a resolved
+Duplicate, Pin/Unpin (`⌘.`), Hide/Show in Root Search, Show in Finder (`⌘F`, only for a resolved
 path), and Delete (`⌘⌫`).
 
 Choosing an _arbitrary_ app belongs to the editor, which has a picker; `PopoverMenu` is a flat list

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,7 +200,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 
 - A copy appears at the top within about a second; an image copy records a thumbnail
 - Search is correct both under and over three characters
-- ⌘P pins and the highlight follows the row into Pinned; ⌘⌫ deletes; ⌘↵ copies without pasting
+- ⌘. pins and the highlight follows the row into Pinned; ⌘⌫ deletes; ⌘↵ copies without pasting
 - ⌃X deletes the selected entry and ⌃⇧X clears the history, from the list and from an open ⌘K menu
 - ⌃⇧X asks first, through Tinycast's own dialog; Cancel and Esc both leave every entry in place
 - ↵ pastes into the previous app; ⌥↵ pastes without closing the palette

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -78,9 +78,10 @@ Always `RoundedRectangle(cornerRadius:, style: .continuous)` — continuous corn
 
 ### Size (`Theme.Size`)
 
-`panelWidth 750` · `panelHeight 475` · `headerHeight 44` · `bottomBarHeight 52` · `rowIcon 24` ·
-`keyCap 18` · `recorderKeyCap 16` · `menuButton 36` · `clipboardListWidth 290` · `menuWidth 276` · `menuIcon 16` ·
-`settingsSidebar 184` · `settingsRowIcon 20` · `dialogWidth 420` · `dialogIcon 32` · `hudWidth 200` ·
+`panelWidth 750` · `panelHeight 475` · `headerHeight 44` · `bottomBarHeight 52` · `barButtonHeight 28` ·
+`rowIcon 24` · `keyCap 18` · `recorderKeyCap 16` · `menuButton 36` · `clipboardListWidth 290` ·
+`menuWidth 276` · `clipboardFilterMenuWidth 200` · `menuIcon 20` ·
+`settingsSidebar 215` · `settingsRowIcon 20` · `dialogWidth 420` · `dialogIcon 32` · `hudWidth 200` ·
 `hudHeight 100` · `volumeTrackHeight 6` · `volumeKnob 16` · `volumeReadout 38`
 
 `keyCap` sizes the palette's keycap chips; `recorderKeyCap` (both size and radius) is the intentionally-smaller Settings shortcut-recorder chip.
@@ -122,6 +123,7 @@ Source: `Palette/PalettePanel.swift`, `Palette/RootPaletteView.swift`.
 - **Header** (`headerHeight 44`): a back-chevron _or_ mode glyph, then the plain `TextField` (no border/background). Sub-screens (Clipboard, Calculator History) show the back chevron; the launcher shows a magnifying glass. The search icon aligns horizontally with row content.
 - **Compact keyboard entry:** pressing `↓` in the collapsed launcher expands the results and selects the first row without replacing or defocusing the shared search field.
 - **Bottom bar** (`bottomBarHeight 52`): a menu circle on the left, the action group on the right — both floating glass, no bar background. The action group is one glass `Capsule` holding the primary-action pill (label + `↵`) and the Actions toggle (`⌘K`).
+- **`BarButton`** is the shared bar control: bare label at rest, a `rowHover` capsule on hover, `barButtonHeight 28`. It carries the footer's two buttons and the clipboard header's type filter, so those hover identically. Hover state lives inside it, so sweeping one never re-renders the palette body.
 
 ---
 
@@ -179,7 +181,8 @@ Source: `Theme.frosted(in:)`, `DesignSystem/PopoverMenu.swift`.
 Glass is **only** for floating controls, never the main surface.
 
 - `View.frosted(in:)` = `glassEffect(.regular.interactive().tint(glassFrost), in:)` + `.tint(.clear)` — interactive lensing with a whitish frost tint (`glassFrost`) so the glass reads brighter than clear. Used on the action-group capsule, the menu circle, `PopoverMenu` and a dialog's buttons — always _inside_ a window that already has a `VisualEffectView` behind it. Neither HUD uses it: on a panel of its own, glass has no backdrop to lens and falls back to an opaque backing that reads as a dark edge, so both take the panel recipe instead (see "Dialogs & HUD"). Tune the frost amount via the `glassFrost` token, not per call site.
-- **Menus are in-window overlays, not system popovers.** `.contextMenu`/`NSMenu` stall clicks for seconds inside a `LazyVStack` and spill outside the panel. Use `PopoverMenu` anchored to a bottom corner via `.overlay`, inset `menuInset` (8pt) so its own corner isn't clipped by the panel's.
+- **Menus are in-window overlays, not system popovers.** `.contextMenu`/`NSMenu` stall clicks for seconds inside a `LazyVStack` and spill outside the panel. Use `PopoverMenu` anchored to a corner via `.overlay`, inset `menuInset` (8pt) so its own corner isn't clipped by the panel's. A menu hung off a control instead of a corner — the clipboard type filter, `.topTrailing` — insets by that control's own metrics so their edges line up.
+- **A menu's `width` is fixed, never intrinsic**, so it can't jitter as its rows change: `menuWidth 276` by default, or a token of its own where that reads too wide (`clipboardFilterMenuWidth 200`).
 - **`PopoverMenu`** uses `glassEffect(.regular, in: RoundedRectangle(menuPanel 16))` with **no hand-tuned shadow** — Tahoe glass carries its own elevation; adding a drop shadow reads heavy and non-native.
 - `PopoverMenuRow`: leading glyph, label, trailing shortcut glyph, `menuHover` fill on hover, `menuRow 10` corner. Menus animate in with `.opacity + .scale(0.96)` from the anchored corner, `easeOut 0.14`.
 - The glyph is a `PopoverMenuIcon`: `.symbol` (SF Symbol, `hierarchical`, secondary — or **red** when `isDestructive`) or `.file` (a real app icon via `IconCache`, used by the paste rows to show the paste target). `PopoverMenuItem` keeps a `systemImage:` convenience init, so symbol rows read exactly as before.


### PR DESCRIPTION
## Related issue

Closes #233

## What changed

A type filter at the trailing edge of the clipboard search bar — **All Types, Text Only, Images Only, Links Only, Emails Only** — opened by its header button or **⌘P**. It's the same `PopoverMenu` as ⌘K Actions, anchored `.topTrailing` under the button, so the glass, rows and hover are shared rather than a second dropdown idiom. No search field and no separators inside it; the button states the active filter, and the menu opens highlighting it the way a pop-up button does.

Three things in the diff are worth a second look:

**Links and emails are derived, never stored.** `ClipboardItem.Kind` stays `text`/`image` — the two things capture can actually tell apart — and `ClipboardFilter` reads `ClipboardItem.textForm` (`plain`/`link`/`email`) off the text on demand. No column, no migration, no backfill: improving the classifier stays a code change. `rows` rebuilds every render, so the classifier is guarded cheapest-first — over 2048 UTF-8 bytes is plain by definition (`utf8.count` is O(1), `count` walks graphemes), then whitespace, then a `scheme://`/`mailto:` prefix, an address shape, and last a bare domain. That last step is the only judgement call, since `report.pdf` and `index.html` are domain-shaped too: a bare domain must be lower case (which is what keeps `Safari.app` out) and end in one of a compact set of TLDs people actually copy. It's a heuristic whose worst case files a row under the wrong type.

**The filter joins the search memo's key.** Keying on the query alone would serve stale rows, because the filter changes without the query moving. Filtering happens *after* the pinned/rest split, so a matching pin still leads its block in pin order.

**One `OpenMenu?` replaced two `Bool`s.** A third menu would have needed a third pairwise `onChange` to keep "only one is open" true; one optional makes it structural and deleted both handlers. `menuContent` resolves the open case to one `PopoverMenuContent`, which is what hands ↑/↓, ↵, Esc and the click-away catcher to the new menu for free.

**⌘P/⌘. rebind.** ⌘P was Pin, through one handler serving both the clipboard's *Pin Entry* and the quicklinks list's *Pin Quicklink*. Both move to **⌘.** so one chord keeps one meaning app-wide. That rebind needed a fix of its own: AppKit binds ⌘. to `cancelOperation:` alongside Escape, so `interpretKeyEvents` gives it to the field editor and `onKeyPress(keys: ["."])` never fires. It now arrives through `PalettePanel`'s existing `onCommandShortcut` seam, which bumps `PaletteState.pinChordToken`; `RootPaletteView` observes that and resolves the row through the current screen, so which row gets pinned still comes from `screen.rows` alone. Documented in `docs/features/palette.md` § "Chords `onKeyPress` never sees", since the next silent chord will be one of those three cases.

Smaller: `BarButton` moved to `DesignSystem/` and gained a `chrome` (`.capsule` for the footer's pills, `.menu` for the filter, sharing `Radius.menuRow` with the menu it opens); `PopoverMenu` gained a `width` defaulting to `menuWidth`; the empty state now names the filter, so one hiding every entry no longer reads as "Clipboard history is empty".

*Files Only* from the mockup is deliberately absent: `ClipboardManager` only captures pasteboard strings and PNG/TIFF, never file URLs, so the row would always be empty.

## Memory footprint

> **Not yet measured — needs a run on a machine with the app.** No new long-lived state: `ClipboardFilter` is a 5-case enum on `PaletteState`, and `textForm` is computed rather than stored, so an untouched filter allocates nothing at launch and adds nothing per row. The one new retained allocation is the filtered result array in the existing one-entry search memo, bounded by the same 1000-row window / `LIMIT 200` as today.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

> **Outstanding.** Needs a side-by-side before/after of the header button and the dropdown, same window size, same actions — not produced here, since a second instance of the Dev channel would have had two pasteboard pollers and two SQLite writers on the same history.

## Drawbacks

- **Bare-domain detection is a heuristic with a TLD list.** `main.cc` and `script.sh` still read as links, and a copied `Apple.com` reads as text because the lower-case rule is what excludes `Safari.app`. Worst case is a row under the wrong filter. The alternative was `NSDataDetector`, rejected because it isn't `Sendable` (a shared instance needs `nonisolated(unsafe)`) and costs far more per item than a character scan.
- **The FTS `LIMIT 200` applies before the filter**, so a narrow filter over a broad query can show fewer rows than the history holds. Pre-existing in shape; the filter makes it reachable. Noted in the feature doc.
- **⌘. is macOS's Cancel chord.** Swallowing it in the palette is deliberate but does take a platform convention; inside a search field it only ever meant cancel.
- **`.help()`, not the in-house `Tooltip`,** on the filter button — `Tooltip` renders above its view and would clip at the panel's top edge. Matches `CompactFavoriteButton`, the other header control.
- The filter resets to All Types on every summon and on any mode change. Chosen over stickiness so a forgotten filter can't silently hide history; trivially reversible if it proves annoying.

## Tests & validation

`./Scripts/run-tests.sh` — **all 25 harnesses pass.** `clipboard-test` gained three cases:

- `textFormClassification` — the links, addresses and the filenames that must *not* read as links (`report.pdf`, `index.html`, `App.swift`, `Safari.app`), plus `@apple.com` and `two@at@signs.com`, the over-length cap, and an image having no text form. Two of these caught real bugs during the work: both address-shaped tokens were classifying as links until host labels were validated.
- `typeFilterSplitsTheHistory` — each filter returns only its kind, and a pinned link still leads its block.
- `typeFilterJoinsTheSearchMemo` — same query, different filter, different rows: the regression a query-only cache key would cause.

`ClipboardFilter.swift` was added to the `clipboard-test`, `hover-arming-test` and `raycast-test` source lists — the last two compile `PaletteState`/`ClipboardStore` and stopped compiling without it, which is the model layer's purity check doing its job.

Also: Debug build succeeds with **no new warnings**, `./Scripts/lint.sh` is clean, and `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` is empty.

**Not exercised by hand** — worth checking before merge: ⌘P opens the dropdown and its glass matches ⌘K side by side; ⌘. pins on both the clipboard and quicklinks screens and ⌘P no longer pins anywhere; typing stays inert while the menu is open; the empty state under Images Only with no images; a filter plus a query together; and the reset to All Types on reopen and on Tab.
