### PR TITLE
Adjust top padding in UpdateWindowView to account for title bar height

### DIFF
--- a/Tinycast/Features/Updates/UI/UpdateWindowView.swift
+++ b/Tinycast/Features/Updates/UI/UpdateWindowView.swift
@@ -22,7 +22,10 @@ struct UpdateWindowView: View {
             detail
             actions
         }
-        .padding(Theme.Spacing.xxl)
+        // Less on top: the title bar already contributes its own 32pt above this, and clearing the
+        // traffic lights is the only reason the hero cannot start at the inset the other edges use.
+        .padding(.top, Theme.Spacing.sm)
+        .padding([.horizontal, .bottom], Theme.Spacing.xxl)
         // Take the ideal height rather than the window's, so the measurement is the content's own
         // and sizing the window to it converges instead of feeding back.
         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Related issue

Closes #

## What changed

<!-- What it does and how it works. Call out anything non-obvious in the diff. -->

## Memory footprint

<!-- Required. Under 100 MB always, and back to baseline after the palette closes. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

<!-- Visual change → side-by-side before/after video. Same window size, same actions.
     "After"-only clips and stills don't count. Delete this section if nothing visual changed. -->

## Drawbacks

<!-- Tradeoffs made on purpose, and anything you're unsure about. "None" is a valid answer. -->

## Tests & validation

<!-- Which Tests/ harnesses you ran and any cases you added, plus what you exercised by hand.
     Commands: docs/development.md § Tests. -->
