### PR TITLE
Make the Settings filter row focus on a click anywhere in it

### DIFF
--- a/Tinycast/DesignSystem/SettingsComponents.swift
+++ b/Tinycast/DesignSystem/SettingsComponents.swift
@@ -102,7 +102,13 @@ struct SettingsFilterField: View {
                 .accessibilityLabel("Clear search")
             }
         }
+        // Padded out then back in, so the tap target is the visible row, not just the glyph strip.
+        .padding(Self.rowReach)
         .contentShape(.rect)
         .onTapGesture { focused = true }
+        .padding(-Self.rowReach)
     }
+
+    /// Past the grouped row's inner padding on every side; the row's clipping trims the excess.
+    private static let rowReach: CGFloat = 15
 }


### PR DESCRIPTION
## Related issue

Closes #250

## What changed

`SettingsFilterField`'s click-to-focus target only covered its content HStack — the ~16 pt text line — while the visible grouped-form row card carries ~10 pt of padding above and below it. Clicks landing in that padding (where a click naturally falls in a ~30 pt row) went nowhere.

The fix pads the content out by `rowReach` before `contentShape`/`onTapGesture` and back in after, so the tap target covers the whole visible row while the layout frame is unchanged. The row view clips hit-testing to its own bounds, so the deliberate overshoot cannot steal clicks from neighbouring rows — verified by clicking between the filter row and the first item row (no focus) and toggling the first item's checkbox (still works).

Verified with real CGEvent clicks at five zones of the row (above-text padding, below-text padding, magnifier, text line, trailing area): all five focus the field after the fix; the two padding zones did not before.

Applies to every pane built on `SettingsFilterField`: Applications, System Settings, System Actions, Commands, Extensions, Quicklinks.

## Memory footprint

Debug build of this branch, `footprint` phys_footprint:

| Step                                          | Memory |
| --------------------------------------------- | ------ |
| Idle after launch                             | 26 MB  |
| Palette open                                  | 42 MB  |
| Feature in use (Applications pane, filtering) | 78 MB  |
| Settings closed, settled                      | 73 MB  |

Opening the Applications pane transiently spikes to ~243 MB for a second while the app-icon burst loads, settling to ~80 MB — that behavior is the pane's own and predates this change (the diff is 6 lines of hit-shape, no allocation).

Leak-tested: `leaks` reports ~19.9 KB total, all rooted in Apple frameworks (AppIntents/XPC connection blocks); nothing rooted in Tinycast code.

## Demo

Non-visual by design — the row renders identically (the negative padding cancels the layout change); only hit-testing changes. Reproduce: Settings › Applications, click just above or below the "Search applications…" placeholder text, still inside the row card — the caret now lands and typing filters.

## Drawbacks

`rowReach = 15` overshoots the row's actual inner padding on purpose; correctness relies on the row view clipping hit-tests to its bounds, which NSTableView-backed Form rows do. If a future Form stops clipping, the shape could extend a few points past the card.

## Tests & validation

- `./Scripts/run-tests.sh` — all 33 harnesses pass (no engine change, no new cases).
- `./Scripts/lint.sh` clean; Debug build with no new warnings.
- By hand: five-zone click matrix before/after (above/below padding, magnifier, text line, trailing), between-rows click doesn't steal focus, item checkbox and Restore Defaults still work, filter + clear button behave.
