### PR TITLE
Reorder favorites, and launch them by ⌘-digit

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -72,6 +72,7 @@ run file-search-session-test Tinycast/Platform/Signposts.swift \
                              Tinycast/Features/FileSearch/Service/*.swift
 run ranking-test           $L/SearchRelevance.swift $L/LauncherRankingStore.swift
 run scopes-test            $L/SearchScopes.swift
+run favorites-test         $L/FavoriteSlots.swift
 run calc-test              Tinycast/Features/Calculator/Model/*.swift
 run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift

--- a/Tests/favorites-test.swift
+++ b/Tests/favorites-test.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@main
+struct FavoritesTest {
+    static func main() {
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        // Ten digit keys is the ceiling: there is no ⌘10, so the eleventh favorite gets no chord.
+        check("ten slots", FavoriteSlots.digits.count == 10)
+        check("no digit repeats", Set(FavoriteSlots.digits).count == FavoriteSlots.digits.count)
+
+        check("⌘1 is the first favorite", FavoriteSlots.index(for: "1") == 0)
+        check("⌘9 is the ninth", FavoriteSlots.index(for: "9") == 8)
+        check("⌘0 is the tenth, not the first", FavoriteSlots.index(for: "0") == 9)
+        check("a letter is not a slot", FavoriteSlots.index(for: "a") == nil)
+
+        check("the first row shows 1", FavoriteSlots.digit(at: 0) == "1")
+        check("the tenth row shows 0", FavoriteSlots.digit(at: 9) == "0")
+        check("the eleventh row shows nothing", FavoriteSlots.digit(at: 10) == nil)
+        check("a negative index shows nothing", FavoriteSlots.digit(at: -1) == nil)
+
+        // The row overlay and the key handler must agree, or a row advertises another's chord.
+        for index in FavoriteSlots.digits.indices {
+            guard let digit = FavoriteSlots.digit(at: index) else {
+                check("slot \(index) has a digit", false)
+                continue
+            }
+            check("slot \(index) round-trips", FavoriteSlots.index(for: digit) == index)
+        }
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		74ACDD85B9F03C36E9258695 /* SettingsSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AA1305D43303E055DEE1E9 /* SettingsSplitViewController.swift */; };
 		74BE9E8319C8302EF525E6B2 /* QuicklinkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685FB7FD7E4E5BE6606440D0 /* QuicklinkStore.swift */; };
 		75AED41394E66D6E9CBDA7EA /* NotesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F84B7743B803F55C41D5C4A /* NotesRepository.swift */; };
+		75EF3CFF00A2215D57A4FBFF /* FavoriteSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE591549F24AE554C13CD0C /* FavoriteSlots.swift */; };
 		7833FD6E0A6036954FE285CE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D35CA0655717E1798AFDA7B /* FrequentEmojiStore.swift */; };
 		7BDB7CF7F1352015F6AC96C3 /* SnippetsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375734577C888260A8023181 /* SnippetsStore.swift */; };
 		7CC503824FDF49F788C85BB3 /* SettingsBackupCoverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5FFE395B9164BDC77B3470 /* SettingsBackupCoverage.swift */; };
@@ -379,6 +380,7 @@
 		3C504229760FFFFA9D8A7799 /* SettingsHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHistory.swift; sourceTree = "<group>"; };
 		3E16AEF81320A101E384098E /* KeyShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyShortcut.swift; sourceTree = "<group>"; };
 		3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScopes.swift; sourceTree = "<group>"; };
+		3FE591549F24AE554C13CD0C /* FavoriteSlots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteSlots.swift; sourceTree = "<group>"; };
 		410684C9DEB3754962C20C9C /* ExtensionStoreClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStoreClient.swift; sourceTree = "<group>"; };
 		418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideView.swift; sourceTree = "<group>"; };
 		418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
@@ -1508,6 +1510,7 @@
 			children = (
 				5F0A68B2040582996EFBA877 /* CommandCatalog.swift */,
 				164CB3E1BB5B7D87AF8E7023 /* CommandID.swift */,
+				3FE591549F24AE554C13CD0C /* FavoriteSlots.swift */,
 				0EDB1EEB97CC5F6B0B81FFD6 /* LauncherRankingStore.swift */,
 				ABB9DB77DCE25C41D86BB955 /* SearchRelevance.swift */,
 				3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */,
@@ -1763,6 +1766,7 @@
 				1A831E78CC5D84D543763B9C /* ExtensionStoreSheet.swift in Sources */,
 				62C75AA7315CDEFE82ECD21B /* ExtensionTintColors.swift in Sources */,
 				330540BBA991E36DD4C4BF53 /* ExtensionsSettingsView.swift in Sources */,
+				75EF3CFF00A2215D57A4FBFF /* FavoriteSlots.swift in Sources */,
 				555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */,
 				345D1FCC2085BD0D699DD236 /* FileSearchCoordinator.swift in Sources */,
 				5970306ABC24B03028E66D45 /* FileSearchIgnoreList.swift in Sources */,

--- a/Tinycast/Features/Launcher/Model/FavoriteSlots.swift
+++ b/Tinycast/Features/Launcher/Model/FavoriteSlots.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// The ⌘-digit slots the Favorites section answers to: ⌘1…⌘9 then ⌘0, which is the tenth the way a
+/// tab bar spells ten. Favorites past the tenth are listed and reorderable but carry no chord.
+enum FavoriteSlots {
+    static let digits: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]
+
+    /// The favorite a digit launches, or nil when that key is not a slot.
+    static func index(for digit: Character) -> Int? { digits.firstIndex(of: digit) }
+
+    /// The digit shown on the row at `index`, or nil past the last slot.
+    static func digit(at index: Int) -> Character? {
+        digits.indices.contains(index) ? digits[index] : nil
+    }
+}

