### PR TITLE
Switch Space instantly with a synthetic Dock swipe (#297)

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -118,6 +118,8 @@ run volume-test            Tinycast/Features/SystemActions/Model/VolumeLevel.swi
 run window-command-test    Tinycast/Features/WindowManagement/WindowCommand.swift \
                            Tinycast/Features/WindowManagement/WindowLayout.swift \
                            Tinycast/Features/WindowManagement/WindowActionMemory.swift
+run space-gesture-test     Tinycast/Features/WindowManagement/WindowCommand.swift \
+                           Tinycast/Features/WindowManagement/SpaceGesture.swift
 run custom-command-test    Tinycast/Features/CustomCommands/Model/CustomCommand.swift \
                            Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
 run uninstall-test         Tinycast/Features/Uninstall/Model/UninstallTarget.swift \

--- a/Tests/space-gesture-test.swift
+++ b/Tests/space-gesture-test.swift
@@ -1,0 +1,228 @@
+// Standalone contract tests for the pure Space-switch gesture tables and IOHID payload bytes.
+import Foundation
+
+@main
+@MainActor
+struct SpaceGestureTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func expectEqual<T: Equatable>(_ actual: T, _ expected: T, _ message: String) {
+        if actual == expected {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message) — got \(actual), expected \(expected)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// The payload is packed little-endian, so every read mirrors how the WindowServer parses it.
+    static func read<T: FixedWidthInteger>(_ data: Data, at offset: Int, as type: T.Type) -> T {
+        let start = data.startIndex + offset
+        return data[start..<start + MemoryLayout<T>.size]
+            .reversed()
+            .reduce(T(0)) { $0 << 8 | T($1) }
+    }
+
+    static func fields(
+        _ phase: SpaceGesture.Phase, _ direction: SpaceDirection, augmented: Bool
+    ) -> [SpaceGesture.Field] {
+        SpaceGesture.fields(
+            phase: phase, direction: direction, augmented: augmented, timestamp: 12_345)
+    }
+
+    static func value(_ fields: [SpaceGesture.Field], _ raw: UInt32) -> SpaceGesture.FieldValue? {
+        fields.first { $0.raw == raw }?.value
+    }
+
+    static func double(_ fields: [SpaceGesture.Field], _ raw: UInt32) -> Double? {
+        guard case .double(let value) = value(fields, raw) else { return nil }
+        return value
+    }
+
+    static func integer(_ fields: [SpaceGesture.Field], _ raw: UInt32) -> Int64? {
+        guard case .integer(let value) = value(fields, raw) else { return nil }
+        return value
+    }
+
+    static func main() {
+        testDirection()
+        testFixedPoint()
+        testCommonFields()
+        testLegacyFields()
+        testAugmentedFields()
+        testPayloadShape()
+        testPayloadValues()
+        testRecordHeader()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Direction
+
+    static func testDirection() {
+        expect(SpaceDirection(.nextSpace) == .next, "next-space maps to the next direction")
+        expect(SpaceDirection(.previousSpace) == .previous, "previous-space maps to previous")
+        expect(SpaceDirection(.leftHalf) == nil, "a geometry command is not a direction")
+        expect(SpaceDirection(.toggleFullscreen) == nil, "fullscreen is not a direction")
+        expect(
+            WindowCommand.ID.allCases.filter { SpaceDirection($0) != nil }.count == 2,
+            "exactly two commands are space switches")
+    }
+
+    // MARK: - Fixed point
+
+    static func testFixedPoint() {
+        expectEqual(SpaceGesture.fixed1616(0), 0, "zero encodes as zero")
+        expectEqual(SpaceGesture.fixed1616(1), 65_536, "one encodes as one whole unit")
+        expectEqual(SpaceGesture.fixed1616(-1), -65_536, "negatives encode symmetrically")
+        expectEqual(SpaceGesture.fixed1616(0.5), 32_768, "a half encodes as half a unit")
+        expectEqual(SpaceGesture.fixed1616(1000), 65_536_000, "the gesture velocity fits in 16.16")
+        // The floor is what keeps a deliberately tiny progress from quantizing away to a no-op.
+        expectEqual(SpaceGesture.fixed1616(1e-9), 1, "a value below the step floors to +1")
+        expectEqual(SpaceGesture.fixed1616(-1e-9), -1, "a negative value below the step floors to -1")
+        expectEqual(
+            SpaceGesture.fixed1616(Double(Float.leastNonzeroMagnitude)), 1,
+            "the legacy progress magnitude survives as +1 rather than vanishing")
+    }
+
+    // MARK: - Fields
+
+    static func testCommonFields() {
+        for augmented in [false, true] {
+            for phase in SpaceGesture.Phase.allCases {
+                let table = fields(phase, .next, augmented: augmented)
+                expectEqual(integer(table, 55), 30, "the event is a DockControl event")
+                expectEqual(integer(table, 110), 23, "the HID type is a dock swipe")
+                expectEqual(integer(table, 132), phase.rawValue, "the phase is carried verbatim")
+                expectEqual(integer(table, 123), 1, "the motion is horizontal")
+                expect(
+                    Set(table.map(\.raw)).count == table.count,
+                    "no field is written twice for \(phase) augmented=\(augmented)")
+            }
+        }
+        expectEqual(
+            SpaceGesture.Phase.allCases.map(\.rawValue), [1, 2, 4],
+            "began, changed and ended are posted in order")
+    }
+
+    static func testLegacyFields() {
+        for phase in SpaceGesture.Phase.allCases {
+            let next = fields(phase, .next, augmented: false)
+            let previous = fields(phase, .previous, augmented: false)
+            expectEqual(
+                double(next, 124), Double(Float.leastNonzeroMagnitude),
+                "legacy progress is the smallest float, positive for next")
+            expectEqual(
+                double(previous, 124), -Double(Float.leastNonzeroMagnitude),
+                "legacy progress is negative for previous")
+            expectEqual(double(next, 129), 1000, "legacy velocity rides on every phase")
+            expectEqual(double(next, 130), 1000, "legacy carries velocity on both axes")
+            expectEqual(double(previous, 129), -1000, "legacy velocity is signed by direction")
+            expect(value(next, 4205) == nil, "the payload is never written as an ordinary field")
+        }
+        expect(
+            fields(.began, .next, augmented: false).allSatisfy { $0.raw != 134 },
+            "the legacy path writes no phase alias")
+    }
+
+    static func testAugmentedFields() {
+        for phase in SpaceGesture.Phase.allCases {
+            let next = fields(phase, .next, augmented: true)
+            let previous = fields(phase, .previous, augmented: true)
+            expectEqual(integer(next, 134), phase.rawValue, "the phase alias mirrors the phase")
+            expectEqual(double(next, 138), 3, "the zoom delta is the constant the Dock expects")
+            expectEqual(double(next, 125), 0.1, "the swipe starts at a nonzero position")
+            expectEqual(double(next, 169), 12_345, "the process alias carries the timestamp")
+            // Sign stays consistent with the legacy path; inverting it moves the wrong way.
+            expect(double(next, 124)! > 0, "augmented progress is positive for next")
+            expect(double(previous, 124)! < 0, "augmented progress is negative for previous")
+            expectEqual(
+                SpaceGesture.fixed1616(double(next, 124)!), 1,
+                "augmented progress survives 16.16 quantization as exactly one step")
+            expect(value(next, 130) == nil, "the augmented path writes no Y velocity")
+        }
+        expect(
+            value(fields(.began, .next, augmented: true), 129) == nil,
+            "velocity before the last phase would bounce the Space back")
+        expect(
+            value(fields(.changed, .next, augmented: true), 129) == nil,
+            "the changed phase carries no velocity either")
+        expectEqual(
+            double(fields(.ended, .next, augmented: true), 129), 1000,
+            "only the ended phase flings")
+        expectEqual(
+            double(fields(.ended, .previous, augmented: true), 129), -1000,
+            "the fling is signed by direction")
+    }
+
+    // MARK: - Payload
+
+    static func testPayloadShape() {
+        for phase in [SpaceGesture.Phase.began, .changed] {
+            let payload = SpaceGesture.payload(phase: phase, direction: .next, timestamp: 7)
+            expectEqual(payload.count, 68, "a \(phase) payload is a header plus a fluid record")
+            expectEqual(read(payload, at: 24, as: UInt32.self), 1, "\(phase) reports one event")
+        }
+        let ended = SpaceGesture.payload(phase: .ended, direction: .next, timestamp: 7)
+        expectEqual(ended.count, 96, "the ended payload appends a velocity record")
+        expectEqual(read(ended, at: 24, as: UInt32.self), 2, "the ended payload reports two events")
+    }
+
+    static func testPayloadValues() {
+        let payload = SpaceGesture.payload(phase: .ended, direction: .next, timestamp: 99)
+        expectEqual(read(payload, at: 0, as: UInt64.self), 99, "the header carries the timestamp")
+        expectEqual(read(payload, at: 8, as: UInt64.self), 0, "the sender id is unset")
+        expectEqual(read(payload, at: 20, as: UInt32.self), 0, "there are no trailing attributes")
+
+        expectEqual(read(payload, at: 28, as: UInt32.self), 40, "the fluid record declares its size")
+        expectEqual(read(payload, at: 32, as: UInt32.self), 23, "the fluid record is a touch gesture")
+        expectEqual(
+            read(payload, at: 36, as: UInt32.self), UInt32(SpaceGesture.Phase.ended.rawValue) << 24,
+            "the phase rides in the top byte of the record options")
+        expectEqual(read(payload, at: 40, as: UInt8.self), 0, "the fluid record sits at depth zero")
+        expectEqual(read(payload, at: 44, as: Int32.self), 6_553, "the start position is 0.1 in 16.16")
+        expectEqual(read(payload, at: 56, as: UInt32.self), 0, "no swipe mask is claimed")
+        expectEqual(read(payload, at: 60, as: UInt16.self), 1, "the record motion is horizontal")
+        expectEqual(read(payload, at: 62, as: UInt16.self), 3, "the flavour is the primary dock swipe")
+        expectEqual(read(payload, at: 64, as: Int32.self), 1, "progress lands on a single step")
+
+        expectEqual(read(payload, at: 68, as: UInt32.self), 28, "the velocity record declares its size")
+        expectEqual(read(payload, at: 72, as: UInt32.self), 9, "the velocity record is a velocity")
+        expectEqual(read(payload, at: 80, as: UInt8.self), 1, "the velocity record sits at depth one")
+        expectEqual(
+            read(payload, at: 84, as: Int32.self), 1000 * 65_536, "the fling velocity is in 16.16")
+        expectEqual(read(payload, at: 88, as: Int32.self), 0, "the fling has no vertical component")
+
+        let previous = SpaceGesture.payload(phase: .ended, direction: .previous, timestamp: 99)
+        expectEqual(read(previous, at: 64, as: Int32.self), -1, "previous reverses progress")
+        expectEqual(
+            read(previous, at: 84, as: Int32.self), -1000 * 65_536, "previous reverses the fling")
+    }
+
+    static func testRecordHeader() {
+        expectEqual(
+            SpaceGesture.payloadRecordHeader(payloadCount: 68), [0, 68, 0x10, 0x6D],
+            "a 68-byte blob is framed big-endian against field 4205")
+        expectEqual(
+            SpaceGesture.payloadRecordHeader(payloadCount: 96), [0, 96, 0x10, 0x6D],
+            "the framed size tracks the payload")
+        expectEqual(
+            SpaceGesture.payloadRecordHeader(payloadCount: 300), [1, 44, 0x10, 0x6D],
+            "a size past one byte splits across the big-endian pair")
+        expectEqual(SpaceGesture.payloadField, 4205, "the payload rides in the raw IOHID field")
+        expectEqual(SpaceGesture.dataVersion, [0, 0, 0, 2], "only serialization version 2 is spliced")
+    }
+}

--- a/Tests/window-command-test.swift
+++ b/Tests/window-command-test.swift
@@ -71,7 +71,7 @@ struct WindowCommandTests {
 
     static func testCatalog() {
         let commands = WindowCommandCatalog.all
-        expect(commands.count == 30, "catalog contains all 30 agreed commands")
+        expect(commands.count == 32, "catalog contains all 32 agreed commands")
         expect(commands.map(\.id) == WindowCommand.ID.allCases, "catalog covers every ID once")
         expect(
             Set(commands.map { $0.name.lowercased() }).count == commands.count, "names are unique")
@@ -110,6 +110,17 @@ struct WindowCommandTests {
         expect(
             Set(commands.filter { $0.kind == .restore }.map(\.id)) == [.restore],
             "only Restore is a restore command")
+        expect(
+            Set(commands.filter { $0.kind == .space }.map(\.id)) == [.previousSpace, .nextSpace],
+            "only the two Space switches are space commands")
+        expect(
+            commands.filter { $0.kind == .space }.allSatisfy {
+                WindowLayout.placement(
+                    for: WindowLayout.Input(
+                        command: $0.id, windowFrame: mainScreen.frame, screens: [mainScreen],
+                        gap: 0, step: 0, restoreFrame: nil, lastTileCommand: nil)) == nil
+            },
+            "a space command resolves no placement, so the mover writes nothing")
 
         // Grouping drives the Settings list; every command must land in exactly one group.
         let grouped = WindowCommandCatalog.grouped()
@@ -123,6 +134,7 @@ struct WindowCommandTests {
         expect(grouped.first { $0.group == .thirds }?.commands.count == 5, "five thirds")
         expect(grouped.first { $0.group == .sizing }?.commands.count == 10, "ten sizing commands")
         expect(grouped.first { $0.group == .moving }?.commands.count == 6, "six moving commands")
+        expect(grouped.first { $0.group == .spaces }?.commands.count == 2, "two space commands")
 
         expect(
             WindowLayout.isTileCommand(.leftHalf) && WindowLayout.isTileCommand(.centerHalf),

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		2C788DCDF146ED245150EF82 /* WindowCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */; };
 		2D51D92BE8EAB5440F4C8517 /* ExtensionPaletteModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0FB3A9CA762A7A8DB99BA6 /* ExtensionPaletteModifiers.swift */; };
 		2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C7F0C39D24F068A8F84864 /* CurrencyData.generated.swift */; };
+		2F1161E2706CD883E9599000 /* SpaceGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCE65EC20B4FB06BE31FE4 /* SpaceGesture.swift */; };
 		2F2360730BE4992D5745FAD3 /* ExtensionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471E1C3C250FD0A89E2C6430 /* ExtensionListView.swift */; };
 		2F38A89B3481A4C9A13F13A8 /* SnippetKeywordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B00EC4FD8D4D0CD2FE596A /* SnippetKeywordPolicy.swift */; };
 		303FC5342B61A7862EBC1C32 /* FocusRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9A0079D05A5D9B21A1CFCE /* FocusRelease.swift */; };
