### PR TITLE
Fix getSelectedText() reading the system-wide focused element

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -122,6 +122,7 @@ run quicklink-test         Tinycast/Features/Quicklinks/Model/Quicklink.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkArchive.swift
 run snippets-test          Tinycast/Platform/NotificationToken.swift \
                            Tinycast/Platform/HealthTicker.swift \
+                           Tinycast/Platform/AccessibilityText.swift \
                            Tinycast/Features/Snippets/Model/*.swift \
                            Tinycast/Features/Snippets/Service/*.swift
 run notes-test             Tinycast/Platform/Signposts.swift \

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		07726F26DC68689F8984F467 /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D0784E49BC5899A585F285 /* Scrypt.swift */; };
 		0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395BACF833C810961A248F0 /* BarButton.swift */; };
 		089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ABE4AF80DD5F5F8E91F63E /* SpotlightNames.swift */; };
+		0A3273195B033B62952A7220 /* PaletteSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227B7D0CBA27AAF08D53F21A /* PaletteSearchField.swift */; };
 		0B9C941402B85C69A33200C2 /* UninstallProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A48095F6487DEE76663F88 /* UninstallProtection.swift */; };
 		0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42664C60B760276FBAAD61 /* EmojiSettingsView.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
@@ -153,7 +154,6 @@
 		7FDE88F4E065FF80DCB92445 /* NotesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B77DA46386E7E459406E4 /* NotesStore.swift */; };
 		7FF6A0A4702E1C1365F2D76A /* LauncherScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */; };
 		8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */; };
-		8090FBE343746D9D43EE2B25 /* PaletteSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */; };
 		80E77985425032856DEECDFD /* CalloutShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */; };
 		82D95EF7539498A9A484B3D1 /* SystemActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEB022D080E6DAF703D8132 /* SystemActionsSettingsView.swift */; };
 		8453CF4C0D8D015A66C9B400 /* HoverArming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */; };
@@ -240,6 +240,7 @@
 		CC984C9647779469629461E7 /* LauncherItemsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A2ACAEC4D2D25D3112634 /* LauncherItemsSection.swift */; };
 		CC9A286B77E32C22B21A22BE /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */; };
 		CCC775255627E23DC5B567AE /* CustomCommandEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40049CE320BEE3A4388CDFF /* CustomCommandEditorSheet.swift */; };
+		CD04C9CA00C002C0EC82756A /* AccessibilityText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEA89E08994378FB044B4BB /* AccessibilityText.swift */; };
 		CE15888F3C15EE2706E108A0 /* AppDisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */; };
 		CEE0B612FFDB0AFFEF23A8A1 /* SearchScopesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC45597561DCD90F51506F7 /* SearchScopesSection.swift */; };
 		CF1015EA1573EFBBA647B93B /* ExtensionRegistriesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA081CD5CEA054447D0691F /* ExtensionRegistriesSheet.swift */; };
@@ -328,6 +329,7 @@
 		201FCD08ACA933378876385B /* ClipboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardStore.swift; sourceTree = "<group>"; };
 		209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
 		2258D4A6B6C22AB7C5D421BE /* DoubleTapMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapMonitor.swift; sourceTree = "<group>"; };
+		227B7D0CBA27AAF08D53F21A /* PaletteSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteSearchField.swift; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		23F7C8CBD0AA75D016DBFC06 /* SettingsPaneScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScanner.swift; sourceTree = "<group>"; };
 		2575583134BE03EA9FA719CD /* ActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicy.swift; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 		AA99178E0DCF6CBB521FB098 /* WindowMover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowMover.swift; sourceTree = "<group>"; };
 		AAD838940E655559E32BE8EA /* UninstallPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallPlan.swift; sourceTree = "<group>"; };
 		ABB9DB77DCE25C41D86BB955 /* SearchRelevance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRelevance.swift; sourceTree = "<group>"; };
+		ABEA89E08994378FB044B4BB /* AccessibilityText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityText.swift; sourceTree = "<group>"; };
 		ACC8371BCD366F2549E0B01B /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
 		ADC45597561DCD90F51506F7 /* SearchScopesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopesSection.swift; sourceTree = "<group>"; };
 		ADD4CE330F75BC5FE5EAD99E /* Tooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tooltip.swift; sourceTree = "<group>"; };
@@ -515,7 +518,6 @@
 		B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherScreen.swift; sourceTree = "<group>"; };
 		B9F568F2F6EF857274F1A9D8 /* ExtensionIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionIconCache.swift; sourceTree = "<group>"; };
 		BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePanel.swift; sourceTree = "<group>"; };
-		BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteSearchField.swift; sourceTree = "<group>"; };
 		BDB241B179A08518424F7C1B /* DialogPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogPanel.swift; sourceTree = "<group>"; };
 		BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		BE6972F177922B1EB8831735 /* OnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
@@ -609,6 +611,7 @@
 			children = (
 				7073D3C441D37F94E780B1D7 /* Compression */,
 				DD0FEE8E2D95BD51907D383E /* Images */,
