### PR TITLE
Switch to the previous or next Space instantly, without the macOS slide

### DIFF
--- a/Tests/window-command-test.swift
+++ b/Tests/window-command-test.swift
@@ -71,7 +71,7 @@ struct WindowCommandTests {
 
     static func testCatalog() {
         let commands = WindowCommandCatalog.all
-        expect(commands.count == 30, "catalog contains all 30 agreed commands")
+        expect(commands.count == 32, "catalog contains all 32 agreed commands")
         expect(commands.map(\.id) == WindowCommand.ID.allCases, "catalog covers every ID once")
         expect(
             Set(commands.map { $0.name.lowercased() }).count == commands.count, "names are unique")
@@ -110,6 +110,10 @@ struct WindowCommandTests {
         expect(
             Set(commands.filter { $0.kind == .restore }.map(\.id)) == [.restore],
             "only Restore is a restore command")
+        expect(
+            Set(commands.filter { $0.kind == .space }.map(\.id))
+                == [.switchToPreviousSpace, .switchToNextSpace],
+            "only the two Space commands leave every window alone")
 
         // Grouping drives the Settings list; every command must land in exactly one group.
         let grouped = WindowCommandCatalog.grouped()
@@ -123,6 +127,7 @@ struct WindowCommandTests {
         expect(grouped.first { $0.group == .thirds }?.commands.count == 5, "five thirds")
         expect(grouped.first { $0.group == .sizing }?.commands.count == 10, "ten sizing commands")
         expect(grouped.first { $0.group == .moving }?.commands.count == 6, "six moving commands")
+        expect(grouped.first { $0.group == .spaces }?.commands.count == 2, "two Space commands")
 
         expect(
             WindowLayout.isTileCommand(.leftHalf) && WindowLayout.isTileCommand(.centerHalf),
@@ -133,6 +138,9 @@ struct WindowCommandTests {
 
         // Fullscreen has no geometry at all — the mover branches before ever asking for a placement.
         expect(frame(.toggleFullscreen) == nil, "Toggle Fullscreen produces no placement")
+        expect(
+            frame(.switchToPreviousSpace) == nil && frame(.switchToNextSpace) == nil,
+            "the Space commands produce no placement")
     }
 
     // MARK: - Convention lock

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		64AD2324BDA6293464C98913 /* EmojiCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EB979ECD44738BCD9E2F90 /* EmojiCoordinator.swift */; };
 		6527B404C220924885C070B3 /* AppWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9979DED5579535D1F0A32DBF /* AppWindowController.swift */; };
 		68537C3544E4EBC40E3ACD39 /* HUDPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BAD6EE1BA3036C4B5A3D19 /* HUDPresenter.swift */; };
+		68DE5268907FD4F96C1A346E /* SpaceSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */; };
 		68F25E0E441706E9F591B302 /* NotesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525AE0062E8E8F00E21BAEF9 /* NotesWindowController.swift */; };
 		68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B629EC3B716FEE881BB0075 /* TinycastApp.swift */; };
 		691ADED3F9F3F730E1F36DB8 /* FileSearchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03757CDEFC14359CAEF4CE93 /* FileSearchSession.swift */; };
