### PR TITLE
Add per-entry launcher aliases

### DIFF
--- a/Tests/fuzz-test.swift
+++ b/Tests/fuzz-test.swift
@@ -10,11 +10,13 @@ struct FuzzTest {
         var alternates: [String] = []
         var bundleID: String?
         var executable: String?
+        var userAlias: String?
 
         /// Mirrors AppEntry.searchFields, including the alternate-name sanitizing the scan applies.
         var fields: SearchFields {
             SearchFields(
                 names: [name],
+                userAlias: userAlias,
                 alternateNames: SearchFields.usableAlternateNames(
                     alternates, displayName: name, fileName: name + ".app"),
                 bundleID: bundleID, executableName: executable)
@@ -53,7 +55,11 @@ struct FuzzTest {
         // Ships an untranslated localization placeholder — see SearchFields.usableAlternateNames.
         App(name: "Maps", alternates: ["ALTERNATE_NAME_1", "Maps.app"]),
         // Alternate that only repeats the display name; contributes nothing.
-        App(name: "Image Playground", alternates: ["Image Playground", "Image Playground.app"])
+        App(name: "Image Playground", alternates: ["Image Playground", "Image Playground.app"]),
+        // The corpus entries with user aliases, so the property loop exercises the alias bands.
+        App(name: "Figma", userAlias: "fg"),
+        // The band-6 overreach repro: `term` inside `iterm` must not beat Terminal's own prefix.
+        App(name: "Kitty", userAlias: "iterm")
     ]
 
     static func app(_ name: String) -> App { apps.first { $0.name == name }! }
@@ -99,6 +105,7 @@ struct FuzzTest {
     static func main() {
         displayNameRanking()
         fieldPriority()
+        userAliases()
         alternateNameSanitizing()
         identifierFields()
         edgeCases()
@@ -197,15 +204,19 @@ struct FuzzTest {
             rank("system preferences").first == "System Settings")
 
         // Band ordering, asserted directly on the scores.
+        let userAlias = score("fg", "Figma")!
         let nameLiteral = score("chatgpt", "ChatGPT")!
         let aliasLiteral = score("codex", "ChatGPT")!
         let nameSubsequence = score("codex", "Code Explorer")!
         let aliasSubsequence = score("aplbks", "Books")!
         let identifier = score("openai", "ChatGPT")!
         let executable = score("electron", "Visual Studio Code")!
-        let ordered = [nameLiteral, aliasLiteral, nameSubsequence, aliasSubsequence, identifier, executable]
+        let ordered = [
+            userAlias, nameLiteral, aliasLiteral, nameSubsequence, aliasSubsequence, identifier,
+            executable
+        ]
         check(
-            "bands are strictly ordered: name > alias > name-fuzzy > alias-fuzzy > id > exec",
+            "bands are strictly ordered: user-alias > name > alias > name-fuzzy > alias-fuzzy > id > exec",
             zip(ordered, ordered.dropFirst()).allSatisfy { $0 > $1 }, "got \(ordered)")
         check(
             "every band is a whole stride apart",
@@ -219,6 +230,49 @@ struct FuzzTest {
             score("safari", "Safari")! >= 5 * SearchRelevance.bandStride)
         check(
             "an entry with no matching field scores nil", score("qqqq", "Safari") == nil)
+    }
+
+    // MARK: - User aliases
+
+    static func userAliases() {
+        print("\n# user aliases")
+
+        let fg = rank("fg")
+        check("'fg' finds Figma by user alias", fg.first == "Figma", "got \(fg)")
+        check(
+            "the user alias sits in the band above the display name",
+            score("fg", "Figma")! >= 6 * SearchRelevance.bandStride)
+        check(
+            "a user alias outranks another entry's exact display name",
+            SearchRelevance.score(query: "code", fields: SearchFields(names: ["Mail"], userAlias: "code"))!
+                > SearchRelevance.score(query: "code", fields: SearchFields(names: ["Code"]))!)
+        check(
+            "a user alias matches literally: exact, prefix and substring",
+            ["mail2", "mai", "ail"].allSatisfy {
+                SearchRelevance.score(
+                    query: $0, fields: SearchFields(names: ["\u{FFFF}"], userAlias: "mail2")) != nil
+            })
+        check(
+            "a user alias never subsequence-matches",
+            SearchRelevance.score(
+                query: "fga", fields: SearchFields(names: ["\u{FFFF}"], userAlias: "figalias")) == nil)
+        let figma = SearchRelevance.score(query: "figma", fields: app("Figma").fields)!
+        check(
+            "the strongest field still wins on an aliased entry",
+            figma >= 5 * SearchRelevance.bandStride && figma < 6 * SearchRelevance.bandStride)
+
+        // Anchoring: only exact and prefix hits earn band 6; inside hits rank with vendor aliases.
+        let term = rank("term")
+        check(
+            "an inside alias hit does not beat another entry's own prefix",
+            above(term, "Terminal", "Kitty"), "got \(term)")
+        check("...but the aliased entry is still findable", term.contains("Kitty"), "got \(term)")
+        check("an alias prefix hit still ranks first", rank("ite").first == "Kitty", "got \(rank("ite"))")
+        let inside = SearchRelevance.score(
+            query: "ail", fields: SearchFields(names: ["\u{FFFF}"], userAlias: "mail2"))!
+        check(
+            "an inside alias hit ranks in the vendor-alias band",
+            inside >= 4 * SearchRelevance.bandStride && inside < 5 * SearchRelevance.bandStride)
     }
 
     // MARK: - Spotlight junk
@@ -366,7 +420,8 @@ struct FuzzTest {
 
         let alphabet = Array("abcdefghijklmnopqrstuvwxyz .-_0123456789浏览器사파리🙂\u{200E}\u{0301}")
         let allText = apps.flatMap { app -> [String] in
-            [app.name] + app.alternates + [app.bundleID, app.executable].compactMap { $0 }
+            [app.name] + app.alternates
+                + [app.bundleID, app.executable, app.userAlias].compactMap { $0 }
         }
         var rng = Random(seed: 0x5EED_1234_ABCD_0001)
 
@@ -401,7 +456,7 @@ struct FuzzTest {
                 // Every score sits inside exactly one band, and the boost cap cannot lift it out.
                 let band = score / SearchRelevance.bandStride
                 let offset = score - band * SearchRelevance.bandStride
-                if offset < 0 || offset > FuzzyMatch.maximumScore || band > 5 { bandViolations += 1 }
+                if offset < 0 || offset > FuzzyMatch.maximumScore || band > 6 { bandViolations += 1 }
                 if (score + LauncherRankingBoostCap) / SearchRelevance.bandStride != band {
                     boostCrossedBand += 1
                 }
@@ -427,6 +482,7 @@ struct FuzzTest {
         for _ in 0..<20_000 {
             let text = rng2.element(allText)
             let asName = SearchFields(names: [text])
+            let asUserAlias = SearchFields(names: ["\u{FFFF}"], userAlias: text)
             let asAlternate = SearchFields(names: ["\u{FFFF}"], alternateNames: [text])
             let asBundleID = SearchFields(names: ["\u{FFFF}"], bundleID: text)
             let asExecutable = SearchFields(names: ["\u{FFFF}"], executableName: text)
@@ -436,10 +492,17 @@ struct FuzzTest {
             guard !query.isEmpty,
                 let name = SearchRelevance.score(query: query, fields: asName)
             else { continue }
+            let userAlias = SearchRelevance.score(query: query, fields: asUserAlias)
             let alternate = SearchRelevance.score(query: query, fields: asAlternate)
             let bundleID = SearchRelevance.score(query: query, fields: asBundleID)
             let executable = SearchRelevance.score(query: query, fields: asExecutable)
             // Same text, weaker field: the score must drop, and identifier fields may drop out entirely.
+            // An anchored alias hit outranks the name; an inside hit ranks below with vendor aliases.
+            if let userAlias, let tier = FuzzyMatch.match(query: query, candidate: text)?.tier,
+                tier.isAnchored ? userAlias <= name : userAlias >= name
+            {
+                inversions += 1
+            }
             if let alternate, alternate >= name { inversions += 1 }
             if let bundleID, let alternate, bundleID >= alternate { inversions += 1 }
             if let executable, let bundleID, executable >= bundleID { inversions += 1 }

--- a/Tests/raycast-test.swift
+++ b/Tests/raycast-test.swift
@@ -125,6 +125,9 @@ enum RaycastTests {
             !RaycastFormat.v1.supportedOptions.contains(.launchAtLogin),
             "v1 exports no launch-at-login preference")
         expect(
+            !RaycastFormat.v1.supportedOptions.contains(.aliases),
+            "v1 exports no aliases")
+        expect(
             RaycastFormat.v1.supportedOptions.contains(.shortcuts),
             "v1 still carries app and command hotkeys")
     }

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		D3F07F4AEBEAA489EDCD0763 /* FileSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FE27F894A8777C8ACCF1D /* FileSearchList.swift */; };
 		D44E20726F1EB11C8C297C4D /* WindowActionMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */; };
 		D4A45373662D6658706E4DA4 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27773F8955543E8A24CC0D28 /* ClipboardSettingsView.swift */; };
+		D68E7585496722BEC72E788C /* AliasStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */; };
 		D736A0FE574A343AA0FD3911 /* AppIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E58EBB08450BA3426DF0565 /* AppIndex.swift */; };
 		D9113113F828FD6983715D6B /* UninstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */; };
 		DA1EE0A8933EADD357FCE32C /* QuicklinkArgumentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E48A8D5E2BC00E9E1CD5BF /* QuicklinkArgumentSession.swift */; };
@@ -537,6 +538,7 @@
 		D43F1080FB443A1D0616790E /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearance.swift; sourceTree = "<group>"; };
 		D8B10DA3A9B1CBD9A03F3DE5 /* NoteDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocument.swift; sourceTree = "<group>"; };
+		DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasStore.swift; sourceTree = "<group>"; };
 		DA8CBA97041AAA96C0B7FF2E /* BackupActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupActions.swift; sourceTree = "<group>"; };
 		DB1752929BA1ACC0BC54865C /* HUDPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanel.swift; sourceTree = "<group>"; };
 		DB5FA545F484D7666E9A5F14 /* RunningAppsMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningAppsMonitor.swift; sourceTree = "<group>"; };
@@ -1429,6 +1431,7 @@
 		DDBAA9841D534DAA078B1220 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */,
 				8E58EBB08450BA3426DF0565 /* AppIndex.swift */,
 				33994DC2FB0A6B23A403CA29 /* AppLauncher.swift */,
 				D43F1080FB443A1D0616790E /* FavoritesStore.swift */,