--- a/Tinycast/Features/Launcher/Service/FavoritesStore.swift
+++ b/Tinycast/Features/Launcher/Service/FavoritesStore.swift
@@ -22,8 +22,7 @@ final class FavoritesStore {
     /// Replace the whole favorites list at once (used when importing a settings backup).
     func replace(keys newKeys: [String]) {
         keys = newKeys
-        revision &+= 1
-        defaults.set(keys, forKey: key)
+        commit()
     }
 
     func remove(keys removedKeys: Set<String>) {
@@ -31,8 +30,7 @@ final class FavoritesStore {
         let updated = keys.filter { !removedKeys.contains($0) }
         guard updated != keys else { return }
         keys = updated
-        revision &+= 1
-        defaults.set(keys, forKey: key)
+        commit()
     }
 
     func toggle(_ app: AppEntry) {
@@ -42,6 +40,20 @@ final class FavoritesStore {
         } else {
             keys.append(k)
         }
+        commit()
+    }
+
+    /// Exchange two favorites' stored positions. The caller picks the pair from the visible order,
+    /// so keys for hidden or unindexed entries keep their slots.
+    func exchange(_ first: String, with second: String) {
+        guard let a = keys.firstIndex(of: first), let b = keys.firstIndex(of: second), a != b else {
+            return
+        }
+        keys.swapAt(a, b)
+        commit()
+    }
+
+    private func commit() {
         revision &+= 1
         defaults.set(keys, forKey: key)
     }

--- a/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
+++ b/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
@@ -3,9 +3,20 @@ import SwiftUI
 /// Actions menu for a launcher app, from right-click or the Actions pill.
 @MainActor
 enum AppActionsMenu {
+    /// The favorites rows for one entry — what they may do and how to run them, resolved by the
+    /// screen that owns the visible order. Every row here runs the same call its chord does.
+    @MainActor
+    struct FavoriteActions {
+        let isFavorite: Bool
+        let canMoveUp: Bool
+        let canMoveDown: Bool
+        let toggle: () -> Void
+        let move: (Int) -> Void
+    }
+
     static func content(
-        app: AppEntry, searchQuery: String, core: AppCore, favorites: FavoritesStore,
-        running: Bool, onResetRanking: @escaping () -> Void
+        app: AppEntry, searchQuery: String, core: AppCore, running: Bool,
+        favorites: FavoriteActions, onResetRanking: @escaping () -> Void
     ) -> PopoverMenuContent {
         var items: [PopoverMenuItem] = [
             PopoverMenuItem(
@@ -13,15 +24,25 @@ enum AppActionsMenu {
                 shortcut: "↵"
             ) { core.launcherCoordinator.launch(app, searchQuery: searchQuery) }
         ]
-        if favorites.isFavorite(app) {
+        items.append(
+            PopoverMenuItem(
+                title: favorites.isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                systemImage: favorites.isFavorite ? "star.slash" : "star", shortcut: "⇧⌘F",
+                action: favorites.toggle))
+        if favorites.canMoveUp {
             items.append(
-                PopoverMenuItem(title: "Remove from Favorites", systemImage: "star.slash") {
-                    favorites.toggle(app)
+                PopoverMenuItem(
+                    title: "Move Favorite Up", systemImage: "arrow.up", shortcut: "⌥⌘↑"
+                ) {
+                    favorites.move(-1)
                 })
-        } else {
+        }
+        if favorites.canMoveDown {
             items.append(
-                PopoverMenuItem(title: "Add to Favorites", systemImage: "star") {
-                    favorites.toggle(app)
+                PopoverMenuItem(
+                    title: "Move Favorite Down", systemImage: "arrow.down", shortcut: "⌥⌘↓"
+                ) {
+                    favorites.move(1)
                 })
         }
         if core.launcherRanking.hasRanking(for: app.preferenceKey) {

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -21,12 +21,13 @@ struct LauncherList: View {
     private enum Row: Identifiable {
         case header(String)
         case calc(CalcResult)
-        case app(AppEntry)
+        /// `slot` is the row's ⌘-digit, carried from the section build so no row has to search for it.
+        case app(AppEntry, slot: Character?)
         var id: String {
             switch self {
             case .header(let title): return "header-" + title
             case .calc: return LauncherList.calcRowID
-            case .app(let app): return app.id
+            case .app(let app, _): return app.id
             }
         }
     }
@@ -44,7 +45,7 @@ struct LauncherList: View {
         if let calc { calcRows = [.header("Calculator"), .calc(calc)] }
         guard showSections else {
             guard !results.isEmpty else { return calcRows }
-            return calcRows + [.header("Results")] + results.map(Row.app)
+            return calcRows + [.header("Results")] + results.map { .app($0, slot: nil) }
         }
         var rows: [Row] = calcRows
         let favorites = results.prefix(favoriteCount)
@@ -53,7 +54,10 @@ struct LauncherList: View {
         for app in rest { grouped[app.kind, default: []].append(app) }
         if !favorites.isEmpty {
             rows.append(.header("Favorites"))
-            rows.append(contentsOf: favorites.map(Row.app))
+            rows.append(
+                contentsOf: favorites.enumerated().map {
+                    .app($1, slot: FavoriteSlots.digit(at: $0))
+                })
         }
         // Publication order, so rows match the flat index.
         let kinds: [AppEntry.Kind] = [
@@ -63,7 +67,7 @@ struct LauncherList: View {
         for kind in kinds {
             guard let group = grouped[kind], !group.isEmpty else { continue }
             rows.append(.header(kind.descriptor.sectionTitle))
-            rows.append(contentsOf: group.map(Row.app))
+            rows.append(contentsOf: group.map { .app($0, slot: nil) })
         }
         // A kind missing from `kinds` doesn't just hide its rows — every row after it in the flat
         // index would then activate its neighbour. Cheap to assert, silent and confusing to debug.
@@ -94,11 +98,12 @@ struct LauncherList: View {
                                         .onRightClick(perform: onCalcActions)
                                         .padding(.bottom, Theme.Spacing.xs)
                                         .selectionFrame(calcSelected)
-                                case .app(let app):
+                                case .app(let app, let slot):
                                     AppRow(
                                         app: app,
                                         selected: app.id == selectedID,
-                                        running: runningApps.isRunning(app)
+                                        running: runningApps.isRunning(app),
+                                        slot: slot
                                     )
                                     .contentShape(Rectangle())
                                     .onTapGesture { onActivate(app) }
@@ -128,10 +133,14 @@ private struct AppRow: View {
     let app: AppEntry
     let selected: Bool
     let running: Bool
+    /// This row's ⌘-digit, or nil for a row no chord launches.
+    let slot: Character?
     /// Observed so a hotkey set/cleared in Settings re-renders the row's keycaps immediately.
     @Environment(HotKeyManager.self) private var hotKeys
     /// Observed for the same reason: an alias edit re-renders the row's badge at once.
     @Environment(AliasStore.self) private var aliases
+    /// Observed here rather than up in the list, so a ⌘ press re-renders rows and not the palette.
+    @Environment(PaletteState.self) private var palette
     @State private var hovered = false
 
     /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
@@ -181,9 +190,17 @@ private struct AppRow: View {
                 }
             }
             Spacer()
-            Text(app.kindLabel)
-                .font(Theme.Typography.rowTrailing)
-                .foregroundStyle(.secondary)
+            // Holding ⌘ turns the trailing label into the chord that launches this row.
+            if let slot, palette.commandHeld {
+                HStack(spacing: Theme.Spacing.xxs) {
+                    KeyCapChip(text: "⌘", style: .outline)
+                    KeyCapChip(text: String(slot), style: .outline)
+                }
+            } else {
+                Text(app.kindLabel)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -10,17 +10,23 @@ struct LauncherScreen: PaletteScreen {
     /// Sampled by `openActions`, so the Quit row can't appear or vanish while the menu is up.
     let running: Bool
     let openActions: () -> Void
+    /// Called when an action reorders the list, so the highlight scrolls back into view.
+    let scrollToFollow: () -> Void
 
     /// The one ordered result list; an empty query pins favorites above the ranked matches.
     private let results: [AppEntry]
     private let calc: CalcResult?
+    /// Sections stand in for the ranked Results list, which a typed query collapses to.
+    private let showSections: Bool
+    /// How many of `results` are the pinned favorites; zero unless the Favorites section is showing.
+    private let favoriteCount: Int
     /// Resolved in `init`: the palette indexes this several times per event, so it can't recompute.
     let rows: [Row]
 
     init(
         appIndex: AppIndex, favorites: FavoritesStore, visibility: VisibilityStore,
         currencyRates: CurrencyRateStore, core: AppCore, vm: PaletteState, running: Bool,
-        openActions: @escaping () -> Void
+        openActions: @escaping () -> Void, scrollToFollow: @escaping () -> Void
     ) {
         self.appIndex = appIndex
         self.favorites = favorites
@@ -29,13 +35,17 @@ struct LauncherScreen: PaletteScreen {
         self.vm = vm
         self.running = running
         self.openActions = openActions
+        self.scrollToFollow = scrollToFollow
 
         let results = appIndex.orderedResults(
             query: vm.query, visibility: visibility, favorites: favorites)
         let calc = CalcMemo.evaluate(vm.query, rates: currencyRates.rates)
         let entries = results.map(Row.entry)
+        let showSections = vm.query.trimmingCharacters(in: .whitespaces).isEmpty
         self.results = results
         self.calc = calc
+        self.showSections = showSections
+        self.favoriteCount = showSections ? results.prefix(while: favorites.isFavorite).count : 0
         self.rows = calc.map { [.calc($0)] + entries } ?? entries
     }
 
@@ -121,7 +131,8 @@ struct LauncherScreen: PaletteScreen {
             return result.isActionable ? CalcActionsMenu.content(result: result, core: core) : nil
         case .entry(let app):
             return AppActionsMenu.content(
-                app: app, searchQuery: vm.query, core: core, favorites: favorites, running: running,
+                app: app, searchQuery: vm.query, core: core, running: running,
+                favorites: favoriteActions(for: app, at: selection),
                 onResetRanking: {
                     core.launcherCoordinator.resetRanking(for: app)
                     // Reset can move the item; keep the highlight on the item whose action ran.
@@ -159,6 +170,70 @@ struct LauncherScreen: PaletteScreen {
         return true
     }
 
+    /// ⇧⌘F — mirrors the Add/Remove Favorites row. The highlight stays in the Favorites section
+    /// rather than chasing the entry: the top of it on add, the neighbour above the one that left.
+    func toggleFavorite(at selection: Int) -> Bool {
+        guard let app = entry(at: selection) else { return false }
+        let removed = favoriteIndex(of: app)
+        favorites.toggle(app)
+        // A typed query never pins favorites, so nothing moved and the highlight belongs where it is.
+        guard showSections else { return true }
+        selectFavorite(at: removed.map { $0 - 1 } ?? 0)
+        return true
+    }
+
+    /// ⌥⌘↑/↓ — swap with the neighbouring favorite; the ends of the section have nowhere to go.
+    func moveFavorite(_ delta: Int, at selection: Int) -> Bool {
+        guard let app = entry(at: selection), let index = favoriteIndex(of: app) else { return false }
+        let target = index + delta
+        guard target >= 0, target < favoriteCount else { return false }
+        favorites.exchange(favorites.key(for: app), with: favorites.key(for: results[target]))
+        follow(app)
+        return true
+    }
+
+    /// The favorites rows the Actions menu offers for an entry; the ends drop the move they can't
+    /// run, and both rows call straight back here so a row can't drift from its chord.
+    private func favoriteActions(for app: AppEntry, at selection: Int)
+        -> AppActionsMenu.FavoriteActions
+    {
+        let index = favoriteIndex(of: app)
+        return AppActionsMenu.FavoriteActions(
+            isFavorite: favorites.isFavorite(app),
+            canMoveUp: index.map { $0 > 0 } ?? false,
+            canMoveDown: index.map { $0 < favoriteCount - 1 } ?? false,
+            toggle: { _ = toggleFavorite(at: selection) },
+            move: { _ = moveFavorite($0, at: selection) })
+    }
+
+    /// Position inside the Favorites section, or nil when the entry isn't reorderable there.
+    private func favoriteIndex(of app: AppEntry) -> Int? {
+        guard let index = results.firstIndex(of: app), index < favoriteCount else { return nil }
+        return index
+    }
+
+    /// The list reorders under an action; keep the highlight and the scroll on the row that moved.
+    private func follow(_ app: AppEntry) {
+        guard let index = reorderedResults().firstIndex(of: app) else { return }
+        select(row: index)
+    }
+
+    /// Highlight a row of the Favorites section, clamped into what the section now holds.
+    private func selectFavorite(at index: Int) {
+        let count = reorderedResults().prefix(while: favorites.isFavorite).count
+        select(row: min(max(index, 0), max(count - 1, 0)))
+    }
+
+    /// Re-read the order the change just invalidated; this warms the key the next render reads.
+    private func reorderedResults() -> [AppEntry] {
+        appIndex.orderedResults(query: vm.query, visibility: visibility, favorites: favorites)
+    }
+
+    private func select(row index: Int) {
+        vm.selection = index + (calc == nil ? 0 : 1)
+        scrollToFollow()
+    }
+
     /// The sample `openActions` takes; only an app row can ever carry a Quit action.
     func isRunning(at selection: Int) -> Bool {
         guard let app = entry(at: selection) else { return false }
@@ -180,12 +255,10 @@ struct LauncherScreen: PaletteScreen {
 
     @ViewBuilder
     private func content(selection: Int, scroll: ScrollIntent) -> some View {
-        // Sections stand in for the ranked Results list, which a typed query collapses to.
-        let showSections = vm.query.trimmingCharacters(in: .whitespaces).isEmpty
         LauncherList(
             results: results,
             selectedID: entry(at: selection)?.id,
-            favoriteCount: showSections ? results.prefix(while: favorites.isFavorite).count : 0,
+            favoriteCount: favoriteCount,
             showSections: showSections,
             scroll: scroll,
             calc: calc,

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -182,6 +182,17 @@ struct LauncherScreen: PaletteScreen {
         return true
     }
 
+    /// ⌘1–⌘9/⌘0 — launch a favorite by position, in either palette size.
+    func launchFavorite(at index: Int) -> Bool {
+        guard let app = pinnedFavorites.dropFirst(index).first else { return false }
+        core.launcherCoordinator.launch(app)
+        return true
+    }
+
+    /// The favorites the chords address and the compact strip draws from. Empty while a query is
+    /// typed, which is also the only state in which the section isn't on screen.
+    private var pinnedFavorites: ArraySlice<AppEntry> { results.prefix(favoriteCount) }
+
     /// ⌥⌘↑/↓ — swap with the neighbouring favorite; the ends of the section have nowhere to go.
     func moveFavorite(_ delta: Int, at selection: Int) -> Bool {
         guard let app = entry(at: selection), let index = favoriteIndex(of: app) else { return false }
@@ -194,7 +205,9 @@ struct LauncherScreen: PaletteScreen {
 
     /// The favorites rows the Actions menu offers for an entry; the ends drop the move they can't
     /// run, and both rows call straight back here so a row can't drift from its chord.
-    private func favoriteActions(for app: AppEntry, at selection: Int)
+    private func favoriteActions(
+        for app: AppEntry, at selection: Int
+    )
         -> AppActionsMenu.FavoriteActions
     {
         let index = favoriteIndex(of: app)
@@ -240,14 +253,11 @@ struct LauncherScreen: PaletteScreen {
         return core.runningApps.isRunning(app)
     }
 
-    /// The compact bar's favorite slots: 5 apps, or 4 plus an overflow that expands.
-    var compactFavoriteSlots: [CompactFavoriteSlot] {
-        let ordered = appIndex.orderedResults(
-            query: "", visibility: visibility, favorites: favorites)
-        let favs = ordered.prefix(while: favorites.isFavorite)
-        if favs.count <= 5 { return favs.map(CompactFavoriteSlot.app) }
-        return favs.prefix(4).map(CompactFavoriteSlot.app) + [.more]
-    }
+    /// The compact bar's icons: the first five favorites. The "…" that follows them is not one.
+    var compactFavorites: [AppEntry] { Array(pinnedFavorites.prefix(5)) }
+
+    /// Whether the compact bar's "…" has anything to reveal.
+    var hasUnshownFavorites: Bool { favoriteCount > compactFavorites.count }
 
     func body(selection: Int, scroll: ScrollIntent) -> AnyView {
         AnyView(content(selection: selection, scroll: scroll))

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -130,6 +130,8 @@ final class PalettePanel: NSPanel {
         // Keys and scrolling both slide rows under the pointer without it choosing any of them.
         case .keyDown, .scrollWheel:
             paletteState?.disarmHoverHighlight(pointerAt: NSEvent.mouseLocation)
+        case .flagsChanged:
+            paletteState?.noteCommandHeld(event.modifierFlags.contains(.command))
         default: break
         }
         defer { applyCursorPolicy(for: event) }
@@ -188,6 +190,12 @@ final class PalettePanel: NSPanel {
         // The controller owns the frame; without this the top edge drifts on the swap.
         hosting.sizingOptions = []
         contentView = hosting
+    }
+
+    /// Losing the keyboard is the last modifier news the panel gets; a re-show may skip `prepare`.
+    override func resignKey() {
+        super.resignKey()
+        paletteState?.noteCommandHeld(false)
     }
 
     override var canBecomeKey: Bool { true }

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -27,6 +27,8 @@ final class PaletteState {
     /// Values typed into the inline argument fields an extension command declares, keyed by
     /// `argumentKey`. Cleared with the rest of the screen.
     var commandArguments: [String: String] = [:]
+    /// True while ⌘ is held, which numbers the favorite rows. The panel is the only writer.
+    private(set) var commandHeld = false
     /// True only once the pointer has moved of its own accord; untracked, so it never re-renders.
     @ObservationIgnored private(set) var hoverHighlightArmed = false
     /// Bumped when the highlight drops, so a lit row clears even though the pointer never left it.
@@ -62,6 +64,11 @@ final class PaletteState {
 
     func notePinChord() {
         pinChordToken = UUID()
+    }
+
+    func noteCommandHeld(_ held: Bool) {
+        guard held != commandHeld else { return }
+        commandHeld = held
     }
 
     /// The pointer moved, which re-lights the highlight once it has cleared the arming slop.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -266,21 +266,14 @@ struct RootPaletteView: View {
         .onChange(of: core.paletteCoordinator.paletteIsCollapsed) {
             core.paletteCoordinator.syncPaletteSize()
         }
-        // ⌘1–⌘5 launch the compact bar's favorite slots, or expand for the overflow.
-        .onKeyPress(keys: ["1", "2", "3", "4", "5"], phases: .down) { press in
-            guard isCollapsed, settings.showFavoritesInCompactMode,
-                press.modifiers.contains(.command),
-                let digit = press.key.character.wholeNumberValue,
+        // ⌘1–⌘9/⌘0 launch favorites by position, in both palette sizes.
+        .onKeyPress(keys: Self.favoriteSlotKeys, phases: .down) { press in
+            guard press.modifiers.contains(.command),
+                !isCollapsed || settings.showFavoritesInCompactMode,
+                let index = FavoriteSlots.index(for: press.key.character),
                 let launcher = screen as? LauncherScreen
             else { return .ignored }
-            let slots = launcher.compactFavoriteSlots
-            let index = digit - 1
-            guard slots.indices.contains(index) else { return .ignored }
-            switch slots[index] {
-            case .app(let app): core.launcherCoordinator.launch(app)
-            case .more: core.paletteCoordinator.expandFromCompact()
-            }
-            return .handled
+            return launcher.launchFavorite(at: index) ? .handled : .ignored
         }
         // Repeat included: holding the key must keep stepping, as the bare-key form does by default.
         .onKeyPress(keys: [.downArrow], phases: [.down, .repeat]) { press in
@@ -484,11 +477,12 @@ struct RootPaletteView: View {
             if isCollapsed, settings.showFavoritesInCompactMode,
                 let launcher = screen as? LauncherScreen
             {
-                let slots = launcher.compactFavoriteSlots
-                if !slots.isEmpty {
+                let favorites = launcher.compactFavorites
+                if !favorites.isEmpty {
                     headerGutter(width: Theme.Spacing.md)
                     CompactFavoritesRow(
-                        slots: slots,
+                        favorites: favorites,
+                        showsOverflow: launcher.hasUnshownFavorites,
                         onLaunch: { core.launcherCoordinator.launch($0) },
                         onOverflow: { core.paletteCoordinator.expandFromCompact() }
                     )
@@ -657,6 +651,10 @@ struct RootPaletteView: View {
     private func closeMenus() {
         withAnimation(Self.menuAnimation) { openMenu = nil }
     }
+
+    /// SwiftUI wants a Set; built once so the palette isn't allocating one per render.
+    private static let favoriteSlotKeys: Set<KeyEquivalent> =
+        Set(FavoriteSlots.digits.map { KeyEquivalent($0) })
 
     /// Inset from the bottom corners, so the menu's own corner isn't clipped.
     private static let menuInset: CGFloat = 8
@@ -838,52 +836,44 @@ struct EmptyResults: View {
     }
 }
 
-/// A compact-bar favorites slot: a launchable app, or the overflow that expands.
-enum CompactFavoriteSlot {
-    case app(AppEntry)
-    case more
-
-    // Stable identity, so a reorder moves icons with their app rather than by position.
-    var id: String {
-        switch self {
-        case .app(let app): return app.id
-        case .more: return "__tinycast.more__"
-        }
-    }
-}
-
-/// The compact bar's favorites strip: up to 5 buttons, ⌘1–⌘5 in each tooltip.
+/// The compact bar's favorites strip: up to 5 buttons carrying their chord in the tooltip, then the
+/// overflow, which is a button rather than a slot so no favorite loses its digit to it.
 private struct CompactFavoritesRow: View {
-    let slots: [CompactFavoriteSlot]
+    let favorites: [AppEntry]
+    let showsOverflow: Bool
     let onLaunch: (AppEntry) -> Void
     let onOverflow: () -> Void
 
     var body: some View {
         HStack(spacing: Theme.Spacing.xs) {
-            ForEach(Array(slots.enumerated()), id: \.element.id) { index, slot in
-                switch slot {
-                case .app(let app):
-                    CompactFavoriteButton(help: "\(app.name)  ⌘\(index + 1)") {
-                        onLaunch(app)
-                    } content: {
-                        AppIconView(app: app)
-                            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
-                    }
-                case .more:
-                    CompactFavoriteButton(help: "Show all  ⌘\(index + 1)", action: onOverflow) {
-                        Image(systemName: "ellipsis")
-                            .font(.system(size: 10))
-                            .foregroundStyle(Theme.Colors.textSecondary)
-                            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .fill(Theme.Colors.controlSurface)
-                                    .padding(Theme.Spacing.xxs)
-                            )
-                    }
+            // Identified by the app, so a reorder moves an icon with its app rather than by position.
+            ForEach(Array(favorites.enumerated()), id: \.element.id) { index, app in
+                CompactFavoriteButton(help: help(for: app, at: index)) {
+                    onLaunch(app)
+                } content: {
+                    AppIconView(app: app)
+                        .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                }
+            }
+            if showsOverflow {
+                CompactFavoriteButton(help: "Show all  ↓", action: onOverflow) {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Theme.Colors.controlSurface)
+                                .padding(Theme.Spacing.xxs)
+                        )
                 }
             }
         }
+    }
+
+    private func help(for app: AppEntry, at index: Int) -> String {
+        guard let digit = FavoriteSlots.digit(at: index) else { return app.name }
+        return "\(app.name)  ⌘\(digit)"
     }
 }
 

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -40,7 +40,8 @@ struct RootPaletteView: View {
             return LauncherScreen(
                 appIndex: appIndex, favorites: favorites, visibility: visibility,
                 currencyRates: currencyRates, core: core, vm: vm, running: selectionIsRunning,
-                openActions: openActions)
+                openActions: openActions,
+                scrollToFollow: { scroll = ScrollIntent(kind: .follow) })
         case .uninstall:
             return UninstallScreen(
                 session: uninstall, core: core, vm: vm, openActions: openActions)
@@ -281,7 +282,9 @@ struct RootPaletteView: View {
             }
             return .handled
         }
-        .onKeyPress(.downArrow) {
+        // Repeat included: holding the key must keep stepping, as the bare-key form does by default.
+        .onKeyPress(keys: [.downArrow], phases: [.down, .repeat]) { press in
+            if let reorder = moveFavorite(1, modifiers: press.modifiers) { return reorder }
             if isCollapsed {
                 // The compact bar shows no selection, so Down reveals the list's first row.
                 vm.selection = 0
@@ -295,7 +298,8 @@ struct RootPaletteView: View {
             moveVertically(1)
             return .handled
         }
-        .onKeyPress(.upArrow) {
+        .onKeyPress(keys: [.upArrow], phases: [.down, .repeat]) { press in
+            if let reorder = moveFavorite(-1, modifiers: press.modifiers) { return reorder }
             if isCollapsed { return .ignored }
             if menuOpen {
                 moveMenu(-1)
@@ -401,6 +405,15 @@ struct RootPaletteView: View {
             guard press.modifiers.contains(.command) else { return .ignored }
             guard !isCollapsed, vm.mode == .clipboard else { return .ignored }
             toggleClipboardFilter()
+            return .handled
+        }
+        // ⇧⌘F mirrors the Add/Remove Favorites row, closing an open menu the way that row does.
+        .onKeyPress(keys: ["f", "F"], phases: .down) { press in
+            guard press.modifiers.contains(.command), press.modifiers.contains(.shift),
+                !isCollapsed, let launcher = screen as? LauncherScreen
+            else { return .ignored }
+            guard launcher.toggleFavorite(at: selection(in: launcher)) else { return .ignored }
+            if menuOpen { closeMenus() }
             return .handled
         }
         // Both cases, Shift uppercasing the key; the compact bar shows no target.
@@ -687,6 +700,16 @@ struct RootPaletteView: View {
         vm.selection = next
         scroll = ScrollIntent(kind: .follow)
         return true
+    }
+
+    /// ⌥⌘↑/↓ — reorder the Favorites section, mirroring its rows. Claimed whole on the launcher, so
+    /// a press at an end of the section can't fall through to the caret; nil leaves ↑/↓ their own.
+    private func moveFavorite(_ delta: Int, modifiers: EventModifiers) -> KeyPress.Result? {
+        guard modifiers.contains(.command), modifiers.contains(.option), !isCollapsed,
+            let launcher = screen as? LauncherScreen
+        else { return nil }
+        if launcher.moveFavorite(delta, at: selection(in: launcher)), menuOpen { closeMenus() }
+        return .handled
     }
 
     /// Move the open menu's highlight, clamped at the ends (no wrap — consistent with `move`).

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -276,6 +276,28 @@ highlight lands differs on purpose: a **move** follows the entry, since the poin
 where that entry now sits, while a **toggle** stays with the section rather than chasing an entry
 across the list — the top of Favorites on add, the neighbour above the one that left on remove.
 
+### ⌘-digit slots
+
+`FavoriteSlots` (`Launcher/Model/FavoriteSlots.swift`) is the whole rule: **⌘1…⌘9 then ⌘0 for the
+tenth**, ten digit keys being the physical ceiling — there is no ⌘10. The eleventh favorite is still
+listed and reorderable, and simply has no chord and no number. Three places read that table — the key
+handler, the row's number, the compact tooltip — so none of them can invent an eleventh slot.
+
+Both palette sizes serve the chords from the same prefix, because `paletteIsCollapsed` already
+requires an empty query: **compact implies empty implies `favoriteCount` is the pinned prefix**. That
+is why `LauncherScreen.pinnedFavorites` feeds the strip, the chords and the numbered rows alike,
+rather than the compact bar re-deriving an empty-query order of its own. In compact the strip draws
+the first five; ⌘6–⌘0 still launch favorites it has no room for, and the "…" is a button after them
+rather than a slot, so no favorite loses its digit to the overflow.
+
+Holding ⌘ swaps each numbered row's kind label for its chord. `PalettePanel` publishes the modifier
+into `PaletteState.commandHeld` from `.flagsChanged` and clears it in `resignKey` — not in `prepare`,
+which a re-show that preserves state skips entirely. **`AppRow` observes that flag itself**: reading
+it any higher would attach it to `RootPaletteView`'s body and rebuild the whole palette on every ⌘
+press, where a row-level read re-runs only the handful of rows the `LazyVStack` has realized. The
+digit each row shows is carried on its `Row` case from the section build, so no row searches for its
+own position.
+
 ## Reveal in Finder
 
 Application and System Settings results expose **Show in Finder** in their ⌘K Actions menu and on

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -249,6 +249,33 @@ paths; see the command in `development.md`.
 Launcher icons use a persistent 32 MB cost-capped `NSCache`. Fitted file-row icons use a separate
 transient 8 MB cache that is purged when its palette list disappears (`IconCache`).
 
+## Favorites
+
+`FavoritesStore.keys` is the order — the array *is* the ranking, and it only shows while the query is
+empty, where `AppIndex.orderedResults` pins it as a prefix of the results. `LauncherScreen` resolves
+that prefix once in `init` (`favoriteCount`), and the list, the reorder rows and the chord guards all
+read that one number, so the visible section and what a move acts on can't disagree.
+
+The ⌘K menu carries **Add / Remove from Favorites** (⇧⌘F) plus **Move Favorite Up / Down** (⌥⌘↑ /
+⌥⌘↓). A move row is only built in a direction that exists, so the first favorite has no Up row and
+the last has no Down.
+
+**Every one of those rows runs the same call its chord does** — the menu is handed an
+`AppActionsMenu.FavoriteActions` built by `LauncherScreen` and never touches `FavoritesStore` itself.
+A row that mutates the store directly looks identical on screen and then behaves differently from its
+chord, because the store knows nothing about where the highlight should land.
+
+`FavoritesStore.exchange` swaps two stored positions rather than removing and re-inserting. `keys`
+retains entries that `VisibilityStore` hides or that aren't currently indexed — `ordered(_:)` drops
+them with `compactMap` and never prunes them, which is how a favorite survives an unmounted volume —
+so exchanging the two *visible* keys leaves every such key on its own slot.
+
+Both actions re-ask `orderedResults` afterwards and restate `vm.selection` against it; the mutation
+already invalidated the memo, so that call warms the exact key the next render reads. Where the
+highlight lands differs on purpose: a **move** follows the entry, since the point of the action is
+where that entry now sits, while a **toggle** stays with the section rather than chasing an entry
+across the list — the top of Favorites on add, the neighbour above the one that left on remove.
+
 ## Reveal in Finder
 
 Application and System Settings results expose **Show in Finder** in their ⌘K Actions menu and on

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -251,6 +251,9 @@ filter (`.topTrailing`, hung under its header button). `menuContent` resolves th
 menu without knowing which is up. Every open path goes through `open(_:highlighting:)` and states
 where the highlight starts: the first row, except the type filter, which opens on the active filter.
 
+Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
+list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.
+
 ## Menu-open input freeze
 
 While a popover menu (⌘K Actions / app menu / clipboard type filter) is open the search field reads as inert but

--- a/website/content/docs/launcher/favorites.md
+++ b/website/content/docs/launcher/favorites.md
@@ -7,7 +7,20 @@ A favorite is pinned above everything else when the launcher opens with an empty
 
 ## Adding one
 
-Select an entry and press <kbd>⌘</kbd><kbd>K</kbd> → **Add to Favorites**. The same menu removes it.
+Select an entry and press <kbd>⌘</kbd><kbd>K</kbd> → **Add to Favorites**, or press
+<kbd>⇧</kbd><kbd>⌘</kbd><kbd>F</kbd> on the selected row. The same menu and the same chord remove it.
+
+Adding leaves the highlight on the first favorite; removing leaves it on the favorite above the one
+you just took out, so the section stays under your fingers either way.
+
+## Reordering
+
+Favorites sit in the order you put them in. With an empty query, select one and use
+<kbd>⌥</kbd><kbd>⌘</kbd><kbd>↑</kbd> / <kbd>⌥</kbd><kbd>⌘</kbd><kbd>↓</kbd>, or
+<kbd>⌘</kbd><kbd>K</kbd> → **Move Favorite Up** / **Move Favorite Down**.
+
+The first favorite offers no Move Up and the last offers no Move Down. The chords keep the entry
+selected as it moves, so holding one walks it to where you want it.
 
 ## In compact mode
 

--- a/website/content/docs/launcher/favorites.md
+++ b/website/content/docs/launcher/favorites.md
@@ -22,13 +22,27 @@ Favorites sit in the order you put them in. With an empty query, select one and 
 The first favorite offers no Move Up and the last offers no Move Down. The chords keep the entry
 selected as it moves, so holding one walks it to where you want it.
 
+## Launching by number
+
+<kbd>⌘</kbd><kbd>1</kbd> launches your first favorite, <kbd>⌘</kbd><kbd>2</kbd> the second, and so on
+to <kbd>⌘</kbd><kbd>9</kbd> — then <kbd>⌘</kbd><kbd>0</kbd> for the tenth, since there is no
+<kbd>⌘</kbd><kbd>10</kbd> key. Favorites past the tenth have no number; move one up with
+<kbd>⌥</kbd><kbd>⌘</kbd><kbd>↑</kbd> if you want it on a chord.
+
+**Hold <kbd>⌘</kbd>** and each numbered favorite shows its number in place of the category label on
+the right of the row, so you never have to count.
+
+The numbers work whenever the Favorites section is on screen — that is, at an empty query. Type a
+search and the list becomes ranked results, where a position number would mean nothing.
+
 ## In compact mode
 
 With [compact mode](/docs/palette#compact-mode) on and **Show favorites in compact mode** enabled,
 your favorites appear as icons at the right of the slim search bar.
 
-<kbd>⌘</kbd><kbd>1</kbd> through <kbd>⌘</kbd><kbd>5</kbd> launch them directly. If you have more than
-five, the fifth slot becomes an overflow that expands the list.
+The strip has room for five icons, and the same numbers launch them. If you have more than five, a
+**…** button follows them — click it, or press <kbd>↓</kbd>, to expand into the full list.
+<kbd>⌘</kbd><kbd>6</kbd> and up still launch favorites the strip has no room to draw.
 
 ## Favorites do not teach ranking
 

--- a/website/content/docs/palette.md
+++ b/website/content/docs/palette.md
@@ -94,7 +94,8 @@ Tinycast follows that only while its own theme is set to System.
 expands into the full list as you type. <kbd>↓</kbd> expands it and selects the first row.
 
 With **Show favorites in compact mode** on, your favorite app icons sit at the right of the bar and
-<kbd>⌘</kbd><kbd>1</kbd> through <kbd>⌘</kbd><kbd>5</kbd> launch them. See
+<kbd>⌘</kbd><kbd>1</kbd> through <kbd>⌘</kbd><kbd>5</kbd> launch them; a **…** button appears past
+five to expand into the rest. The same numbers work in the expanded list. See
 [Favorites](/docs/launcher/favorites).
 
 ## Pop to root


### PR DESCRIPTION
## Related issue

Closes #272

## What changed

Two passes over favorites: they can now be **ordered**, and they can be **launched by number** from
either palette size.

### Reordering

`FavoritesStore.keys` has always been the order, but nothing could change it — a new favorite is
appended, so moving one to the top meant removing and re-adding everything after it.

- **Move Favorite Up / Down** in an entry's ⌘K menu, built only in a direction that exists: the
  first favorite has no Up row, the last has no Down.
- **⇧⌘F** on Add / Remove from Favorites, **⌥⌘↑ / ⌥⌘↓** on the moves.
- Reordering shows only at an empty query, where `AppIndex.orderedResults` pins favorites as a
  prefix — the only place the order is observable.

### ⌘-digit slots

The compact bar bound ⌘1–⌘5 to its icons; the expanded launcher bound nothing. One rule now covers
both: **⌘N launches the Nth favorite.**

- `FavoriteSlots` is the whole table — **⌘1…⌘9 then ⌘0 for the tenth**, ten digit keys being the
  physical ceiling. The eleventh favorite stays listed and reorderable, with no chord and no number.
- **Holding ⌘ numbers the favorite rows**, replacing the kind label on the right. Only favorite rows
  are numbered — the chord launches favorites by position, so numbering anything else would
  advertise a dead shortcut.
- The compact **"…" stops being a numbered slot** and becomes a button after the five icons, still
  only shown when there are more than five, so no favorite loses its digit to the overflow. ⌘6–⌘0
  launch favorites the strip has no room to draw; the button and ↓ both expand.

## Non-obvious bits of the diff

- **The chords need no `sendEvent` interception.** AppKit's `StandardKeyBinding.dict` binds ⌘, ⌥, ⌃
  and ⇧⌘ with an arrow, but nothing is bound to ⌥⌘ with one, so it reaches `onKeyPress` on its own.
- **`FavoritesStore.exchange` swaps positions rather than removing and re-inserting.** `keys`
  retains entries `VisibilityStore` hides or that aren't currently indexed — `ordered(_:)` drops
  them with `compactMap` and never prunes them, which is how a favorite survives an unmounted
  volume — so exchanging the two *visible* keys leaves every such key on its own slot.
- **`AppActionsMenu.content` no longer takes `FavoritesStore`.** It takes a `FavoriteActions` built
  by `LauncherScreen`, so every row runs the same call its chord does. This was a real bug mid-
  review: the rows called `favorites.toggle(app)` directly, looked identical on screen, and landed
  the highlight somewhere else, because the store knows nothing about the selection.
- **Where the highlight lands differs by action, on purpose.** A move follows its entry, since that
  position is the point of the action. A toggle stays with the section: the top of Favorites on
  add, the neighbour above the one that left on remove.
- **Both palette sizes share one prefix.** `paletteIsCollapsed` already requires an empty query, so
  compact implies empty implies `favoriteCount` *is* the pinned prefix — which makes the compact
  bar's separate `orderedResults(query: "")` recompute provably redundant. It's gone, along with
  `CompactFavoriteSlot` and its synthetic id.
- **`AppRow` observes `commandHeld` itself.** Reading it any higher attaches it to
  `RootPaletteView`'s body and rebuilds the whole palette on every ⌘ press; read in the row, a press
  re-runs only the rows the `LazyVStack` has realized. The flag clears in `PalettePanel.resignKey`
  rather than `prepare`, which a re-show that preserves state skips entirely, and is deliberately
  not seeded on show so a ⌘-carrying global hotkey doesn't flash numbers on every summon.
- **The arrow handlers moved to the `keys:` form** to read modifiers. They pass
  `phases: [.down, .repeat]` explicitly — that is the bare-key form's default, and dropping it
  silently kills key repeat on ↑/↓.

## Memory footprint

<!-- Not measured — needs an Instruments pass on this branch before merge. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

<!-- Pending: a favorite being walked up the section, and the ⌘-hold numbering. -->

## Drawbacks

- **No chord past the tenth favorite.** ⌘0-as-ten is a tab-bar convention that reads a little oddly
  in a list, and there is no eleventh digit key; reaching further would mean a second modifier.
- The move rows close the menu like every other row, so walking an entry several places from the
  menu means reopening it. The chord is the repeatable path, and works with the menu closed.
- The compact strip still draws five icons, so ⌘6–⌘0 launch favorites that aren't visible there.
- Reordering is keyboard/menu only — no drag.
- `FavoritesStore` itself has no harness: it reaches `AppEntry`, which lives in `AppIndex.swift`
  behind `import AppKit`, so it can't compile into a pure one without moving `AppEntry` out.

## Tests & validation

- `./Scripts/run-tests.sh` — 35 harnesses pass, including a new `favorites-test` over
  `FavoriteSlots` that pins the ⌘0→index 9 off-by-one and round-trips every slot.
- Debug build with no new warnings; `./Scripts/lint.sh` clean; the `Features/*/Model/` import grep
  returns nothing (which is what keeps the new `FavoriteSlots` Foundation-only).
- By hand: the Up/Down rows appearing only where they apply; both chords with the menu open and
  closed; key repeat on plain ↑/↓ and on ⌥⌘↑/↓; the toggle's landing spot from both the chord and
  the menu; ⌘1–⌘0 in expanded and compact; the ⌘-hold numbering following a reorder; the "…"
  appearing only past five favorites; order surviving a relaunch.
