### PR TITLE
Anchor the launcher to the menu-bar display when the cursor setting is off

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0047FE6A50E746CCF0FC6810 /* SystemActionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AEDBB526AB2C0406D8226D5 /* SystemActionRunner.swift */; };
+		00D813D3D99D0856E743168B /* ScreenTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C7C096F258D1EC8B42F818 /* ScreenTarget.swift */; };
 		0120AF7AB3AD249C484C8A03 /* ExtensionStoreResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7732FB0ED92C8FBFE22599CE /* ExtensionStoreResponse.swift */; };
 		017FB0EDDC9AF28ED81EA6A8 /* EntryIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08279257B0F5995E86FF2C03 /* EntryIconView.swift */; };
 		02452CD187D25FD9CD3EF2CF /* QuicklinkLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B865FF16D3C395A8D509B94 /* QuicklinkLauncher.swift */; };
@@ -112,7 +113,6 @@
 		552B7230E78D2C05793EC013 /* ExtensionNodeShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A0A3867D1B8E1D3284471 /* ExtensionNodeShims.swift */; };
 		555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F1080FB443A1D0616790E /* FavoritesStore.swift */; };
 		5770FB1A3FD29E27C25C944E /* SearchRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB9DB77DCE25C41D86BB955 /* SearchRelevance.swift */; };
-		57D7D94F9CB94B1152D44879 /* CursorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9163FDA8F7ADDEF49A62D72C /* CursorScreen.swift */; };
 		58D369977E702AD66F070913 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */; };
 		5970306ABC24B03028E66D45 /* FileSearchIgnoreList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFF39C46E98D0808B188E2E /* FileSearchIgnoreList.swift */; };
 		5A91C58340D02ED0939BCAE2 /* CurrencyFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE35B5E7B1CC94F759116097 /* CurrencyFeed.swift */; };
@@ -474,7 +474,6 @@
 		8FEAC591704D983A2C31188F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
 		90E23F92F4B4DEEE55077C7C /* AppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconView.swift; sourceTree = "<group>"; };
 		91151402A1A4586B2496BF35 /* NotesPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesPanel.swift; sourceTree = "<group>"; };
-		9163FDA8F7ADDEF49A62D72C /* CursorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorScreen.swift; sourceTree = "<group>"; };
 		91D0784E49BC5899A585F285 /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
 		92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutShape.swift; sourceTree = "<group>"; };
 		92B4495E56754B05B5F3551D /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
@@ -500,6 +499,7 @@
 		A5A8F78D3F1BFA8E86F9CB47 /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
 		A5DFA4E0FDAC12379F2D38B5 /* CalloutPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutPlacement.swift; sourceTree = "<group>"; };
 		A7751EBF0F632A123B4A2363 /* ExtensionTintColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionTintColors.swift; sourceTree = "<group>"; };
+		A7C7C096F258D1EC8B42F818 /* ScreenTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTarget.swift; sourceTree = "<group>"; };
 		A7DDDF0D150C30D0D0FC0BFD /* ExtensionCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCatalog.swift; sourceTree = "<group>"; };
 		A80495AE6BF7CE22BD6B20EE /* SnippetArgumentsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetArgumentsPrompt.swift; sourceTree = "<group>"; };
 		A8AD14D51F74D1891D5532B0 /* NoteSwitcherInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSwitcherInteraction.swift; sourceTree = "<group>"; };
@@ -626,7 +626,6 @@
 				5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */,
 				8E5F9675F2090C3AA9EEBF65 /* Appearance.swift */,
 				B6A96350EBE68EC79497FA2D /* AppPaths.swift */,
-				9163FDA8F7ADDEF49A62D72C /* CursorScreen.swift */,
 				BFB023D167225228757CC4B2 /* HealthTicker.swift */,
 				2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */,
 				3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */,
@@ -634,6 +633,7 @@
 				E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */,
 				AA7B3EB88881CEEFCE71448D /* Permissions.swift */,
 				4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */,
+				A7C7C096F258D1EC8B42F818 /* ScreenTarget.swift */,
 				F9044F107ADD5896746DBC35 /* Signposts.swift */,
 			);
 			path = Platform;
