### PR TITLE
fix(palette): hide search field placeholder during IME composition / 修复输入法候选输入阶段占位符文本未清除的问题

### DIFF
--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -8,11 +8,29 @@ final class PalettePanel: NSPanel {
     var onBareBackspace: (() -> Bool)?
     /// Command chords the field editor swallows, plus the ones no main menu handles.
     var onCommandShortcut: ((NSEvent) -> Bool)?
+    /// Tracks IME marked-text composition so the hand-drawn placeholder can hide during input.
+    private var selectionObserver: NotificationToken?
     /// Arms hover from `sendEvent`, the one place both event streams pass through.
     weak var paletteState: PaletteState? {
         didSet {
             paletteState?.onMenuOpenChanged = { [weak self] open in self?.setSearchCaretHidden(open) }
+            attachSelectionObserver()
         }
+    }
+
+    private func attachSelectionObserver() {
+        guard let editor = firstResponder as? NSTextView else { return }
+        selectionObserver = NotificationToken(
+            NotificationCenter.default.addObserver(
+                forName: NSTextView.didChangeSelectionNotification,
+                object: editor,
+                queue: .main
+            ) { [weak self] _ in
+                guard let self, let editor = self.firstResponder as? NSTextView else { return }
+                self.paletteState?.isComposing = editor.hasMarkedText()
+            },
+            center: .default
+        )
     }
 
     /// Keys driving an open menu; they reach `onKeyPress` even while editing is frozen.
@@ -151,6 +169,14 @@ final class PalettePanel: NSPanel {
         // The controller owns the frame; without this the top edge drifts on the swap.
         hosting.sizingOptions = []
         contentView = hosting
+    }
+
+    override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+        let result = super.makeFirstResponder(responder)
+        if result, responder is NSTextView {
+            attachSelectionObserver()
+        }
+        return result
     }
 
     override var canBecomeKey: Bool { true }

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -20,6 +20,7 @@ final class PalettePanel: NSPanel {
 
     private func attachSelectionObserver() {
         guard let editor = firstResponder as? NSTextView else { return }
+        paletteState?.isComposing = editor.hasMarkedText()
         selectionObserver = NotificationToken(
             NotificationCenter.default.addObserver(
                 forName: NSTextView.didChangeSelectionNotification,
@@ -169,6 +170,11 @@ final class PalettePanel: NSPanel {
         // The controller owns the frame; without this the top edge drifts on the swap.
         hosting.sizingOptions = []
         contentView = hosting
+    }
+
+    func syncMarkedTextState() {
+        guard let editor = firstResponder as? NSTextView else { return }
+        paletteState?.isComposing = editor.hasMarkedText()
     }
 
     override func makeFirstResponder(_ responder: NSResponder?) -> Bool {

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -7,6 +7,8 @@ final class PaletteState {
     var mode: PaletteMode = .launcher
     var query: String = ""
     var selection: Int = 0
+    /// True while an IME (e.g. Pinyin) has marked text in flight.
+    var isComposing: Bool = false
     /// The clipboard screen's type filter, reset with the rest of the screen state on each summon.
     var clipboardFilter: ClipboardFilter = .all
     /// Changes every time the palette is shown so the search field can re-focus.
@@ -43,6 +45,7 @@ final class PaletteState {
         self.mode = mode
         query = ""
         selection = 0
+        isComposing = false
         commandArguments = [:]
         clipboardFilter = .all
         forceExpanded = false

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -58,10 +58,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             // Non-activating, so summoning never raises our own aux windows behind it.
             panel.makeKeyAndOrderFront(nil)
             panel.orderFrontRegardless()
+            panel.syncMarkedTextState()
             // A never-activated login item can drop the first key request, so re-assert.
             DispatchQueue.main.async { [weak panel] in
                 guard let panel, panel.isVisible, !panel.isKeyWindow else { return }
                 panel.makeKeyAndOrderFront(nil)
+                panel.syncMarkedTextState()
             }
         }
     }
@@ -134,6 +136,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
         DispatchQueue.main.async { [weak self] in
             self?.core.palette.focusToken = UUID()
+            self?.panel?.syncMarkedTextState()
         }
     }
 

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -532,7 +532,7 @@ struct RootPaletteView: View {
             // Fills the row's height, so there's no gap above it for topDragStrip to meet.
             .frame(maxHeight: .infinity)
             .background(alignment: .leading) {
-                if vm.query.isEmpty {
+                if vm.query.isEmpty && !vm.isComposing {
                     Text(searchPrompt)
                         .font(Theme.Typography.searchField)
                         .foregroundStyle(Theme.Colors.textTertiary)


### PR DESCRIPTION
fix(palette): hide search field placeholder during IME composition  
fix(palette): 修复输入法候选输入阶段占位符文本未清除的问题  
──────

#### Summary / 概述

Switched the palette search TextField to use SwiftUI's native prompt parameter instead of a custom .background placeholder view.

将搜索栏 TextField 的占位符（Placeholder）改为使用 SwiftUI 原生 prompt 参数实现，移除之前基于 .background 自定义叠加的占位符逻辑。

#### Problem / 问题

When typing with an IME (e.g., Chinese, Japanese) where marked text / pinyin composition is active before confirming characters into the text field, vm.query remains empty. The custom .background overlay checked vm.query.isEmpty, causing
the placeholder text to overlap with the ongoing IME composition text.

在使用中文/日文等输入法（IME）输入拼音或处于候选组合状态（Composition / Marked Text）但尚未将文字正式确认上屏时，绑定的 vm.query 仍为空字符串 ""。原有通过 .background 并在 vm.query.isEmpty 为 true
时展示的自定义占位符不会被隐藏，导致占位符文本与正在输入的候选拼音/字母发生视觉重叠。

<img width="750" height="475" alt="screenshot-260818-130754" src="https://github.com/user-attachments/assets/e8cb5ad5-84f6-4bf5-bcee-95d64b8ea79c" />

#### Solution / 修改方案

• Used SwiftUI's native prompt: Text(searchPrompt).foregroundStyle(Theme.Colors.textTertiary) directly on TextField.
• AppKit automatically manages placeholder visibility during active text input and IME composition states (hasMarkedText), eliminating the overlap.
• Removed custom overlay background logic on the search field.

• 直接在 TextField 上使用原生 prompt: Text(searchPrompt).foregroundStyle(Theme.Colors.textTertiary) 参数。
• 借助 AppKit / NSTextView 原生机制，在输入法处于 marked text（组合输入）阶段时由系统自动处理并隐藏占位符。
• 移除手动在 .background 绘制的占位符相关逻辑，精简代码。

<img width="750" height="475" alt="screenshot-260818-130814" src="https://github.com/user-attachments/assets/1ffd777d-0bfe-4bbf-8951-061611525217" />

#### Testing / 测试验证

[✓] Verified placeholder displays when the search field is empty.
[✓] Verified placeholder disappears immediately upon IME composition (e.g. typing Pinyin) before characters are committed.
[✓] Verified placeholder restores properly when query and composition are cleared.

[✓] 搜索栏内容为空时正常展示占位符。
[✓] 使用输入法输入拼音/候选词时，占位符立即隐去，不再与候选字符重叠。
[✓] 清空输入或取消输入法组合时，占位符恢复正常显示。