@@ -418,6 +419,7 @@
 		60CCB1A47E0022BAEDD1EE96 /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
 		61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkDestination.swift; sourceTree = "<group>"; };
 		622E1F1C01B954DCA2199BCD /* ScrollIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollIntent.swift; sourceTree = "<group>"; };
+		628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitcher.swift; sourceTree = "<group>"; };
 		62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
 		648F0F43FEEE537F6451756B /* SelectionReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReveal.swift; sourceTree = "<group>"; };
 		64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolImage.swift; sourceTree = "<group>"; };
@@ -1398,6 +1400,7 @@
 		CBA05AA0E4FE94ADE97BC7E5 /* WindowManagement */ = {
 			isa = PBXGroup;
 			children = (
+				628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */,
 				0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */,
 				9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */,
 				06125F7DDE68BB4D52065C06 /* WindowCommandCoordinator.swift */,
@@ -1904,6 +1907,7 @@
 				A2073E8EBBAAB620E27F0BD5 /* SnippetTextInjector.swift in Sources */,
 				3BC6CC35889FFC77D640C7CA /* SnippetsSettingsView.swift in Sources */,
 				7BDB7CF7F1352015F6AC96C3 /* SnippetsStore.swift in Sources */,
+				68DE5268907FD4F96C1A346E /* SpaceSwitcher.swift in Sources */,
 				089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */,
 				9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */,
 				FF934DD9FBD8F26BAB72ACD1 /* SymbolImage.swift in Sources */,

--- a/Tinycast/Features/WindowManagement/SpaceSwitcher.swift
+++ b/Tinycast/Features/WindowManagement/SpaceSwitcher.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+
+/// Switches macOS Space by synthesising the Dock's own horizontal swipe, minus the slide.
+@MainActor
+enum SpaceSwitcher {
+    enum Direction: Sendable {
+        case previous
+        case next
+    }
+
+    /// Quiet on refusal like the mover, and the grant is prompted for from this explicit gesture.
+    @discardableResult
+    static func switchSpace(_ direction: Direction) -> Bool {
+        guard Permissions.ensureAccessibility() else { return false }
+        // Three phases, not two: with two the Dock is left mid-gesture and never lands the switch.
+        for phase in [Phase.began, .changed, .ended] {
+            guard post(phase, direction: direction) else { return false }
+        }
+        return true
+    }
+
+    /// Undocumented `CGEventField`s; the open C enum lets these raw values import as-is.
+    private enum Field {
+        static let eventType = CGEventField(rawValue: 55)!
+        static let gestureHIDType = CGEventField(rawValue: 110)!
+        static let swipeMotion = CGEventField(rawValue: 123)!
+        static let swipeProgress = CGEventField(rawValue: 124)!
+        static let swipeVelocityX = CGEventField(rawValue: 129)!
+        static let swipeVelocityY = CGEventField(rawValue: 130)!
+        static let phase = CGEventField(rawValue: 132)!
+    }
+
+    private enum Phase: Int64 {
+        case began = 1
+        case changed = 2
+        case ended = 4
+    }
+
+    private static let dockControlEventType: Int64 = 30
+    private static let dockSwipeHIDEventType: Int64 = 23
+    private static let horizontalMotion: Int64 = 1
+    private static let velocity = 2000.0
+
+    /// The trick: a swipe reported as already complete leaves the window server nothing to animate.
+    private static let completedProgress = Double(Float.leastNonzeroMagnitude)
+
+    private static func post(_ phase: Phase, direction: Direction) -> Bool {
+        guard let event = CGEvent(source: nil) else { return false }
+        let sign = direction == .next ? 1.0 : -1.0
+        event.setIntegerValueField(Field.eventType, value: dockControlEventType)
+        event.setIntegerValueField(Field.gestureHIDType, value: dockSwipeHIDEventType)
+        event.setIntegerValueField(Field.phase, value: phase.rawValue)
+        event.setIntegerValueField(Field.swipeMotion, value: horizontalMotion)
+        event.setDoubleValueField(Field.swipeProgress, value: sign * completedProgress)
+        event.setDoubleValueField(Field.swipeVelocityX, value: sign * velocity)
+        event.setDoubleValueField(Field.swipeVelocityY, value: sign * velocity)
+        event.post(tap: .cgSessionEventTap)
+        return true
+    }
+}

--- a/Tinycast/Features/WindowManagement/WindowCommand.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommand.swift
@@ -32,9 +32,11 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case nextDisplay = "next-display"
         case previousDisplay = "previous-display"
         case toggleFullscreen = "toggle-fullscreen"
+        case switchToPreviousSpace = "switch-to-previous-space"
+        case switchToNextSpace = "switch-to-next-space"
     }
 
-    /// What the mover has to do, so its dispatch stays exhaustive over the catalog.
+    /// What running the command takes, so the dispatch that routes it stays exhaustive.
     enum Kind: String, Sendable {
         /// Resolve a target frame from the screen and write it.
         case geometry
@@ -42,6 +44,8 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case restore
         /// No geometry at all — the native `AXFullScreen` toggle.
         case fullscreen
+        /// No window at all: it moves the user, so the coordinator runs it instead of the mover.
+        case space
     }
 
     /// The launcher section a command belongs to, and the order the Settings panel lists them in.
@@ -52,6 +56,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case sizing
         case moving
         case fullscreen
+        case spaces
 
         var title: String {
             switch self {
@@ -61,6 +66,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
             case .sizing: return "Sizing"
             case .moving: return "Moving"
             case .fullscreen: return "Fullscreen"
+            case .spaces: return "Spaces"
             }
         }
     }