@@ -1708,7 +1708,6 @@
 				2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */,
 				5A91C58340D02ED0939BCAE2 /* CurrencyFeed.swift in Sources */,
 				17F61DEF6389FBCFCCFB467C /* CurrencyRateStore.swift in Sources */,
-				57D7D94F9CB94B1152D44879 /* CursorScreen.swift in Sources */,
 				8CC7A4A5D4205843219A81C8 /* CustomCommand.swift in Sources */,
 				11C3F9D5C786EF1D11787E0C /* CustomCommandCoordinator.swift in Sources */,
 				CCC775255627E23DC5B567AE /* CustomCommandEditorSheet.swift in Sources */,
@@ -1868,6 +1867,7 @@
 				AD98F015439106F0E9D32015 /* RightClick.swift in Sources */,
 				47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */,
 				9A80D2997DCF835AF225A586 /* RunningAppsMonitor.swift in Sources */,
+				00D813D3D99D0856E743168B /* ScreenTarget.swift in Sources */,
 				31E0E4E0782A79504CEB588D /* ScrollIntent.swift in Sources */,
 				07726F26DC68689F8984F467 /* Scrypt.swift in Sources */,
 				5770FB1A3FD29E27C25C944E /* SearchRelevance.swift in Sources */,

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -291,12 +291,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.setFrame(frame, display: true)
     }
 
-    /// The display to anchor to; `NSScreen.main` would give the menu-bar one instead.
+    /// The display to anchor to; never `NSScreen.main`, which follows the focused window either way.
     private func targetScreen() -> NSScreen? {
-        guard core.settings.openOnCursorScreen else { return NSScreen.main }
-        let mouse = NSEvent.mouseLocation
-        // NSMouseInRect, not `contains`: the topmost row otherwise reads as the display above.
-        return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+        core.settings.openOnCursorScreen ? NSScreen.underCursor : NSScreen.primary
     }
 
     /// The session anchor, cached until hide so both placements read one `visibleFrame`. A

--- a/Tinycast/Platform/ScreenTarget.swift
+++ b/Tinycast/Platform/ScreenTarget.swift
@@ -7,4 +7,9 @@ extension NSScreen {
         // NSMouseInRect, not `contains`: the topmost row otherwise reads as the display above.
         return screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? main
     }
+
+    /// The menu-bar display: the one at the global origin, which `NSScreen.main` is not.
+    static var primary: NSScreen? {
+        screens.first { $0.frame.origin == .zero } ?? screens.first
+    }
 }

--- a/Tinycast/Windows/HUD/MessageHUDController.swift
+++ b/Tinycast/Windows/HUD/MessageHUDController.swift
@@ -9,7 +9,7 @@ final class MessageHUDController {
         presenter = HUDPresenter(
             anchor: .edgeInset(Theme.Size.hudEdgeOffset),
             dwell: Theme.Duration.messageHUD,
-            screen: { settings.openOnCursorScreen ? .underCursor : .main })
+            screen: { settings.openOnCursorScreen ? .underCursor : .primary })
     }
 
     func show(message: String, tone: DialogTone = .success) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,7 +176,7 @@ Tinycast/
   App/              @main, AppDelegate, AppCore — the composition root
   DesignSystem/     Theme (the token source), KeyCapChip, Tooltip, SymbolImage,
                     VisualEffectView, PopoverMenu, SettingsComponents, Scrolling/, Interaction/
-  Platform/         system shims: Permissions, LaunchAtLogin, InputSourceSwitcher, CursorScreen,
+  Platform/         system shims: Permissions, LaunchAtLogin, InputSourceSwitcher, ScreenTarget,
                     AppDisplayName,
                     NotificationToken, AppPaths, Signposts, HealthTicker, Memo, ActivationPolicy,
                     Images/, Compression/

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -162,18 +162,21 @@ reason the Settings window autosaves its frame instead ([backup.md](backup.md)).
 Which display an *unremembered* palette anchors to depends on the **Follow the cursor across displays**
 setting (`AppSettings.openOnCursorScreen`, on by default):
 
-- **On** — the screen holding `NSEvent.mouseLocation`, i.e. the display under the pointer.
-- **Off** — `NSScreen.main`.
+- **On** — `NSScreen.underCursor`: the screen holding `NSEvent.mouseLocation`, i.e. the display under
+  the pointer.
+- **Off** — `NSScreen.primary`: the screen at the global origin, i.e. the one with the menu bar.
 