+				ABEA89E08994378FB044B4BB /* AccessibilityText.swift */,
 				2575583134BE03EA9FA719CD /* ActivationPolicy.swift */,
 				5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */,
 				B6A96350EBE68EC79497FA2D /* AppPaths.swift */,
@@ -1331,9 +1334,9 @@
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
-				BA9F3FA9925873D25EAF7D04 /* PaletteSearchField.swift */,
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
 				445B0374FD5D74DBE23243CD /* PaletteScreen.swift */,
+				227B7D0CBA27AAF08D53F21A /* PaletteSearchField.swift */,
 				188A6D3C5B6BC67716F15F83 /* PaletteState.swift */,
 				209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */,
 				D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */,
@@ -1639,6 +1642,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				540F1433DC46BC97C9F80E06 /* AboutView.swift in Sources */,
+				CD04C9CA00C002C0EC82756A /* AccessibilityText.swift in Sources */,
 				16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */,
 				D68E7585496722BEC72E788C /* AliasStore.swift in Sources */,
 				EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */,
@@ -1808,10 +1812,10 @@
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
-				8090FBE343746D9D43EE2B25 /* PaletteSearchField.swift in Sources */,
 				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,
 				9F8806D46EBAF7058FC2EAEC /* PaletteRowIndex.swift in Sources */,
 				DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */,
+				0A3273195B033B62952A7220 /* PaletteSearchField.swift in Sources */,
 				1BC16048EE05A1FD25739CB4 /* PaletteState.swift in Sources */,
 				52C4F57BB26F420CCD22C1D7 /* PaletteWindowController.swift in Sources */,
 				E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */,

--- a/Tinycast/Features/Extensions/Service/ExtensionHostBridge.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionHostBridge.swift
@@ -438,24 +438,18 @@ final class ExtensionHostBridge: ExtensionHostAPI {
         ]
     }
 
-    /// Reuses the Accessibility grant the paste path already needs.
+    /// Reads the app the palette displaced, never the system-wide focus, which is our own field here.
     private func selectedText() throws -> String {
         guard Permissions.ensureAccessibility() else {
             throw ExtensionHostError.unsupported("getSelectedText without the Accessibility permission")
         }
-        let system = AXUIElementCreateSystemWide()
-        var focused: AnyObject?
-        guard
-            AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &focused)
-                == .success,
-            let element = focused as! AXUIElement?
-        else { throw ExtensionHostError.unsupported("getSelectedText (no focused element)") }
+        guard let target = context?.pasteTarget,
+            target.processIdentifier != NSRunningApplication.current.processIdentifier
+        else { throw ExtensionHostError.unsupported("getSelectedText (no target application)") }
 
-        var value: AnyObject?
-        guard
-            AXUIElementCopyAttributeValue(element, kAXSelectedTextAttribute as CFString, &value)
-                == .success, let text = value as? String
-        else { throw ExtensionHostError.unsupported("getSelectedText (no selection)") }
+        guard let text = AccessibilityText.selection(in: target), !text.isEmpty else {
+            throw ExtensionHostError.unsupported("getSelectedText (no selection)")
+        }
         return text
     }
 

--- a/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
+++ b/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
@@ -128,7 +128,8 @@ private struct AliasField: View {
         .background(shape.fill(Theme.Colors.cardFill))
         .overlay(
             shape.strokeBorder(
-                isEditing ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1))
+                isEditing ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1)
+        )
         .clipShape(shape)
         .accessibilityLabel("Alias for \(entry.name)")
     }