@@ -136,6 +137,7 @@
 		64AD2324BDA6293464C98913 /* EmojiCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EB979ECD44738BCD9E2F90 /* EmojiCoordinator.swift */; };
 		6527B404C220924885C070B3 /* AppWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9979DED5579535D1F0A32DBF /* AppWindowController.swift */; };
 		68537C3544E4EBC40E3ACD39 /* HUDPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BAD6EE1BA3036C4B5A3D19 /* HUDPresenter.swift */; };
+		68DE5268907FD4F96C1A346E /* SpaceSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */; };
 		68F25E0E441706E9F591B302 /* NotesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525AE0062E8E8F00E21BAEF9 /* NotesWindowController.swift */; };
 		68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B629EC3B716FEE881BB0075 /* TinycastApp.swift */; };
 		691ADED3F9F3F730E1F36DB8 /* FileSearchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03757CDEFC14359CAEF4CE93 /* FileSearchSession.swift */; };
@@ -370,6 +372,7 @@
 		375734577C888260A8023181 /* SnippetsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsStore.swift; sourceTree = "<group>"; };
 		37A48095F6487DEE76663F88 /* UninstallProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallProtection.swift; sourceTree = "<group>"; };
 		37B00EC4FD8D4D0CD2FE596A /* SnippetKeywordPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordPolicy.swift; sourceTree = "<group>"; };
+		37DCE65EC20B4FB06BE31FE4 /* SpaceGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceGesture.swift; sourceTree = "<group>"; };
 		384485BD1794D25503534525 /* AppSettingsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsKey.swift; sourceTree = "<group>"; };
 		38765BC6C35D03659655BD2B /* ExtensionHostBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionHostBridge.swift; sourceTree = "<group>"; };
 		387BE675F580496656E72559 /* SymbolCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolCatalog.swift; sourceTree = "<group>"; };
@@ -418,6 +421,7 @@
 		60CCB1A47E0022BAEDD1EE96 /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
 		61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkDestination.swift; sourceTree = "<group>"; };
 		622E1F1C01B954DCA2199BCD /* ScrollIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollIntent.swift; sourceTree = "<group>"; };
+		628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitcher.swift; sourceTree = "<group>"; };
 		62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
 		648F0F43FEEE537F6451756B /* SelectionReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReveal.swift; sourceTree = "<group>"; };
 		64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolImage.swift; sourceTree = "<group>"; };
@@ -1398,6 +1402,8 @@
 		CBA05AA0E4FE94ADE97BC7E5 /* WindowManagement */ = {
 			isa = PBXGroup;
 			children = (
+				37DCE65EC20B4FB06BE31FE4 /* SpaceGesture.swift */,
+				628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */,
 				0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */,
 				9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */,
 				06125F7DDE68BB4D52065C06 /* WindowCommandCoordinator.swift */,
@@ -1904,6 +1910,8 @@
 				A2073E8EBBAAB620E27F0BD5 /* SnippetTextInjector.swift in Sources */,
 				3BC6CC35889FFC77D640C7CA /* SnippetsSettingsView.swift in Sources */,
 				7BDB7CF7F1352015F6AC96C3 /* SnippetsStore.swift in Sources */,
+				2F1161E2706CD883E9599000 /* SpaceGesture.swift in Sources */,
+				68DE5268907FD4F96C1A346E /* SpaceSwitcher.swift in Sources */,
 				089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */,
 				9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */,
 				FF934DD9FBD8F26BAB72ACD1 /* SymbolImage.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -19,6 +19,7 @@ final class AppCore {
     let hotKeys = HotKeyManager()
     let hyperKeyTap = HyperKeyTap()
     let windowMover = WindowMover()
+    let spaceSwitcher = SpaceSwitcher()
     let inputSourceSwitcher = InputSourceSwitcher()
     let settings: AppSettings
     @ObservationIgnored private var appearanceObservation: NSKeyValueObservation?
@@ -73,7 +74,8 @@ final class AppCore {
         extensions: extensions, palette: palette, paletteCoordinator: paletteCoordinator,
         settingsCoordinator: settingsCoordinator, settings: settings, core: self)
     @ObservationIgnored private(set) lazy var windowCommandCoordinator = WindowCommandCoordinator(
-        settings: settings, paletteCoordinator: paletteCoordinator, windowMover: windowMover)
+        settings: settings, paletteCoordinator: paletteCoordinator, windowMover: windowMover,
+        spaceSwitcher: spaceSwitcher)
     @ObservationIgnored private(set) lazy var customCommandCoordinator = CustomCommandCoordinator(
         store: customCommands, settings: settings, appIndex: appIndex,
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,

--- a/Tinycast/Features/WindowManagement/SpaceGesture.swift
+++ b/Tinycast/Features/WindowManagement/SpaceGesture.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// Which adjacent Space a switch command moves to.
+enum SpaceDirection: Sendable {
+    case previous
+    case next
+
+    init?(_ command: WindowCommand.ID) {
+        switch command {
+        case .previousSpace: self = .previous
+        case .nextSpace: self = .next
+        default: return nil
+        }
+    }
+}
+
+/// The synthetic Dock swipe macOS switches Spaces with, as data rather than events.
+/// See docs/features/window-management.md#switching-space.
+enum SpaceGesture {
+    /// The Dock ignores a gesture that skips a phase, so all three are always posted.
+    enum Phase: Int64, CaseIterable, Sendable {
+        case began = 1
+        case changed = 2
+        case ended = 4
+    }
+
+    enum FieldValue: Equatable, Sendable {
+        case integer(Int64)
+        case double(Double)
+    }
+
+    /// One `CGEvent` field write, keyed by raw number so this file needs no CoreGraphics.
+    struct Field: Equatable, Sendable {
+        let raw: UInt32
+        let value: FieldValue
+    }
+
+    /// Momentum, not speed: 2000 overshoots by two Spaces, and lowering it costs no latency.
+    static let velocity = 1000.0
+
+    /// macOS 27 coalesces phases posted back-to-back, which lands as a double move.
+    static let phaseDelay = Duration.milliseconds(10)
+
+    /// The serialization version `CGEventCreateData` emits; the splice only knows this layout.
+    static let dataVersion: [UInt8] = [0, 0, 0, 2]
+
+    // MARK: - Fields
+
+    /// The gesture fields for one phase. `augmented` selects the macOS 27 encoding.
+    static func fields(
+        phase: Phase, direction: SpaceDirection, augmented: Bool, timestamp: UInt64
+    ) -> [Field] {
+        let sign = direction == .next ? 1.0 : -1.0
+        var fields = [
+            Field(raw: eventTypeField, value: .integer(dockControlEventType)),
+            Field(raw: hidTypeField, value: .integer(dockSwipeHIDType)),
+            Field(raw: phaseField, value: .integer(phase.rawValue)),
+            Field(raw: progressField, value: .double(sign * progressMagnitude(augmented))),
+            Field(raw: motionField, value: .integer(horizontalMotion))
+        ]
+
+        guard augmented else {
+            fields.append(Field(raw: velocityXField, value: .double(sign * velocity)))
+            fields.append(Field(raw: velocityYField, value: .double(sign * velocity)))
+            return fields
+        }
+
+        fields.append(Field(raw: phaseAliasField, value: .integer(phase.rawValue)))
+        fields.append(Field(raw: zoomDeltaYField, value: .double(zoomDeltaY)))
+        fields.append(Field(raw: processAliasField, value: .double(Double(timestamp))))
+        fields.append(Field(raw: positionXField, value: .double(positionX)))
+        // Velocity on any phase but the last makes the Space slide back before it settles.
+        if phase == .ended {
+            fields.append(Field(raw: velocityXField, value: .double(sign * velocity)))
+        }
+        return fields
+    }
+
+    // MARK: - IOHID payload
+
+    /// The record header `CGEventCreateData` frames a field with: big-endian size, then tag and id.
+    static func payloadRecordHeader(payloadCount: Int) -> [UInt8] {
+        [
+            UInt8(truncatingIfNeeded: payloadCount >> 8), UInt8(truncatingIfNeeded: payloadCount),
+            UInt8(truncatingIfNeeded: payloadField >> 8), UInt8(truncatingIfNeeded: payloadField)
+        ]
+    }
+
+    /// The IOHID queue element macOS 27 validates the gesture against, for `payloadField`.
+    static func payload(phase: Phase, direction: SpaceDirection, timestamp: UInt64) -> Data {
+        let sign = direction == .next ? 1.0 : -1.0
+        let carriesVelocity = phase == .ended
+
+        var payload = queueHeader(
+            timestamp: timestamp, eventCount: carriesVelocity ? 2 : 1)
+        payload.append(fluidRecord(phase: phase, progress: sign * progressMagnitude(true)))
+        guard carriesVelocity else { return payload }
+        payload.append(velocityRecord(x: sign * velocity))
+        return payload
+    }
+
+    /// 16.16 fixed point, floored to ±1 so a value too small to encode never lands on zero.
+    static func fixed1616(_ value: Double) -> Int32 {
+        let fixed = Int32(value * 65536)
+        if fixed == 0, value != 0 { return value > 0 ? 1 : -1 }
+        return fixed
+    }
+
+    /// `IOHIDSystemQueueElementHeader`: timestamp, sender id, options, attribute length, count.
+    private static func queueHeader(timestamp: UInt64, eventCount: UInt32) -> Data {
+        var header = Data()
+        header.append(littleEndian: timestamp)
+        header.append(littleEndian: UInt64(0))
+        header.append(littleEndian: UInt32(0))
+        header.append(littleEndian: UInt32(0))
+        header.append(littleEndian: eventCount)
+        return header
+    }
+
+    /// `IOHIDFluidTouchGestureData`: position x/y/z, swipe mask, motion, flavour, progress.
+    private static func fluidRecord(phase: Phase, progress: Double) -> Data {
+        var record = eventBase(
+            size: fluidRecordSize, type: fluidTouchGestureType,
+            options: UInt32(truncatingIfNeeded: phase.rawValue & 0xFF) << 24, depth: 0)
+        record.append(littleEndian: fixed1616(positionX))
+        record.append(littleEndian: Int32(0))
+        record.append(littleEndian: Int32(0))
+        record.append(littleEndian: UInt32(0))
+        record.append(littleEndian: UInt16(truncatingIfNeeded: horizontalMotion))
+        record.append(littleEndian: dockPrimaryFlavor)
+        record.append(littleEndian: fixed1616(progress))
+        return record
+    }
+
+    /// `IOHIDVelocityEventData`: velocity x/y/z.
+    private static func velocityRecord(x: Double) -> Data {
+        var record = eventBase(size: velocityRecordSize, type: velocityType, options: 0, depth: 1)
+        record.append(littleEndian: fixed1616(x))
+        record.append(littleEndian: Int32(0))
+        record.append(littleEndian: Int32(0))
+        return record
+    }
+
+    /// `IOHIDEventBase`: size, type, options, depth, then three reserved bytes.
+    private static func eventBase(
+        size: UInt32, type: UInt32, options: UInt32, depth: UInt8
+    ) -> Data {
+        var base = Data()
+        base.append(littleEndian: size)
+        base.append(littleEndian: type)
+        base.append(littleEndian: options)
+        base.append(littleEndian: depth)
+        base.append(contentsOf: [0, 0, 0])
+        return base
+    }
+
+    /// `leastNonzeroMagnitude` survives the legacy path but truncates to zero in 16.16.
+    private static func progressMagnitude(_ augmented: Bool) -> Double {
+        augmented ? 0.000016 : Double(Float.leastNonzeroMagnitude)
+    }
+
+    // MARK: - Undocumented constants
+
+    static let payloadField: UInt32 = 4205
+
+    private static let eventTypeField: UInt32 = 55
+    private static let hidTypeField: UInt32 = 110
+    private static let motionField: UInt32 = 123
+    private static let progressField: UInt32 = 124
+    private static let positionXField: UInt32 = 125
+    private static let velocityXField: UInt32 = 129
+    private static let velocityYField: UInt32 = 130
+    private static let phaseField: UInt32 = 132
+    private static let phaseAliasField: UInt32 = 134
+    private static let zoomDeltaYField: UInt32 = 138
+    private static let processAliasField: UInt32 = 169
+
+    private static let dockControlEventType: Int64 = 30
+    private static let dockSwipeHIDType: Int64 = 23
+    private static let horizontalMotion: Int64 = 1
+
+    private static let fluidRecordSize: UInt32 = 40
+    private static let velocityRecordSize: UInt32 = 28
+    private static let fluidTouchGestureType: UInt32 = 23
+    private static let velocityType: UInt32 = 9
+    private static let dockPrimaryFlavor: UInt16 = 3
+
+    private static let positionX = 0.1
+    private static let zoomDeltaY = 3.0
+}
+
+extension Data {
+    /// The IOHID queue is a packed little-endian layout, so every scalar goes in as raw bytes.
+    fileprivate mutating func append<T: FixedWidthInteger>(littleEndian value: T) {
+        Swift.withUnsafeBytes(of: value.littleEndian) { append(contentsOf: $0) }
+    }
+}

--- a/Tinycast/Features/WindowManagement/SpaceSwitcher.swift
+++ b/Tinycast/Features/WindowManagement/SpaceSwitcher.swift
@@ -1,0 +1,62 @@
+import CoreGraphics
+import Foundation
+
+/// Switches Space with a synthetic Dock swipe, so macOS skips its sliding transition.
+/// See docs/features/window-management.md#switching-space.
+@MainActor
+final class SpaceSwitcher {
+    /// The running OS decides whether the payload is required, so this cannot be `#available`.
+    private nonisolated static let augmentsEvents = ProcessInfo.processInfo.isOperatingSystemAtLeast(
+        OperatingSystemVersion(majorVersion: 27, minorVersion: 0, patchVersion: 0))
+
+    private var gesture: Task<Void, Never>?
+
+    /// A second gesture overlapping the first makes the Dock move two Spaces, so it is dropped.
+    func perform(_ direction: SpaceDirection) {
+        guard gesture == nil, Permissions.ensureAccessibility() else { return }
+        gesture = Task {
+            await Self.post(direction)
+            gesture = nil
+        }
+    }
+
+    private nonisolated static func post(_ direction: SpaceDirection) async {
+        for phase in SpaceGesture.Phase.allCases {
+            guard let event = event(phase: phase, direction: direction) else { return }
+            event.post(tap: .cgSessionEventTap)
+            guard augmentsEvents, phase != .ended else { continue }
+            try? await Task.sleep(for: SpaceGesture.phaseDelay)
+        }
+    }
+
+    private nonisolated static func event(
+        phase: SpaceGesture.Phase, direction: SpaceDirection
+    ) -> CGEvent? {
+        guard let event = CGEvent(source: nil) else { return nil }
+        // A freshly created event carries no timestamp, which the payload cannot be built without.
+        let timestamp = mach_absolute_time()
+        let fields = SpaceGesture.fields(
+            phase: phase, direction: direction, augmented: augmentsEvents, timestamp: timestamp)
+        for field in fields {
+            guard let key = CGEventField(rawValue: field.raw) else { continue }
+            switch field.value {
+            case .integer(let value): event.setIntegerValueField(key, value: value)
+            case .double(let value): event.setDoubleValueField(key, value: value)
+            }
+        }
+        guard augmentsEvents else { return event }
+        let payload = SpaceGesture.payload(
+            phase: phase, direction: direction, timestamp: timestamp)
+        return augmented(event, payload: payload)
+    }
+
+    /// No setter reaches field 4205, so the payload is spliced into the serialized event instead.
+    private nonisolated static func augmented(_ event: CGEvent, payload: Data) -> CGEvent? {
+        guard var bytes = event.__data(allocator: nil) as Data?,
+            bytes.starts(with: SpaceGesture.dataVersion)
+        else { return nil }
+        bytes.append(contentsOf: SpaceGesture.payloadRecordHeader(payloadCount: payload.count))
+        bytes.append(payload)
+        return CGEvent(withDataAllocator: nil, data: bytes as CFData)
+    }
+}

--- a/Tinycast/Features/WindowManagement/WindowCommand.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommand.swift
@@ -32,6 +32,8 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case nextDisplay = "next-display"
         case previousDisplay = "previous-display"
         case toggleFullscreen = "toggle-fullscreen"
+        case previousSpace = "previous-space"
+        case nextSpace = "next-space"
     }
 
     /// What the mover has to do, so its dispatch stays exhaustive over the catalog.
@@ -42,6 +44,8 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case restore
         /// No geometry at all — the native `AXFullScreen` toggle.
         case fullscreen
+        /// No window at all — a synthetic Dock gesture that moves between Spaces.
+        case space
     }
 
     /// The launcher section a command belongs to, and the order the Settings panel lists them in.
@@ -52,6 +56,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case sizing
         case moving
         case fullscreen
+        case spaces
 
         var title: String {
             switch self {
@@ -61,6 +66,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
             case .sizing: return "Sizing"
             case .moving: return "Moving"
             case .fullscreen: return "Fullscreen"
+            case .spaces: return "Spaces"
             }
         }
     }
@@ -140,6 +146,8 @@ enum WindowCommandCatalog {
         case .nextDisplay: return "Move to Next Display"
         case .previousDisplay: return "Move to Previous Display"
         case .toggleFullscreen: return "Toggle Fullscreen"
+        case .previousSpace: return "Switch to Previous Space"
+        case .nextSpace: return "Switch to Next Space"
         }
     }
 
@@ -173,6 +181,8 @@ enum WindowCommandCatalog {
         case .nextDisplay: return "rectangle.on.rectangle.angled"
         case .previousDisplay: return "rectangle.on.rectangle.angled"
         case .toggleFullscreen: return "arrow.up.left.and.arrow.down.right.square"
+        case .previousSpace: return "chevron.backward.2"
+        case .nextSpace: return "chevron.forward.2"
         }
     }
 
@@ -180,6 +190,7 @@ enum WindowCommandCatalog {
         switch id {
         case .restore: return .restore
         case .toggleFullscreen: return .fullscreen
+        case .previousSpace, .nextSpace: return .space
         default: return .geometry
         }
     }
@@ -199,6 +210,8 @@ enum WindowCommandCatalog {
             return .moving
         case .toggleFullscreen:
             return .fullscreen
+        case .previousSpace, .nextSpace:
+            return .spaces
         }
     }
 }

--- a/Tinycast/Features/WindowManagement/WindowCommandCoordinator.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommandCoordinator.swift
@@ -6,18 +6,27 @@ final class WindowCommandCoordinator {
     private let settings: AppSettings
     private let paletteCoordinator: PaletteCoordinator
     private let windowMover: WindowMover
+    private let spaceSwitcher: SpaceSwitcher
 
     init(
-        settings: AppSettings, paletteCoordinator: PaletteCoordinator, windowMover: WindowMover
+        settings: AppSettings, paletteCoordinator: PaletteCoordinator, windowMover: WindowMover,
+        spaceSwitcher: SpaceSwitcher
     ) {
         self.settings = settings
         self.paletteCoordinator = paletteCoordinator
         self.windowMover = windowMover
+        self.spaceSwitcher = spaceSwitcher
     }
 
     /// The one funnel for palette and hotkey alike. See docs/features/window-management.md#wiring.
     func runWindowCommand(id: WindowCommand.ID) {
         guard settings.windowManagementEnabled else { return }
+        if let direction = SpaceDirection(id) {
+            // Restoring focus reactivates an app that may live elsewhere, pulling its Space forward.
+            if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: false) }
+            spaceSwitcher.perform(direction)
+            return
+        }
         let target = paletteCoordinator.targetApp
         if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: true) }
         windowMover.perform(

--- a/Tinycast/Features/WindowManagement/WindowLayout.swift
+++ b/Tinycast/Features/WindowManagement/WindowLayout.swift
@@ -90,7 +90,7 @@ enum WindowLayout {
     /// The target placement, or `nil` when the mover should write nothing at all.
     static func placement(for input: Input) -> Placement? {
         guard let command = WindowCommandCatalog.command(id: input.command),
-            command.kind != .fullscreen,
+            command.kind == .geometry || command.kind == .restore,
             !input.screens.isEmpty
         else { return nil }
 

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -222,7 +222,7 @@ dismissal matches Accessibility subroles rather than English labels.
 
 ## Window commands
 
-`WindowCommandCatalog` supplies the 30 window actions as a static slice, published as a whole by
+`WindowCommandCatalog` supplies the 32 window actions as a static slice, published as a whole by
 `AppIndex.setWindowCommandsVisible(_:)` and shown under a "Window Management" section. Like system
 actions they carry dedicated global hotkeys (`AppEntry.hotKeyAction` returns `.windowCommand(id:)`),
 so launcher rows render keycaps for them. Their per-command shortcut and visibility controls live in

--- a/docs/features/window-management.md
+++ b/docs/features/window-management.md
@@ -1,8 +1,9 @@
 # Window Management
 
-Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves and native
-fullscreen — searchable in the palette and bindable to global shortcuts. 30 commands, no new
-dependencies and no new permission: they reuse the Accessibility grant clipboard paste already needs.
+Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves, native
+fullscreen and Space switching — searchable in the palette and bindable to global shortcuts. 32
+commands, no new dependencies and no new permission: they reuse the Accessibility grant clipboard
+paste already needs.
 
 Ships **off**. Settings › Window Management is the switch, and while it is off there are no launcher
 entries and a still-registered shortcut moves nothing.
@@ -15,9 +16,13 @@ entries and a still-registered shortcut moves nothing.
   every mixed-size setup.
 - **Nothing in this feature touches `backingScaleFactor`.** All three of `NSScreen.frame`, `visibleFrame`
   and AX coordinates are in points, so mixed-DPI correctness is automatic.
-- **`WindowCommand.swift`, `WindowLayout.swift` and `WindowActionMemory.swift` stay Foundation +
-  CoreGraphics and pure** — no AX, no `NSScreen`, no clock (`WindowActionMemory` takes `now` as a
-  parameter). Every `AXUIElement` call and the Cocoa↔AX flip live in `WindowMover.swift`.
+- **`WindowCommand.swift`, `WindowLayout.swift`, `WindowActionMemory.swift` and `SpaceGesture.swift`
+  stay Foundation + CoreGraphics and pure** — no AX, no `NSScreen`, no clock (`WindowActionMemory`
+  takes `now` as a parameter, `SpaceGesture` takes `timestamp`). Every `AXUIElement` call and the
+  Cocoa↔AX flip live in `WindowMover.swift`; every `CGEvent` call lives in `SpaceSwitcher.swift`.
+- **A Space command never reaches `WindowMover`.** `WindowLayout.placement` answers only for
+  `.geometry` and `.restore`, and `WindowCommandCoordinator` branches on `SpaceDirection` first — the
+  mover requires a target app and a resolvable AX window, and a Space switch has neither.
 
 ## Layout
 
@@ -27,15 +32,18 @@ entries and a still-registered shortcut moves nothing.
 | `Features/WindowManagement/WindowLayout.swift`       | Foundation + CoreGraphics    | **Pure.** Every frame the commands produce                          |
 | `Features/WindowManagement/WindowActionMemory.swift` | Foundation + CoreGraphics    | **Pure.** Per-window cycle position and restore point               |
 | `Features/WindowManagement/WindowMover.swift`        | AppKit + ApplicationServices | `@MainActor`. Every `AXUIElement` call and the coordinate flip      |
+| `Features/WindowManagement/SpaceGesture.swift`       | Foundation                   | **Pure.** The Dock-swipe field tables and the IOHID payload bytes   |
+| `Features/WindowManagement/SpaceSwitcher.swift`      | CoreGraphics                 | `@MainActor`. Every `CGEvent` call and the payload splice           |
 
-The first three compile into `Tests/window-command-test.swift`, so they must not gain an AppKit,
-SwiftUI or `NSScreen` dependency, and must stay pure — `WindowActionMemory` takes `now` as a parameter
-rather than reading a clock. CoreGraphics is needed only because `CGRect`'s `Equatable` conformance
-lives in that overlay rather than in Foundation.
+The first three compile into `Tests/window-command-test.swift` and `SpaceGesture.swift` compiles into
+`Tests/space-gesture-test.swift`, so none of them may gain an AppKit, SwiftUI or `NSScreen`
+dependency, and all must stay pure — `WindowActionMemory` takes `now` as a parameter rather than
+reading a clock. CoreGraphics is needed only because `CGRect`'s `Equatable` conformance lives in that
+overlay rather than in Foundation.
 
 Adding a command is four edits in `WindowCommand.swift` (a case in `ID`, plus `name`, `symbol` and
 `group` arms), an arm in `WindowLayout.placement` or `tileFractions`, and bumping
-`commands.count == 30` in the harness.
+`commands.count == 32` and its group count in the harness.
 
 ## Coordinate space
 
@@ -168,6 +176,53 @@ some apps reinterpret frame writes while it is on — but never while VoiceOver 
 break the screen reader. **This mitigation is inherited convention and unverified on macOS 26**; if a
 stock Electron app tiles correctly without it, delete the helper rather than keep it.
 
+## Switching Space
+
+Switch to Next/Previous Space does not move a window at all. It synthesises the **trackpad Dock swipe**
+macOS switches Spaces with, at a velocity high enough that the WindowServer completes the transition
+instead of animating it — about 56 ms against roughly 1100 ms for the system's own ⌃← / ⌃→.
+
+Everything else was measured and rejected: `CGSManagedDisplaySetCurrentSpace` updates the bookkeeping
+but never performs the transition, so you keep looking at the same windows; a synthetic ⌃← is ignored
+because the Space hotkey only accepts real HID events; and driving System Events costs the full
+animation. The gesture is the only path that both works and skips the slide, and it needs no private
+framework linkage and no SIP change — only public `CGEvent` calls carrying undocumented field numbers.
+
+`SpaceSwitcher` posts three phases — began, changed, ended — to `.cgSessionEventTap`. A two-phase
+gesture is ignored. Fields 55 (`DockControl`), 110 (dock-swipe HID type), 132 (phase), 123 (horizontal
+motion) and 124 (progress) are common to both encodings; **positive is always "next"**. Progress is
+deliberately the smallest representable nudge: a real distance makes the WindowServer draw the slide.
+
+**macOS 27 changed the contract.** Through macOS 26 the public fields are enough, and velocity (129 and
+130) rides on every phase. From macOS 27 the Dock validates the gesture against a raw IOHID queue
+payload that no setter can reach, so `SpaceSwitcher` serialises the event with `CGEventCreateData`,
+appends the payload as a field-4205 record, and reparses it with `CGEventCreateFromData`. That path
+also adds fields 134, 138, 169 and 125, and carries velocity **only** on the ended phase — velocity
+earlier makes the Space slide back before it settles. `SpaceGesture` owns both tables so the two
+encodings can never drift apart, and the runtime OS selects between them: the SDK cannot, because a
+build made on 26 still has to work on 27.
+
+Three details are load-bearing and each was expensive to learn:
+
+- **Phases are paced ~10 ms apart on macOS 27.** Posted back-to-back they coalesce and the Dock moves
+  two Spaces. That pacing is why `perform` is asynchronous rather than a straight-line call.
+- **Velocity is momentum, not latency.** 2000 overshoots by two Spaces; 1000 lands exactly one, and
+  lowering it does not make the switch slower.
+- **The Dock ignores a gesture from a short-lived process.** The calls all report success and nothing
+  happens. Tinycast is a resident menu-bar app, so this is free — but it is why a one-shot CLI cannot
+  be used to reproduce a bug here.
+
+Boundaries are left to macOS. The private `CGSGetActiveSpace` lags behind the Dock after a synthetic
+switch, so a pre-check returns stale answers during exactly the rapid switching it would exist to
+protect; skipping it also means this feature links no private symbol at all. A second gesture arriving
+while one is in flight is dropped rather than queued, for the same reason the phases are paced.
+
+The serialized `CGEvent` format is a big-endian tagged record list behind a version word, which
+`SpaceSwitcher` checks is `2` before splicing; a bumped version makes the command a quiet no-op rather
+than posting a corrupt event. The payload itself is packed little-endian with 16.16 fixed-point
+scalars, which is why `SpaceGesture.fixed1616` floors to ±1 — the tiny progress value would otherwise
+quantize to zero and the gesture would do nothing.
+
 ## Wiring
 
 - **`AppEntry.Kind.windowCommand`** — entries are `window-command:<id>`, published by
@@ -179,7 +234,10 @@ stock Electron app tiles correctly without it, delete the helper rather than kee
   custom commands there is no bound-ID index to maintain: the catalog is fixed, so `HotKeyManager.start`
   and `conflictOwner` iterate `WindowCommand.ID.allCases` and `register` no-ops on an unbound command.
 - **`WindowCommandCoordinator.runWindowCommand(id:)`** is the one funnel for both palette activation and the global
-  hotkey, so the feature switch cannot be bypassed by either.
+  hotkey, so the feature switch cannot be bypassed by either. A Space command branches out of it first
+  and hides the palette with `restoreFocus: false`: restoring focus reactivates the recorded previous
+  app, and activating an app that lives on another Space pulls that Space forward — a race against the
+  gesture that can land on the opposite Space from the one asked for.
 - **Settings** — `windowManagementEnabled` (off), `windowManagementShowInLauncher` (on), `windowGap`
   (0) and `windowCycleOnRepeat` (off). All four ride in settings backups: unlike `snippetsEnabled` they
   grant no permission class of their own.
@@ -197,8 +255,14 @@ moves and wrapping, restore recovery, every `WindowActionMemory` rule, and a fuz
 command × gap × screen × degenerate window frame checking for non-finite output, negative dimensions,
 off-screen results, non-determinism and drift on repeat.
 
-Everything runs headless because the layer is pure. `WindowMover` is not compiled into the harness and
-has no automated coverage — the AX paths need manual verification, particularly:
+`Tests/space-gesture-test.swift` (121 assertions) covers the other pure half: the fixed-point encoding
+and its ±1 floor, both field tables and the sign convention shared between them, the ended-only fling
+on the augmented path, the payload's size, record offsets and every scalar in it, and the big-endian
+framing of the field-4205 record.
+
+Everything runs headless because the layer is pure. `WindowMover` and `SpaceSwitcher` are not compiled
+into either harness and have no automated coverage — the AX and `CGEvent` paths need manual
+verification, particularly:
 
 1. A non-resizable window (System Information) must fail silently, left untouched rather than
    half-moved.
@@ -207,3 +271,8 @@ has no automated coverage — the AX paths need manual verification, particularl
 3. Toggle Fullscreen on a window that accepts it and one that refuses it.
 4. Cycling: three presses of Left Half, then drag the window and confirm the next press restarts at ½.
 5. Restore on a window Tinycast has never moved.
+6. **Space switching, on the real desktop with three or more Spaces.** Next and Previous each move
+   exactly one Space with no visible slide, in and out of a fullscreen Space, and a held shortcut does
+   not wedge the Dock or land two Spaces at once. A Space switch is not observable until it settles —
+   sampling sooner than about three seconds returns mid-transition state that reads as a dropped or
+   doubled move, which will make a working build look broken.

--- a/website/content/docs/features/window-management.md
+++ b/website/content/docs/features/window-management.md
@@ -1,6 +1,6 @@
 ---
 title: Window management
-description: 30 tiling commands — halves, quarters, thirds, nudges and display moves.
+description: 32 commands — halves, quarters, thirds, nudges, display moves and instant Space switching.
 ---
 
 Move and resize the window you were last in, without installing anything else.
@@ -25,6 +25,8 @@ Center · Center Half · Make Larger · Make Smaller · Restore
 **Moving** — Left · Right · Up · Down · Next Display · Previous Display
 
 **Fullscreen** — Toggle Fullscreen
+
+**Spaces** — Switch to Previous Space · Switch to Next Space
 
 ## Settings
 
@@ -82,6 +84,19 @@ There is deliberately no synthetic <kbd>⌃</kbd><kbd>⌘</kbd><kbd>F</kbd> atte
 and firing an unrelated menu command would be worse than doing nothing.
 
 It clears the cycle chain but keeps the restore point.
+
+## Spaces
+
+**Switch to Previous Space** and **Switch to Next Space** move between macOS Spaces without the
+sliding transition — roughly 56 ms, against about a second for the system's own
+<kbd>⌃</kbd><kbd>←</kbd> and <kbd>⌃</kbd><kbd>→</kbd>.
+
+They work by synthesising the trackpad swipe macOS already switches Spaces with, at a velocity high
+enough that the transition finishes rather than animates. Desktop Spaces and fullscreen Spaces are
+both included, since it is the same gesture either way.
+
+Held down, presses that arrive while a switch is still in flight are dropped rather than queued, so a
+long press never overshoots. At the first or last Space, macOS does whatever it normally does.
 
 ## Failing quietly
 

--- a/website/src/data/features.ts
+++ b/website/src/data/features.ts
@@ -60,7 +60,7 @@ export const features: Feature[] = [
   {
     icon: "windows",
     title: "Window management",
-    body: "Halves, quarters, thirds, nudges and display moves — 30 commands, with no new permission and nothing new to install.",
+    body: "Halves, quarters, thirds, nudges, display moves and instant Space switching — 32 commands, with no new permission and nothing new to install.",
     href: "/docs/features/window-management",
   },
   {


### PR DESCRIPTION
Closes #297.

Adds **Switch to Previous Space** and **Switch to Next Space** to the window-management catalog. They land on the adjacent Space with no sliding transition — about 56 ms, against roughly 1100 ms for the system's own <kbd>⌃</kbd><kbd>←</kbd> / <kbd>⌃</kbd><kbd>→</kbd>.

## How

The commands synthesize the **trackpad Dock swipe** macOS already switches Spaces with, at a velocity high enough that the WindowServer completes the transition rather than animating it. Everything else was measured and rejected:

| Approach | Result |
| --- | --- |
| `CGSManagedDisplaySetCurrentSpace` | Bookkeeping only — reports the new Space, never performs the transition |
| Synthetic <kbd>⌃</kbd><kbd>←</kbd> | Ignored; the Space hotkey only accepts real HID events |
| System Events pressing <kbd>⌃</kbd><kbd>←</kbd> | Works, but pays the full ~1100 ms animation |
| High-velocity Dock swipe | Works, and skips the animation |

No private framework is linked and no SIP change is needed — only public `CGEvent` calls carrying undocumented field numbers, under the Accessibility grant clipboard paste already requires.

**macOS 27 changed the contract.** Through macOS 26 the public gesture fields are enough. From macOS 27 the Dock validates the gesture against a raw IOHID queue payload no setter can reach, so the event is serialized with `CGEventCreateData`, given a field-4205 record, and reparsed with `CGEventCreateFromData`. Both encodings live in one table so they cannot drift apart, and the **running** OS selects between them — a build made on 26 still has to work on 27.

Three details are load-bearing:

- **Phases are paced ~10 ms apart on macOS 27.** Posted back-to-back they coalesce and the Dock moves two Spaces. That pacing is why `perform` is asynchronous.
- **Velocity is momentum, not latency.** 2000 overshoots by two Spaces; 1000 lands exactly one, and lowering it does not slow the switch.
- **The Dock ignores a gesture from a short-lived process** — every call reports success and nothing happens. Tinycast is resident, so this is free, but it is why a one-shot CLI cannot reproduce a bug here.

Boundaries are left to macOS: `CGSGetActiveSpace` lags behind the Dock after a synthetic switch, so a pre-check returns stale answers during exactly the rapid switching it would exist to protect. Skipping it also means this feature links no private symbol at all. A gesture arriving while one is in flight is dropped rather than queued.

## Shape

| File | Imports | Role |
| --- | --- | --- |
| `SpaceGesture.swift` | Foundation | **Pure.** Direction, both field tables, 16.16 fixed point, the IOHID payload bytes |
| `SpaceSwitcher.swift` | CoreGraphics | `@MainActor`. Every `CGEvent` call, the splice, the OS branch, the permission gate |

The pure/impure split matches what the feature already enforces for `WindowLayout` — the packed byte layout is the error-prone part and the only part testable headlessly.

A Space command branches out of `WindowCommandCoordinator` **before** the mover, which requires a target app and a resolvable AX window it would never have. It hides the palette with `restoreFocus: false`: restoring focus reactivates the recorded previous app, and activating an app on another Space pulls that Space forward — a race that can land on the opposite Space from the one asked for.

Everything else is free — launcher entry, icon, search, favorites, `VisibilityStore`, the Settings row, hotkey candidacy and registration, conflict reporting and settings backup all derive from `WindowCommand.ID.allCases`.

## Validation

- `./Scripts/run-tests.sh` — all 36 harnesses pass, including the new `space-gesture-test` (121 assertions: the fixed-point floor, both field tables and their shared sign convention, the ended-only fling, payload size, every record offset and scalar, and the big-endian field-4205 framing).
- `Tests/window-command-test.swift` — catalog bumped to 32 with a new Spaces group, plus an assertion that a space command resolves no placement so the mover writes nothing.
- `./Scripts/lint.sh` — clean. Debug build — **BUILD SUCCEEDED**, no new warnings.
- Model purity grep — empty.
- Docs updated: `docs/features/window-management.md` (new `## Switching Space` section, invariants, layout table, testing), `docs/features/launcher.md`, and the website's feature list and docs page.

## One thing left

**Direction polarity and the macOS 27 payload need a real-desktop pass.** Positive progress is treated as "next" throughout; if Next moves left, the sign flips in one place (`SpaceGesture.fields`) and covers both encodings. Worth checking with three or more Spaces, into and out of a fullscreen Space, and with the shortcut held down.

Note when testing: a Space switch is not observable until it settles — sampling sooner than ~3 s returns mid-transition state that reads as a dropped or doubled move, which makes a working build look broken.

## Credit

The macOS 27 serialization approach is [mgbowen's in FasterSwiper](https://github.com/mgbowen/FasterSwiper); the space-switching core is [jurplel's in InstantSpaceSwitcher](https://github.com/jurplel/InstantSpaceSwitcher); the resident-process, pacing and velocity findings are [SanRive's in instantswitch](https://github.com/SanRive/instantswitch). This is an independent Swift implementation, not vendored code.