### PR TITLE
Search the launcher by category name

### DIFF
--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 struct AppEntry: Identifiable, Hashable, Sendable {
-    enum Kind: String, Sendable {
+    enum Kind: String, CaseIterable, Sendable {
         case application
         case systemSettings
         case command
@@ -148,6 +148,19 @@ struct AppEntry: Identifiable, Hashable, Sendable {
 
     /// Icon identity for a row's async load: re-skinning changes the glyph while `id` stays put.
     var iconKey: String { "\(id)|\(iconSource)" }
+}
+
+extension AppEntry.Kind {
+    /// The descriptors' own words, lowercased once, so a keystroke costs a lookup and not a scan.
+    private static let byCategoryName: [String: AppEntry.Kind] = allCases.reduce(into: [:]) {
+        $0[$1.descriptor.sectionTitle.lowercased()] = $1
+        $0[$1.descriptor.label.lowercased()] = $1
+    }
+
+    /// The category a query names outright. Exact only — a prefix would take a word from an entry.
+    static func named(by query: String) -> AppEntry.Kind? {
+        byCategoryName[query.trimmingCharacters(in: .whitespaces).lowercased()]
+    }
 }
 
 @MainActor
@@ -397,14 +410,23 @@ final class AppIndex {
         entriesRevision &+= 1
     }
 
-    /// Ranked matches. Empty query returns the full alphabetical list.
+    /// Ranked matches, or a whole category when the query names one. Empty returns the full list.
     func matches(_ query: String, limit: Int = 200) -> [AppEntry] {
         let q = query.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return apps }
         let key = MatchKey(
             query: q, entriesRevision: entriesRevision, rankingRevision: ranking.revision,
             aliasRevision: aliases.revision)
-        return matchMemo.value(for: key) { rank(q, limit: limit) }
+        return matchMemo.value(for: key) {
+            guard let kind = AppEntry.Kind.named(by: q) else { return rank(q, limit: limit) }
+            return categoryListing(kind, query: q)
+        }
+    }
+
+    /// A whole category, plus any entry the query names outright — `System Settings` is both. Slice
+    /// order is section order, so filtering alone keeps the sections and the flat selection aligned.
+    private func categoryListing(_ kind: AppEntry.Kind, query: String) -> [AppEntry] {
+        apps.filter { $0.kind == kind || $0.name.caseInsensitiveCompare(query) == .orderedSame }
     }
 
     /// The launcher's ordered list: ranked matches minus hidden entries, favorites pinned first.

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -53,7 +53,8 @@ final class LauncherCoordinator {
     func launch(
         _ app: AppEntry, searchQuery: String? = nil, arguments: [String: String] = [:]
     ) {
-        if let searchQuery {
+        // A category listing is not a search for the row that ran; learning it would rank it under "s".
+        if let searchQuery, AppEntry.Kind.named(by: searchQuery) == nil {
             ranking.record(itemKey: app.preferenceKey, query: searchQuery)
         }
         // Commands dispatch before the palette hides: mode-switching commands keep it open.

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -18,6 +18,8 @@ struct LauncherScreen: PaletteScreen {
     private let calc: CalcResult?
     /// Sections stand in for the ranked Results list, which a typed query collapses to.
     private let showSections: Bool
+    /// Only the empty query pins favorites — a category shows its sections without one of its own.
+    private let pinsFavorites: Bool
     /// How many of `results` are the pinned favorites; zero unless the Favorites section is showing.
     private let favoriteCount: Int
     /// Resolved in `init`: the palette indexes this several times per event, so it can't recompute.
@@ -41,11 +43,12 @@ struct LauncherScreen: PaletteScreen {
             query: vm.query, visibility: visibility, favorites: favorites)
         let calc = CalcMemo.evaluate(vm.query, rates: currencyRates.rates)
         let entries = results.map(Row.entry)
-        let showSections = vm.query.trimmingCharacters(in: .whitespaces).isEmpty
+        let pinsFavorites = vm.query.trimmingCharacters(in: .whitespaces).isEmpty
         self.results = results
         self.calc = calc
-        self.showSections = showSections
-        self.favoriteCount = showSections ? results.prefix(while: favorites.isFavorite).count : 0
+        self.showSections = pinsFavorites || AppEntry.Kind.named(by: vm.query) != nil
+        self.pinsFavorites = pinsFavorites
+        self.favoriteCount = pinsFavorites ? results.prefix(while: favorites.isFavorite).count : 0
         self.rows = calc.map { [.calc($0)] + entries } ?? entries
     }
 
@@ -177,7 +180,7 @@ struct LauncherScreen: PaletteScreen {
         let removed = favoriteIndex(of: app)
         favorites.toggle(app)
         // A typed query never pins favorites, so nothing moved and the highlight belongs where it is.
-        guard showSections else { return true }
+        guard pinsFavorites else { return true }
         selectFavorite(at: removed.map { $0 - 1 } ?? 0)
         return true
     }

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -91,6 +91,26 @@ order. For the same reason a bundle id is matched with its leading component str
 (`apple.Photos`, not `com.apple.Photos`): `com` alone prefixes almost every installed app. The full id
 still matches exactly, so a pasted identifier resolves.
 
+### Category search
+
+A query that *equals* a category's own name lists that whole category under its section header, in the
+order the section shows when the field is empty. Both words a kind already carries work — the section
+title and the singular label, `Snippets`/`Snippet`, `Window Management`/`Window Command` — read straight
+off `KindDescriptor` by `AppEntry.Kind.named(by:)`, so no category name is written a second time and a
+new `Kind` case gets its category word for free.
+
+**The trigger is exact equality, never a prefix or a fuzzy hit**, because a looser rule would take a word
+away from a real entry: `System Settings` names both a category and an installed application. That one
+collision is answered rather than avoided — an entry whose display name equals the query joins the
+listing, so the app appears under Applications above the panes. Since slice order is section order
+(`publishEntries`), `categoryListing` is a filter with no sort, and the sectioned view stays 1:1 with the
+flat selection. Visibility still applies downstream, and no `limit` does, matching the empty query.
+
+`LauncherScreen` therefore separates the two jobs the empty query used to do at once: `showSections`
+draws the headers, `pinsFavorites` pins the Favorites prefix and hands out the ⌘-digit slots. A category
+listing takes the first only. Opening a row from one also records nothing in `LauncherRankingStore` — a
+category word is not a search for the row that ran, and learning it would rank that row under `s`.
+
 ### User aliases
 
 `AliasStore` (`Launcher/Service/`) keeps one user-chosen alias per entry, keyed by `preferenceKey`


### PR DESCRIPTION
## Related issue

Closes #273

## What changed

The launcher matches five fields — display name, Spotlight alternate names, user alias, bundle id, executable name — and a category is not one of them. Quicklinks only felt searchable because "Quicklinks" is the name of its command; snippets, having no such command, had nothing to type at all.

A query that **equals** a category's own name now lists that whole category under its section header, in the order the section shows when the field is empty. Both words a kind already carries work — the section title and the singular label, so `Snippets`/`Snippet` and `Window Management`/`Window Command` — read straight off `KindDescriptor` by `AppEntry.Kind.named(by:)`. No category name is written a second time, the words are the same strings the headers draw, and a new `Kind` case gets its category word for free.

Non-obvious bits of the diff:

- **The trigger is exact equality, never a prefix and never a fuzzy hit.** A looser rule takes a word away from a real entry: `System Settings` names both a category and an installed application. The collision is answered rather than avoided — an entry whose display name equals the query joins the listing, so the app lands under Applications above the panes.
- **`categoryListing` is one filter with no sort.** Slice order is already section order: `publishEntries` emits its slices in the order `LauncherList.rows` groups them, and each slice arrives in its own display order. Filtering preserves both, so the sectioned view stays 1:1 with the flat selection and the assert there keeps holding. `LauncherList` itself is untouched.
- **The branch sits inside the existing `matchMemo`**, so a category costs a dictionary lookup and one filter per query, not per render. Visibility still filters downstream in `orderedResults`; no `limit` applies, matching the empty-query path.
- **`LauncherScreen` splits the two jobs the empty query used to do at once.** `showSections` draws the headers; `pinsFavorites` pins the Favorites prefix and hands out the ⌘-digit slots. A category listing takes the first only — without the split, a favorite that happened to lead the listing would collect a Favorites header and a ⌘1 that launches something else.
- **A category listing records nothing in `LauncherRankingStore`.** A category word is not a search for the row that ran, and learning it would rank that row under `s`, `sn` and `sni`.

## Memory footprint

_Not yet measured — to fill in from a dev-build run._

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

_To add: a before/after clip of typing `Snippets` and `System Settings`._

## Drawbacks

- Nine category words stop being fuzzy-searchable text and become listing triggers. `Commands` and `System Settings` are the ones a user might have typed before; `System Settings` still opens the app, from the top of its own listing, and the rest are section headers nobody was typing to reach an entry.
- The listing is unranked on purpose, so a long category — Applications — is a plain alphabetical wall. Frecency inside a category was considered and dropped: the list would then move under the user between opens.
- Only the display name joins a listing on an exact hit. A user alias or a snippet keyword that happens to equal a category word does not, which keeps the rule one line and one field.

## Tests & validation

- `./Scripts/run-tests.sh` — all 35 harnesses pass. No new harness: the resolver reads `KindDescriptor`, which lives with `AppEntry` in an AppKit-importing service file, so nothing can compile it standalone the way `fuzz-test` compiles `SearchRelevance.swift`. Moving `AppEntry.Kind` into `Model/` to buy coverage would be a rename across the feature for one dictionary lookup.
- Debug build with no new warnings; `./Scripts/lint.sh` clean; the `Features/*/Model/` import grep is empty.
- Not yet exercised by hand — the palette needs a real key press and the dev build starts with no
  hotkeys bound. Pending checks:
  - [ ] `Snippets` and `Snippet` list the snippets under their header; `snip` still ranks normally.
  - [ ] `System Settings` puts the application first, then the panes, and ↵ opens the right one from
        each section.
  - [ ] Arrow to the last row of a listing and press ↵ — it opens that row, not its neighbour.
  - [ ] A listing shows no Favorites header and no ⌘-digit labels while ⌘ is held; ⇧⌘F still toggles
        and leaves the highlight where it is.
  - [ ] Open a snippet from the `Snippets` listing, then type `s` — it has not jumped to the top.
  - [ ] Hidden entries stay out of their category listing; an empty category (Window Management off)
        shows nothing and does not crash.
