### PR TITLE
Read a browser's selection through the text marker API

### DIFF
--- a/Tinycast/Platform/AccessibilityText.swift
+++ b/Tinycast/Platform/AccessibilityText.swift
@@ -30,10 +30,33 @@ enum AccessibilityText {
     static func selection(in app: NSRunningApplication) -> String? {
         guard let element = focusedElement(in: app) else { return nil }
         var value: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            &value)
+        let text = status == .success ? value as? String : nil
+        if let text, !text.isEmpty { return text }
+        return webSelection(in: element) ?? text
+    }
+
+    /// Browsers have no `AXSelectedText`: web selection exists only as an opaque marker range.
+    private static func webSelection(in element: AXUIElement) -> String? {
+        var range: CFTypeRef?
         guard
             AXUIElementCopyAttributeValue(
                 element,
-                kAXSelectedTextAttribute as CFString,
+                kAXSelectedTextMarkerRangeAttribute as CFString,
+                &range) == .success,
+            let range,
+            CFGetTypeID(range) == AXTextMarkerRangeGetTypeID()
+        else { return nil }
+
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyParameterizedAttributeValue(
+                element,
+                kAXStringForTextMarkerRangeParameterizedAttribute as CFString,
+                range,
                 &value) == .success
         else { return nil }
         return value as? String


### PR DESCRIPTION
## Related issue

Closes #280

## What changed

`AccessibilityText.selection(in:)` read only `AXSelectedText`. WebKit, Blink and Gecko all implement
that attribute for real text controls and nothing else, so an `AXWebArea` answers `.success` with an
empty string — which is why the fix in #262 made native apps work while browsers kept returning `""`.

Web content publishes its selection only as an opaque `AXSelectedTextMarkerRange`, and the
parameterized `AXStringForTextMarkerRange` turns that range back into a string. `selection(in:)` now
falls back to that pair when `AXSelectedText` comes back empty.

Non-obvious bits of the diff:

- The fallback is `webSelection(in:) ?? text`, not `webSelection(in:)`. A native app with the caret
  parked and nothing selected reads back a successful `""`, and that has to stay `""` rather than
  becoming `nil` — `ExtensionHostBridge` and `SnippetTextInjector` both branch on the difference.
- The second round trip only happens when the first found nothing, so native apps pay for exactly one
  AX call, as before.
- No `AXUIElementSetMessagingTimeout` call is added. `focusedElement(in:)` already sets the 1 s timeout
  on the element it returns, and the timeout is per element, so both reads inherit it.
- Every symbol is public API — `kAXSelectedTextMarkerRangeAttribute` and
  `kAXStringForTextMarkerRangeParameterizedAttribute` live in `AXWebConstants.h`,
  `AXTextMarkerRangeGetTypeID()` in `AXUIElement.h`. Both constants import into Swift as `String`, hence
  the `as CFString` casts the file already uses. The `CFGetTypeID` check keeps a non-marker reply from
  reaching the parameterized call.

## Memory footprint

Two stack-local `CFTypeRef?` values on a path that runs once per `getSelectedText()` call. Nothing is
retained past the function, and nothing new is allocated at launch or on the summon path.

| Step                    | Memory     |
| ----------------------- | ---------- |
| Idle after launch       | unaffected |
| Palette open            | unaffected |
| Feature in use (peak)   | unaffected |
| Palette closed, settled | unaffected |

Leak-tested: N/A — no new ownership. Both `CFTypeRef` results come from `Copy` calls bridged straight
into Swift, which takes the +1 the way it does everywhere else in this file.

## Drawbacks

An app that implements `AXSelectedTextMarkerRange` but leaves `AXSelectedText` empty for a genuinely
empty selection now costs two AX round trips instead of one. Both are bounded by the existing 1 s
messaging timeout, and the path is per invocation rather than per keystroke.

The fallback reads the marker range off the focused element only — no parent walk. Every browser engine
serves the attribute generically rather than from a fixed attribute-names list, so the walk would be
speculative complexity.

## Tests & validation

`./Scripts/run-tests.sh` — all 34 harnesses pass. No harness covers this: `AccessibilityText` is a
`Platform/` shim over live AX calls into another process, so there is nothing to exercise without one.

Debug build compiles with no new warnings. `./Scripts/lint.sh` is clean — the `force_cast` warning at
`AccessibilityText.swift:25` predates this change. `swift-format` reports the file clean.

I have not yet driven a live selection in Firefox or Chrome against this build; that check is still
worth doing before merge.