--- a/Tinycast/Features/Snippets/Service/SnippetTextInjector.swift
+++ b/Tinycast/Features/Snippets/Service/SnippetTextInjector.swift
@@ -30,9 +30,6 @@ final class SnippetDeliveryCompletion {
 final class SnippetTextInjector {
     typealias AutomaticGeneration = UInt
 
-    /// Generous for a responsive app, short enough that a wedged one can't stall a keystroke.
-    private static let accessibilityTimeout: Float = 1
-
     private let clipboardManager: ClipboardManager
     private let settings: AppSettings
     private let deliveryQueue = SnippetDeliveryQueue()
@@ -418,7 +415,7 @@ final class SnippetTextInjector {
         keywordLength: Int
     ) -> SnippetAccessibilityReplacement {
         guard let targetApp,
-            let element = focusedElement(in: targetApp),
+            let element = AccessibilityText.focusedElement(in: targetApp),
             isAttributeSettable(kAXSelectedTextRangeAttribute, in: element),
             isAttributeSettable(kAXSelectedTextAttribute, in: element),
             let value = stringValue(in: element),
@@ -500,30 +497,11 @@ final class SnippetTextInjector {
         in targetApp: NSRunningApplication?
     ) -> AccessibilityTextState? {
         guard let targetApp,
-            let element = focusedElement(in: targetApp),
+            let element = AccessibilityText.focusedElement(in: targetApp),
             let value = stringValue(in: element),
             let selectedRange = selectedRange(in: element)
         else { return nil }
         return AccessibilityTextState(value: value, selectedRange: selectedRange)
-    }
-
-    private func focusedElement(in targetApp: NSRunningApplication) -> AXUIElement? {
-        let application = AXUIElementCreateApplication(targetApp.processIdentifier)
-        // Per element and never inherited, so the focused element needs its own against a hang.
-        AXUIElementSetMessagingTimeout(application, Self.accessibilityTimeout)
-        var focusedValue: CFTypeRef?
-        guard
-            AXUIElementCopyAttributeValue(
-                application,
-                kAXFocusedUIElementAttribute as CFString,
-                &focusedValue) == .success,
-            let focusedValue,
-            CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
-        else { return nil }
-
-        let element = focusedValue as! AXUIElement
-        AXUIElementSetMessagingTimeout(element, Self.accessibilityTimeout)
-        return element
     }
 
     private func stringValue(in element: AXUIElement) -> String? {
@@ -581,19 +559,8 @@ final class SnippetTextInjector {
     }
 
     private func selectedText(in targetApp: NSRunningApplication?) -> String? {
-        guard Permissions.isAccessibilityTrusted(),
-            let targetApp,
-            let element = focusedElement(in: targetApp)
-        else { return nil }
-
-        var selectionValue: CFTypeRef?
-        guard
-            AXUIElementCopyAttributeValue(
-                element,
-                kAXSelectedTextAttribute as CFString,
-                &selectionValue) == .success
-        else { return nil }
-        return selectionValue as? String
+        guard Permissions.isAccessibilityTrusted(), let targetApp else { return nil }
+        return AccessibilityText.selection(in: targetApp)
     }
 
     private func makeUnicodeEvents(_ text: String) -> [CGEvent]? {

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -503,7 +503,9 @@ struct RootPaletteView: View {
 
     /// The search field answers first and the caret keeps whatever the palette declines. Argument
     /// fields are SwiftUI's, so the same handlers stay on `onKeyPress` for when one holds focus.
-    private func handleSearchKey(_ key: PaletteSearchKey, _ modifiers: NSEvent.ModifierFlags)
+    private func handleSearchKey(
+        _ key: PaletteSearchKey, _ modifiers: NSEvent.ModifierFlags
+    )
         -> Bool
     {
         switch key {

--- a/Tinycast/Platform/AccessibilityText.swift
+++ b/Tinycast/Platform/AccessibilityText.swift
@@ -1,0 +1,41 @@
+import AppKit
+// `@preconcurrency` downgrades AX diagnostics: the attribute keys are constant C globals.
+@preconcurrency import ApplicationServices
+
+/// Reads text out of another app over Accessibility, always against a named process: the system-wide
+/// focused element follows whichever window holds key, so it answers with ours while a panel is up.
+enum AccessibilityText {
+    /// Generous for a responsive app, short enough that a wedged one can't stall the main actor.
+    private static let timeout: Float = 1
+
+    static func focusedElement(in app: NSRunningApplication) -> AXUIElement? {
+        let application = AXUIElementCreateApplication(app.processIdentifier)
+        // Per element and never inherited, so the focused element needs its own against a hang.
+        AXUIElementSetMessagingTimeout(application, timeout)
+        var focusedValue: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(
+                application,
+                kAXFocusedUIElementAttribute as CFString,
+                &focusedValue) == .success,
+            let focusedValue,
+            CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
+        else { return nil }
+
+        let element = focusedValue as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, timeout)
+        return element
+    }
+
+    static func selection(in app: NSRunningApplication) -> String? {
+        guard let element = focusedElement(in: app) else { return nil }
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(
+                element,
+                kAXSelectedTextAttribute as CFString,
+                &value) == .success
+        else { return nil }
+        return value as? String
+    }
+}


### PR DESCRIPTION
## Summary

`getSelectedText()` always returned an empty string because it read the AX **system-wide** focused element (`AXUIElementCreateSystemWide`). While the palette panel holds key focus that element is Tinycast's own search field, not whatever the user had selected in the app the palette displaced — so the lookup failed even for native apps like TextEdit that expose `AXSelectedText` correctly.

Extension commands and snippet expansion already track the displaced app as `pasteTarget` / `targetApp` for pasting. This fixes `selectedText()` in `ExtensionHostBridge` to read the focused element from that same app via `AXUIElementCreateApplication`, matching how paste already targets it, instead of the system-wide element.

The AX focused-element/selection lookup was duplicated in `SnippetTextInjector`; both call sites now share one implementation in `Tinycast/Platform/AccessibilityText.swift`.

Fixes #262

## Test plan
- [x] `./Scripts/run-tests.sh` — all 33 harnesses pass
- [x] `./Scripts/lint.sh` — clean, no new warnings
- [x] Debug build via `xcodebuild` — succeeds, no new warnings
- [x] Manual: select text in TextEdit, run a Raycast extension command calling `getSelectedText()`, confirm it returns the selection (not covered by the harnesses, which have no AppKit/AX runtime)