### PR TITLE
Scan one subfolder deep for apps installed under /Applications

### DIFF
--- a/Tests/scopes-test.swift
+++ b/Tests/scopes-test.swift
@@ -23,24 +23,27 @@ struct ScopesTest {
             try? fm.createDirectory(at: url, withIntermediateDirectories: true)
         }
 
-        // A scope directory with two apps, a non-app sibling, a hidden app, and a nested app.
+        // Two direct apps, a non-app file, a hidden app, one nested app, one two-deep nested app.
         let apps = root.appendingPathComponent("Apps")
         makeDir(apps.appendingPathComponent("Alpha.app"))
         makeDir(apps.appendingPathComponent("Beta.app"))
         makeDir(apps.appendingPathComponent("Notes.txt"))
         makeDir(apps.appendingPathComponent(".Hidden.app"))
-        let nested = apps.appendingPathComponent("Sub")
-        makeDir(nested.appendingPathComponent("Deep.app"))
+        let vendor = apps.appendingPathComponent("Vendor")
+        makeDir(vendor.appendingPathComponent("Nested.app"))
+        let deep = vendor.appendingPathComponent("Deeper")
+        makeDir(deep.appendingPathComponent("TooDeep.app"))
 
         let found = SearchScopes.appBundles(in: [apps.path]).map(\.lastPathComponent)
-        check("direct .app children are indexed", Set(found) == ["Alpha.app", "Beta.app"])
+        check(
+            "direct and one-level-nested .app children are indexed",
+            Set(found) == ["Alpha.app", "Beta.app", "Nested.app"])
         check("non-app children are skipped", !found.contains("Notes.txt"))
         check("hidden bundles are skipped", !found.contains(".Hidden.app"))
-        // Flat by contract: a nested folder is indexed by adding it as its own scope.
-        check("nested bundles are not indexed", !found.contains("Deep.app"))
+        check("bundles nested two levels deep are not indexed", !found.contains("TooDeep.app"))
         check(
-            "a nested folder works as its own scope",
-            SearchScopes.appBundles(in: [nested.path]).map(\.lastPathComponent) == ["Deep.app"])
+            "a deeply nested folder works as its own scope",
+            SearchScopes.appBundles(in: [deep.path]).map(\.lastPathComponent) == ["TooDeep.app"])
 
         // A scope may be a single bundle rather than a directory — that's how Finder ships as a default.
         check(
@@ -52,13 +55,13 @@ struct ScopesTest {
             SearchScopes.appBundles(in: [apps.appendingPathComponent("Gone.app").path]).isEmpty)
         check(
             "a missing directory scope is skipped without failing the rest",
-            SearchScopes.appBundles(in: [root.appendingPathComponent("Nope").path, nested.path])
-                .map(\.lastPathComponent) == ["Deep.app"])
+            SearchScopes.appBundles(in: [root.appendingPathComponent("Nope").path, deep.path])
+                .map(\.lastPathComponent) == ["TooDeep.app"])
 
         check(
             "scopes are scanned in order",
-            SearchScopes.appBundles(in: [nested.path, apps.path]).map(\.lastPathComponent).first
-                == "Deep.app")
+            SearchScopes.appBundles(in: [deep.path, apps.path]).map(\.lastPathComponent).first
+                == "TooDeep.app")
 
         let home = fm.homeDirectoryForCurrentUser.path
         check(

--- a/Tinycast/Features/Launcher/Model/SearchScopes.swift
+++ b/Tinycast/Features/Launcher/Model/SearchScopes.swift
@@ -32,7 +32,7 @@ enum SearchScopes {
         return paths.map(abbreviate).filter { !$0.isEmpty && seen.insert($0).inserted }
     }
 
-    /// Every `.app` the scopes point at. Flat: a nested folder needs its own scope.
+    /// Every `.app` the scopes point at. One subfolder deep; deeper nesting needs its own scope.
     static func appBundles(in scopes: [String]) -> [URL] {
         let fm = FileManager.default
         var result: [URL] = []
@@ -42,12 +42,28 @@ enum SearchScopes {
                 if fm.fileExists(atPath: url.path) { result.append(url) }
                 continue
             }
-            guard
-                let items = try? fm.contentsOfDirectory(
-                    at: url, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
-                )
-            else { continue }
-            result.append(contentsOf: items.filter { $0.pathExtension == "app" })
+            result.append(contentsOf: appBundles(under: url, subfolderDepth: 1))
+        }
+        return result
+    }
+
+    /// `.app` is a leaf here — never descended into, only real subfolders recurse.
+    private static func appBundles(under url: URL, subfolderDepth: Int) -> [URL] {
+        guard
+            let items = try? FileManager.default.contentsOfDirectory(
+                at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+            )
+        else { return [] }
+
+        var result: [URL] = []
+        for item in items {
+            if item.pathExtension == "app" {
+                result.append(item)
+            } else if subfolderDepth > 0,
+                (try? item.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            {
+                result.append(contentsOf: appBundles(under: item, subfolderDepth: subfolderDepth - 1))
+            }
         }
         return result
     }

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -23,10 +23,12 @@ earliest scope wins).
 Settings and persisted as `AppSettings.searchScopes`. A scope is either a directory or a single `.app`
 bundle, stored tilde-abbreviated so the UI reads cleanly and a settings backup stays portable.
 
-Enumeration is **flat** — one `contentsOfDirectory` per scope, no recursion. A nested folder such as
-`/Applications/Adobe` is indexed by adding it as its own scope, which keeps the list honest: what it
-shows is exactly what is scanned. (A one-level nested walk was measured against the flat list over the
-real default set: same 96 apps, same ~0.5 ms once `Bundle()` metadata reads are counted.)
+Enumeration descends **one subfolder deep** — a scope's own `.app` children, plus any inside an
+immediate subfolder, are indexed. That catches vendor-folder installs like
+`/Applications/Blackmagic Design/DaVinci Resolve.app` without the folder needing its own scope
+(#256). The walk stays bounded rather than fully recursive: it never opens an `.app` bundle's own
+`Contents/` tree, because `.app` is treated as a leaf, and a subfolder nested deeper than one level
+still needs its own scope.
 
 The defaults cover `/Applications` and `/System/Applications` plus their `Utilities` folders,
 `/System/Library/CoreServices/Applications`, the cryptex apps under


### PR DESCRIPTION
## Summary
- `SearchScopes.appBundles(in:)` only listed a scope directory's direct children, so an app installed a folder deeper (e.g. `/Applications/Blackmagic Design/DaVinci Resolve.app`) never showed up unless that vendor folder was manually added as its own scope.
- Enumeration now descends one subfolder level automatically. The walk stays bounded — a fixed depth of 1, and an `.app` bundle is always treated as a leaf, so it never opens a bundle's own `Contents/` tree.
- Updated `docs/features/launcher.md` to describe the new bounded-descent behavior instead of the old "flat, no recursion" rationale.
- Updated `Tests/scopes-test.swift` to cover one-level-deep (now found) and two-level-deep (still requires its own scope) nesting.

Closes #256

## Test plan
- [x] `./Scripts/run-tests.sh` — all 33 harnesses pass, including updated `scopes-test`
- [x] `./Scripts/lint.sh` — clean
- [x] `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` — empty
- [x] Debug build compiles with no new warnings