### PR TITLE
Add a custom search paths setting for extension package managers

### DIFF
--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -49,6 +49,9 @@ enum SettingsBackupCoverage {
             "Names a tool on this Mac; the machine a backup lands on may not have it.",
         AppSettingsKey.extensionRegistries.rawValue:
             "A registry is a source of executable code; adding one has to be a deliberate act.",
+        AppSettingsKey.extensionCustomSearchPaths.rawValue:
+            "Machine-local toolchain paths; the Mac a backup lands on may not have them, or may have "
+            + "something else there.",
         AppSettingsKey.extensionsEnabled.rawValue:
             "Doubles as consent to run third-party JavaScript; an import must not switch it on.",
         AppSettingsKey.palettePosition.rawValue:

--- a/Tinycast/Features/Extensions/Model/ExtensionPackageManager.swift
+++ b/Tinycast/Features/Extensions/Model/ExtensionPackageManager.swift
@@ -55,7 +55,9 @@ enum ExtensionPackageManager: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// Where to look, for a GUI app inheriting none of a shell's PATH: Homebrew, Volta, asdf, fnm, nvm.
+    /// Where to look, for a GUI app inheriting none of a shell's PATH: Homebrew, Volta, asdf, fnm, nvm,
+    /// mise. A version manager too obscure or too machine-specific to hardcode (Nix among them) is what
+    /// `extensionCustomSearchPaths` is for.
     static let searchPaths: [String] = [
         "/opt/homebrew/bin",
         "/usr/local/bin",
@@ -64,6 +66,7 @@ enum ExtensionPackageManager: String, CaseIterable, Identifiable, Sendable {
         NSHomeDirectory() + "/.volta/bin",
         NSHomeDirectory() + "/.bun/bin",
         NSHomeDirectory() + "/.asdf/shims",
+        NSHomeDirectory() + "/.local/share/mise/shims",
         NSHomeDirectory() + "/.local/share/fnm/aliases/default/bin",
         NSHomeDirectory() + "/.nvm/versions/node/current/bin",
         NSHomeDirectory() + "/.yarn/bin",
@@ -71,14 +74,21 @@ enum ExtensionPackageManager: String, CaseIterable, Identifiable, Sendable {
     ]
 
     /// The executable, or nil when it isn't installed. `automatic` resolves to the first one found.
-    func resolve(in fileManager: FileManager = .default) -> (manager: ExtensionPackageManager, url: URL)? {
+    /// `additionalSearchPaths` is checked first, so a user-supplied folder can win over a built-in one.
+    func resolve(
+        in fileManager: FileManager = .default, additionalSearchPaths: [String] = []
+    ) -> (manager: ExtensionPackageManager, url: URL)? {
         guard self != .automatic else {
             for candidate in Self.preferenceOrder {
-                if let found = candidate.resolve(in: fileManager) { return found }
+                if let found = candidate.resolve(
+                    in: fileManager, additionalSearchPaths: additionalSearchPaths)
+                {
+                    return found
+                }
             }
             return nil
         }
-        for directory in Self.searchPaths {
+        for directory in additionalSearchPaths + Self.searchPaths {
             let candidate = URL(fileURLWithPath: directory).appendingPathComponent(executableName)
             if fileManager.isExecutableFile(atPath: candidate.path) { return (self, candidate) }
         }
@@ -86,8 +96,10 @@ enum ExtensionPackageManager: String, CaseIterable, Identifiable, Sendable {
     }
 
     /// `ray build` runs on Node, and bun is the one manager that doesn't imply it.
-    static func nodeURL(in fileManager: FileManager = .default) -> URL? {
-        for directory in searchPaths {
+    static func nodeURL(
+        in fileManager: FileManager = .default, additionalSearchPaths: [String] = []
+    ) -> URL? {
+        for directory in additionalSearchPaths + searchPaths {
             let candidate = URL(fileURLWithPath: directory).appendingPathComponent("node")
             if fileManager.isExecutableFile(atPath: candidate.path) { return candidate }
         }

--- a/Tinycast/Features/Extensions/Service/ExtensionInstaller.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionInstaller.swift
@@ -24,10 +24,16 @@ struct ExtensionInstaller: Sendable {
 
     let client: ExtensionStoreClient
     let packageManager: ExtensionPackageManager
+    /// From `extensionCustomSearchPaths`, checked before the built-in list — a mise or Nix shim folder.
+    let additionalSearchPaths: [String]
 
-    init(client: ExtensionStoreClient = ExtensionStoreClient(), packageManager: ExtensionPackageManager) {
+    init(
+        client: ExtensionStoreClient = ExtensionStoreClient(), packageManager: ExtensionPackageManager,
+        additionalSearchPaths: [String] = []
+    ) {
         self.client = client
         self.packageManager = packageManager
+        self.additionalSearchPaths = additionalSearchPaths
     }
 
     /// Copies into place before the workspace goes, which is why it hands back the install, not a path.
@@ -99,10 +105,11 @@ struct ExtensionInstaller: Sendable {
     private func build(
         at source: URL, into output: URL, onProgress: @Sendable @escaping (Progress) -> Void
     ) async throws -> URL {
-        guard let resolved = packageManager.resolve() else {
+        guard let resolved = packageManager.resolve(additionalSearchPaths: additionalSearchPaths) else {
             throw ExtensionStoreError.noPackageManager
         }
-        guard let node = ExtensionPackageManager.nodeURL() else {
+        guard let node = ExtensionPackageManager.nodeURL(additionalSearchPaths: additionalSearchPaths)
+        else {
             throw ExtensionStoreError.noNode
         }
 
@@ -167,7 +174,7 @@ struct ExtensionInstaller: Sendable {
         process.currentDirectoryURL = directory
 
         var environment = ProcessInfo.processInfo.environment
-        var searchPath = ExtensionPackageManager.searchPaths
+        var searchPath = additionalSearchPaths + ExtensionPackageManager.searchPaths
         // Node first: the package manager spawns `ray` off PATH, and a version manager hides Node.
         if let node { searchPath.insert(node.deletingLastPathComponent().path, at: 0) }
         environment["PATH"] = searchPath.joined(separator: ":")

--- a/Tinycast/Features/Extensions/Service/ExtensionManager.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionManager.swift
@@ -185,9 +185,11 @@ final class ExtensionManager: ExtensionRuntimeDelegate, ExtensionHostContext {
     /// Progress is reported per step: building from source can take minutes.
     func install(
         listing: ExtensionListing, packageManager: ExtensionPackageManager,
+        additionalSearchPaths: [String] = [],
         onProgress: @Sendable @escaping (ExtensionInstaller.Progress) -> Void
     ) async throws {
-        let installer = ExtensionInstaller(packageManager: packageManager)
+        let installer = ExtensionInstaller(
+            packageManager: packageManager, additionalSearchPaths: additionalSearchPaths)
         try await installer.install(listing, onProgress: onProgress)
         await refresh()
     }

--- a/Tinycast/Features/Extensions/Settings/ExtensionRegistriesSheet.swift
+++ b/Tinycast/Features/Extensions/Settings/ExtensionRegistriesSheet.swift
@@ -11,6 +11,9 @@ struct ExtensionRegistriesSheet: View {
 
     @Environment(AppCore.self) private var core
     @State private var addingRegistry = false
+    /// Mirrors `extensionCustomSearchPaths`, joined with `:`; only written back on a real edit, so a
+    /// live round trip through the setting can't strip the trailing separator mid-keystroke.
+    @State private var customSearchPathsText = ""
 
     private var settings: AppSettings { core.settings }
 
@@ -58,6 +61,7 @@ struct ExtensionRegistriesSheet: View {
                     // source, and only source has to be built.
                     if !gitHubRegistries.isEmpty {
                         buildingRow
+                        customSearchPathsRow
                     }
                 } header: {
                     Text("GitHub Registries")
@@ -82,7 +86,10 @@ struct ExtensionRegistriesSheet: View {
             }
             .padding(Theme.Spacing.xxl)
         }
-        .frame(width: Theme.Size.editorSheetWidth, height: 560)
+        .frame(width: Theme.Size.editorSheetWidth, height: 600)
+        .onAppear {
+            customSearchPathsText = settings.extensionCustomSearchPaths.joined(separator: ":")
+        }
         .sheet(isPresented: $addingRegistry) {
             RegistryEditorSheet(
                 onAdd: { registry in
@@ -139,7 +146,8 @@ struct ExtensionRegistriesSheet: View {
 
     private var packageManagerDetail: String {
         let chosen = settings.extensionPackageManager
-        guard let resolved = chosen.resolve() else {
+        let additionalSearchPaths = settings.extensionCustomSearchPaths
+        guard let resolved = chosen.resolve(additionalSearchPaths: additionalSearchPaths) else {
             return chosen == .automatic
                 ? "None found on this Mac. Install pnpm, npm, Yarn or Bun to use a source registry."
                 : "\(chosen.title) isn't installed on this Mac."
@@ -147,6 +155,46 @@ struct ExtensionRegistriesSheet: View {
         return chosen == .automatic
             ? "Found \(resolved.manager.title) at \(resolved.url.path)."
             : "Found at \(resolved.url.path)."
+    }
+
+    /// Extra PATH folders Tinycast checks before its built-in list — for a package manager or Node
+    /// install it wouldn't otherwise find, such as a mise or Nix shim directory. The explanation runs
+    /// as its own wrapping line rather than a `SettingsRow` subtitle, which truncates mid-word instead
+    /// of wrapping — unreadable for anything longer than a few words.
+    private var customSearchPathsRow: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            SettingsRow(title: "Custom search paths") {
+                Image(systemName: "folder.badge.gearshape")
+                    .foregroundStyle(.secondary)
+            } trailing: {
+                TextField(
+                    "", text: $customSearchPathsText,
+                    prompt: Text("~/.local/share/mise/shims")
+                )
+                .textFieldStyle(.roundedBorder)
+                .labelsHidden()
+                .pointerStyle(.horizontalText)
+                .frame(width: 220)
+                .onChange(of: customSearchPathsText) { _, value in
+                    settings.extensionCustomSearchPaths = Self.parseSearchPaths(value)
+                }
+            }
+            Text(
+                "Colon-separated, like PATH — checked before Homebrew and the rest. For mise: "
+                    + "~/.local/share/mise/shims. For Nix (Home Manager): "
+                    + "/etc/profiles/per-user/<you>/home-path/bin."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Splits on `:`, the same separator PATH itself uses, dropping anything blank in between.
+    private static func parseSearchPaths(_ text: String) -> [String] {
+        text.split(separator: ":", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
     }
 
     @ViewBuilder

--- a/Tinycast/Features/Extensions/Settings/ExtensionStoreSheet.swift
+++ b/Tinycast/Features/Extensions/Settings/ExtensionStoreSheet.swift
@@ -223,6 +223,7 @@ struct ExtensionStoreSheet: View {
                 try await core.extensions.install(
                     listing: listing,
                     packageManager: core.settings.extensionPackageManager,
+                    additionalSearchPaths: core.settings.extensionCustomSearchPaths,
                     onProgress: { progress in
                         Task { @MainActor in installing[listing.id] = progress }
                     })

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -182,6 +182,15 @@ final class AppSettings {
         }
     }
 
+    /// Extra PATH folders searched before the built-in list, for a toolchain in a place Tinycast
+    /// doesn't already know — mise or Nix shims are the common case. Empty means nothing extra.
+    var extensionCustomSearchPaths: [String] {
+        didSet {
+            defaults.set(
+                extensionCustomSearchPaths, forKey: Key.extensionCustomSearchPaths.rawValue)
+        }
+    }
+
     /// Off means fully off: no launcher entries, and a still-registered shortcut moves nothing.
     var windowManagementEnabled: Bool {
         didSet {
@@ -311,6 +320,8 @@ final class AppSettings {
             defaults.data(forKey: Key.extensionRegistries.rawValue)
             .flatMap { try? JSONDecoder().decode([ExtensionRegistry].self, from: $0) }
             ?? ExtensionRegistry.defaults
+        extensionCustomSearchPaths =
+            defaults.stringArray(forKey: Key.extensionCustomSearchPaths.rawValue) ?? []
         windowManagementEnabled = defaults.bool(forKey: Key.windowManagementEnabled.rawValue)
         windowManagementShowInLauncher =
             defaults.object(forKey: Key.windowManagementShowInLauncher.rawValue) == nil

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -37,4 +37,5 @@ enum AppSettingsKey: String, CaseIterable {
     case extensionsShowInLauncher = "extensionsShowInLauncher"
     case extensionPackageManager = "extensionPackageManager"
     case extensionRegistries = "extensionRegistries"
+    case extensionCustomSearchPaths = "extensionCustomSearchPaths"
 }

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -250,10 +250,17 @@ source, which is the only contract such an extension offers. Lifecycle scripts a
 build script is the contract, a `postinstall` is code nobody asked to run. The package manager is
 `Automatic` by default, which takes the first of pnpm, Bun, Yarn and npm that is installed — a GUI app
 inherits none of a login shell's `PATH`, so `ExtensionPackageManager.searchPaths` is where they are
-looked for, version managers included.
+looked for, version managers included (Homebrew, Volta, asdf, mise, fnm, nvm, Yarn).
 
-Neither the registry list nor the package manager rides a settings backup: one names a tool the
-machine an import lands on may not have, the other is a source of code that will be run.
+That hardcoded list can never cover every toolchain layout — Nix among them — so the Registries sheet
+also has "Custom search paths": a `:`-separated list, `extensionCustomSearchPaths` in `AppSettings`,
+checked *before* the built-in list wherever it resolves a package manager or Node. Set once, it applies
+to every future install; nothing about it needs entering per-install. `ExtensionInstaller` takes it as
+`additionalSearchPaths` rather than reading settings itself, keeping the Model/Service split intact.
+
+Neither the registry list, the package manager, nor the custom search paths ride a settings backup:
+the first two name a tool or a source of code the machine an import lands on may not have or want, and
+the last is a set of paths specific to this Mac's toolchain layout.
 
 ## Shortcuts
 


### PR DESCRIPTION
## Summary

- `ExtensionPackageManager.searchPaths` is a hardcoded list Tinycast checks for pnpm/npm/yarn/bun/node, since a GUI app inherits none of a login shell's `PATH`. It didn't cover mise or Nix (Home Manager), so those installs silently fell back to another manager or failed outright.
- Added a "Custom search paths" field to the Registries sheet — a colon-separated list (same syntax as `PATH`), stored in `extensionCustomSearchPaths`, checked *before* the built-in list wherever a package manager or Node gets resolved. Set once, it applies to every future install automatically.
- Also added mise's own shim folder (`~/.local/share/mise/shims`) to the built-in list itself, since it's as stable and common as the `asdf` entry already there — most mise users need nothing further.
- The setting is excluded from settings backups, same reasoning as `extensionPackageManager`: it names paths specific to this Mac's toolchain layout.

## Test plan

- [x] `./Scripts/run-tests.sh` — all 33 harnesses pass
- [x] Debug build compiles with no new warnings
- [x] `./Scripts/lint.sh` — clean
- [x] `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` — empty
- [x] Manually reviewed the Registries sheet layout (field, placeholder example, wrapping caption naming both mise and Nix Home Manager with real paths)

Closes #259