@@ -140,6 +146,8 @@ enum WindowCommandCatalog {
         case .nextDisplay: return "Move to Next Display"
         case .previousDisplay: return "Move to Previous Display"
         case .toggleFullscreen: return "Toggle Fullscreen"
+        case .switchToPreviousSpace: return "Switch to Previous Space"
+        case .switchToNextSpace: return "Switch to Next Space"
         }
     }
 
@@ -173,6 +181,8 @@ enum WindowCommandCatalog {
         case .nextDisplay: return "rectangle.on.rectangle.angled"
         case .previousDisplay: return "rectangle.on.rectangle.angled"
         case .toggleFullscreen: return "arrow.up.left.and.arrow.down.right.square"
+        case .switchToPreviousSpace: return "arrow.left.square"
+        case .switchToNextSpace: return "arrow.right.square"
         }
     }
 
@@ -180,6 +190,7 @@ enum WindowCommandCatalog {
         switch id {
         case .restore: return .restore
         case .toggleFullscreen: return .fullscreen
+        case .switchToPreviousSpace, .switchToNextSpace: return .space
         default: return .geometry
         }
     }
@@ -199,6 +210,8 @@ enum WindowCommandCatalog {
             return .moving
         case .toggleFullscreen:
             return .fullscreen
+        case .switchToPreviousSpace, .switchToNextSpace:
+            return .spaces
         }
     }
 }