@@ -1634,6 +1637,7 @@
 			files = (
 				540F1433DC46BC97C9F80E06 /* AboutView.swift in Sources */,
 				16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */,
+				D68E7585496722BEC72E788C /* AliasStore.swift in Sources */,
 				EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */,
 				E8CB7624CCA5905AF1A4FAD9 /* AppCore.swift in Sources */,
 				C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -22,6 +22,7 @@ final class AppCore {
     let settings: AppSettings
     let favorites = FavoritesStore()
     let visibility = VisibilityStore()
+    let aliases = AliasStore()
     let calcHistory = CalculatorHistoryStore()
     let currencyRates = CurrencyRateStore()
     let emojiIndex = EmojiIndex()
@@ -45,7 +46,8 @@ final class AppCore {
     @ObservationIgnored private(set) lazy var quicklinkCoordinator = QuicklinkCoordinator(
         store: quicklinks, argumentSession: quicklinkArguments, settings: settings,
         appIndex: appIndex, injector: snippetTextInjector, hotKeys: hotKeys, favorites: favorites,
-        visibility: visibility, ranking: launcherRanking, windowController: windowController,
+        visibility: visibility, ranking: launcherRanking, aliases: aliases,
+        windowController: windowController,
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,
         clipboardHistory: { [unowned self] in self.snippetExpansion.clipboardHistoryForExpansion() },
         core: self)
@@ -63,7 +65,7 @@ final class AppCore {
     @ObservationIgnored private(set) lazy var uninstallCoordinator = UninstallCoordinator(
         session: uninstall, palette: palette, paletteCoordinator: paletteCoordinator,
         appIndex: appIndex, runningApps: runningApps, hotKeys: hotKeys, favorites: favorites,
-        visibility: visibility, ranking: launcherRanking, core: self)
+        visibility: visibility, ranking: launcherRanking, aliases: aliases, core: self)
     @ObservationIgnored private(set) lazy var extensionCoordinator = ExtensionCoordinator(
         extensions: extensions, palette: palette, paletteCoordinator: paletteCoordinator,
         settingsCoordinator: settingsCoordinator, settings: settings, core: self)
@@ -73,7 +75,7 @@ final class AppCore {
         store: customCommands, settings: settings, appIndex: appIndex,
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,
         hotKeys: hotKeys, favorites: favorites, visibility: visibility,
-        ranking: launcherRanking, core: self)
+        ranking: launcherRanking, aliases: aliases, core: self)
     @ObservationIgnored private(set) lazy var notesCoordinator = NotesCoordinator(
         store: notesStore,
         settings: settings,
@@ -114,7 +116,7 @@ final class AppCore {
         let settings = AppSettings()
         self.launcherRanking = launcherRanking
         self.settings = settings
-        appIndex = AppIndex(ranking: launcherRanking)
+        appIndex = AppIndex(ranking: launcherRanking, aliases: aliases)
         let clipboardManager = ClipboardManager(store: clipboardStore, settings: settings)
         self.clipboardManager = clipboardManager
         extensions = ExtensionManager(clipboardStore: clipboardStore)

--- a/Tinycast/DesignSystem/Interaction/FocusRelease.swift
+++ b/Tinycast/DesignSystem/Interaction/FocusRelease.swift
@@ -9,9 +9,12 @@ import SwiftUI
 /// click or fire alongside the one that is focusing a *different* field, and take its focus away.
 private struct FocusReleaseOnOutsideClick: ViewModifier {
     @State private var monitor: Any?
+    // A box, not `@State` on the window: resolving it must not invalidate the view mid-layout.
+    @State private var host = HostWindowBox()
 
     func body(content: Content) -> some View {
         content
+            .background(HostWindowReader { host.window = $0 })
             .onAppear {
                 guard monitor == nil else { return }
                 monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { event in
@@ -26,7 +29,8 @@ private struct FocusReleaseOnOutsideClick: ViewModifier {
     }
 
     private func release(on event: NSEvent) {
-        guard let window = event.window,
+        // A local monitor sees every window in the app; only this pane's own is ours to touch.
+        guard let window = event.window, window === host.window,
             // Only while something is actually being edited: the field editor is the responder.
             let editor = window.firstResponder as? NSTextView, editor.isFieldEditor
         else { return }
@@ -37,8 +41,36 @@ private struct FocusReleaseOnOutsideClick: ViewModifier {
     }
 }
 
+private final class HostWindowBox {
+    weak var window: NSWindow?
+}
+
+/// The window a SwiftUI view landed in; `NSViewRepresentable` is the only route to it.
+private struct HostWindowReader: NSViewRepresentable {
+    var onResolve: (NSWindow?) -> Void
+
+    func makeNSView(context: Context) -> NSView { HostWindowReaderView(onResolve: onResolve) }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private final class HostWindowReaderView: NSView {
+    private let onResolve: (NSWindow?) -> Void
+
+    init(onResolve: @escaping (NSWindow?) -> Void) {
+        self.onResolve = onResolve
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onResolve(window)
+    }
+}
+
 extension View {
-    /// Drops keyboard focus when a click lands outside the field being edited.
+    /// Drops keyboard focus when a click lands outside the field being edited, in this window only.
     func releasesFocusOnOutsideClick() -> some View {
         modifier(FocusReleaseOnOutsideClick())
     }

--- a/Tinycast/Features/Backup/Model/RaycastFormat.swift
+++ b/Tinycast/Features/Backup/Model/RaycastFormat.swift
@@ -26,9 +26,10 @@ struct RaycastImportOptions: OptionSet, Sendable {
     static let popToRoot = RaycastImportOptions(rawValue: 1 << 6)
     static let compactMode = RaycastImportOptions(rawValue: 1 << 7)
     static let snippets = RaycastImportOptions(rawValue: 1 << 8)
+    static let aliases = RaycastImportOptions(rawValue: 1 << 9)
     static let all: RaycastImportOptions = [
         .shortcuts, .favorites, .emojiSkinTone, .launchAtLogin, .menuBarVisibility, .clipboardHistory,
-        .popToRoot, .compactMode, .snippets
+        .popToRoot, .compactMode, .snippets, .aliases
     ]
 }
 
@@ -58,7 +59,7 @@ enum RaycastFormat: Sendable, Equatable {
     /// Categories the format carries; offering one it lacks would import nothing.
     var supportedOptions: RaycastImportOptions {
         switch self {
-        case .v1: return RaycastImportOptions.all.subtracting(.launchAtLogin)
+        case .v1: return RaycastImportOptions.all.subtracting([.launchAtLogin, .aliases])
         case .v2: return .all
         }
     }

--- a/Tinycast/Features/Backup/Model/RaycastImport.swift
+++ b/Tinycast/Features/Backup/Model/RaycastImport.swift
@@ -14,6 +14,7 @@ enum RaycastImport {
             var trimmed = SettingsBackup()
             if options.contains(.shortcuts) { trimmed.hotkeys = backup.hotkeys }
             if options.contains(.favorites) { trimmed.favoriteApps = backup.favoriteApps }
+            if options.contains(.aliases) { trimmed.launcherAliases = backup.launcherAliases }
 
             var settings = SettingsBackup.SettingsData()
             var hasSettings = false

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -10,6 +10,7 @@ struct SettingsBackup: Codable {
     var favoriteApps: [String]?
     var hiddenLauncherItems: [String]?
     var hiddenLauncherKinds: [String]?
+    var launcherAliases: [String: String]?
 
     /// Enums store by raw value, so an unknown one is ignored rather than failing.
     struct SettingsData: Codable {
@@ -74,6 +75,7 @@ struct SettingsBackup: Codable {
         var hotkeys = 0
         var favorites = 0
         var hiddenItems = 0
+        var aliases = 0
         var customCommands = 0
         var quicklinks = 0
     }
@@ -160,6 +162,7 @@ extension SettingsBackup {
         backup.favoriteApps = core.favorites.keys
         backup.hiddenLauncherItems = Array(core.visibility.hiddenItemKeys)
         backup.hiddenLauncherKinds = Array(core.visibility.hiddenKinds)
+        backup.launcherAliases = core.aliases.aliases
         return backup
     }
 
@@ -184,6 +187,11 @@ extension SettingsBackup {
             let kinds = hiddenLauncherKinds ?? Array(core.visibility.hiddenKinds)
             core.visibility.replace(hiddenItems: items, hiddenKinds: kinds)
             summary.hiddenItems = items.count
+        }
+        if let launcherAliases {
+            core.aliases.replace(launcherAliases)
+            // Counted after the store, which drops blanks the file may carry.
+            summary.aliases = core.aliases.aliases.count
         }
         return summary
     }

--- a/Tinycast/Features/Backup/Service/BackupActions.swift
+++ b/Tinycast/Features/Backup/Service/BackupActions.swift
@@ -150,6 +150,7 @@ enum BackupActions {
         if s.hotkeys > 0 { parts.append("\(s.hotkeys) shortcuts") }
         if s.favorites > 0 { parts.append("\(s.favorites) favorites") }
         if s.hiddenItems > 0 { parts.append("\(s.hiddenItems) hidden items") }
+        if s.aliases > 0 { parts.append("\(s.aliases) aliases") }
         if s.customCommands > 0 { parts.append("\(s.customCommands) custom commands") }
         if s.quicklinks > 0 { parts.append("\(s.quicklinks) quicklinks") }
         guard !parts.isEmpty else { return nil }

--- a/Tinycast/Features/Backup/Service/RaycastImportV2.swift
+++ b/Tinycast/Features/Backup/Service/RaycastImportV2.swift
@@ -48,6 +48,7 @@ enum RaycastImportV2 {
         backup.settings = mapSettings(json)
         backup.hotkeys = mapHotkeys(json)
         backup.favoriteApps = mapFavorites(json)
+        backup.launcherAliases = mapAliases(json)
         let (clipboard, missing) = mapClipboard(json)
         let snippets = RaycastSnippetImport.parse(
             (json["builtin_package_snippets"] as? [String: Any])?["snippets"])
@@ -190,6 +191,24 @@ enum RaycastImportV2 {
             .sorted { $0.order < $1.order }
             .map(\.bundleID)
         return favorites.isEmpty ? nil : favorites
+    }
+
+    /// Only application aliases map over, keyed by bundle ID like the hotkeys above.
+    private static func mapAliases(_ json: [String: Any]) -> [String: String]? {
+        guard let commands = (json["settings"] as? [String: Any])?["commands"] as? [[String: Any]]
+        else { return nil }
+        var aliases: [String: String] = [:]
+        for command in commands {
+            guard command["extensionId"] as? String == "e:r:applications",
+                let alias = (command["alias"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                !alias.isEmpty,
+                let path = appPath(fromCommandID: command["id"] as? String),
+                let bundleID = Bundle(url: URL(fileURLWithPath: path))?.bundleIdentifier
+            else { continue }
+            aliases[bundleID] = alias
+        }
+        return aliases.isEmpty ? nil : aliases
     }
 
     /// The launched app's path is the tail of an applications command id.

--- a/Tinycast/Features/Backup/Settings/RaycastImportSelection.swift
+++ b/Tinycast/Features/Backup/Settings/RaycastImportSelection.swift
@@ -15,6 +15,7 @@ struct RaycastImportSelection: View {
     private static let categories: [Category] = [
         .init(option: .shortcuts, symbol: "command", label: "Shortcuts"),
         .init(option: .favorites, symbol: "star", label: "Favorites"),
+        .init(option: .aliases, symbol: "character.cursor.ibeam", label: "Aliases"),
         .init(option: .emojiSkinTone, symbol: "face.smiling", label: "Emoji skin tone"),
         .init(option: .launchAtLogin, symbol: "power", label: "Launch at login"),
         .init(option: .menuBarVisibility, symbol: "menubar.rectangle", label: "Menu-bar icon"),

--- a/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
@@ -46,6 +46,7 @@ struct CommandsSettingsView: View {
             .settingsEnabled(settings.customCommandsEnabled)
         }
         .formStyle(.grouped)
+        .releasesFocusOnOutsideClick()
         .sheet(item: $editor) { target in
             CustomCommandEditorSheet(command: target.command)
         }

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
@@ -12,6 +12,7 @@ final class CustomCommandCoordinator {
     private let favorites: FavoritesStore
     private let visibility: VisibilityStore
     private let ranking: LauncherRankingStore
+    private let aliases: AliasStore
     /// Dialog and message-HUD presentation only — never for state this type owns.
     private unowned let core: AppCore
 
@@ -25,6 +26,7 @@ final class CustomCommandCoordinator {
         favorites: FavoritesStore,
         visibility: VisibilityStore,
         ranking: LauncherRankingStore,
+        aliases: AliasStore,
         core: AppCore
     ) {
         self.store = store
@@ -36,6 +38,7 @@ final class CustomCommandCoordinator {
         self.favorites = favorites
         self.visibility = visibility
         self.ranking = ranking
+        self.aliases = aliases
         self.core = core
     }
 
@@ -114,6 +117,7 @@ final class CustomCommandCoordinator {
         }
         favorites.remove(keys: entryIDs)
         visibility.removeItemKeys(entryIDs)
+        aliases.removeKeys(entryIDs)
         for entryID in entryIDs {
             ranking.reset(itemKey: entryID)
         }

--- a/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
@@ -137,6 +137,7 @@ final class ExtensionCoordinator {
         }
         core.favorites.remove(keys: Set(entryIDs))
         core.visibility.removeItemKeys(Set(entryIDs))
+        core.aliases.removeKeys(Set(entryIDs))
     }
 
     /// A view command takes over the palette; a no-view command closes it and runs headless.

--- a/Tinycast/Features/Launcher/Model/SearchRelevance.swift
+++ b/Tinycast/Features/Launcher/Model/SearchRelevance.swift
@@ -10,6 +10,8 @@ enum FuzzyMatch {
         case subsequence
 
         var isLiteral: Bool { self != .subsequence }
+        /// Anchored at the candidate's start: what a short, deliberate field must match to win its band.
+        var isAnchored: Bool { self == .exact || self == .prefix }
     }
 
     struct Match: Sendable {
@@ -120,6 +122,8 @@ enum FuzzyMatch {
 struct SearchFields: Sendable {
     /// The display name, plus anything identifying the entry just as strongly.
     var names: [String]
+    /// The user's own alias for the entry; deliberate, so it outranks every vendor field.
+    var userAlias: String?
     /// Spotlight's `kMDItemAlternateNames`: `iBooks`, `Codex`, `浏览器`.
     var alternateNames: [String] = []
     var bundleID: String?
@@ -135,6 +139,7 @@ enum SearchRelevance {
         case nameSubsequence = 3
         case alternateNameLiteral = 4
         case nameLiteral = 5
+        case userAlias = 6
 
         var offset: Int { rawValue * SearchRelevance.bandStride }
     }
@@ -156,6 +161,13 @@ enum SearchRelevance {
             best = max(best ?? Int.min, band.offset + match.score)
         }
 
+        // Only a hit from the alias's start earns the top band; one inside it ranks like a vendor alias.
+        if let alias = fields.userAlias, let match = FuzzyMatch.match(query, candidate: alias),
+            match.tier.isLiteral
+        {
+            let band: Band = match.tier.isAnchored ? .userAlias : .alternateNameLiteral
+            best = max(best ?? Int.min, band.offset + match.score)
+        }
         for name in fields.names {
             consider(name, literal: .nameLiteral, subsequence: .nameSubsequence)
         }

--- a/Tinycast/Features/Launcher/Service/AliasStore.swift
+++ b/Tinycast/Features/Launcher/Service/AliasStore.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The user's per-entry aliases, keyed like favorites and ranking by `preferenceKey`.
+@MainActor
+@Observable
+final class AliasStore {
+    private let defaults = UserDefaults.standard
+    private let defaultsKey = "launcherAliases"
+
+    private(set) var aliases: [String: String]
+    /// AppIndex includes this in its result key, invalidating a ranking when an alias changes.
+    private(set) var revision = 0
+
+    init() {
+        aliases = defaults.dictionary(forKey: defaultsKey) as? [String: String] ?? [:]
+    }
+
+    func alias(for entryKey: String) -> String? { aliases[entryKey] }
+
+    /// Stored as typed — trimming here would eat the space mid-word — but blank still means none.
+    func setAlias(_ alias: String, for entryKey: String) {
+        let value = alias.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : alias
+        guard aliases[entryKey] != value else { return }
+        aliases[entryKey] = value
+        revision &+= 1
+        defaults.set(aliases, forKey: defaultsKey)
+    }
+
+    func removeKeys(_ keys: Set<String>) {
+        let remaining = aliases.filter { !keys.contains($0.key) }
+        guard remaining.count != aliases.count else { return }
+        aliases = remaining
+        revision &+= 1
+        defaults.set(aliases, forKey: defaultsKey)
+    }
+
+    /// Replace the whole table at once (used when importing a settings backup).
+    func replace(_ new: [String: String]) {
+        // An import obeys the same rule as typing: blank means none, or it lands unclearable.
+        aliases = new.filter { !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        revision &+= 1
+        defaults.set(aliases, forKey: defaultsKey)
+    }
+}

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -157,12 +157,14 @@ final class AppIndex {
         let query: String
         let entriesRevision: Int
         let rankingRevision: Int
+        let aliasRevision: Int
     }
 
     private struct ResultsKey: Equatable {
         let query: String
         let entriesRevision: Int
         let rankingRevision: Int
+        let aliasRevision: Int
         let visibilityRevision: Int
         let favoritesRevision: Int
     }
@@ -204,10 +206,12 @@ final class AppIndex {
     /// Set when a refresh lands mid-scan, so a scope edit is never silently dropped.
     private var refreshPending = false
     private let ranking: LauncherRankingStore
+    private let aliases: AliasStore
     private var settings: AppSettings?
 
-    init(ranking: LauncherRankingStore) {
+    init(ranking: LauncherRankingStore, aliases: AliasStore) {
         self.ranking = ranking
+        self.aliases = aliases
     }
 
     /// The always-relevant built-ins, plus whatever a disabled feature has not hidden.
@@ -394,7 +398,8 @@ final class AppIndex {
         let q = query.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return apps }
         let key = MatchKey(
-            query: q, entriesRevision: entriesRevision, rankingRevision: ranking.revision)
+            query: q, entriesRevision: entriesRevision, rankingRevision: ranking.revision,
+            aliasRevision: aliases.revision)
         return matchMemo.value(for: key) { rank(q, limit: limit) }
     }
 
@@ -405,7 +410,8 @@ final class AppIndex {
         let q = query.trimmingCharacters(in: .whitespaces)
         let key = ResultsKey(
             query: q, entriesRevision: entriesRevision, rankingRevision: ranking.revision,
-            visibilityRevision: visibility.revision, favoritesRevision: favorites.revision)
+            aliasRevision: aliases.revision, visibilityRevision: visibility.revision,
+            favoritesRevision: favorites.revision)
         return resultsMemo.value(for: key) {
             // Filtering stays downstream of `matches` so that memo is never keyed on hidden state.
             let base = matches(q).filter(visibility.isVisible)
@@ -419,8 +425,10 @@ final class AppIndex {
         Signposts.interval("AppIndex.rank") {
             let learned = ranking.boosts(query: q)
             let scored = apps.compactMap { app -> (AppEntry, Int)? in
+                var fields = app.searchFields
+                fields.userAlias = aliases.alias(for: app.preferenceKey)
                 // Base relevance is the strongest field; the boost is added blind to it.
-                guard let score = SearchRelevance.score(query: q, fields: app.searchFields) else {
+                guard let score = SearchRelevance.score(query: q, fields: fields) else {
                     return nil
                 }
                 return (app, score + (learned[app.preferenceKey] ?? 0))

--- a/Tinycast/Features/Launcher/Settings/ApplicationsSettingsView.swift
+++ b/Tinycast/Features/Launcher/Settings/ApplicationsSettingsView.swift
@@ -12,5 +12,6 @@ struct ApplicationsSettingsView: View {
                 searchPrompt: "Search applications…")
         }
         .formStyle(.grouped)
+        .releasesFocusOnOutsideClick()
     }
 }

--- a/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
+++ b/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
@@ -11,9 +11,11 @@ struct LauncherItemsSection: View {
     @State private var query = ""
 
     private var entries: [AppEntry] {
-        // Run the matcher once per render, then scope the results to this category.
-        let matched = query.isEmpty ? appIndex.apps : appIndex.matches(query)
-        return matched.filter { $0.kind == kind }
+        let scoped = appIndex.apps.filter { $0.kind == kind }
+        guard !query.isEmpty else { return scoped }
+        // Membership only: score order would move the row being edited out from under the caret.
+        let matched = Set(appIndex.matches(query).map(\.id))
+        return scoped.filter { matched.contains($0.id) }
     }
 
     var body: some View {
@@ -68,6 +70,7 @@ private struct LauncherItemRow: View {
         SettingsRow(title: entry.name) {
             AppIconView(app: entry).frame(width: 18, height: 18)
         } trailing: {
+            AliasField(entry: entry)
             if let action = entry.hotKeyAction {
                 ShortcutRecorder(action: action)
             }
@@ -83,5 +86,67 @@ private struct LauncherItemRow: View {
             get: { visibility.isItemVisible(entry) },
             set: { visibility.setItemVisible($0, for: entry) }
         )
+    }
+}
+
+/// The per-row alias well, dressed like `ShortcutRecorder` so the trailing controls read as a set.
+/// A label until clicked: a form's field editor won't center, and a `Text` centers like Record's.
+private struct AliasField: View {
+    let entry: AppEntry
+    @Environment(AliasStore.self) private var aliases
+    @State private var isEditing = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+        Group {
+            if isEditing {
+                TextField("", text: $draft)
+                    .textFieldStyle(.plain)
+                    .font(Theme.Typography.keyCap)
+                    .focused($focused)
+                    .onSubmit(finishEditing)
+                    .onExitCommand(perform: cancelEditing)
+                    // The pane's `releasesFocusOnOutsideClick` resigns; this catches it landing.
+                    .onChange(of: focused) { _, now in
+                        if !now { finishEditing() }
+                    }
+                    .onAppear { focused = true }
+            } else {
+                Text(aliases.alias(for: entry.preferenceKey) ?? "Add Alias")
+                    .font(Theme.Typography.keyCap)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity)
+                    .contentShape(shape)
+                    .onTapGesture(perform: beginEditing)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.sm)
+        .frame(width: Theme.Size.shortcutRecorder, height: 24)
+        .background(shape.fill(Theme.Colors.cardFill))
+        .overlay(
+            shape.strokeBorder(
+                isEditing ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1))
+        .clipShape(shape)
+        .accessibilityLabel("Alias for \(entry.name)")
+    }
+
+    private func beginEditing() {
+        draft = aliases.alias(for: entry.preferenceKey) ?? ""
+        isEditing = true
+    }
+
+    /// The one commit path — ↵ or focus landing elsewhere; a blank draft removes the alias.
+    private func finishEditing() {
+        guard isEditing else { return }
+        isEditing = false
+        aliases.setAlias(
+            draft.trimmingCharacters(in: .whitespacesAndNewlines), for: entry.preferenceKey)
+    }
+
+    private func cancelEditing() {
+        isEditing = false
     }
 }

--- a/Tinycast/Features/Launcher/Settings/SystemSettingsSettingsView.swift
+++ b/Tinycast/Features/Launcher/Settings/SystemSettingsSettingsView.swift
@@ -10,5 +10,6 @@ struct SystemSettingsSettingsView: View {
                 searchPrompt: "Search System Settings…")
         }
         .formStyle(.grouped)
+        .releasesFocusOnOutsideClick()
     }
 }

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -130,6 +130,8 @@ private struct AppRow: View {
     let running: Bool
     /// Observed so a hotkey set/cleared in Settings re-renders the row's keycaps immediately.
     @Environment(HotKeyManager.self) private var hotKeys
+    /// Observed for the same reason: an alias edit re-renders the row's badge at once.
+    @Environment(AliasStore.self) private var aliases
     @State private var hovered = false
 
     /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
@@ -160,6 +162,17 @@ private struct AppRow: View {
             Text(app.name)
                 .font(Theme.Typography.rowTitle)
                 .lineLimit(1)
+            if let alias = aliases.alias(for: app.preferenceKey) {
+                Text(alias)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .padding(.horizontal, Theme.Spacing.sm)
+                    .padding(.vertical, Theme.Spacing.xxs)
+                    .background(
+                        RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                            .fill(Theme.Colors.controlSurface))
+            }
             if let caps = shortcutCaps {
                 HStack(spacing: Theme.Spacing.xxs) {
                     ForEach(Array(caps.enumerated()), id: \.offset) { _, cap in

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
@@ -12,6 +12,7 @@ final class QuicklinkCoordinator {
     private let favorites: FavoritesStore
     private let visibility: VisibilityStore
     private let ranking: LauncherRankingStore
+    private let aliases: AliasStore
     private let windowController: PaletteWindowController
     private let paletteCoordinator: PaletteCoordinator
     private let settingsCoordinator: SettingsCoordinator
@@ -33,6 +34,7 @@ final class QuicklinkCoordinator {
         favorites: FavoritesStore,
         visibility: VisibilityStore,
         ranking: LauncherRankingStore,
+        aliases: AliasStore,
         windowController: PaletteWindowController,
         paletteCoordinator: PaletteCoordinator,
         settingsCoordinator: SettingsCoordinator,
@@ -48,6 +50,7 @@ final class QuicklinkCoordinator {
         self.favorites = favorites
         self.visibility = visibility
         self.ranking = ranking
+        self.aliases = aliases
         self.windowController = windowController
         self.paletteCoordinator = paletteCoordinator
         self.settingsCoordinator = settingsCoordinator
@@ -260,6 +263,7 @@ final class QuicklinkCoordinator {
         }
         favorites.remove(keys: entryIDs)
         visibility.removeItemKeys(entryIDs)
+        aliases.removeKeys(entryIDs)
         for entryID in entryIDs {
             ranking.reset(itemKey: entryID)
         }

--- a/Tinycast/Features/Settings/SettingsCoordinator.swift
+++ b/Tinycast/Features/Settings/SettingsCoordinator.swift
@@ -40,6 +40,7 @@ final class SettingsCoordinator {
             .environment(core.appIndex)
             .environment(core.hotKeys)
             .environment(core.visibility)
+            .environment(core.aliases)
             .environment(core.customCommands)
             .environment(core.snippetsStore)
             .environment(core.quicklinks)

--- a/Tinycast/Features/SystemActions/Settings/SystemActionsSettingsView.swift
+++ b/Tinycast/Features/SystemActions/Settings/SystemActionsSettingsView.swift
@@ -9,5 +9,6 @@ struct SystemActionsSettingsView: View {
                 searchPrompt: "Search system actions…")
         }
         .formStyle(.grouped)
+        .releasesFocusOnOutsideClick()
     }
 }

--- a/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
@@ -12,6 +12,7 @@ final class UninstallCoordinator {
     private let favorites: FavoritesStore
     private let visibility: VisibilityStore
     private let ranking: LauncherRankingStore
+    private let aliases: AliasStore
     /// Dialog and message-HUD presentation only — never for state this type owns.
     private unowned let core: AppCore
 
@@ -25,6 +26,7 @@ final class UninstallCoordinator {
         favorites: FavoritesStore,
         visibility: VisibilityStore,
         ranking: LauncherRankingStore,
+        aliases: AliasStore,
         core: AppCore
     ) {
         self.session = session
@@ -36,6 +38,7 @@ final class UninstallCoordinator {
         self.favorites = favorites
         self.visibility = visibility
         self.ranking = ranking
+        self.aliases = aliases
         self.core = core
     }
 
@@ -112,6 +115,7 @@ final class UninstallCoordinator {
         favorites.remove(keys: [app.preferenceKey])
         visibility.removeItemKeys([app.preferenceKey])
         ranking.reset(itemKey: app.preferenceKey)
+        aliases.removeKeys([app.preferenceKey])
     }
 
     private func presentUninstallReport(_ report: UninstallReport) async {

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -202,6 +202,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             .environment(core.clipboardStore)
             .environment(core.favorites)
             .environment(core.visibility)
+            .environment(core.aliases)
             .environment(core.calcHistory)
             .environment(core.currencyRates)
             .environment(core.emojiIndex)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ the shared primitives and system shims every feature draws on. Neither may depen
 
 `AppCore.shared` (`App/AppCore.swift`) is a `@MainActor` singleton owning every long-lived thing in the
 app: the stores (`AppIndex`, `ClipboardStore`, `SnippetsStore`, `QuicklinkStore`, `CustomCommandStore`,
-`FavoritesStore`, `VisibilityStore`, `LauncherRankingStore`, `CalculatorHistoryStore`,
+`FavoritesStore`, `VisibilityStore`, `AliasStore`, `LauncherRankingStore`, `CalculatorHistoryStore`,
 `CurrencyRateStore`, `FrequentEmojiStore`), the managers and monitors (`ClipboardManager`,
 `HotKeyManager`, `HyperKeyTap`, `RunningAppsMonitor`, `SnippetKeywordListener`), the shared state
 (`AppSettings`, `PaletteState`, `FileSearchSession`, `UninstallSession`,

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -370,12 +370,13 @@ never shares with an installed copy.
 | Icon override | `UserDefaults` → `extensionAppearances` | yes |
 | Command shortcuts | `UserDefaults` → `hotkey.extensionCommand.<entry id>` | yes |
 | Favorites, hidden items | `UserDefaults` → `favoriteApps`, `hiddenItemKeys` | yes |
+| User alias | `UserDefaults` → `launcherAliases` | yes |
 | Launch ranking | `Caches/<bundle id>/launcher-ranking.json` | yes |
 
 `ExtensionCatalog.safeName` maps an npm-style name onto one path segment, and is the **only** copy of
 that mapping — a second one that drifts orphans every file the first one wrote.
 
-The last three rows are pruned by `ExtensionCoordinator.removeExtensionReferences`, reached through
+The last four rows are pruned by `ExtensionCoordinator.removeExtensionReferences`, reached through
 `ExtensionManager.onDidUninstall`. An extension's `preferenceKey` is its entry id, because it has no
 bundle id, so `extension:<name>/<command>` is what those stores are keyed by. `CustomCommandCoordinator`
 and `QuicklinkCoordinator` prune the same stores the same way; extensions are not a special case.

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -51,14 +51,15 @@ format scalars first, since app metadata can contain bidi/zero-width markers bef
 
 ## Searchable fields
 
-An app is matched on four fields kept deliberately separate — flattening them into one string would
+An app is matched on five fields kept deliberately separate — flattening them into one string would
 lose the thing that decides the ranking. `SearchRelevance.score` evaluates each independently and the
 strongest one becomes the entry's base relevance:
 
 | Band | Field                                   | Match strength                                    |
 | ---- | --------------------------------------- | ------------------------------------------------- |
+| 6    | user alias (any entry kind)             | anchored literal — exact / prefix                 |
 | 5    | display name (plus a snippet's keyword) | literal — exact / prefix / word-start / substring |
-| 4    | Spotlight alternate names               | literal                                           |
+| 4    | Spotlight alternate names, plus a user alias's word-start / substring hits | literal |
 | 3    | display name                            | subsequence                                       |
 | 2    | Spotlight alternate names               | subsequence                                       |
 | 1    | bundle identifier                       | literal only                                      |
@@ -87,6 +88,30 @@ query (`cop` ⊂ `com.apple.Photos`), which would change _which_ apps appear rat
 order. For the same reason a bundle id is matched with its leading component stripped
 (`apple.Photos`, not `com.apple.Photos`): `com` alone prefixes almost every installed app. The full id
 still matches exactly, so a pasted identifier resolves.
+
+### User aliases
+
+`AliasStore` (`Launcher/Service/`) keeps one user-chosen alias per entry, keyed by `preferenceKey`
+like favorites and learned ranking, so every entry kind — apps, commands, quicklinks, snippets —
+can carry one. An alias is deliberate in a way no vendor field is, so a hit **from its start** —
+exact or prefix — occupies the top band and ranks its entry first. A hit *inside* the alias ranks
+with the Spotlight aliases instead (`term` inside `iterm` must not beat Terminal's own prefix),
+and a subsequence of a short alias would be noise, so it never matches at all. `AppIndex` folds the
+alias into `SearchFields.userAlias` at rank time, keying its memos on the store's revision.
+
+A launcher row shows its entry's alias as a small chip after the name, so what a badge-bearing
+result will answer to is visible without opening anything.
+
+Editing lives in Settings only — an alias is one-time configuration like a shortcut or a
+visibility checkbox, not a per-invocation action, so the ⌘K menu stays out of it. Every pane built
+on `LauncherItemsSection` puts an `AliasField` on each row, dressed like the `ShortcutRecorder`
+beside it; edits store as typed and trim when the field loses focus, and a blank means none. That
+list filters by **membership only**, keeping the index's name order — re-ranking it per keystroke
+would move the row being edited out from under its own field editor.
+
+Aliases ride along in a settings backup (`launcherAliases`), and deleting what an alias points at —
+uninstalling an app, deleting a quicklink or custom command, uninstalling an extension — removes it
+with the entry's other per-entry preferences.
 
 ### Alternate names
 

--- a/docs/features/raycast-import.md
+++ b/docs/features/raycast-import.md
@@ -79,8 +79,10 @@ Notes that matter:
 - **Clipboard records are flat** (`text` / `filePath` / `category`), not v2's nested representations,
   and their timestamps carry no fractional seconds. Only `image` becomes an image clip: a `file`
   record can be any document and Tinycast has no kind for that, so its label imports as text.
-- **v1 exports no launch-at-login preference and no global palette hotkey**, so neither is ever
-  mapped. That is why `.launchAtLogin` is absent from `RaycastFormat.v1.supportedOptions`.
+- **v1 exports no launch-at-login preference, no global palette hotkey and no aliases**, so none is
+  ever mapped. That is why `.launchAtLogin` and `.aliases` are absent from
+  `RaycastFormat.v1.supportedOptions`. (v2 carries an `alias` string per `settings.commands[]` entry;
+  application ones map to `launcherAliases` by bundle ID, the same resolution the hotkey mapper uses.)
 - `builtin_package_navigation` and `builtin_package_snippets` are mapped defensively — no export with
   favorites or snippets configured has been available to verify their exact shape.
 


### PR DESCRIPTION
## Related issue

Closes #251

## What changed

Every launcher entry can carry one user-chosen **alias**, Raycast-style, ranked above everything else when searched.

- **Store** — `AliasStore` (`Launcher/Service/`), one alias per `preferenceKey` in UserDefaults, with a revision counter like `VisibilityStore`'s. Cleaned up on app uninstall alongside favorites/ranking; rides settings backups as `launcherAliases` (data, not a capability — nothing here grants a permission class).
- **Matching** — `SearchFields` gains `userAlias`; `SearchRelevance` gains band 6 above `nameLiteral`, matched **literally only** (like the identifier fields — a subsequence of a short alias is noise). `AppIndex` folds the alias in at rank time and keys both memos on the store's revision. The band-stride contract is untouched; the learned boost still reorders only within a band.
- **⌘K → Set Alias** — new row in `AppActionsMenu` for every entry kind. It opens `AliasEditorPanel`, an in-palette glass panel in the Actions menu's corner (same anchor, transition and `glassEffect` recipe as `PopoverMenu`): header, focused text field, footer with the entry's icon + name and Close (Esc) / Save (↵). ↵ or Save commits — an emptied field removes — Esc or click-away closes, and focus returns to the search field. While it is up the palette's ↑/↓/Tab/⌘K/⌃⇧Q handlers yield so the caret owns the keyboard; a click-catcher overlay shields the list and footer. Feedback goes through the existing message pill ("Alias Set" / "Alias Removed").
- **Rows** — a launcher row shows its alias as a small chip after the name (`AppRow` observes the store, so edits re-render live).
- **Settings** — every pane built on `LauncherItemsSection` (Applications, System Settings, System Actions, Commands) gets an inline per-row "Add alias" field; edits write through live and trim on focus loss.

Non-obvious bits: the alias band is deliberately literal-only; the editor panel deliberately does **not** set `PaletteState.menuOpen` (the menu-open input freeze would swallow typing); `AliasStore.setAlias` stores text as typed so a mid-word space isn't fought, with blank-when-trimmed meaning removal and the two commit points (panel save, settings focus loss) trimming.

## Memory footprint

Debug build of this branch, `footprint` phys_footprint:

| Step                                   | Memory |
| -------------------------------------- | ------ |
| Idle after launch                      | 52 MB  |
| Palette open                           | 56 MB  |
| Feature in use (alias panel open, peak)| 62 MB  |
| Palette closed, settled                | 61 MB  |

(Idle figure taken after a long-running session with warm caches; a cold launch idles at ~26 MB.)

Leak-tested: `leaks` reports ~19.7 KB total, all rooted in Apple frameworks (AppIntents/XPC connection blocks); nothing rooted in Tinycast code, and nothing referencing the alias types.

## Demo

Set alias "iterm" on kitty via ⌘K → Set Alias, then typing `iterm` ranks kitty first with an "iterm" chip on the row. Video to follow — flagging up front that it isn't attached yet.

## Drawbacks

- An alias matches literally only; `fga` will not fuzzy-match an alias `figalias`. Deliberate — predictability over reach for a field the user typed themselves.
- One alias per entry (Raycast allows one too). The store shape (`[String: String]`) would need a values-array migration to allow more.
- The Settings alias field stores keystrokes as typed until focus leaves; an edit abandoned mid-word persists un-trimmed until the next commit touches it. Harmless to matching (queries are trimmed) but worth knowing.

## Tests & validation

- `Tests/fuzz-test.swift` (compiles the real scorer): new **user aliases** section — alias tops ranking, band sits at 6×stride, alias beats another entry's exact display name, literal tiers match, subsequence never matches, strongest field still wins on an aliased entry. Band-ordering and stride assertions extended to the new band; the randomized property loop gains a user-alias field variant and corpus entry, and the band-violation bound moves 5 → 6.
- `./Scripts/run-tests.sh` — all 33 harnesses pass. `./Scripts/lint.sh` clean, Debug build with no new warnings, `Features/*/Model` purity grep clean, `xcodegen generate` run and committed.
- By hand (real CGEvent input, AX-verified): set/replace/remove via the ⌘K panel; ↵ saves, Esc and click-away close without saving, focus returns to search; alias chip appears and updates live; searching the alias ranks the entry first and the alias-only query matches nothing else; Settings inline field writes through and trims on blur; backup export includes `launcherAliases`.
