### PR TITLE
Own the palette search field as an NSTextView

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		7FDE88F4E065FF80DCB92445 /* NotesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B77DA46386E7E459406E4 /* NotesStore.swift */; };
 		7FF6A0A4702E1C1365F2D76A /* LauncherScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */; };
 		8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */; };
+		8090FBE343746D9D43EE2B25 /* PaletteSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */; };
 		80E77985425032856DEECDFD /* CalloutShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */; };
 		82D95EF7539498A9A484B3D1 /* SystemActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEB022D080E6DAF703D8132 /* SystemActionsSettingsView.swift */; };
 		8453CF4C0D8D015A66C9B400 /* HoverArming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */; };
@@ -514,6 +515,7 @@
 		B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherScreen.swift; sourceTree = "<group>"; };
 		B9F568F2F6EF857274F1A9D8 /* ExtensionIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionIconCache.swift; sourceTree = "<group>"; };
 		BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePanel.swift; sourceTree = "<group>"; };
+		BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteSearchField.swift; sourceTree = "<group>"; };
 		BDB241B179A08518424F7C1B /* DialogPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogPanel.swift; sourceTree = "<group>"; };
 		BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		BE6972F177922B1EB8831735 /* OnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
@@ -1329,6 +1331,7 @@
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
+				BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */,
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
 				445B0374FD5D74DBE23243CD /* PaletteScreen.swift */,
 				188A6D3C5B6BC67716F15F83 /* PaletteState.swift */,