--- a/Tinycast/Features/WindowManagement/WindowCommandCoordinator.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommandCoordinator.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-/// The one funnel from a palette row or a global hotkey to the mover.
+/// The one funnel from a palette row or a global hotkey to the mover or the Space switcher.
 @MainActor
 final class WindowCommandCoordinator {
     private let settings: AppSettings
@@ -18,6 +18,20 @@ final class WindowCommandCoordinator {
     /// The one funnel for palette and hotkey alike. See docs/features/window-management.md#wiring.
     func runWindowCommand(id: WindowCommand.ID) {
         guard settings.windowManagementEnabled else { return }
+        switch id {
+        case .switchToPreviousSpace: switchSpace(.previous)
+        case .switchToNextSpace: switchSpace(.next)
+        default: moveWindow(id)
+        }
+    }
+
+    /// Nothing to act on, so focus is left to fall where the Space we land on puts it.
+    private func switchSpace(_ direction: SpaceSwitcher.Direction) {
+        if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: false) }
+        SpaceSwitcher.switchSpace(direction)
+    }
+
+    private func moveWindow(_ id: WindowCommand.ID) {
         let target = paletteCoordinator.targetApp
         if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: true) }
         windowMover.perform(

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -222,7 +222,7 @@ dismissal matches Accessibility subroles rather than English labels.
 
 ## Window commands
 
-`WindowCommandCatalog` supplies the 30 window actions as a static slice, published as a whole by
+`WindowCommandCatalog` supplies the 32 window actions as a static slice, published as a whole by
 `AppIndex.setWindowCommandsVisible(_:)` and shown under a "Window Management" section. Like system
 actions they carry dedicated global hotkeys (`AppEntry.hotKeyAction` returns `.windowCommand(id:)`),
 so launcher rows render keycaps for them. Their per-command shortcut and visibility controls live in

--- a/docs/features/window-management.md
+++ b/docs/features/window-management.md
@@ -1,8 +1,9 @@
 # Window Management
 
-Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves and native
-fullscreen — searchable in the palette and bindable to global shortcuts. 30 commands, no new
-dependencies and no new permission: they reuse the Accessibility grant clipboard paste already needs.
+Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves, native
+fullscreen and instant Space switching — searchable in the palette and bindable to global shortcuts.
+32 commands, no new dependencies and no new permission: they reuse the Accessibility grant clipboard
+paste already needs.
 
 Ships **off**. Settings › Window Management is the switch, and while it is off there are no launcher
 entries and a still-registered shortcut moves nothing.
@@ -18,6 +19,9 @@ entries and a still-registered shortcut moves nothing.
 - **`WindowCommand.swift`, `WindowLayout.swift` and `WindowActionMemory.swift` stay Foundation +
   CoreGraphics and pure** — no AX, no `NSScreen`, no clock (`WindowActionMemory` takes `now` as a
   parameter). Every `AXUIElement` call and the Cocoa↔AX flip live in `WindowMover.swift`.
+- **`SpaceSwitcher.swift` is the only file that knows the Dock gesture's undocumented
+  `CGEventField` numbers**, and the only command kind that never reaches `WindowMover`. A `.space`
+  command has no target window, so the coordinator routes it before the mover is asked for anything.
 
 ## Layout
 
@@ -27,6 +31,7 @@ entries and a still-registered shortcut moves nothing.
 | `Features/WindowManagement/WindowLayout.swift`       | Foundation + CoreGraphics    | **Pure.** Every frame the commands produce                          |
 | `Features/WindowManagement/WindowActionMemory.swift` | Foundation + CoreGraphics    | **Pure.** Per-window cycle position and restore point               |
 | `Features/WindowManagement/WindowMover.swift`        | AppKit + ApplicationServices | `@MainActor`. Every `AXUIElement` call and the coordinate flip      |
+| `Features/WindowManagement/SpaceSwitcher.swift`       | CoreGraphics                 | `@MainActor`. The synthetic Dock swipe, and nothing else            |
 
 The first three compile into `Tests/window-command-test.swift`, so they must not gain an AppKit,
 SwiftUI or `NSScreen` dependency, and must stay pure — `WindowActionMemory` takes `now` as a parameter
@@ -35,7 +40,7 @@ lives in that overlay rather than in Foundation.
 
 Adding a command is four edits in `WindowCommand.swift` (a case in `ID`, plus `name`, `symbol` and
 `group` arms), an arm in `WindowLayout.placement` or `tileFractions`, and bumping
-`commands.count == 30` in the harness.
+`commands.count == 32` in the harness.
 
 ## Coordinate space
 
@@ -168,6 +173,24 @@ some apps reinterpret frame writes while it is on — but never while VoiceOver 
 break the screen reader. **This mitigation is inherited convention and unverified on macOS 26**; if a
 stock Electron app tiles correctly without it, delete the helper rather than keep it.
 
+## Switching Space
+
+Switch to Previous/Next Space are the one pair that moves the **user** rather than a window, which is
+why they are their own `Kind` and their own `Group` and why `WindowLayout` never sees them.
+
+`SpaceSwitcher` posts three phases of a horizontal Dock swipe — began, changed, ended — whose progress
+field is already at its terminal value, so the window server treats the gesture as finished on arrival
+and cuts straight to the neighbouring Space with nothing left to animate. Two phases leave the Dock
+mid-gesture and the switch never lands, so all three are load-bearing. The field numbers are
+undocumented and named as constants in that file alone; `CGEventField` is an `enum_extensibility(open)`
+C enum, which is what lets those raw values import at all.
+
+Synthesising ⌃← / ⌃→ was rejected twice over: it plays the full slide, whose duration scales with the
+display's refresh rate, and it rides a Mission Control shortcut the user is free to rebind or switch
+off. Nothing here reads Space bounds or caches an index, so at the first or last Space macOS answers
+with its own rubber-band bounce — the same answer a real trackpad swipe gets, and the reason a held
+hotkey needs nothing invalidated between repeats.
+
 ## Wiring
 
 - **`AppEntry.Kind.windowCommand`** — entries are `window-command:<id>`, published by
@@ -179,7 +202,9 @@ stock Electron app tiles correctly without it, delete the helper rather than kee
   custom commands there is no bound-ID index to maintain: the catalog is fixed, so `HotKeyManager.start`
   and `conflictOwner` iterate `WindowCommand.ID.allCases` and `register` no-ops on an unbound command.
 - **`WindowCommandCoordinator.runWindowCommand(id:)`** is the one funnel for both palette activation and the global
-  hotkey, so the feature switch cannot be bypassed by either.
+  hotkey, so the feature switch cannot be bypassed by either. It is also where `.space` splits off from
+  the mover, and the one place that hides the palette with `restoreFocus: false` — there is no window
+  to act on, so refocusing the previous app would only risk following it back to its own Space.
 - **Settings** — `windowManagementEnabled` (off), `windowManagementShowInLauncher` (on), `windowGap`
   (0) and `windowCycleOnRepeat` (off). All four ride in settings backups: unlike `snippetsEnabled` they
   grant no permission class of their own.
@@ -190,15 +215,15 @@ stock Electron app tiles correctly without it, delete the helper rather than kee
 
 ## Testing
 
-`Tests/window-command-test.swift` (319 assertions) covers the catalog, the AX-space convention lock,
+`Tests/window-command-test.swift` (325 assertions) covers the catalog, the AX-space convention lock,
 tiling on divisible and non-divisible screens, off-origin and negative-coordinate displays, gap
 arithmetic including degenerate values, sizing, the Make Larger/Smaller round trip, nudges, display
 moves and wrapping, restore recovery, every `WindowActionMemory` rule, and a fuzz sweep over every
 command × gap × screen × degenerate window frame checking for non-finite output, negative dimensions,
 off-screen results, non-determinism and drift on repeat.
 
-Everything runs headless because the layer is pure. `WindowMover` is not compiled into the harness and
-has no automated coverage — the AX paths need manual verification, particularly:
+Everything runs headless because the layer is pure. `WindowMover` and `SpaceSwitcher` are not compiled
+into the harness and have no automated coverage — their paths need manual verification, particularly:
 
 1. A non-resizable window (System Information) must fail silently, left untouched rather than
    half-moved.
@@ -207,3 +232,5 @@ has no automated coverage — the AX paths need manual verification, particularl
 3. Toggle Fullscreen on a window that accepts it and one that refuses it.
 4. Cycling: three presses of Left Half, then drag the window and confirm the next press restarts at ½.
 5. Restore on a window Tinycast has never moved.
+6. Switch to Previous/Next Space with a held hotkey, across a full-screen app's Space and at both
+   ends of the Space list, on a second display too.

--- a/website/content/docs/features/window-management.md
+++ b/website/content/docs/features/window-management.md
@@ -1,6 +1,6 @@
 ---
 title: Window management
-description: 30 tiling commands — halves, quarters, thirds, nudges and display moves.
+description: 32 commands — halves, quarters, thirds, nudges, display moves and instant Space switching.
 ---
 
 Move and resize the window you were last in, without installing anything else.
@@ -25,6 +25,8 @@ Center · Center Half · Make Larger · Make Smaller · Restore
 **Moving** — Left · Right · Up · Down · Next Display · Previous Display
 
 **Fullscreen** — Toggle Fullscreen
+
+**Spaces** — Switch to Previous Space · Switch to Next Space
 
 ## Settings
 
@@ -82,6 +84,23 @@ There is deliberately no synthetic <kbd>⌃</kbd><kbd>⌘</kbd><kbd>F</kbd> atte
 and firing an unrelated menu command would be worse than doing nothing.
 
 It clears the cycle chain but keeps the restore point.
+
+## Spaces
+
+**Switch to Previous Space** and **Switch to Next Space** move you to the neighbouring Space with
+**no sliding transition** — the switch is there when your finger leaves the key. macOS normally
+animates the slide, and its duration scales with your display's refresh rate, so the higher the
+refresh rate the longer the wait.
+
+Tinycast does not simulate <kbd>⌃</kbd><kbd>←</kbd> / <kbd>⌃</kbd><kbd>→</kbd>: that still plays the
+animation, and it stops working the moment you rebind the Mission Control shortcuts. It synthesises
+the trackpad's own Space swipe instead, reported as already finished, which leaves nothing to animate.
+
+These two are the one pair that touches no window — they move **you**, not what you were last in, so
+none of the geometry, cycling or restore behaviour applies. They work with regular desktop Spaces and
+with full-screen apps, follow the Space order of the display you are on, and can be held down to move
+several Spaces. At the first or last Space you get macOS's usual bounce, exactly as a real trackpad
+swipe would give you.
 
 ## Failing quietly
 

--- a/website/content/docs/reference/hotkeys.md
+++ b/website/content/docs/reference/hotkeys.md
@@ -13,7 +13,7 @@ description: Recording global shortcuts, double-tap modifiers, and the Hyper key
 - Every application, and every System Settings pane
 - Every quicklink, custom command and extension command
 - All 31 [system actions](/docs/launcher/system-actions)
-- All 30 [window commands](/docs/features/window-management)
+- All 32 [window commands](/docs/features/window-management)
 
 A built-in command's shortcut appears in two panes — Settings → Commands and its own feature pane —
 but it is **one binding, not two settings**.


### PR DESCRIPTION
## Related issue

Closes #297

## What changed

Two new window commands — **Switch to Previous Space** and **Switch to Next Space** — in a new
**Spaces** group at the bottom of Settings › Window Management. Searchable, hideable, aliasable and
bindable like the other 30.

`SpaceSwitcher` posts three phases of a horizontal Dock swipe (began / changed / ended) whose
`swipeProgress` field is already at its terminal value, so the window server treats the gesture as
finished on arrival and cuts straight to the neighbouring Space with nothing left to animate.

Non-obvious bits in the diff:

- **All three phases are load-bearing.** With two, the Dock is left mid-gesture and the switch never
  lands.
- **The seven `CGEventField` numbers are undocumented**, and named as constants in `SpaceSwitcher`
  alone — nothing else in the app learns them. `CGEventField` is an `enum_extensibility(open)` C enum,
  which is the only reason those raw values import at all.
- **`Kind.space` is the first kind that never reaches `WindowMover`** — there is no target window — so
  `WindowCommandCoordinator` routes it instead. `Kind`'s doc comment moved off "what the mover has to
  do" accordingly.
- **It is the one path that hides the palette with `restoreFocus: false`.** There is nothing to act on,
  and refocusing the previous app risks macOS following it back to its own Space.
- **`WindowLayout` needed no edit** — its switches over `command` all carry `default:`, and the harness
  now pins that the two new IDs produce no placement.
- **⌃← / ⌃→ was deliberately not used.** It plays the full slide, whose duration scales with the
  display's refresh rate, and it rides a Mission Control shortcut the user is free to rebind or
  disable.

## Memory footprint

`SpaceSwitcher` holds no state — no cache, no observer, no timer. Every stored property is a `static
let` constant; a switch is three `CGEvent` allocations that are released before the call returns. There
is no steady-state cost to measure and nothing that can outlive the call.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

> **Numbers still to fill in** — these need a local Instruments run against `Tinycast Dev.app`; I have
> not measured them and would rather leave the table blank than guess.

## Demo

**Still to record** — a side-by-side before/after of a bound hotkey switching Space, same window size,
same actions. The whole point of the change is the absence of the slide, so this section is the real
review material and the PR should not merge without it.

## Drawbacks

- **These two sit behind a feature switch that ships off.** `runWindowCommand` returns early unless
  `windowManagementEnabled`, and launcher entries only publish when it is on, so out of the box a bound
  Space hotkey does nothing until the user enables Window Management. Carving an exception into that
  gate would undercut the "disabling a feature disables its shortcuts" rule, so it was left consistent
  — but it is a real difference from where the issue imagined these living.
- **The Accessibility gate is unverified.** `SpaceSwitcher` calls `Permissions.ensureAccessibility()`
  first because a silent no-op with no explanation is the worst failure mode, but I could not confirm
  the window server actually requires the grant to accept a synthetic dock swipe — mouse-class events
  sometimes do not. If revoking the grant still lets the Space switch, the guard should come out.
- **Undocumented event fields are an OS-version risk.** They have been stable for years and are what
  every other instant-Space utility uses, but a future macOS could renumber them. Failure mode is a
  quiet no-op, not a crash.
- **The edges keep macOS's rubber-band bounce.** Suppressing it would mean `dlsym`-ing four private
  CGS symbols, matching the cursor's display by CFUUID, walking `CGSCopyManagedDisplaySpaces`
  dictionaries and carrying a per-display predicted-index cache reset on
  `activeSpaceDidChangeNotification` — ~140 lines of OS-fragile, CI-untestable state whose only reward
  is removing feedback a real trackpad swipe gives you anyway.

## Tests & validation

Automated, all green:

- `./Scripts/run-tests.sh` — 35/35 harnesses. `window-command-test` is now 325 assertions: catalog count
  30 → 32, plus new assertions that only these two carry `Kind.space`, that the Spaces group holds
  exactly two, and that both produce no placement.
- `./Scripts/lint.sh` — `✓ lint-clean`.
- `xcodebuild … -configuration Debug CODE_SIGNING_ALLOWED=NO` — **BUILD SUCCEEDED**, no new warnings.
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` — empty.
- `xcodegen generate` run; `project.pbxproj` committed alongside the new file.

Docs updated in the same commit: `docs/features/window-management.md` (new Invariant, layout row, a
*Switching Space* section, wiring, count, and a sixth item on the manual sweep),
`docs/features/launcher.md`, `website/content/docs/features/window-management.md`,
`website/content/docs/reference/hotkeys.md`.

**Manual verification still outstanding** — I wrote and compiled this but have not driven the real app.
Needs, against `Tinycast Dev.app`:

1. Both rows in the palette under Window Management, searchable by "space", drawing their arrow glyphs;
   both in Settings › Window Management under **Spaces** with a working recorder and visibility box.
2. A bound hotkey switching Space with **no slide**, palette gone before it happens.
3. Held hotkey — smooth repeats, nothing stacked.
4. Crossing a full-screen app's Space in both directions.
5. First and last Space — native bounce, nothing strange.
6. Two displays — the switch follows the Space order of the display the gesture lands on.
7. Accessibility revoked, then granted (see Drawbacks).
