### PR TITLE
Add input source switcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@ Write code as if the platform released yesterday:
   migration scaffolding, no "just in case" fallbacks. The two migrations that exist are scheduled for
   deletion; nothing new may depend on them.
 
-Carbon is the one deliberate exception, and it is a capability gap rather than inertia: nothing modern
-registers a system-wide chord. Full reasoning in [standards.md](docs/standards.md#posture).
+Carbon is a deliberate capability-gap dependency rather than inertia: nothing modern registers a
+system-wide chord, and HIToolbox's TIS APIs remain the public input-source mechanism. Full reasoning in
+[standards.md](docs/standards.md#posture).
 
 ## Where things are
 

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		07726F26DC68689F8984F467 /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D0784E49BC5899A585F285 /* Scrypt.swift */; };
 		0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395BACF833C810961A248F0 /* BarButton.swift */; };
 		089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ABE4AF80DD5F5F8E91F63E /* SpotlightNames.swift */; };
+		0A086C5452FD9FCE68AF4E46 /* InputSourceSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */; };
 		0A3273195B033B62952A7220 /* PaletteSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227B7D0CBA27AAF08D53F21A /* PaletteSearchField.swift */; };
 		0B9C941402B85C69A33200C2 /* UninstallProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A48095F6487DEE76663F88 /* UninstallProtection.swift */; };
 		0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42664C60B760276FBAAD61 /* EmojiSettingsView.swift */; };
@@ -356,6 +357,7 @@
 		2BECF24B674F9458E4A876DA /* AppCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCore.swift; sourceTree = "<group>"; };
 		2C5FFE395B9164BDC77B3470 /* SettingsBackupCoverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBackupCoverage.swift; sourceTree = "<group>"; };
 		2D303E193CFEFE455778C150 /* CommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandsSettingsView.swift; sourceTree = "<group>"; };
+		2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSourceSwitcher.swift; sourceTree = "<group>"; };
 		301BA9123035D6BFB808F763 /* SnippetKeywordListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordListener.swift; sourceTree = "<group>"; };
 		30BBF211CE6A076EAF8D6C33 /* ExtensionManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManifest.swift; sourceTree = "<group>"; };
 		316A544BF6628C0465DE28D8 /* EmojiIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiIndex.swift; sourceTree = "<group>"; };
@@ -626,6 +628,7 @@
 				B6A96350EBE68EC79497FA2D /* AppPaths.swift */,
 				9163FDA8F7ADDEF49A62D72C /* CursorScreen.swift */,
 				BFB023D167225228757CC4B2 /* HealthTicker.swift */,
+				2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */,
 				3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */,
 				EB76FDBFE1E306C2A5B1A29B /* Memo.swift */,
 				E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */,
@@ -1791,6 +1794,7 @@
 				CA6BA9C381351D0B2CADFB9D /* IconCache.swift in Sources */,
 				3E2E2CFAD5C5731A5F059AD5 /* IconStyleMonitor.swift in Sources */,
 				CB95B0CBF0DFEDFCEA837053 /* ImageThumbnail.swift in Sources */,
