### PR TITLE
Distinguish oversized Raycast exports from a wrong passphrase

### DIFF
--- a/Tests/raycast-test.swift
+++ b/Tests/raycast-test.swift
@@ -34,7 +34,12 @@ enum RaycastTests {
             failures += 1
             print("FAIL: \(message) — threw \(error), expected \(expected)")
         } catch {
-            passes += 1
+            if expected == nil {
+                passes += 1
+            } else {
+                failures += 1
+                print("FAIL: \(message) — threw \(error), expected \(String(describing: expected))")
+            }
         }
     }
 
@@ -46,6 +51,7 @@ enum RaycastTests {
         clipboardMapping()
         favoritesAndSnippets()
         gunzipSlices()
+        oversizedInflate()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
@@ -407,5 +413,72 @@ enum RaycastTests {
             "a non-zero-index gzip slice decompresses instead of trapping")
         expect((try? Zlib.gunzip(gzippedJSON)) == plainJSON, "a zero-based gzip still works")
         expect((try? Zlib.gunzip(Data(repeating: 0x00, count: 32))) == nil, "non-gzip throws")
+    }
+
+    // MARK: - Oversized inflate
+
+    static let overDefaultUncompressed = 65 * 1024 * 1024
+
+    // Zeros gzip to a few KB, so a 65 MB inflate fixture stays tiny on disk.
+    static func gzipZeros(_ count: Int) -> Data {
+        do {
+            return try Zlib.gzip(Data(repeating: 0, count: count))
+        } catch {
+            preconditionFailure("fixture gzip failed: \(error)")
+        }
+    }
+
+    static func oversizedInflate() {
+        let gz = gzipZeros(overDefaultUncompressed)
+
+        do {
+            _ = try Zlib.gunzip(gz)
+            failures += 1
+            print("FAIL: default 64 MB cap — did not throw")
+        } catch ZlibError.tooLarge {
+            passes += 1
+        } catch {
+            failures += 1
+            print("FAIL: default 64 MB cap — threw \(error), expected tooLarge")
+        }
+
+        do {
+            let inflated = try Zlib.gunzip(gz, maxOutput: Zlib.postDecryptMaxOutput)
+            expect(
+                inflated.count == overDefaultUncompressed,
+                "gunzip past 64 MB succeeds under the post-decrypt cap")
+        } catch {
+            failures += 1
+            print("FAIL: gunzip past 64 MB under post-decrypt cap — \(error)")
+        }
+
+        do {
+            _ = try Zlib.gunzip(gz, maxOutput: 1024 * 1024)
+            failures += 1
+            print("FAIL: exceeding a passed cap — did not throw")
+        } catch ZlibError.tooLarge {
+            passes += 1
+        } catch {
+            failures += 1
+            print("FAIL: exceeding a passed cap — threw \(error), expected tooLarge")
+        }
+
+        let file = makeV1File(gz, passphrase: "12345678")
+        do {
+            let decrypted = try RaycastV1Decoder.decrypt(file, passphrase: "12345678")
+            expect(
+                decrypted.count == overDefaultUncompressed,
+                "v1 decrypt of a >64 MB gzip is not incorrectPassphrase")
+        } catch {
+            failures += 1
+            print("FAIL: v1 decrypt of a >64 MB gzip — \(error)")
+        }
+
+        expectThrows("oversized v1 export", .tooLarge) {
+            try RaycastV1Decoder.decrypt(file, passphrase: "12345678", maxOutput: 1024 * 1024)
+        }
+        expectThrows("wrong passphrase on an oversized v1 export", .incorrectPassphrase) {
+            try RaycastV1Decoder.decrypt(file, passphrase: "wrong")
+        }
     }
 }

--- a/Tinycast/Features/Backup/Model/RaycastFormat.swift
+++ b/Tinycast/Features/Backup/Model/RaycastFormat.swift
@@ -1,15 +1,17 @@
 import Foundation
 
