### PR TITLE
fix(palette): add PaletteSearchField to Xcode project and guard placeholder on marked text

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		7FDE88F4E065FF80DCB92445 /* NotesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B77DA46386E7E459406E4 /* NotesStore.swift */; };
 		7FF6A0A4702E1C1365F2D76A /* LauncherScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */; };
 		8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */; };
+		8090FBE343746D9D43EE2B25 /* PaletteSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */; };
 		80E77985425032856DEECDFD /* CalloutShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */; };
 		82D95EF7539498A9A484B3D1 /* SystemActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEB022D080E6DAF703D8132 /* SystemActionsSettingsView.swift */; };
 		8453CF4C0D8D015A66C9B400 /* HoverArming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */; };
@@ -514,6 +515,7 @@
 		B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherScreen.swift; sourceTree = "<group>"; };
 		B9F568F2F6EF857274F1A9D8 /* ExtensionIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionIconCache.swift; sourceTree = "<group>"; };
 		BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePanel.swift; sourceTree = "<group>"; };
+		BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteSearchField.swift; sourceTree = "<group>"; };
 		BDB241B179A08518424F7C1B /* DialogPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogPanel.swift; sourceTree = "<group>"; };
 		BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		BE6972F177922B1EB8831735 /* OnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
@@ -1329,6 +1331,7 @@
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
+				BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */,
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
 				445B0374FD5D74DBE23243CD /* PaletteScreen.swift */,
 				188A6D3C5B6BC67716F15F83 /* PaletteState.swift */,
@@ -1805,6 +1808,7 @@
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
+				8090FBE343746D9D43EE2B25 /* PaletteSearchField.swift in Sources */,
 				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,
 				9F8806D46EBAF7058FC2EAEC /* PaletteRowIndex.swift in Sources */,
 				DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */,

--- a/Tinycast/Palette/PaletteSearchField.swift
+++ b/Tinycast/Palette/PaletteSearchField.swift
@@ -198,7 +198,7 @@ final class PaletteSearchTextView: NSTextView {
     }
 
     private func drawPlaceholder() {
-        guard string.isEmpty, !placeholder.isEmpty, let font else { return }
+        guard string.isEmpty, !hasMarkedText(), !placeholder.isEmpty, let font else { return }
         // The origin TextKit gives the first glyph, so placeholder and query cannot disagree.
         let origin = NSPoint(
             x: textContainerOrigin.x + (textContainer?.lineFragmentPadding ?? 0),


### PR DESCRIPTION
fix(palette): add PaletteSearchField to Xcode project and guard placeholder on marked text

- Add PaletteSearchField.swift to project.pbxproj to fix compilation errors

- Guard PaletteSearchTextView.drawPlaceholder on !hasMarkedText() to prevent overlap during IME composition

#255 now works well.