### PR TITLE
Fix alias field focus bugs and add a clear button

### DIFF
--- a/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
+++ b/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
@@ -89,65 +89,69 @@ private struct LauncherItemRow: View {
     }
 }
 
-/// The per-row alias well, dressed like `ShortcutRecorder` so the trailing controls read as a set.
-/// A label until clicked: a form's field editor won't center, and a `Text` centers like Record's.
+/// Dressed like `ShortcutRecorder`; a persistent `TextField` — swapping views broke repeat focus.
 private struct AliasField: View {
     let entry: AppEntry
     @Environment(AliasStore.self) private var aliases
-    @State private var isEditing = false
     @State private var draft = ""
     @FocusState private var focused: Bool
 
     var body: some View {
         let shape = RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
-        Group {
-            if isEditing {
-                TextField("", text: $draft)
-                    .textFieldStyle(.plain)
-                    .font(Theme.Typography.keyCap)
-                    .focused($focused)
-                    .onSubmit(finishEditing)
-                    .onExitCommand(perform: cancelEditing)
-                    // The pane's `releasesFocusOnOutsideClick` resigns; this catches it landing.
-                    .onChange(of: focused) { _, now in
-                        if !now { finishEditing() }
-                    }
-                    .onAppear { focused = true }
-            } else {
-                Text(aliases.alias(for: entry.preferenceKey) ?? "Add Alias")
-                    .font(Theme.Typography.keyCap)
-                    .foregroundStyle(Theme.Colors.textSecondary)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity)
-                    .contentShape(shape)
-                    .onTapGesture(perform: beginEditing)
+        let placeholder = Text("Add Alias").foregroundStyle(Theme.Colors.textSecondary)
+        HStack(spacing: Theme.Spacing.xs) {
+            TextField("", text: $draft, prompt: placeholder)
+                .textFieldStyle(.plain)
+                .labelsHidden()
+                .font(Theme.Typography.keyCap)
+                .focused($focused)
+                // The system ring insets the field editor on focus, hopping the placeholder left.
+                .focusEffectDisabled()
+                .onSubmit(commit)
+                .onExitCommand(perform: revert)
+                // The pane's `releasesFocusOnOutsideClick` resigns; this catches it landing.
+                .onChange(of: focused) { _, now in
+                    if !now { commit() }
+                }
+            if !draft.isEmpty {
+                Button(action: clear) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear alias for \(entry.name)")
             }
+        }
+        .onAppear { draft = aliases.alias(for: entry.preferenceKey) ?? "" }
+        // A backup import replaces the table out from under an unfocused row.
+        .onChange(of: aliases.revision) { _, _ in
+            if !focused { draft = aliases.alias(for: entry.preferenceKey) ?? "" }
         }
         .padding(.horizontal, Theme.Spacing.sm)
         .frame(width: Theme.Size.shortcutRecorder, height: 24)
         .background(shape.fill(Theme.Colors.cardFill))
         .overlay(
             shape.strokeBorder(
-                isEditing ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1)
+                focused ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1)
         )
         .clipShape(shape)
         .accessibilityLabel("Alias for \(entry.name)")
     }
 
-    private func beginEditing() {
-        draft = aliases.alias(for: entry.preferenceKey) ?? ""
-        isEditing = true
-    }
-
     /// The one commit path — ↵ or focus landing elsewhere; a blank draft removes the alias.
-    private func finishEditing() {
-        guard isEditing else { return }
-        isEditing = false
-        aliases.setAlias(
-            draft.trimmingCharacters(in: .whitespacesAndNewlines), for: entry.preferenceKey)
+    private func commit() {
+        aliases.setAlias(draft, for: entry.preferenceKey)
+        draft = aliases.alias(for: entry.preferenceKey) ?? ""
     }
 
-    private func cancelEditing() {
-        isEditing = false
+    private func revert() {
+        draft = aliases.alias(for: entry.preferenceKey) ?? ""
+        focused = false
+    }
+
+    private func clear() {
+        draft = ""
+        commit()
     }
 }


### PR DESCRIPTION
## Summary
- The per-row alias well (Settings → launcher items) swapped a `Text` label for a fresh `TextField` on tap. Recreating the AppKit-backed field on every edit fought the responder chain: a click's caret could land on the wrong glyph, and a second edit could take SwiftUI focus without the real `NSTextField` becoming first responder — so typing did nothing and macOS beeped.
- Replaced it with one persistent `TextField` (the same pattern `SettingsFilterField` already uses without this issue), with an "Add Alias" placeholder instead of a swapped label.
- Disabled the native focus ring (`.focusEffectDisabled()`), which was shifting the placeholder left on click; the field already draws its own accent border for focus.
- Added a clear (×) button, shown when the field has text, matching the app search field's clear affordance.

## Test plan
- [x] `./Scripts/run-tests.sh` — all 33 harnesses pass
- [x] `./Scripts/lint.sh` — clean
- [x] Debug build compiles with no new warnings
- [x] Manually exercised the alias field in `Tinycast Dev.app`: click-to-edit, retype after committing, Esc to cancel, clear button