@@ -1805,6 +1808,7 @@
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
+				8090FBE343746D9D43EE2B25 /* PaletteSearchField.swift in Sources */,
 				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,
 				9F8806D46EBAF7058FC2EAEC /* PaletteRowIndex.swift in Sources */,
 				DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */,

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -150,10 +150,9 @@ enum Theme {
 
     /// System text styles (not hardcoded sizes) so the UI honors Dynamic Type.
     enum Typography {
-        /// One size, two frameworks: `TextTrailingDragHandle` measures what the field renders.
         static let searchFieldSize: CGFloat = 20
-        static let searchField = Font.system(size: searchFieldSize, weight: .regular)
-        /// `NSFont` is not `Sendable`, hence the isolation; every reader is a view anyway.
+        /// The palette's field is an `NSTextView`, so this is what it renders and what
+        /// `TextTrailingDragHandle` measures. `NSFont` is not `Sendable`; every reader is a view.
         @MainActor static let searchFieldNSFont = NSFont.systemFont(
             ofSize: searchFieldSize, weight: .regular)
         static let headerIcon = Font.system(size: 18, weight: .medium)

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -48,7 +48,7 @@ final class PalettePanel: NSPanel {
             keyCode: UInt16(arrow.code))
     }
 
-    /// Caret hiding on SwiftUI's own field editor. docs/features/palette.md#menu-open-input-freeze
+    /// Caret hiding on the focused text view. docs/features/palette.md#menu-open-input-freeze
     private func setSearchCaretHidden(_ hidden: Bool) {
         guard let editor = firstResponder as? NSTextView else { return }
         editor.insertionPointColor = hidden ? .clear : .white
@@ -63,20 +63,16 @@ final class PalettePanel: NSPanel {
     ]
 
     /// Two AppKit mechanisms disagree over the field — SwiftUI's clip view claims the arrow for
-    /// the whole window as a cursor rect, the field editor claims the I-beam from its tracking
+    /// the whole window as a cursor rect, the search text view claims the I-beam from its tracking
     /// area — so the panel settles it from the field's own frame, after `super` has had its say.
     private func applyCursorPolicy(for event: NSEvent) {
         guard Self.cursorEvents.contains(event.type) else { return }
-        // Outset: the field editor AppKit installs is a point taller than the field it serves.
-        let text = searchFieldRect.insetBy(dx: -Self.fieldEditorSlack, dy: -Self.fieldEditorSlack)
         let cursor: NSCursor =
-            text.contains(convertPoint(fromScreen: NSEvent.mouseLocation)) ? .iBeam : .arrow
+            searchFieldRect.contains(convertPoint(fromScreen: NSEvent.mouseLocation))
+            ? .iBeam : .arrow
         guard NSCursor.current !== cursor else { return }
         cursor.set()
     }
-
-    /// docs/features/palette.md: a 24pt editor in a 23pt field, so its I-beam overhangs.
-    private static let fieldEditorSlack: CGFloat = 2
 
     /// SwiftUI reports the field top-left down; AppKit reads the window bottom-left up.
     private var searchFieldRect: CGRect {

--- a/Tinycast/Palette/PaletteSearchField.swift
+++ b/Tinycast/Palette/PaletteSearchField.swift
@@ -91,6 +91,10 @@ struct PaletteSearchField: NSViewRepresentable {
         }
     }
 
+    /// What AppKit's own field editor pads by: the caret is centred on the insertion point, so
+    /// column 0 loses half of it to the clip view without this.
+    private static let fieldEditorPadding: CGFloat = 2
+
     private static func configure(_ textView: PaletteSearchTextView) {
         textView.isFieldEditor = true
         textView.isRichText = false
@@ -105,7 +109,7 @@ struct PaletteSearchField: NSViewRepresentable {
         textView.textContainer?.widthTracksTextView = false
         textView.textContainer?.size = NSSize(
             width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.lineFragmentPadding = fieldEditorPadding
         textView.font = Theme.Typography.searchFieldNSFont
         textView.textColor = .white
         textView.insertionPointColor = .white

--- a/Tinycast/Palette/PaletteSearchField.swift
+++ b/Tinycast/Palette/PaletteSearchField.swift
@@ -198,7 +198,7 @@ final class PaletteSearchTextView: NSTextView {
     }
 
     private func drawPlaceholder() {
-        guard string.isEmpty, !placeholder.isEmpty, let font else { return }
+        guard string.isEmpty, !hasMarkedText(), !placeholder.isEmpty, let font else { return }
         // The origin TextKit gives the first glyph, so placeholder and query cannot disagree.
         let origin = NSPoint(
             x: textContainerOrigin.x + (textContainer?.lineFragmentPadding ?? 0),

--- a/Tinycast/Palette/PaletteSearchField.swift
+++ b/Tinycast/Palette/PaletteSearchField.swift
@@ -1,0 +1,248 @@
+import AppKit
+import SwiftUI
+
+/// Keys an `NSTextView` would consume before the palette could answer them.
+enum PaletteSearchKey {
+    case up
+    case down
+    case left
+    case right
+    case submit
+    case tab
+    case cancel
+}
+
+/// The palette's search field. One `NSTextView` draws both the query and the placeholder, so
+/// nothing steps when focus moves. docs/features/palette.md#the-search-field-is-tinycasts
+struct PaletteSearchField: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var isFocused: Bool
+    let prompt: String
+    /// `true` keeps the key; `false` leaves it to the caret.
+    let onKeyCommand: (PaletteSearchKey, NSEvent.ModifierFlags) -> Bool
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.verticalScrollElasticity = .none
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.borderType = .noBorder
+        // The header lays out its own metrics; AppKit must not inset the field a second time.
+        scrollView.automaticallyAdjustsContentInsets = false
+
+        let coordinator = context.coordinator
+        let textView = PaletteSearchTextView()
+        Self.configure(textView)
+        textView.delegate = coordinator
+        textView.onKeyCommand = onKeyCommand
+        textView.onFocusChange = { [weak coordinator] in coordinator?.report(focus: $0) }
+        textView.placeholder = prompt
+        textView.setAccessibilityLabel(prompt)
+        textView.string = text
+        scrollView.documentView = textView
+        coordinator.textView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = context.coordinator.textView else { return }
+        textView.onKeyCommand = onKeyCommand
+        if textView.placeholder != prompt {
+            textView.placeholder = prompt
+            textView.setAccessibilityLabel(prompt)
+            textView.needsDisplay = true
+        }
+        // Replacing the storage mid-composition would drop the marked text the IME still owns.
+        if textView.string != text, !textView.hasMarkedText() {
+            textView.replaceWholeString(with: text)
+        }
+        guard isFocused, textView.window?.firstResponder !== textView else { return }
+        textView.window?.makeFirstResponder(textView)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: PaletteSearchField
+        weak var textView: PaletteSearchTextView?
+
+        init(parent: PaletteSearchField) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? PaletteSearchTextView else { return }
+            textView.needsDisplay = true
+            // An IME owns the marked text until it commits; publishing it would search the pinyin.
+            guard !textView.hasMarkedText(), textView.string != parent.text else { return }
+            parent.text = textView.string
+        }
+
+        /// Deferred: AppKit swaps first responder inside a SwiftUI update, and this writes state.
+        func report(focus: Bool) {
+            Task { @MainActor in
+                guard self.parent.isFocused != focus else { return }
+                self.parent.isFocused = focus
+            }
+        }
+    }
+
+    private static func configure(_ textView: PaletteSearchTextView) {
+        textView.isFieldEditor = true
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.drawsBackground = false
+        textView.isVerticallyResizable = false
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.height]
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.size = NSSize(
+            width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.font = Theme.Typography.searchFieldNSFont
+        textView.textColor = .white
+        textView.insertionPointColor = .white
+        textView.selectedTextAttributes = [
+            .backgroundColor: NSColor(Theme.Colors.selection),
+            .foregroundColor: NSColor.white
+        ]
+        // A query is matched literally, so nothing may rewrite what was typed.
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.smartInsertDeleteEnabled = false
+        textView.usesFindPanel = false
+        textView.allowsUndo = true
+        textView.setAccessibilityRole(.textField)
+    }
+}
+
+/// Draws its own placeholder through the same text container as the query, so the two share an
+/// origin no focus change can move. There is no cell to hand the string to and no field editor to
+/// take it back — that swap is what stepped the placeholder a point.
+@MainActor
+final class PaletteSearchTextView: NSTextView {
+    var placeholder = ""
+    var onKeyCommand: ((PaletteSearchKey, NSEvent.ModifierFlags) -> Bool)?
+    var onFocusChange: ((Bool) -> Void)?
+
+    /// `doCommand(by:)` names the action but not the chord that produced it.
+    private var currentModifiers: NSEvent.ModifierFlags = []
+
+    func replaceWholeString(with next: String) {
+        string = next
+        setSelectedRange(NSRange(location: (next as NSString).length, length: 0))
+        needsDisplay = true
+    }
+
+    override func keyDown(with event: NSEvent) {
+        currentModifiers = event.modifierFlags
+        super.keyDown(with: event)
+    }
+
+    override func doCommand(by selector: Selector) {
+        if let key = Self.paletteKey(for: selector),
+            onKeyCommand?(key, currentModifiers) == true
+        {
+            return
+        }
+        super.doCommand(by: selector)
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        if accepted { onFocusChange?(true) }
+        return accepted
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let resigned = super.resignFirstResponder()
+        if resigned { onFocusChange?(false) }
+        return resigned
+    }
+
+    override func layout() {
+        super.layout()
+        matchWidthToClipView()
+        centerLineVertically()
+    }
+
+    /// Never narrower than its clip view, so a click past the last glyph still lands the caret.
+    private func matchWidthToClipView() {
+        guard let clip = enclosingScrollView?.contentView else { return }
+        minSize = NSSize(width: clip.bounds.width, height: 0)
+        guard bounds.width < clip.bounds.width else { return }
+        setFrameSize(NSSize(width: clip.bounds.width, height: bounds.height))
+    }
+
+    /// The field fills the header row, so the single line is centred by inset rather than by frame.
+    private func centerLineVertically() {
+        let inset = max(0, ((bounds.height - lineHeight) / 2).rounded())
+        guard textContainerInset.height != inset else { return }
+        textContainerInset = NSSize(width: 0, height: inset)
+    }
+
+    /// Before `super`, so the caret still draws over the placeholder rather than under it.
+    override func draw(_ dirtyRect: NSRect) {
+        drawPlaceholder()
+        super.draw(dirtyRect)
+    }
+
+    private func drawPlaceholder() {
+        guard string.isEmpty, !placeholder.isEmpty, let font else { return }
+        // The origin TextKit gives the first glyph, so placeholder and query cannot disagree.
+        let origin = NSPoint(
+            x: textContainerOrigin.x + (textContainer?.lineFragmentPadding ?? 0),
+            y: textContainerOrigin.y)
+        NSAttributedString(
+            string: placeholder,
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor(Theme.Colors.textTertiary)
+            ]
+        ).draw(at: origin)
+    }
+
+    private var lineHeight: CGFloat {
+        guard let font else { return 0 }
+        return ceil(font.ascender - font.descender + font.leading)
+    }
+
+    private static func paletteKey(for selector: Selector) -> PaletteSearchKey? {
+        switch selector {
+        case #selector(NSResponder.moveUp(_:)),
+            #selector(NSResponder.moveUpAndModifySelection(_:)),
+            #selector(NSResponder.moveToBeginningOfDocument(_:)):
+            return .up
+        case #selector(NSResponder.moveDown(_:)),
+            #selector(NSResponder.moveDownAndModifySelection(_:)),
+            #selector(NSResponder.moveToEndOfDocument(_:)):
+            return .down
+        case #selector(NSResponder.moveLeft(_:)),
+            #selector(NSResponder.moveLeftAndModifySelection(_:)):
+            return .left
+        case #selector(NSResponder.moveRight(_:)),
+            #selector(NSResponder.moveRightAndModifySelection(_:)):
+            return .right
+        case #selector(NSResponder.insertNewline(_:)),
+            #selector(NSResponder.insertLineBreak(_:)),
+            #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)):
+            return .submit
+        case #selector(NSResponder.insertTab(_:)), #selector(NSResponder.insertBacktab(_:)):
+            return .tab
+        case #selector(NSResponder.cancelOperation(_:)):
+            return .cancel
+        default:
+            return nil
+        }
+    }
+}

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct RootPaletteView: View {
@@ -18,7 +19,8 @@ struct RootPaletteView: View {
     @Environment(QuicklinkArgumentSession.self) private var quicklinkArguments
     @Environment(ExtensionManager.self) private var extensions
     @Environment(AppSettings.self) private var settings
-    @FocusState private var searchFocused: Bool
+    /// Intent, not SwiftUI focus: the search field is an `NSTextView` that takes and reports it.
+    @State private var searchFocused = false
     /// Kept apart from the search field's own focus. See docs/features/palette.md.
     @FocusState private var argumentFocused: String?
     /// Which in-window menu is open; at most one, so the state cannot disagree with itself.
@@ -281,65 +283,19 @@ struct RootPaletteView: View {
             }
             return .handled
         }
-        .onKeyPress(.downArrow) {
-            if isCollapsed {
-                // The compact bar shows no selection, so Down reveals the list's first row.
-                vm.selection = 0
-                core.paletteCoordinator.expandFromCompact()
-                return .handled
-            }
-            if menuOpen {
-                moveMenu(1)
-                return .handled
-            }
-            moveVertically(1)
-            return .handled
-        }
-        .onKeyPress(.upArrow) {
-            if isCollapsed { return .ignored }
-            if menuOpen {
-                moveMenu(-1)
-                return .handled
-            }
-            moveVertically(-1)
-            return .handled
-        }
+        // These reach `onKeyPress` only while an inline argument field holds focus; the search
+        // field consumes them first through `handleSearchKey`.
+        .onKeyPress(.downArrow) { moveDown() ? .handled : .ignored }
+        .onKeyPress(.upArrow) { moveUp() ? .handled : .ignored }
         // Horizontal arrows step the grid; elsewhere they stay with the caret.
-        .onKeyPress(.leftArrow) {
-            if menuOpen { return .handled }
-            return moveHorizontally(-1) ? .handled : .ignored
-        }
-        .onKeyPress(.rightArrow) {
-            if menuOpen { return .handled }
-            return moveHorizontally(1) ? .handled : .ignored
-        }
-        // Plain ↵ activates an open menu's row; a modified ↵ always runs the selection's.
+        .onKeyPress(.leftArrow) { menuOpen || moveHorizontally(-1) ? .handled : .ignored }
+        .onKeyPress(.rightArrow) { menuOpen || moveHorizontally(1) ? .handled : .ignored }
         .onKeyPress(keys: [.return], phases: .down) { press in
-            let command = press.modifiers.contains(.command)
-            let option = press.modifiers.contains(.option)
-            if menuOpen, !command, !option {
-                activateMenuItem(menuSelection)
-                return .handled
-            }
-            guard command || option else { return .ignored }
-            let screen = screen
-            let selection = selection(in: screen)
-            if command { return screen.secondary(at: selection) ? .handled : .ignored }
-            return screen.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
+            submit(
+                command: press.modifiers.contains(.command),
+                option: press.modifiers.contains(.option)) ? .handled : .ignored
         }
-        .onKeyPress(.escape) {
-            if menuOpen {
-                closeMenus()
-                return .handled
-            }
-            // An extension pops its own navigation stack before the command is left.
-            if vm.mode == .extensionCommand {
-                core.extensionCoordinator.exitExtensionScreen()
-                return .handled
-            }
-            core.paletteCoordinator.hidePalette()
-            return .handled
-        }
+        .onKeyPress(.escape) { cancel() ? .handled : .ignored }
         .onKeyPress(.tab) {
             if !menuOpen { advanceTabFocus() }
             return .handled
@@ -523,40 +479,50 @@ struct RootPaletteView: View {
     /// The one search field — past its text it's a drag handle, matching Spotlight.
     private var searchField: some View {
         @Bindable var vm = vm
-        return TextField("", text: $vm.query)
-            .textFieldStyle(.plain)
-            .font(Theme.Typography.searchField)
-            .tint(.white)
-            .focused($searchFocused)
-            .onSubmit(activateSelection)
-            // Fills the row's height, so there's no gap above it for topDragStrip to meet.
-            .frame(maxHeight: .infinity)
-            .background(alignment: .leading) {
-                if vm.query.isEmpty {
-                    Text(searchPrompt)
-                        .font(Theme.Typography.searchField)
-                        .foregroundStyle(Theme.Colors.textTertiary)
-                        .lineLimit(1)
-                        // Never a click target: tapping the placeholder must still land the caret.
-                        .allowsHitTesting(false)
-                }
+        return PaletteSearchField(
+            text: $vm.query, isFocused: $searchFocused, prompt: searchPrompt,
+            onKeyCommand: handleSearchKey
+        )
+        // Fills the row's height, so there's no gap above it for topDragStrip to meet.
+        .frame(maxHeight: .infinity)
+        // Never branches on query — that tore down the text view mid-keystroke once.
+        .overlay {
+            if settings.paletteDraggable {
+                TextTrailingDragHandle(
+                    text: vm.query, font: Theme.Typography.searchFieldNSFont,
+                    onBegan: beginDrag, onEnded: endDrag)
             }
-            // The prompt used to carry this; without it the field would be unlabelled.
-            .accessibilityLabel(Text(searchPrompt))
-            // Never branches on query — that tore down the field editor mid-keystroke once.
-            .overlay {
-                if settings.paletteDraggable {
-                    TextTrailingDragHandle(
-                        text: vm.query, font: Theme.Typography.searchFieldNSFont,
-                        onBegan: beginDrag, onEnded: endDrag)
-                }
-            }
-            // The panel resolves the pointer against this rather than hit-testing for the field.
-            .onGeometryChange(for: CGRect.self) {
-                $0.frame(in: .global)
-            } action: {
-                vm.searchFieldFrame = $0
-            }
+        }
+        // The panel resolves the pointer against this rather than hit-testing for the field.
+        .onGeometryChange(for: CGRect.self) {
+            $0.frame(in: .global)
+        } action: {
+            vm.searchFieldFrame = $0
+        }
+    }
+
+    /// The search field answers first and the caret keeps whatever the palette declines. Argument
+    /// fields are SwiftUI's, so the same handlers stay on `onKeyPress` for when one holds focus.
+    private func handleSearchKey(_ key: PaletteSearchKey, _ modifiers: NSEvent.ModifierFlags)
+        -> Bool
+    {
+        switch key {
+        case .up: return moveUp()
+        case .down: return moveDown()
+        case .left: return menuOpen || moveHorizontally(-1)
+        case .right: return menuOpen || moveHorizontally(1)
+        case .submit:
+            let command = modifiers.contains(.command)
+            let option = modifiers.contains(.option)
+            if submit(command: command, option: option) { return true }
+            // The field's own ↵: what the shared handler declines runs the selection's action.
+            if !command, !option { activateSelection() }
+            return true
+        case .tab:
+            if !menuOpen { advanceTabFocus() }
+            return true
+        case .cancel: return cancel()
+        }
     }
 
     /// The Uninstall screen's primary action is destructive, so its pill isn't white.
@@ -685,6 +651,61 @@ struct RootPaletteView: View {
         }
         vm.selection = next
         scroll = ScrollIntent(kind: .follow)
+        return true
+    }
+
+    /// ↓ reveals the list from the compact bar, else steps the open menu or the rows.
+    private func moveDown() -> Bool {
+        if isCollapsed {
+            // The compact bar shows no selection, so Down reveals the list's first row.
+            vm.selection = 0
+            core.paletteCoordinator.expandFromCompact()
+            return true
+        }
+        if menuOpen {
+            moveMenu(1)
+            return true
+        }
+        moveVertically(1)
+        return true
+    }
+
+    /// The compact bar has nothing above it, so ↑ stays with the caret there.
+    private func moveUp() -> Bool {
+        if isCollapsed { return false }
+        if menuOpen {
+            moveMenu(-1)
+            return true
+        }
+        moveVertically(-1)
+        return true
+    }
+
+    /// Plain ↵ activates an open menu's row; a modified ↵ always runs the selection's.
+    private func submit(command: Bool, option: Bool) -> Bool {
+        if menuOpen, !command, !option {
+            activateMenuItem(menuSelection)
+            return true
+        }
+        guard command || option else { return false }
+        let screen = screen
+        let selection = selection(in: screen)
+        if command { return screen.secondary(at: selection) }
+        return screen.pasteKeepingWindowOpen(at: selection)
+    }
+
+    /// Escape unwinds one layer per press: the open menu, then the extension screen, then the panel.
+    private func cancel() -> Bool {
+        if menuOpen {
+            closeMenus()
+            return true
+        }
+        // An extension pops its own navigation stack before the command is left.
+        if vm.mode == .extensionCommand {
+            core.extensionCoordinator.exitExtensionScreen()
+            return true
+        }
+        core.paletteCoordinator.hidePalette()
         return true
     }
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -196,6 +196,13 @@ on commit and a half-typed romanisation never reaches a search.
 bounds. One number, one owner. The field still fills the header row's height so `topDragStrip` meets it
 with no gap.
 
+**`lineFragmentPadding` is `fieldEditorPadding`, not zero.** macOS draws the caret as an
+`NSTextInsertionIndicator` layer 2pt wide **centred** on the insertion point, so a text box flush with
+its clip view loses the caret's left half at column 0 — it renders 1pt until the first glyph pushes it
+clear. AppKit's own `NSTextField` field editor pads by exactly this for the same reason (a bare
+`NSTextView` uses 5). **Do not set it to zero to simplify the placeholder origin**: that origin adds
+the padding back, which is what keeps the two aligned.
+
 **Keys.** `doCommand(by:)` hands ↑ ↓ ← → ↵ ⇥ and Escape to `RootPaletteView.handleSearchKey` first and
 falls through to the caret on `false` — that is what keeps ← and → stepping the emoji grid while they
 stay with the caret everywhere else. The matching `onKeyPress` handlers are still on the root view and

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -79,7 +79,7 @@ field** — not on a screen of their own. That costs the header its one simple r
 invariants:
 
 - The search field sits at **one structural position, always**. It is never moved inside an `if`:
-  flipping the branch tears down its field editor, which drops first responder mid-navigation. Only
+  flipping the branch tears down its text view, which drops first responder mid-navigation. Only
   its *width* changes — it shrinks to the width of the typed text so the argument chips sit right
   after it, as they do in Raycast.
 - Argument focus is its own `@FocusState`, `argumentFocused`, keyed by argument name. Moving the
@@ -165,25 +165,43 @@ in the half-open interval `(minY, maxY]`: the topmost row is exactly `maxY`, whi
 while that same value is the `minY` of the display stacked above. `contains` would therefore hand a
 pointer parked at the top of one display to its neighbour. `NSMouseInRect` exists for precisely this.
 
-## The placeholder is Tinycast's, not the field's
+## The search field is Tinycast's
 
-The search field is a SwiftUI `TextField` with **no `prompt`**; `RootPaletteView` draws the
-placeholder itself as a leading-aligned background `Text`.
+The search field is **not** a SwiftUI `TextField`. `PaletteSearchField` wraps `PaletteSearchTextView`,
+an `NSTextView` the palette owns outright, and that view draws the query *and* the placeholder.
 
-AppKit gives an `NSTextField` a field editor one point taller than the field (measured: a 24pt editor
-in a 23pt field), and a `prompt` is rendered by whichever of the cell and the editor currently owns
-the text. The same placeholder glyphs therefore sit **one point higher** once the field takes the
-panel's shared field editor. That editor is created lazily and then cached on the window for its
-lifetime, so the step was only ever visible on the first summon after launch — and only where the eye
-could track it, when the outgoing and incoming placeholders share a leading word.
+**Why it is not an `NSTextField`.** An `NSTextField` has two things that draw the same string: the
+cell draws it unfocused, and the window's shared field editor draws it once focus lands. AppKit sizes
+that editor a point taller than the field (measured: a 24pt editor in a 23pt field), and the two paths
+round the baseline differently, so the same glyphs sat **one point higher** while focused. The editor
+is created lazily and then cached on the window, so the step showed only on the first summon after
+launch — and only where the eye could track it, when the outgoing and incoming strings share a leading
+word. A SwiftUI `TextField` is the same machinery, and its field editor is force-cast to a private
+subclass, so a corrected one cannot be vended.
 
-Drawing it in SwiftUI pins it to the layout instead: measured ink is identical in both focus states,
-against a two-backing-pixel step for the real prompt. It is a **background**, not an overlay, so the
-caret still draws over it, and it carries `allowsHitTesting(false)` so clicking the placeholder still
-lands the caret. `PaletteMode.placeholder` is still the one source of the strings; the field takes an
-explicit `accessibilityLabel` because the prompt used to supply it.
+An `NSTextView` **is** its own editor. There is no second renderer, so there is no step to compensate
+for, focused or not. **Do not go back to a `TextField` here**, and do not reintroduce a `prompt:`.
 
-This is the same class of bug as the freeze below — both come from the cell/field-editor swap.
+**The placeholder.** `draw(_:)` renders it when `string` is empty, at `textContainerOrigin` plus the
+container's `lineFragmentPadding` — the exact origin TextKit gives the first real glyph, so the two
+cannot disagree by construction rather than by a tuned constant. It draws under the caret and is not a
+hit target, because it is not a view. `PaletteMode.placeholder` is still the one source of the strings.
+
+**IME composition.** Marked text lands in the view's own storage, so `string` stops being empty the
+moment composition starts and the placeholder goes with it — no overlap with in-flight pinyin or kana.
+`textDidChange` refuses to publish while `hasMarkedText()`, so `PaletteState.query` still changes only
+on commit and a half-typed romanisation never reaches a search.
+
+**Vertical centring** is `textContainerInset.height`, recomputed in `layout()` against the view's own
+bounds. One number, one owner. The field still fills the header row's height so `topDragStrip` meets it
+with no gap.
+
+**Keys.** `doCommand(by:)` hands ↑ ↓ ← → ↵ ⇥ and Escape to `RootPaletteView.handleSearchKey` first and
+falls through to the caret on `false` — that is what keeps ← and → stepping the emoji grid while they
+stay with the caret everywhere else. The matching `onKeyPress` handlers are still on the root view and
+share the same methods: they serve the inline argument fields, which are SwiftUI's and hold focus
+themselves. `keyDown` records the modifier flags because a selector does not carry the chord that
+produced it.
 
 ## The panel settles the pointer itself
 
@@ -193,22 +211,23 @@ whole window and flickers along the field's edge — the two AppKit mechanisms t
 disagree, and neither yields.
 
 - SwiftUI's `HostingClipView` claims the **arrow** across the entire window as a *cursor rect*.
-- The field editor claims the **I-beam** from its own *tracking area*.
+- The search text view claims the **I-beam** from its own *tracking area*.
 
 Both fire on the same crossings, so the cursor alternates while the pointer is over the field, and the
 last claim simply stays put once it leaves — nothing re-evaluates a cursor rect until the pointer
 crosses one, and the arrow rect spans the window, so leaving the field crosses nothing.
 
-Two measured details the policy depends on:
+One measured detail the policy depends on:
 
 - **The field publishes its own frame.** `RootPaletteView` reports it into `PaletteState.searchFieldFrame`
   via `onGeometryChange`, and the panel does a containment test against that. Hit-testing for the field
   instead does not work: SwiftUI rebuilds it as it re-renders, and a hit test taken mid-rebuild misses
   it and reads as *the pointer left the field*. The frame only moves on layout, so it never lies.
   It arrives top-left-down and is flipped into AppKit's bottom-left-up window space.
-- **The rect is outset by 2pt.** AppKit's field editor is a point taller than the field it serves — the
-  same measurement the placeholder section above rests on — so its I-beam overhangs the published
-  frame. Without the slack that 1pt band is a disagreement, and it flickers.
+
+The rect used to be outset by 2pt, because AppKit's field editor overhung the field it served. The
+owned `NSTextView` is exactly the published frame, so the slack is gone. Do not add it back to paper
+over a cursor flicker — a flicker now means the published frame is wrong.
 
 The policy runs after `super.sendEvent`, so it has the last word, and it writes only when the cursor
 actually differs. It must stay **symmetric**: an earlier version left the field alone and only forced
@@ -227,27 +246,29 @@ where the highlight starts: the first row, except the type filter, which opens o
 ## Menu-open input freeze
 
 While a popover menu (⌘K Actions / app menu / clipboard type filter) is open the search field reads as inert but
-**never resigns first responder** — resigning makes the `NSTextField` swap between its field-editor
-and cell rendering, shifting the text / placeholder a point or two, so focus stays put. Input is
-frozen instead:
+**never resigns first responder**. Input is frozen instead:
 
 - `RootPaletteView` mirrors the open state into `PaletteState.menuOpen`, whose `didSet` fires
   `onMenuOpenChanged`.
 - `PalettePanel.sendEvent` then swallows text-editing keystrokes while `menuOpen` (letting ⌘/⌃ chords
-  and menu-nav keys through to SwiftUI `onKeyPress`), which is how ⌘. and ⌃X still reach their rows.
-- The caret is hidden by clearing SwiftUI's **own** live field editor's `insertionPointColor`. SwiftUI
-  force-casts its field editor to a private subclass, so vending a custom one crashes — only the
-  existing one can be tuned.
+  and menu-nav keys through to the search text view and `onKeyPress`), which is how ⌘. and ⌃X still
+  reach their rows.
+- The caret is hidden by clearing the focused text view's `insertionPointColor`.
+
+The original reason for never resigning is gone: it was the `NSTextField` cell/field-editor swap
+shifting the text a point or two, and the owned `NSTextView` has no swap. The freeze is kept as-is
+because it also preserves selection and typing state, but it is now a **candidate for simplification**
+rather than a constraint — resigning first responder here is no longer a visual regression.
 
 ## Chords `onKeyPress` never sees
 
 Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and all of them are handled in
 `PalettePanel.sendEvent` before `super` hands the event to the responder chain:
 
-- **A bare backspace** — the field editor consumes it as an edit (`onBareBackspace`).
+- **A bare backspace** — the search text view consumes it as an edit (`onBareBackspace`).
 - **Chords with no main menu item** — ⌘, and ⌘w, which an app with a menu bar would never see here.
 - **Chords AppKit has already bound to a selector.** `⌘.` is the one that bites: AppKit binds it to
-  `cancelOperation:` alongside Escape, so `interpretKeyEvents` hands it to the field editor and
+  `cancelOperation:` alongside Escape, so `interpretKeyEvents` hands it to the search text view and
   `onKeyPress(keys: ["."])` never fires. Pin (⌘.) therefore arrives through `onCommandShortcut`,
   which bumps `PaletteState.pinChordToken`; `RootPaletteView` observes that and resolves the row
   through the current screen, so **which** row gets pinned still comes from `screen.rows` alone.
@@ -261,7 +282,7 @@ assuming the handler is wrong.
 and everywhere else the horizontal pair falls through to the caret, which is what a native search field
 does.
 
-None of them reach `onKeyPress` on their own: AppKit's key-binding table hands the field editor
+None of them navigate on their own: AppKit's key-binding table hands the search text view
 `moveDown:` / `moveUp:` / `moveForward:` / `moveBackward:` first, and in a one-line field the vertical
 pair walks the caret to the end or the start rather than moving anything.
 
@@ -269,8 +290,8 @@ pair walks the caret to the end or the start rather than moving anything.
 other rule it applies. Nothing else changes: the arrow handlers in `RootPaletteView` are the only
 navigation code, so the compact bar's expand-on-↓, the grid's row and column steps, menu highlight
 movement and the scroll-into-view intent all follow for free. The caret keeps ⌃F/⌃B off the grid
-because `moveHorizontally` leaves →/← `.ignored` there, and the field editor then moves by a character
-exactly as the chord natively would. A chord carrying any modifier beyond ⌃ — ⌃⇧Q, say — is left alone.
+because `moveHorizontally` declines →/← there, and the text view then moves by a character exactly as
+the chord natively would. A chord carrying any modifier beyond ⌃ — ⌃⇧Q, say — is left alone.
 
 ## Focus restoration (load-bearing)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -194,6 +194,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
   old field-editor step showed
 - Clicking anywhere in the field, including well past the last glyph, lands the caret
 - A query longer than the field scrolls horizontally and keeps the caret visible
+- The caret is the same thickness on an empty query as it is mid-word, and stays so after deleting back
 - With a CJK IME: the placeholder clears as soon as composition starts, the composing text never
   overlaps it, and the list filters only once the candidate is committed
 - Typing filters instantly; ↑/↓ move the highlight and scroll it into view without yanking the list

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -189,6 +189,13 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Palette hotkey opens the launcher; pressing it again closes it; Escape closes it; clicking away closes it
 - Reopening focuses the search field with an empty query, in the same position and at the same size
 - Compact mode: typing expands it, and the search bar does **not** shift vertically during the swap
+- The placeholder sits on the same baseline as typed text, and stepping between screens (each with its
+  own placeholder) never moves it a point — check the **first** summon after launch, which is where the
+  old field-editor step showed
+- Clicking anywhere in the field, including well past the last glyph, lands the caret
+- A query longer than the field scrolls horizontally and keeps the caret visible
+- With a CJK IME: the placeholder clears as soon as composition starts, the composing text never
+  overlaps it, and the list filters only once the candidate is committed
 - Typing filters instantly; ↑/↓ move the highlight and scroll it into view without yanking the list
 - ⌃N/⌃P move the highlight as ↓/↑ do; ⌃F/⌃B step the emoji grid's selection, and the caret elsewhere
 - The highlight always sits on the row the footer pill describes

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -94,9 +94,9 @@ Notes adds `noteWindow 520×420` (opening size on a first run only), `noteWindow
 
 ### Typography (`Theme.Typography`)
 
-System fonts only — **no fixed point sizes in views** (honors Dynamic Type). `searchField` is the one
-explicit size (20pt regular). Use `rowTitle` (`.body`), `sectionHeader` (`.subheadline.medium`),
-`rowTrailing`/`bar`/`menuRow`/`keyCap` etc. as named.
+System fonts only — **no fixed point sizes in views** (honors Dynamic Type). `searchFieldNSFont` is the
+one explicit size (20pt regular), because the palette's field is an `NSTextView`. Use `rowTitle`
+(`.body`), `sectionHeader` (`.subheadline.medium`), `rowTrailing`/`bar`/`menuRow`/`keyCap` etc. as named.
 
 ### Colors (`Theme.Colors`) — the white-alpha ramp
 
@@ -461,10 +461,12 @@ The calculator's inline `CalculatorCard` reuses this card language (`cardFill` +
 
 ## The palette search field
 
-Its placeholder is drawn by Tinycast, not by the field's `prompt` — an `NSTextField` renders a prompt
-through either its cell or its (one point taller) field editor, so a real prompt steps vertically when
-focus moves. Don't reintroduce `prompt:` on that field. See
-[features/palette.md](features/palette.md#the-placeholder-is-tinycasts-not-the-fields).
+It is an owned `NSTextView` (`PaletteSearchTextView`), not a SwiftUI `TextField`. An `NSTextField`
+draws its string through its cell when unfocused and through a field editor a point taller once
+focused, so both the text and any `prompt` stepped vertically as focus moved. A text view is its own
+editor, so nothing swaps and nothing steps. **Don't put a `TextField` back here**, and don't add a
+`prompt:` — the view draws the placeholder itself, through the same text container as the query. See
+[features/palette.md](features/palette.md#the-search-field-is-tinycasts).
 
 ## Rules for agents working on the UI
 


### PR DESCRIPTION
Replaces the palette's SwiftUI `TextField` with an `NSTextView` the palette owns, which removes the cause of the 1-point placeholder step instead of working around it. Fixes the IME bug reported in #254 as a side effect.

> [!NOTE]
> **Built, gated and hand-verified on macOS 26.** Debug compiles with no new warnings, `./Scripts/run-tests.sh` passes all 33 harnesses, `./Scripts/lint.sh` is clean, and the palette sweep below was walked by hand. The branch was originally written without a Swift toolchain; everything that needed doing has been done.

---

## Why

An `NSTextField` has **two** things that draw the same string:

- unfocused, the **cell** draws it;
- focused, the window's shared **field editor** draws it.

AppKit sizes that editor one point taller than the field (measured: a 24pt editor in a 23pt field) and the two paths round the baseline differently, so the same glyphs sat one point higher while focused. The editor is created lazily and cached on the window, so the step only showed on the **first summon after launch**, and only where the eye could track it — when the outgoing and incoming placeholders share a leading word. A SwiftUI `TextField` is the same machinery, and SwiftUI force-casts its field editor to a private subclass, so a corrected one cannot be vended.

The previous fix avoided the swap: draw the placeholder in SwiftUI as a background `Text` gated on `vm.query.isEmpty`. That pinned the placeholder to the layout, but `vm.query` stays empty during IME composition, so the placeholder stayed visible and overlapped in-flight pinyin — the bug #254 reports.

An `NSTextView` **is** its own editor. One renderer, no swap, nothing to step, and marked text lands in its own storage so the placeholder clears the instant composition starts. Both bugs go away for the same reason.

## What changed

**New — `Tinycast/Palette/PaletteSearchField.swift`**

- `PaletteSearchTextView: NSTextView` — draws its own placeholder in `draw(_:)` **before** `super`, so the caret still draws over it (the same property the old background `Text` had). The origin is `textContainerOrigin` plus the container's `lineFragmentPadding`: the exact origin TextKit gives the first real glyph, so placeholder and query align by construction rather than by a tuned constant.
- `PaletteSearchField: NSViewRepresentable` — binds `text` and `isFocused`, carries the `prompt`, and forwards keys through `onKeyCommand`.
- Single line via `isFieldEditor = true`; horizontal scrolling via an `NSScrollView` with both scrollers and elasticity off.
- Vertical centring is `textContainerInset.height`, recomputed in `layout()` against the view's own bounds. One number, one owner.
- `matchWidthToClipView()` keeps the view at least as wide as its clip view so a click past the last glyph still lands the caret.
- Literal input: quote/dash/text-replacement substitution, spelling correction and smart insert/delete are all off, and `usesFindPanel = false`.

**The caret**

`lineFragmentPadding` is `fieldEditorPadding` (2), not 0. macOS draws the caret as an `NSTextInsertionIndicator` layer 2pt wide **centred** on the insertion point, so a text box flush with its clip view loses the caret's left half at column 0 — it rendered 1pt on an empty query and snapped to 2pt once the first glyph pushed it clear. AppKit's own `NSTextField` field editor pads by exactly 2 for this reason (a bare `NSTextView` uses 5), so this is the padding a field editor is meant to have rather than a constant tuned against the caret. Measured full width at both edges afterwards, including the `typed + 3` field the header shrinks to when an argument accessory sits beside it. `drawPlaceholder` already adds `lineFragmentPadding` to its origin, so placeholder and query still align by construction.

**IME**

- Marked text is in the view's storage, so `string` is non-empty during composition and the placeholder is hidden.
- `textDidChange` returns early while `hasMarkedText()`, so `PaletteState.query` still changes only on commit and a half-typed romanisation never reaches a search.

**Key routing**

- `doCommand(by:)` maps `moveUp:` / `moveDown:` / `moveLeft:` / `moveRight:` (plus their `…AndModifySelection:` and begin/end-of-document spellings), `insertNewline:` / `insertLineBreak:` / `insertNewlineIgnoringFieldEditor:`, `insertTab:` / `insertBacktab:` and `cancelOperation:` onto `RootPaletteView.handleSearchKey`.
- The closure returns `true` to keep the key and `false` to fall through to `super.doCommand(by:)` — that is what keeps ← and → stepping the emoji grid while staying with the caret everywhere else.
- `keyDown` records the modifier flags, because a selector does not carry the chord that produced it.
- The matching `onKeyPress` handlers are **still on the root view**. They serve the inline argument fields, which are SwiftUI's and hold focus themselves. Both paths now call the same five methods (`moveUp`, `moveDown`, `moveHorizontally`, `submit`, `cancel`) instead of duplicating the logic.

**Focus**

- `searchFocused` moved from `@FocusState` to `@State`. It is now intent, driven two-way: `updateNSView` takes first responder when it is `true`, and `becomeFirstResponder` / `resignFirstResponder` report back (deferred through a `Task` so the write does not land inside a SwiftUI update).

**Deletions**

- `PalettePanel.fieldEditorSlack` and the 2pt cursor-rect outset — they existed only because AppKit's field editor overhung the field. The owned view *is* the published frame.
- `Theme.Typography.searchField` (the SwiftUI `Font`), now unused. `searchFieldSize` and `searchFieldNSFont` stay.
- The SwiftUI placeholder `background`, its `allowsHitTesting(false)`, and the explicit `accessibilityLabel` (the text view sets its own).

**Docs**

- `docs/features/palette.md`: the placeholder section is rewritten as "The search field is Tinycast's" (anchor changed); the `lineFragmentPadding` invariant is stated with its reason; cursor-policy, emacs-chord and menu-open-freeze sections lost their field-editor references.
- `docs/ui.md`: "The palette search field" and the typography note.
- `docs/testing.md`: five new palette checks, including the CJK IME one and the caret thickness one.

## Deliberate behaviour changes

- **⌥← / ⌥→ now do word movement in the field** instead of stepping the emoji grid. Previously `onKeyPress(.leftArrow)` fired regardless of modifiers. The new behaviour is more correct for a text field, but it *is* a change — revert by mapping `moveWordLeft:` / `moveWordRight:` in `paletteKey(for:)` if you disagree.
- **The cursor rect is now exact.** If the I-beam flickers at the field's edge, the published frame is wrong — do **not** re-add the slack to paper over it.
- **Glyphs start 2pt in**, as they do in every `NSTextField`. Worth an A/B against `main` if the header's leading metric is meant to be pixel-identical; the 2pt comes off the `headerGutter` before the field if so, never off the padding.

## Explicitly out of scope

The **menu-open input freeze** is untouched. Its stated reason (never resign first responder, because resigning swapped the `NSTextField` between cell and field editor and shifted the text a point) is now obsolete, and `docs/features/palette.md` says so and marks it a candidate for simplification. Changing first-responder behaviour there is a separate, testable change and does not belong in this branch.

## Verification

**Gate**

- [x] `./Scripts/run-tests.sh` — all 33 harnesses pass
- [x] Debug build compiles with no new warnings
- [x] `./Scripts/lint.sh` clean
- [x] `Features/*/Model/` imports no AppKit or SwiftUI

**Field width and scrolling**

- [x] A click well past the last glyph lands the caret
- [x] A click in an empty field lands the caret at position 0
- [x] A query longer than the field scrolls horizontally and keeps the caret visible
- [x] Deleting back down never leaves the field narrower than its clip view

**The bug this branch exists to kill**

- [x] Placeholder and typed text share a baseline
- [x] **First summon after launch**, stepping between screens with different placeholders (`Search…` → `Search apps…`) does not move it a point
- [x] Placeholder colour is `textTertiary` (white 0.40)
- [x] Compact → expanded does not shift the search bar vertically

**Caret**

- [x] Same thickness on an empty query as mid-word, and after deleting back to empty
- [x] I-beam over the field, arrow everywhere else, no flicker along the edge

**IME (#254)**

- [x] The placeholder clears the moment composition starts, and composing text never overlaps it
- [x] The list filters only once the candidate is committed
- [x] Committing by clicking the IME candidate window still publishes the query
- [x] Cancelling composition restores the placeholder

**Focus handoff**

- [x] Reopening the palette focuses the field with an empty query
- [x] Tab walks search field → each argument → back
- [x] Clicking an argument field directly is not stolen back by the search field
- [x] ↵ on a blank required argument focuses it instead of launching
- [x] Moving the selection off a command hands focus back to the search field

**Keys**

- [x] ↑/↓ move the highlight and scroll it into view
- [x] ↓ from the compact bar expands and selects the first row; ↑ moves the caret
- [x] ←/→ step the emoji grid; elsewhere they move the caret
- [x] ⌃N/⌃P/⌃F/⌃B behave as ↓/↑/→/←
- [x] Plain ↵ activates, ⌘↵ runs the secondary action, ⌥↵ pastes keeping the window open
- [x] Escape closes an open menu, then an extension screen, then the palette
- [x] Tab toggles launcher ↔ clipboard when the selection has no arguments
- [x] Bare Backspace on an empty query backs out of a sub-screen
- [x] ⌘. pins, ⌃X deletes, ⌘K opens Actions
- [x] While a menu is open: typing does not change the query, the caret is hidden, and ↑/↓/↵/Esc drive the menu

Closes #254 — this supersedes it. The bug report is what drove this fix, and it is the reporter's in origin.