+				0A086C5452FD9FCE68AF4E46 /* InputSourceSwitcher.swift in Sources */,
 				8855C67C7EE196E3F9EDE778 /* KeyCapChip.swift in Sources */,
 				AE3144FCC55FADC48955D17A /* KeyShortcut.swift in Sources */,
 				DEBCF434AB244DAD43DB8A6A /* LaunchAtLogin.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -19,6 +19,7 @@ final class AppCore {
     let hotKeys = HotKeyManager()
     let hyperKeyTap = HyperKeyTap()
     let windowMover = WindowMover()
+    let inputSourceSwitcher = InputSourceSwitcher()
     let settings: AppSettings
     @ObservationIgnored private var appearanceObservation: NSKeyValueObservation?
     @ObservationIgnored private let iconStyle = IconStyleMonitor()
@@ -268,6 +269,7 @@ final class AppCore {
     func prepareForTermination() {
         // Caps Lock first: its remap is the one teardown that outlives the process.
         hyperKeyTap.prepareForTermination()
+        inputSourceSwitcher.endSession()
         snippetTextInjector.prepareForTermination()
         snippetListener.stop()
         snippetsStore.stop()

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -56,6 +56,8 @@ enum SettingsBackupCoverage {
         AppSettingsKey.extensionsEnabled.rawValue:
             "Doubles as consent to run third-party JavaScript; an import must not switch it on.",
         AppSettingsKey.palettePosition.rawValue:
-            "Machine-local geometry: a point restored onto another display layout lands nowhere."
+            "Machine-local geometry: a point restored onto another display layout lands nowhere.",
+        AppSettingsKey.autoSwitchInputSource.rawValue:
+            "Names a keyboard input source installed on this Mac; another Mac may not have it."
     ]
 }

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -99,6 +99,16 @@ final class AppSettings {
         didSet { defaults.set(openOnCursorScreen, forKey: Key.openOnCursorScreen.rawValue) }
     }
 
+    var autoSwitchInputSourceID: String? {
+        didSet {
+            guard let autoSwitchInputSourceID else {
+                defaults.removeObject(forKey: Key.autoSwitchInputSource.rawValue)
+                return
+            }
+            defaults.set(autoSwitchInputSourceID, forKey: Key.autoSwitchInputSource.rawValue)
+        }
+    }
+
     /// Lets the panel be dragged by its top edge; off by default, so most launches never grab it.
     var paletteDraggable: Bool {
         didSet { defaults.set(paletteDraggable, forKey: Key.paletteDraggable.rawValue) }
@@ -294,6 +304,7 @@ final class AppSettings {
         openOnCursorScreen =
             defaults.object(forKey: Key.openOnCursorScreen.rawValue) == nil
             || defaults.bool(forKey: Key.openOnCursorScreen.rawValue)
+        autoSwitchInputSourceID = defaults.string(forKey: Key.autoSwitchInputSource.rawValue)
         paletteDraggable = defaults.bool(forKey: Key.paletteDraggable.rawValue)
         // A half-written pair is no position at all, so both coordinates have to be there.
         palettePosition = (defaults.array(forKey: Key.palettePosition.rawValue) as? [Double])

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -15,6 +15,7 @@ enum AppSettingsKey: String, CaseIterable {
     case showFavoritesInCompactMode = "showFavoritesInCompactMode"
     case searchScopes = "launcherSearchScopes"
     case openOnCursorScreen = "openOnCursorScreen"
+    case autoSwitchInputSource = "autoSwitchInputSource"
     case paletteDraggable = "paletteDraggable"
     case palettePosition = "palettePosition"
     case fileSearchEnabled = "fileSearchEnabled"

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -1,5 +1,3 @@
-import AppKit
-import Combine
 import SwiftUI
 
 struct GeneralSettingsView: View {
@@ -163,17 +161,16 @@ struct GeneralSettingsView: View {
                     Text("Pop to Root Search")
                     Text("Reset to the launcher this long after the window closes.")
                 }
-                if inputSources.count > 1 {
+                // Empty only when TIS fails; one layout still lists, so the row does not come and go.
+                if !inputSources.isEmpty {
                     Picker(selection: $settings.autoSwitchInputSourceID) {
                         Text("None").tag(nil as String?)
                         ForEach(inputSources) { source in
                             Text(source.title).tag(Optional(source.id))
                         }
                     } label: {
-                        Text("Auto-switch Input Source")
-                        Text(
-                            "Tinycast will automatically switch keyboard to selected input source when opening the window."
-                        )
+                        Text("Auto-switch input source")
+                        Text("Switch the keyboard to this source while the launcher is open.")
                     }
                 }
             } header: {
@@ -195,18 +192,14 @@ struct GeneralSettingsView: View {
         }
         .onAppear(perform: refreshInputSources)
         .onReceive(
-            NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+            DistributedNotificationCenter.default().publisher(
+                for: InputSourceSwitcher.sourcesDidChange)
         ) { _ in
             refreshInputSources()
         }
     }
 
     private func refreshInputSources() {
-        inputSources = core.inputSourceSwitcher.availableSources()
-        if let selected = settings.autoSwitchInputSourceID,
-            !inputSources.contains(where: { $0.id == selected })
-        {
-            settings.autoSwitchInputSourceID = nil
-        }
+        inputSources = core.inputSourceSwitcher.options(selecting: settings.autoSwitchInputSourceID)
     }
 }

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Combine
 import SwiftUI
 
 struct GeneralSettingsView: View {
@@ -8,6 +10,7 @@ struct GeneralSettingsView: View {
     // The same key `MenuBarExtra(isInserted:)` binds, so this updates the icon live.
     @AppStorage(SettingsKey.showInMenuBar) private var showInMenuBar = true
     @State private var confirmingRankingReset = false
+    @State private var inputSources: [InputSourceSwitcher.Option] = []
 
     /// The Hyper modifier chord as prose glyphs, tracking the Include Shift toggle.
     private var hyperGlyphs: String { settings.hyperKeyIncludesShift ? "⌃⌥⇧⌘" : "⌃⌥⌘" }
@@ -160,6 +163,19 @@ struct GeneralSettingsView: View {
                     Text("Pop to Root Search")
                     Text("Reset to the launcher this long after the window closes.")
                 }
+                if inputSources.count > 1 {
+                    Picker(selection: $settings.autoSwitchInputSourceID) {
+                        Text("None").tag(nil as String?)
+                        ForEach(inputSources) { source in
+                            Text(source.title).tag(Optional(source.id))
+                        }
+                    } label: {
+                        Text("Auto-switch Input Source")
+                        Text(
+                            "Tinycast will automatically switch keyboard to selected input source when opening the window."
+                        )
+                    }
+                }
             } header: {
                 Text("General")
             }
@@ -176,6 +192,21 @@ struct GeneralSettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Tinycast will relearn your preferred results as you use the launcher.")
+        }
+        .onAppear(perform: refreshInputSources)
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+        ) { _ in
+            refreshInputSources()
+        }
+    }
+
+    private func refreshInputSources() {
+        inputSources = core.inputSourceSwitcher.availableSources()
+        if let selected = settings.autoSwitchInputSourceID,
+            !inputSources.contains(where: { $0.id == selected })
+        {
+            settings.autoSwitchInputSourceID = nil
         }
     }
 }

--- a/Tinycast/Palette/PaletteSearchField.swift
+++ b/Tinycast/Palette/PaletteSearchField.swift
@@ -18,6 +18,7 @@ struct PaletteSearchField: NSViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     let prompt: String
+    let onFocused: (NSTextInputContext) -> Void
     /// `true` keeps the key; `false` leaves it to the caret.
     let onKeyCommand: (PaletteSearchKey, NSEvent.ModifierFlags) -> Bool
 
@@ -61,8 +62,13 @@ struct PaletteSearchField: NSViewRepresentable {
         if textView.string != text, !textView.hasMarkedText() {
             textView.replaceWholeString(with: text)
         }
-        guard isFocused, textView.window?.firstResponder !== textView else { return }
-        textView.window?.makeFirstResponder(textView)
+        guard isFocused else { return }
+        if textView.window?.firstResponder !== textView,
+            textView.window?.makeFirstResponder(textView) != true
+        {
+            return
+        }
+        if let inputContext = textView.inputContext { onFocused(inputContext) }
     }
 
     @MainActor

--- a/Tinycast/Palette/PaletteSearchField.swift
+++ b/Tinycast/Palette/PaletteSearchField.swift
@@ -18,6 +18,7 @@ struct PaletteSearchField: NSViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     let prompt: String
+    /// Runs on every update the field holds focus for, not only on the move into focus.
     let onFocused: (NSTextInputContext) -> Void
     /// `true` keeps the key; `false` leaves it to the caret.
     let onKeyCommand: (PaletteSearchKey, NSEvent.ModifierFlags) -> Bool
@@ -63,10 +64,8 @@ struct PaletteSearchField: NSViewRepresentable {
             textView.replaceWholeString(with: text)
         }
         guard isFocused else { return }
-        if textView.window?.firstResponder !== textView,
-            textView.window?.makeFirstResponder(textView) != true
-        {
-            return
+        if textView.window?.firstResponder !== textView {
+            guard textView.window?.makeFirstResponder(textView) == true else { return }
         }
         if let inputContext = textView.inputContext { onFocused(inputContext) }
     }

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -55,6 +55,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             positionPanel(panel, collapsed: core.paletteCoordinator.paletteIsCollapsed)
             // Flush first-mount layout off-screen, so the safe-area settle isn't visible.
             panel.contentView?.layoutSubtreeIfNeeded()
+            core.inputSourceSwitcher.beginSession(
+                preferredInputSourceID: core.settings.autoSwitchInputSourceID)
             // Non-activating, so summoning never raises our own aux windows behind it.
             panel.makeKeyAndOrderFront(nil)
             panel.orderFrontRegardless()
@@ -68,6 +70,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     func hide(restoreFocus: Bool) {
         panel?.orderOut(nil)
+        core.inputSourceSwitcher.endSession()
         // Drop the anchor, so the next summon re-resolves for the screen in use then.
         anchor = nil
         // The guides must never outlive the panel they point at.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -481,6 +481,7 @@ struct RootPaletteView: View {
         @Bindable var vm = vm
         return PaletteSearchField(
             text: $vm.query, isFocused: $searchFocused, prompt: searchPrompt,
+            onFocused: core.inputSourceSwitcher.applySession(to:),
             onKeyCommand: handleSearchKey
         )
         // Fills the row's height, so there's no gap above it for topDragStrip to meet.

--- a/Tinycast/Platform/InputSourceSwitcher.swift
+++ b/Tinycast/Platform/InputSourceSwitcher.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Carbon.HIToolbox
+
+@MainActor
+final class InputSourceSwitcher {
+    struct Option: Identifiable, Hashable {
+        let id: String
+        let title: String
+    }
+
+    private struct Session {
+        let previousInputSourceID: String
+        let preferredInputSourceID: String
+        var didApplyPreferredSource = false
+    }
+
+    private var session: Session?
+
+    func availableSources() -> [Option] {
+        Self.selectableSources().compactMap { source in
+            guard
+                let id = Self.stringProperty(kTISPropertyInputSourceID, source: source),
+                let title = Self.stringProperty(kTISPropertyLocalizedName, source: source)
+            else { return nil }
+            return Option(id: id as String, title: title as String)
+        }
+    }
+
+    func beginSession(preferredInputSourceID: String?) {
+        guard session == nil, let preferredInputSourceID,
+            Self.source(id: preferredInputSourceID) != nil,
+            let currentInputSourceID = Self.currentInputSourceID()
+        else { return }
+        session = Session(
+            previousInputSourceID: currentInputSourceID,
+            preferredInputSourceID: preferredInputSourceID)
+    }
+
+    func applySession(to inputContext: NSTextInputContext) {
+        guard var session, !session.didApplyPreferredSource else { return }
+        inputContext.selectedKeyboardInputSource = session.preferredInputSourceID
+        session.didApplyPreferredSource = true
+        self.session = session
+    }
+
+    func endSession() {
+        guard let session else { return }
+        self.session = nil
+        Self.selectInputSource(id: session.previousInputSourceID)
+    }
+
+    private static func currentInputSourceID() -> String? {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+            let id = stringProperty(kTISPropertyInputSourceID, source: source)
+        else { return nil }
+        return id as String
+    }
+
+    @discardableResult
+    private static func selectInputSource(id: String) -> Bool {
+        guard let source = source(id: id) else { return false }
+        return TISSelectInputSource(source) == noErr
+    }
+
+    private static func source(id: String) -> TISInputSource? {
+        selectableSources().first {
+            stringProperty(kTISPropertyInputSourceID, source: $0) as String? == id
+        }
+    }
+
+    private static func selectableSources() -> [TISInputSource] {
+        guard let list = TISCreateInputSourceList(nil, false)?.takeRetainedValue() else { return [] }
+        var sources: [TISInputSource] = []
+        for case let source as TISInputSource in list as NSArray {
+            guard
+                let category = stringProperty(kTISPropertyInputSourceCategory, source: source),
+                CFEqual(category, kTISCategoryKeyboardInputSource),
+                boolProperty(kTISPropertyInputSourceIsSelectCapable, source: source)
+            else { continue }
+            sources.append(source)
+        }
+        return sources
+    }
+
+    private static func stringProperty(
+        _ key: CFString, source: TISInputSource
+    ) -> CFString? {
+        guard let value = TISGetInputSourceProperty(source, key) else { return nil }
+        return unsafeBitCast(value, to: CFString.self)
+    }
+
+    private static func boolProperty(_ key: CFString, source: TISInputSource) -> Bool {
+        guard let value = TISGetInputSourceProperty(source, key) else { return false }
+        return CFBooleanGetValue(unsafeBitCast(value, to: CFBoolean.self))
+    }
+}

--- a/Tinycast/Platform/InputSourceSwitcher.swift
+++ b/Tinycast/Platform/InputSourceSwitcher.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Carbon.HIToolbox
 
+/// Holds the keyboard input source at the palette's preferred one for the life of one summon.
 @MainActor
 final class InputSourceSwitcher {
     struct Option: Identifiable, Hashable {
@@ -8,89 +9,87 @@ final class InputSourceSwitcher {
         let title: String
     }
 
+    /// Posted by TIS when a keyboard source is added or removed in System Settings.
+    static let sourcesDidChange = Notification.Name(
+        kTISNotifyEnabledKeyboardInputSourcesChanged as String)
+
+    /// The source to restore is kept as the object TIS vended, so hiding never re-reads the list.
     private struct Session {
-        let previousInputSourceID: String
+        let previousSource: TISInputSource
         let preferredInputSourceID: String
-        var didApplyPreferredSource = false
+        var applied = false
     }
 
     private var session: Session?
 
-    func availableSources() -> [Option] {
-        Self.selectableSources().compactMap { source in
-            guard
-                let id = Self.stringProperty(kTISPropertyInputSourceID, source: source),
-                let title = Self.stringProperty(kTISPropertyLocalizedName, source: source)
-            else { return nil }
-            return Option(id: id as String, title: title as String)
+    /// Every enabled keyboard source; a `selected` one that is gone stays listed, so Settings keeps it.
+    func options(selecting selected: String?) -> [Option] {
+        var options = Self.enabledKeyboardSources().compactMap(Self.option(for:))
+        if let selected, !options.contains(where: { $0.id == selected }) {
+            options.append(Option(id: selected, title: selected))
         }
+        return options
     }
 
+    /// Records what to go back to; skipped when the preferred source is already the active one.
     func beginSession(preferredInputSourceID: String?) {
         guard session == nil, let preferredInputSourceID,
-            Self.source(id: preferredInputSourceID) != nil,
-            let currentInputSourceID = Self.currentInputSourceID()
+            let current = Self.currentSource(),
+            Self.identifier(of: current) != preferredInputSourceID
         else { return }
-        session = Session(
-            previousInputSourceID: currentInputSourceID,
-            preferredInputSourceID: preferredInputSourceID)
+        session = Session(previousSource: current, preferredInputSourceID: preferredInputSourceID)
     }
 
+    /// Goes through the field's own context, so the switch follows the palette's focus.
     func applySession(to inputContext: NSTextInputContext) {
-        guard var session, !session.didApplyPreferredSource else { return }
+        guard let session, !session.applied else { return }
         inputContext.selectedKeyboardInputSource = session.preferredInputSourceID
-        session.didApplyPreferredSource = true
-        self.session = session
+        self.session?.applied = true
     }
 
+    /// Undoes only our own switch: a source picked since, by the user or another app, stands.
     func endSession() {
         guard let session else { return }
         self.session = nil
-        Self.selectInputSource(id: session.previousInputSourceID)
+        guard session.applied, let current = Self.currentSource(),
+            Self.identifier(of: current) == session.preferredInputSourceID
+        else { return }
+        TISSelectInputSource(session.previousSource)
     }
 
-    private static func currentInputSourceID() -> String? {
-        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
-            let id = stringProperty(kTISPropertyInputSourceID, source: source)
+    private static func currentSource() -> TISInputSource? {
+        TISCopyCurrentKeyboardInputSource()?.takeRetainedValue()
+    }
+
+    private static func option(for source: TISInputSource) -> Option? {
+        guard let id = identifier(of: source),
+            let title: String = property(kTISPropertyLocalizedName, of: source)
         else { return nil }
-        return id as String
+        return Option(id: id, title: title)
     }
 
-    @discardableResult
-    private static func selectInputSource(id: String) -> Bool {
-        guard let source = source(id: id) else { return false }
-        return TISSelectInputSource(source) == noErr
+    private static func identifier(of source: TISInputSource) -> String? {
+        property(kTISPropertyInputSourceID, of: source)
     }
 
-    private static func source(id: String) -> TISInputSource? {
-        selectableSources().first {
-            stringProperty(kTISPropertyInputSourceID, source: $0) as String? == id
-        }
-    }
-
-    private static func selectableSources() -> [TISInputSource] {
+    private static func enabledKeyboardSources() -> [TISInputSource] {
         guard let list = TISCreateInputSourceList(nil, false)?.takeRetainedValue() else { return [] }
         var sources: [TISInputSource] = []
-        for case let source as TISInputSource in list as NSArray {
-            guard
-                let category = stringProperty(kTISPropertyInputSourceCategory, source: source),
-                CFEqual(category, kTISCategoryKeyboardInputSource),
-                boolProperty(kTISPropertyInputSourceIsSelectCapable, source: source)
-            else { continue }
+        for case let source as TISInputSource in list as NSArray where isSelectableKeyboard(source) {
             sources.append(source)
         }
         return sources
     }
 
-    private static func stringProperty(
-        _ key: CFString, source: TISInputSource
-    ) -> CFString? {
-        guard let value = TISGetInputSourceProperty(source, key) else { return nil }
-        return unsafeBitCast(value, to: CFString.self)
+    private static func isSelectableKeyboard(_ source: TISInputSource) -> Bool {
+        let category: String? = property(kTISPropertyInputSourceCategory, of: source)
+        return category == kTISCategoryKeyboardInputSource as String
+            && property(kTISPropertyInputSourceIsSelectCapable, of: source) == true
     }
 
-    private static func boolProperty(_ key: CFString, source: TISInputSource) -> Bool {
-        guard let value = TISGetInputSourceProperty(source, key) else { return false }
-        return CFBooleanGetValue(unsafeBitCast(value, to: CFBoolean.self))
+    /// TIS vends properties as untyped pointers, so an unexpected type must read as absent, not trap.
+    private static func property<Value>(_ key: CFString, of source: TISInputSource) -> Value? {
+        guard let value = TISGetInputSourceProperty(source, key) else { return nil }
+        return Unmanaged<AnyObject>.fromOpaque(value).takeUnretainedValue() as? Value
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,7 +176,8 @@ Tinycast/
   App/              @main, AppDelegate, AppCore — the composition root
   DesignSystem/     Theme (the token source), KeyCapChip, Tooltip, SymbolImage,
                     VisualEffectView, PopoverMenu, SettingsComponents, Scrolling/, Interaction/
-  Platform/         system shims: Permissions, LaunchAtLogin, CursorScreen, AppDisplayName,
+  Platform/         system shims: Permissions, LaunchAtLogin, InputSourceSwitcher, CursorScreen,
+                    AppDisplayName,
                     NotificationToken, AppPaths, Signposts, HealthTicker, Memo, ActivationPolicy,
                     Images/, Compression/
   Resources/        RaycastRuntime.generated.js, the embedded extension runtime

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -20,8 +20,9 @@ The command palette is a borderless floating `NSPanel` hosting SwiftUI; see
 - **Focus restoration is load-bearing.** Paste targets the recorded `previousApp` and requires the
   Accessibility permission (`Permissions.ensureAccessibility()`).
 - **Input-source switching is a palette session.** The source active at summon time is captured before
-  the panel becomes key, the configured source is applied after the search field receives its input
-  context, and the captured source is restored on every hide and on termination.
+  the panel becomes key, the configured source is applied through the search field's input context, and
+  the captured source is restored on hide and on termination — but only when the palette is still on the
+  source it applied, so a switch made since, by the user or another app, stands.
 
 ## Summoning
 
@@ -34,7 +35,7 @@ The command palette is a borderless floating `NSPanel` hosting SwiftUI; see
                                             · records previousApp (the paste / focus target)
                                             · resolves PasteTarget once per summon
                                             · resolves the screen anchor once per summon
-                                            · captures the current input source for the session
+                                            · captures the input source to restore, once per summon
                                             · positions, lays out off-screen, orders front
                                                               ↓
                                                     RootPaletteView.body

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -19,6 +19,9 @@ The command palette is a borderless floating `NSPanel` hosting SwiftUI; see
   instead; resigning shifts the text a point or two.
 - **Focus restoration is load-bearing.** Paste targets the recorded `previousApp` and requires the
   Accessibility permission (`Permissions.ensureAccessibility()`).
+- **Input-source switching is a palette session.** The source active at summon time is captured before
+  the panel becomes key, the configured source is applied after the search field receives its input
+  context, and the captured source is restored on every hide and on termination.
 
 ## Summoning
 
@@ -31,9 +34,12 @@ The command palette is a borderless floating `NSPanel` hosting SwiftUI; see
                                             · records previousApp (the paste / focus target)
                                             · resolves PasteTarget once per summon
                                             · resolves the screen anchor once per summon
+                                            · captures the current input source for the session
                                             · positions, lays out off-screen, orders front
                                                               ↓
                                                     RootPaletteView.body
+                                            · focuses the search field
+                                            · applies the configured source to its input context
 ```
 
 Everything resolved "once per summon" is resolved there deliberately, not per render. `AppCore` holds

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -26,10 +26,11 @@ never a completion handler or a `DispatchQueue` hop; `SMAppService` and never an
 shim; structured concurrency and never detached bookkeeping you have to remember to cancel. When one of
 these gains a successor, the migration is the change — not a wrapper preserving the old spelling.
 
-Carbon is the one deliberate exception. The global hotkey engine uses `RegisterEventHotKey` because
-nothing modern can register a system-wide chord, and `CGEventTap` cannot see a lone modifier press.
-That is a capability gap, not inertia — and every raw C pointer is decoded to plain values before it
-crosses into actor code.
+Carbon has two deliberate capability-gap uses. The global hotkey engine uses `RegisterEventHotKey`
+because nothing modern can register a system-wide chord, and `CGEventTap` cannot see a lone modifier
+press. `InputSourceSwitcher` uses HIToolbox's TIS APIs because they remain the public mechanism for
+enumerating and selecting keyboard input sources. Neither use is inertia, and every raw C pointer is
+decoded to plain values before it crosses into actor code.
 
 ## Architecture and feature organization
 


### PR DESCRIPTION
## What changed

 Added an `Auto-switch Input Source` picker to Settings → General. The picker is shown only when more than one keyboard input source is available.

When the palette opens, Tinycast captures the current input source and applies the configured source after the search field receives focus. When the palette closes or Tinycast terminates, the previously active input source is restored.

## Memory footprint

Not measured

## Demo

https://github.com/user-attachments/assets/daf97cb1-ebec-44eb-bb5d-2f5a9fc077c4

## Drawbacks

Input sources are refreshed when Tinycast is reactivated to reduce CPU cycles, not immediately while it remains active.

Input-source enumeration and global restoration use HIToolbox TIS APIs because AppKit does not provide equivalent global lifecycle control.

## Tests & validation

- Ran all 33 test harnesses with `./Scripts/run-tests.sh`.
- Ran `./Scripts/lint.sh`.
- Verified the pure Model layer contains no AppKit, SwiftUI, or Cocoa imports.
- Built the Debug configuration successfully with code signing disabled.
- No new warnings were introduced.
- No new harness cases were added because the behavior depends on the real AppKit input context and installed macOS input sources.
