### PR TITLE
Keep the notes editor harness off the general pasteboard

### DIFF
--- a/Tests/notes-editor-test.swift
+++ b/Tests/notes-editor-test.swift
@@ -24,18 +24,20 @@ struct NotesEditorTests {
             epoch: 1)
         var changes: [String] = []
         let editor = makeEditor(input: input, onSourceChange: { changes.append($0) })
+        let pasteboard = NSPasteboard.withUniqueName()
+        defer { pasteboard.releaseGlobally() }
 
         check("the editor displays literal Markdown source", editor.textView.string == source)
         check("the plain editor enables native Find", editor.textView.usesFindPanel)
 
         let boldRange = (editor.textView.string as NSString).range(of: "**bold**")
         editor.textView.setSelectedRange(boldRange)
-        editor.textView.copy(nil)
+        copySelection(of: editor.textView, to: pasteboard)
         check(
             "native Copy preserves literal Markdown",
-            NSPasteboard.general.string(forType: .string) == "**bold**")
+            pasteboard.string(forType: .string) == "**bold**")
 
-        editor.textView.cut(nil)
+        cutSelection(of: editor.textView, to: pasteboard)
         check("native Cut publishes one literal source update", changes.count == 1)
         check("native Cut removes the selected source", !editor.textView.string.contains("**bold**"))
         editor.coordinator.editorUndoManager.undo()
@@ -43,12 +45,9 @@ struct NotesEditorTests {
         editor.coordinator.editorUndoManager.redo()
         check("native Redo restores the cut", editor.textView.string == changes.last)
 
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(" [literal](url)", forType: .string)
         let end = (editor.textView.string as NSString).length
         editor.textView.setSelectedRange(NSRange(location: end, length: 0))
-        editor.textView.paste(nil)
+        paste(" [literal](url)", into: editor.textView, from: pasteboard)
         check("native Paste inserts exact source", editor.textView.string.hasSuffix(" [literal](url)"))
 
         let unicode = " 🧑🏽‍💻e\u{301}"
@@ -119,6 +118,26 @@ struct NotesEditorTests {
         check(
             "a stale count cannot be attributed to the replacement note",
             reports.last?.0.id == second.id && reports.last?.1 == 6)
+    }
+
+    /// The primitives `copy:`/`cut:`/`paste:` delegate to; the actions clobber the real clipboard.
+    private static func copySelection(of textView: NSTextView, to pasteboard: NSPasteboard) {
+        let types = textView.writablePasteboardTypes
+        pasteboard.declareTypes(types, owner: nil)
+        _ = textView.writeSelection(to: pasteboard, types: types)
+    }
+
+    private static func cutSelection(of textView: NSTextView, to pasteboard: NSPasteboard) {
+        copySelection(of: textView, to: pasteboard)
+        textView.delete(nil)
+    }
+
+    private static func paste(
+        _ text: String, into textView: NSTextView, from pasteboard: NSPasteboard
+    ) {
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        _ = textView.readSelection(from: pasteboard)
     }
 
     private static func makeEditor(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,14 @@ the pure-layer boundary real: a harness that stops *compiling* means AppKit or S
 `Model/` folder, or an effect has leaked into a decision. That is a more common failure than a broken
 assertion, and it is the more important one.
 
+A harness also runs in your own login session against the real system, with no sandbox and no fixture
+world, so it must never mutate state the machine shares with the apps you use. `NSPasteboard.general`
+is the trap: a running Tinycast records every write to it as a genuine copy, so a fixture left there
+lands in clipboard history looking like something the user copied. `notes-editor-test` seeded one on
+every run from #232 onward by calling the native `copy:`/`cut:`/`paste:` actions; it now drives the
+`writeSelection(to:types:)` and `readSelection(from:)` primitives those actions delegate to, against
+`NSPasteboard.withUniqueName()`. Same AppKit path, no shared side effect.
+
 Never join a compile to its run with `&&` in a `set -e` script. `set -e` is specified to ignore a
 failing command in a non-final AND-OR list member, so `swiftc … && /tmp/x` swallows a compile error and
 the script sails on. CI reported success over a harness that had not compiled for twenty-five phases


### PR DESCRIPTION
## Related issue

None — found while investigating unexplained entries in clipboard history.

## What changed

`notes-editor-test` drove the native `copy:`, `cut:` and `paste:` actions. Those hardcode
`NSPasteboard.general`, so every run of the suite clobbered the developer's real clipboard and left
`" [literal](url)"` sitting on it.

A running Tinycast then did exactly what it is supposed to do: the poll saw a foreign write carrying
no `internalType` marker and recorded it as a genuine copy, attributed to whichever app happened to be
frontmost. That last part is what made it hard to spot — the entries were credited to VS Code, a
browser, Activity Monitor, even System Settings, because a harness running as a background CLI has no
frontmost app of its own. One machine's Dev history had 26 of them.

`copy:`/`cut:`/`paste:` are thin wrappers over `NSTextView`'s pasteboard primitives, and those take an
explicit pasteboard. The harness now allocates `NSPasteboard.withUniqueName()`, releases it on the way
out, and goes through `writeSelection(to:types:)` and `readSelection(from:)` directly. Cut is copy plus
`delete(nil)`, which is what `cut:` itself does, so the `changes.count == 1` and undo/redo assertions
still mean what they meant.

Every assertion is unchanged, including the `**bold**` round-trip and the `hasSuffix` paste check. No
shipped source is touched.

`docs/testing.md` gains the general rule the defect broke: a harness runs unsandboxed in your own login
session, so it must never mutate state the machine shares with your apps. Nothing lints this.

## Memory footprint

N/A — `Tests/` and `docs/` only. No shipped source changed, so the app binary is unaffected.

| Step                    | Memory      |
| ----------------------- | ----------- |
| Idle after launch       | unaffected  |
| Palette open            | unaffected  |
| Feature in use (peak)   | unaffected  |
| Palette closed, settled | unaffected  |

Leak-tested: N/A. The one allocation added is a unique-name pasteboard released via `defer` in the same
scope.

## Drawbacks

It exercises the pasteboard primitives rather than the `copy:`/`paste:` action selectors themselves, so
a future AppKit regression in the actions' own plumbing — the selector-to-primitive dispatch, not the
text handling — would not be caught here. That is the narrow half of the coverage, and the trade buys
back a harness that no longer has a global side effect.

The alternative was keeping the native actions and snapshotting/restoring `NSPasteboard.general` around
them. Rejected: the restore cannot close the window between the fixture write and Tinycast's 0.5 s
poll, so the bug would come back intermittently, which is worse than reliably absent.

## Tests & validation

- `./Scripts/run-tests.sh` — all 34 harnesses pass.
- `./Scripts/run-tests.sh notes-editor-test` with a sentinel string on the clipboard: sentinel
  survives, harness passes, and the only new clipboard-history row is the sentinel itself. Nothing from
  the run is captured.
- Full suite with a sentinel: clipboard survives that too.
- `./Scripts/lint.sh` — clean, no warnings in the touched file.
- Debug build — succeeds, no new warnings.
- Pure-layer grep — empty.
- `grep -rn 'NSPasteboard.general' Tests/` now returns nothing, so this harness was the only offender.

Mechanism confirmed before fixing, not inferred: a pasteboard watcher recorded the live write during a
harness run (`types: public.utf8-plain-text`, `string(15): " [literal](url)"`) and the matching history
row appeared one poll later.