-enum RaycastImportError: LocalizedError {
+enum RaycastImportError: LocalizedError, Equatable {
     case notRaycastFile
     case incorrectPassphrase
     case corrupt
+    case tooLarge
 
     var errorDescription: String? {
         switch self {
         case .notRaycastFile: return "This doesn't look like a Raycast export (.rayconfig)."
         case .incorrectPassphrase: return "Incorrect passphrase, or the file is corrupted."
         case .corrupt: return "The Raycast export could not be read."
+        case .tooLarge: return "This export decompresses past the import limit."
         }
     }
 }

--- a/Tinycast/Features/Backup/Model/RaycastV1Decoder.swift
+++ b/Tinycast/Features/Backup/Model/RaycastV1Decoder.swift
@@ -42,7 +42,9 @@ struct RaycastV1Payload: Sendable, Equatable {
 
 /// Decrypts a bare 1.x `.rayconfig` blob. See docs/features/raycast-import.md.
 enum RaycastV1Decoder {
-    static func decrypt(_ raw: Data, passphrase: String) throws -> Data {
+    static func decrypt(
+        _ raw: Data, passphrase: String, maxOutput: Int = Zlib.postDecryptMaxOutput
+    ) throws -> Data {
         guard raw.count >= 32, raw.count % 16 == 0 else { throw RaycastImportError.notRaycastFile }
         let plaintext = try decryptCBC(
             Data(raw.dropFirst(ivLength)),
@@ -51,10 +53,16 @@ enum RaycastV1Decoder {
 
         // PKCS#7 unpads cleanly ~1 in 256 times, so the gzip header is the real check.
         let magic = [UInt8](plaintext.prefix(3))
-        guard magic.count == 3, magic[0] == 0x1f, magic[1] == 0x8b, magic[2] == 0x08,
-            let json = try? Zlib.gunzip(plaintext)
-        else { throw RaycastImportError.incorrectPassphrase }
-        return json
+        guard magic.count == 3, magic[0] == 0x1f, magic[1] == 0x8b, magic[2] == 0x08 else {
+            throw RaycastImportError.incorrectPassphrase
+        }
+        do {
+            return try Zlib.gunzip(plaintext, maxOutput: maxOutput)
+        } catch ZlibError.tooLarge {
+            throw RaycastImportError.tooLarge
+        } catch {
+            throw RaycastImportError.incorrectPassphrase
+        }
     }
 
     static func payload(_ decrypted: Data) throws -> RaycastV1Payload {

--- a/Tinycast/Features/Backup/Service/RaycastImportV2.swift
+++ b/Tinycast/Features/Backup/Service/RaycastImportV2.swift
@@ -32,10 +32,13 @@ enum RaycastImportV2 {
         } catch {
             throw RaycastImportError.incorrectPassphrase
         }
-        guard let plaintext = try? Zlib.gunzip(plaintextGz) else {
+        do {
+            return try Zlib.gunzip(plaintextGz, maxOutput: Zlib.postDecryptMaxOutput)
+        } catch ZlibError.tooLarge {
+            throw RaycastImportError.tooLarge
+        } catch {
             throw RaycastImportError.corrupt
         }
-        return plaintext
     }
 
     // MARK: - Map

--- a/Tinycast/Platform/Compression/Zlib.swift
+++ b/Tinycast/Platform/Compression/Zlib.swift
@@ -10,9 +10,10 @@ enum ZlibError: Error { case notGzip, corrupt, tooLarge }
 /// any zlib linkage or build-system detour, and serves two callers: the Raycast settings import, and
 /// the `zlib` Node shim extensions reach for.
 enum Zlib {
-    /// Real inputs here are a Raycast export (a few KB) or an extension's own payload; the cap stops a
-    /// hand-crafted bomb — the import envelope is inflated before it is ever authenticated.
+    /// Unauthenticated inflate. Authenticated Raycast payloads use postDecryptMaxOutput instead.
     static let defaultMaxOutput = 64 * 1024 * 1024
+    /// Clipboard-heavy Raycast exports decompress past 64 MB after AES has already authenticated them.
+    static let postDecryptMaxOutput = 1024 * 1024 * 1024
 
     // MARK: - gzip (RFC 1952)
 

--- a/docs/features/raycast-import.md
+++ b/docs/features/raycast-import.md
@@ -21,6 +21,11 @@ rewritten app and share almost no data shape, so each has its own decrypt and it
   `RaycastImportV1`, not the decoder, validates them against `PopToRootTimeout` / `EmojiSkinTone` /
   `HyperKeyPhysicalKey` / `KeyShortcut`.
 - **Never commit a real `.rayconfig` as a fixture.** The harness builds its own.
+- **Unauthenticated gzip is 64 MB; post-decrypt gzip is 1 GiB.** The v2 envelope is inflated before
+  AES-GCM, so that gunzip stays on `Zlib.defaultMaxOutput` (64 MB) as a zip-bomb bound. After AES,
+  v1's plaintext gzip and v2's inner gzip use `Zlib.postDecryptMaxOutput` (1 GiB): clipboard-heavy v1
+  exports decompress to hundreds of MB, and that is not a wrong passphrase. Category selection runs
+  after inflate and parse, so unchecking Clipboard history does not skip the gunzip.
 
 ## Detection
 
@@ -31,6 +36,21 @@ other, so a wrong passphrase reports a wrong passphrase instead of "not a Raycas
 
 Detection needs no passphrase, so the Backup pane runs it the moment a file is chosen: it labels the
 row and disables the categories that format can't carry (`RaycastFormat.supportedOptions`).
+
+## Inflate caps
+
+Two gunzip caps, because one of the two streams is not yet authenticated:
+
+| Stream | When | Cap | Constant |
+| ------ | ---- | --- | -------- |
+| v2 envelope gzip | before AES-GCM | 64 MB | `Zlib.defaultMaxOutput` |
+| v1 plaintext gzip | after AES-CBC | 1 GiB | `Zlib.postDecryptMaxOutput` |
+| v2 inner gzip | after AES-GCM open | 1 GiB | `Zlib.postDecryptMaxOutput` |
+
+Exceeding the post-decrypt cap is `RaycastImportError.tooLarge`, not `incorrectPassphrase`. A gzip
+magic miss after v1 CBC still reports a wrong passphrase — PKCS#7 unpads cleanly about 1 in 256
+times, so the header remains the real key check. Other post-header gunzip failures stay
+`incorrectPassphrase` on v1 (lucky-magic wrong keys) and `corrupt` on v2 (the GCM tag already passed).
 
 ## v1 wire format
 


### PR DESCRIPTION
## Related issue

Closes #305

## What changed

- Add `RaycastImportError.tooLarge` so a post-decrypt gzip that exceeds the inflate cap is not reported as `incorrectPassphrase`.
- v1: check gzip magic first (wrong key still `incorrectPassphrase`), then `Zlib.gunzip` with `Zlib.postDecryptMaxOutput` (1 GiB). `ZlibError.tooLarge` maps to `.tooLarge`; other gunzip failures stay `.incorrectPassphrase`.
- v2 inner gunzip after AES-GCM uses the same 1 GiB cap and `.tooLarge` mapping. The unauthenticated v2 envelope gunzip stays on the 64 MB `defaultMaxOutput` zip-bomb bound.
- Docs state the 64 MB / post-decrypt split. Harness covers a synthetic >64 MB gzip (zeros, small on disk): default cap throws, post-decrypt cap succeeds, decoder maps tooLarge, wrong passphrase is unchanged.

This PR does not stream-parse the 440 MB JSON. Follow-up.

## Memory footprint

Idle / palette unchanged. Import peak scales with decompressed JSON (440 MB payload observed in the wild). Not leak-tested against a personal export.

| Step | Memory |
| Idle after launch | unchanged |
| Palette open | unchanged |
| Feature in use (peak) | one-shot inflate; scales with export |
| Palette closed, settled | unchanged |

Leak-tested: n/a (no UI / no resident allocation)

## Demo

Non-visual: decrypt of a v1 file with a valid password no longer fails as incorrectPassphrase when gzip > 64 MB. Harness covers cap / error mapping.

## Drawbacks

Peak RAM during import now scales with the decompressed export (one-shot, off-main). A clipboard-heavy file that used to fail immediately can succeed and hold hundreds of MB until parse finishes. Idle and palette are unchanged. 1 GiB is a hard cap, not a stream; streaming the JSON is a follow-up.

## Tests & validation

- [x] `./Scripts/run-tests.sh raycast-test` — 80 passed, 0 failed
- [ ] `./Scripts/lint.sh` — swiftlint not installed in this environment