-`NSScreen.main` alone can't implement the follow-the-cursor case: it is documented as the _key window's_
-screen, and an accessory app driving a non-activating panel has no key window on the display the user is
-looking at, so `main` resolves to the menu-bar display regardless of where the pointer is.
+**Neither case may use `NSScreen.main`**, which is documented as the screen of the window with keyboard
+focus — the frontmost app's, wherever the user last clicked. It therefore follows the user across
+displays, which is the wrong answer for both settings and made the off case do exactly what turning it
+off was meant to stop ([#270](https://github.com/abue-ammar/tinycast/issues/270)). The menu-bar display
+is the one whose `frame.origin` is `.zero`, which is what `primary` looks for.
 
-The hit test is `NSMouseInRect(mouse, screen.frame, false)`, **not** `CGRect.contains`. A mouse location
-is the CoreGraphics cursor position flipped about the primary display's height, so a screen's rows land
-in the half-open interval `(minY, maxY]`: the topmost row is exactly `maxY`, which `contains` excludes,
-while that same value is the `minY` of the display stacked above. `contains` would therefore hand a
-pointer parked at the top of one display to its neighbour. `NSMouseInRect` exists for precisely this.
+The cursor hit test is `NSMouseInRect(mouse, screen.frame, false)`, **not** `CGRect.contains`. A mouse
+location is the CoreGraphics cursor position flipped about the primary display's height, so a screen's
+rows land in the half-open interval `(minY, maxY]`: the topmost row is exactly `maxY`, which `contains`
+excludes, while that same value is the `minY` of the display stacked above. `contains` would therefore
+hand a pointer parked at the top of one display to its neighbour. `NSMouseInRect` exists for this.
 
 ## The placeholder is Tinycast's, not the field's
 


### PR DESCRIPTION
Fixes #270.

## The bug

Unchecking **Follow the cursor across displays** changed nothing — the launcher kept opening on whichever display the pointer was on.

The off branch of `targetScreen()` returned `NSScreen.main`, and both the code comment and `palette.md` asserted that `main` means "the menu-bar display". It does not. AppKit documents `NSScreen.main` as *the screen containing the window with keyboard focus*, so it follows the frontmost app's window across displays — precisely what turning the setting off is meant to stop. The setting was implemented with an API that follows the user.

## The fix

- **`NSScreen.primary`** (new, in `ScreenTarget.swift`) — the screen whose `frame.origin` is `.zero`, i.e. the one with the menu bar, with `screens.first` as the fallback so it is nil only when there are no displays.
- **`targetScreen()`** collapses to `openOnCursorScreen ? .underCursor : .primary`, calling the existing `underCursor` helper instead of duplicating its `NSMouseInRect` hit test and the reasoning behind it.
- **`MessageHUDController`** carried the identical `.main`, so the confirmation pill drifted off the launcher's display whenever the setting was off. Both surfaces now name the same screen.
- **`CursorScreen.swift` → `ScreenTarget.swift`** — the file answers which display a surface targets, and half that answer is no longer about the cursor.
- `palette.md` had the false premise written down as an explanation; corrected, along with the `Platform/` file list in `architecture.md`.

A remembered drag position still outranks the setting, unchanged: `PalettePlacement.restored` never consulted a display preference. Worth repeating to anyone who hits this — if the launcher was ever dragged onto a second display it will keep opening there, and snapping it back onto the drop guides clears the stored position.

## Verification

- `xcodegen generate` re-run for the rename; `Tinycast.xcodeproj` committed alongside.
- Debug build succeeds, no new warnings.
- `./Scripts/run-tests.sh` — all 35 harnesses pass.
- `./Scripts/lint.sh` clean; `Features/*/Model/` import grep clean.

**Not verified on hardware:** I have one display, so I could not watch the launcher stay put across two. On a single display `main` and `primary` resolve to the same screen — I confirmed that by dumping both — which makes this provably a no-op for single-monitor users. The two-display behaviour rests on the documented contract of `NSScreen.main` versus `screens[0]`. Confirmation from anyone with a second monitor would be welcome.