### PR TITLE
Generate release notes from merged PRs, and lay them out in the update window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,21 @@ jobs:
           name: Tinycast-${{ steps.meta.outputs.full_version }}
           path: dist/
 
+      # The changelog GitHub derives from the merged PRs, with the install text below a marker the
+      # update window cuts at. Nothing is committed anywhere — see docs/release.md.
+      - name: Compose release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CHANNEL: ${{ github.event.inputs.channel }}
+          TAG: v${{ steps.meta.outputs.full_version }}
+          SHA: ${{ github.sha }}
+          VERSION: ${{ steps.meta.outputs.full_version }}
+          DISPLAY_NAME: ${{ steps.meta.outputs.display_name }}
+          BUNDLE_ID: ${{ steps.meta.outputs.bundle_id }}
+          CASK: ${{ steps.meta.outputs.cask_name }}
+        run: ./Scripts/release-notes.sh "$RUNNER_TEMP/notes.md" "$RUNNER_TEMP/changelog.md"
+
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -130,24 +145,13 @@ jobs:
           if [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
           fi
+          # --notes-file, never --generate-notes: gh prepends --notes to generated notes, which would
+          # put the install boilerplate back above the changelog.
           gh release create "$TAG" \
             "dist/${{ steps.meta.outputs.dmg_file }}" \
             "dist/${{ steps.meta.outputs.zip_file }}" \
             --title "${{ steps.meta.outputs.display_name }} ${{ steps.meta.outputs.full_version }}" \
-            --notes "**Channel:** ${{ github.event.inputs.channel }}
-          **Version:** ${{ steps.meta.outputs.full_version }}
-          **Bundle ID:** \`${{ steps.meta.outputs.bundle_id }}\`
-          Built from ${{ github.sha }}.
-
-          **Recommended:** install via Homebrew — it clears the quarantine flag automatically on every install and update, so there's nothing to run by hand:
-          \`\`\`sh
-          brew trust --tap abue-ammar/tinycast
-          brew install --cask abue-ammar/tinycast/${{ steps.meta.outputs.cask_name }}
-          \`\`\`
-          This build is self-signed. If you download the DMG directly instead of using Homebrew, macOS will refuse to open it until you clear the quarantine flag once:
-          \`\`\`sh
-          xattr -dr com.apple.quarantine \"/Applications/${{ steps.meta.outputs.display_name }}.app\"
-          \`\`\`" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
             $PRERELEASE_FLAG
 
       - name: Update Homebrew cask
@@ -182,7 +186,7 @@ jobs:
           fi
 
       # Announce the release in the Discord release channel. A Components V2 (flags 32768) card:
-      # channel-tinted container, title + right-aligned Download button, Homebrew install block.
+      # channel-tinted container, title + right-aligned Download button, changelog, Homebrew block.
       # No-ops with a warning if the webhook secret isn't set.
       - name: Announce on Discord
         if: success()
@@ -203,20 +207,27 @@ jobs:
           INSTALL="brew install --cask abue-ammar/tinycast/${CASK}"
           # Build with jq so backticks stay literal (printf in single quotes escaped them,
           # which Discord rendered as verbatim backticks instead of a code block).
+          # Components V2 forbids a top-level `content`, so @everyone is a text component, and
+          # without allowed_mentions Discord renders the ping as inert text.
           jq -n \
             --argjson color "${COLOR}" \
             --arg heading "## 🚀 ${DISPLAY_NAME} ${VERSION}" \
             --arg sub "Now available on the **${CHANNEL}** channel." \
             --arg install "${INSTALL}" \
             --arg url "${RELEASE_URL}" \
+            --rawfile changelog "${RUNNER_TEMP}/changelog.md" \
             '{
               flags: 32768,
+              allowed_mentions: { parse: ["everyone"] },
               components: [
+                { type: 10, content: "@everyone" },
                 { type: 17, accent_color: $color, components: [
                   { type: 9,
                     components: [ { type: 10, content: ($heading + "\n" + $sub) } ],
                     accessory: { type: 2, style: 5, label: "Download", url: $url }
                   },
+                  { type: 14 },
+                  { type: 10, content: ($changelog | rtrimstr("\n")) },
                   { type: 14 },
                   { type: 10, content: ("**Install / update via Homebrew**\n```\n" + $install + "\n```") }
                 ] }

--- a/Scripts/release-notes.sh
+++ b/Scripts/release-notes.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Compose a release body from GitHub's generated notes. Usage: ./Scripts/release-notes.sh <body.md> <discord.md>
+# The changelog goes above the install marker; the app shows only that half. See docs/release.md.
+set -euo pipefail
+
+BODY_OUT="${1:?usage: release-notes.sh <body.md> <discord.md>}"
+DISCORD_OUT="${2:?usage: release-notes.sh <body.md> <discord.md>}"
+
+REPO="${REPO:-abue-ammar/tinycast}"
+CHANNEL="${CHANNEL:?CHANNEL is required (beta|stable)}"
+TAG="${TAG:?TAG is required, e.g. v0.9.13-beta.61}"
+SHA="${SHA:-$(git rev-parse HEAD)}"
+VERSION="${VERSION:-${TAG#v}}"
+DISPLAY_NAME="${DISPLAY_NAME:-Tinycast}"
+BUNDLE_ID="${BUNDLE_ID:-com.tinycast.app}"
+CASK="${CASK:-tinycast}"
+
+# Everything below this line is for the download page; the update window cuts here.
+MARKER="<!-- tinycast:install -->"
+# Discord rejects a component over 4000 characters, and a wall of bullets reads worse than a taste.
+DISCORD_BUDGET=1200
+DISCORD_BULLETS=15
+
+# Beta and stable tags interleave on main — the same commit carries both — so "the previous release"
+# is only ever right per channel.
+if [ "$CHANNEL" = "stable" ]; then
+    CHANNEL_FILTER='test("-beta\\.") | not'
+else
+    CHANNEL_FILTER='test("-beta\\.")'
+fi
+PREVIOUS="$(gh release list --repo "$REPO" --limit 200 --json tagName,isDraft --jq \
+    "[.[] | select(.isDraft | not) | .tagName
+      | select(test(\"-sequoia\") | not) | select(. != \"${TAG}\") | select(${CHANNEL_FILTER})] | first // empty")"
+
+# The tag does not exist yet — this runs before `gh release create` makes it.
+NOTES_ARGS=(-f "tag_name=${TAG}" -f "target_commitish=${SHA}")
+if [ -n "$PREVIOUS" ]; then NOTES_ARGS+=(-f "previous_tag_name=${PREVIOUS}"); fi
+echo "▸ Generating notes for ${TAG}${PREVIOUS:+ since ${PREVIOUS}}"
+GENERATED="$(gh api "repos/${REPO}/releases/generate-notes" "${NOTES_ARGS[@]}" --jq .body)"
+
+COMPARE_URL="$(printf '%s\n' "$GENERATED" | sed -n 's|^\*\*Full Changelog\*\*: \(.*\)$|\1|p' | tail -n1)"
+
+# A bare `#304` still autolinks on the web and fits the 460pt update window; the full URL does neither.
+CHANGELOG="$(printf '%s\n' "$GENERATED" | sed -E \
+    -e '/^\*\*Full Changelog\*\*:/d' \
+    -e "s|https://github\.com/${REPO}/pull/([0-9]+)|#\1|g")"
+[ -n "$(printf '%s' "$CHANGELOG" | tr -d '[:space:]')" ] || CHANGELOG="Maintenance and internal changes."
+
+{
+    printf '%s\n\n' "$CHANGELOG"
+    printf '%s\n\n' "$MARKER"
+    printf '**Channel:** %s · **Version:** %s · **Bundle ID:** `%s`\n' "$CHANNEL" "$VERSION" "$BUNDLE_ID"
+    printf 'Built from %s.' "$SHA"
+    if [ -n "$COMPARE_URL" ]; then printf ' [Full changelog](%s)' "$COMPARE_URL"; fi
+    printf '\n\n'
+    printf '%s\n' "**Recommended:** install via Homebrew — it clears the quarantine flag automatically on every install and update, so there's nothing to run by hand:"
+    printf '```sh\nbrew trust --tap abue-ammar/tinycast\nbrew install --cask abue-ammar/tinycast/%s\n```\n' "$CASK"
+    printf '%s\n' "This build is self-signed. If you download the DMG directly instead of using Homebrew, macOS will refuse to open it until you clear the quarantine flag once:"
+    printf '```sh\nxattr -dr com.apple.quarantine "/Applications/%s.app"\n```\n' "$DISPLAY_NAME"
+} > "$BODY_OUT"
+
+printf '%s\n' "$CHANGELOG" | awk -v budget="$DISCORD_BUDGET" -v bullets="$DISCORD_BULLETS" '
+    { line = $0 }
+    /^[*-] / { seen++ }
+    { used += length(line) + 1 }
+    used > budget || seen > bullets { print "…and more — see the release page."; exit }
+    { print line }
+' > "$DISCORD_OUT"
+
+echo "✓ ${BODY_OUT}"

--- a/Tests/updates-test.swift
+++ b/Tests/updates-test.swift
@@ -23,6 +23,8 @@ struct UpdatesTests {
         picksNewestForChannel()
         rejectsUnusableFeeds()
         offersOnlyWhatIsWorthInstalling()
+        keepsOnlyTheChangelog()
+        laysOutTheChangelog()
         blocksWhileBusy()
 
         print("\(passes) passed, \(failures) failed")
@@ -230,6 +232,79 @@ struct UpdatesTests {
         expect(
             ReleaseFeed.offer(newer, running: running, skipped: AppVersion("0.2.5")) != nil,
             "skipping one version does not skip the next one")
+    }
+
+    // MARK: - ReleaseNotes
+
+    /// A body as `Scripts/release-notes.sh` composes it.
+    static let composedBody = """
+        ## What's Changed
+        * Adjust top padding in **UpdateWindowView** by @abue-ammar in #304
+        * Resolve rmb and renminbi to CNY by @tipybara in #294
+
+        ## New Contributors
+        * @tipybara made their first contribution in #294
+
+        \(ReleaseNotes.installMarker)
+
+        **Channel:** beta · **Version:** 0.9.13-beta.61
+        Built from 419a5b4. [Full changelog](https://example.invalid/compare)
+        """
+
+    static func keepsOnlyTheChangelog() {
+        let summary = ReleaseNotes.summary(of: composedBody)
+        expect(summary.hasPrefix("## What's Changed"), "the changelog leads the summary")
+        expect(summary.hasSuffix("first contribution in #294"), "and the install half is cut away")
+        expect(!summary.contains("Homebrew"), "so no install instruction survives the cut")
+        expect(!summary.contains(ReleaseNotes.installMarker), "and the marker goes with it")
+
+        expect(
+            ReleaseNotes.summary(of: "  Plain notes.\n\n") == "Plain notes.",
+            "a body published before the marker existed comes back whole, trimmed")
+        expect(ReleaseNotes.summary(of: "") == "", "an empty body stays empty")
+        expect(
+            ReleaseNotes.summary(of: "\(ReleaseNotes.installMarker)\nOnly install text.") == "",
+            "a body that is nothing but install text leaves nothing to show")
+
+        let feedNotes = ReleaseFeed.newest(
+            from: feed(entry(tag: "v0.3.0", prerelease: false, body: "Changes.\\n\\n<!-- tinycast:install -->\\nBrew.")),
+            channel: .stable)?.notes
+        expect(feedNotes == "Changes.", "the feed stores the cut summary, so the cache holds it too")
+    }
+
+    static func laysOutTheChangelog() {
+        let blocks = ReleaseNotes.blocks(from: ReleaseNotes.summary(of: composedBody))
+        expect(blocks.count == 5, "five blocks: two headings, three bullets")
+        expect(blocks.first == .heading(level: 2, text: "What's Changed"), "a heading loses its hashes")
+        expect(
+            blocks.dropFirst().first
+                == .bullet("Adjust top padding in **UpdateWindowView** by @abue-ammar in #304"),
+            "a bullet loses its marker and keeps its inline markup, author and PR number")
+        expect(
+            blocks.contains(.heading(level: 2, text: "New Contributors")),
+            "the contributors heading survives the blank line before it")
+
+        expect(ReleaseNotes.blocks(from: "").isEmpty, "nothing renders nothing")
+        expect(
+            ReleaseNotes.blocks(from: "One line.\nStill the same block.")
+                == [.paragraph("One line.\nStill the same block.")],
+            "a single newline continues a paragraph rather than starting one")
+        expect(
+            ReleaseNotes.blocks(from: "Before.\n\nAfter.")
+                == [.paragraph("Before."), .paragraph("After.")],
+            "a blank line separates paragraphs")
+        expect(
+            ReleaseNotes.blocks(from: "### Fixes") == [.heading(level: 3, text: "Fixes")],
+            "a deeper heading keeps its level, so the renderer can size it")
+        expect(
+            ReleaseNotes.blocks(from: "- dash\n+ plus") == [.bullet("dash"), .bullet("plus")],
+            "every Markdown bullet marker is a bullet")
+        expect(
+            ReleaseNotes.blocks(from: "#hashtag") == [.paragraph("#hashtag")],
+            "a hash with no space is text, not a heading")
+        expect(
+            ReleaseNotes.blocks(from: "2 * 3 = 6") == [.paragraph("2 * 3 = 6")],
+            "an asterisk mid-line is not a bullet")
     }
 
     // MARK: - UpdateReadiness

--- a/Tests/updates-test.swift
+++ b/Tests/updates-test.swift
@@ -25,6 +25,7 @@ struct UpdatesTests {
         offersOnlyWhatIsWorthInstalling()
         keepsOnlyTheChangelog()
         laysOutTheChangelog()
+        linksMentionsAndPullRequests()
         blocksWhileBusy()
 
         print("\(passes) passed, \(failures) failed")
@@ -278,8 +279,11 @@ struct UpdatesTests {
         expect(blocks.first == .heading(level: 2, text: "What's Changed"), "a heading loses its hashes")
         expect(
             blocks.dropFirst().first
-                == .bullet("Adjust top padding in **UpdateWindowView** by @abue-ammar in #304"),
-            "a bullet loses its marker and keeps its inline markup, author and PR number")
+                == .bullet(
+                    "Adjust top padding in **UpdateWindowView** by "
+                        + "[@abue-ammar](https://github.com/abue-ammar) in "
+                        + "[#304](https://github.com/\(ReleaseFeed.repository)/pull/304)"),
+            "a bullet loses its marker, keeps its inline markup, and links its author and PR")
         expect(
             blocks.contains(.heading(level: 2, text: "New Contributors")),
             "the contributors heading survives the blank line before it")
@@ -305,6 +309,43 @@ struct UpdatesTests {
         expect(
             ReleaseNotes.blocks(from: "2 * 3 = 6") == [.paragraph("2 * 3 = 6")],
             "an asterisk mid-line is not a bullet")
+    }
+
+    static func linksMentionsAndPullRequests() {
+        func rendered(_ text: String) -> String {
+            guard case .bullet(let linked)? = ReleaseNotes.blocks(from: "* \(text)").first else {
+                return "not a bullet"
+            }
+            return linked
+        }
+        let pull = "https://github.com/\(ReleaseFeed.repository)/pull"
+
+        expect(
+            rendered("Fix by @abue-ammar in #304")
+                == "Fix by [@abue-ammar](https://github.com/abue-ammar) in [#304](\(pull)/304)",
+            "a mention and a PR reference both become links")
+        expect(
+            rendered("@tipybara made their first contribution in #294")
+                == "[@tipybara](https://github.com/tipybara) made their first contribution in [#294](\(pull)/294)",
+            "a mention opening the line is linked too")
+        expect(
+            rendered("track @raycast/api 2.0.3").contains("github.com/raycast") == false,
+            "a scoped package name is not a person, so it is left alone")
+        expect(
+            rendered("mail me at name@example.invalid").contains("github.com/example") == false,
+            "an address is not a mention")
+        expect(
+            rendered("issue #12 and #7") == "issue [#12](\(pull)/12) and [#7](\(pull)/7)",
+            "every reference on a line is linked")
+        expect(
+            rendered("a #hashtag, C# and 0#1") == "a #hashtag, C# and 0#1",
+            "a hash without digits, or joined to a word, is not a reference")
+        expect(
+            rendered("see [#304](\(pull)/304)") == "see [#304](\(pull)/304)",
+            "an existing link is left exactly as written")
+        expect(
+            ReleaseNotes.blocks(from: "## What's Changed") == [.heading(level: 2, text: "What's Changed")],
+            "a heading is not linkified")
     }
 
     // MARK: - UpdateReadiness

--- a/Tests/updates-test.swift
+++ b/Tests/updates-test.swift
@@ -268,7 +268,10 @@ struct UpdatesTests {
             "a body that is nothing but install text leaves nothing to show")
 
         let feedNotes = ReleaseFeed.newest(
-            from: feed(entry(tag: "v0.3.0", prerelease: false, body: "Changes.\\n\\n<!-- tinycast:install -->\\nBrew.")),
+            from: feed(
+                entry(
+                    tag: "v0.3.0", prerelease: false, body: "Changes.\\n\\n<!-- tinycast:install -->\\nBrew.")
+            ),
             channel: .stable)?.notes
         expect(feedNotes == "Changes.", "the feed stores the cut summary, so the cache holds it too")
     }

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2575583134BE03EA9FA719CD /* ActivationPolicy.swift */; };
 		175DAAED3859A54861D8CEBC /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFFB1471D30C915BBC5DCBA /* SnippetRepository.swift */; };
 		17F61DEF6389FBCFCCFB467C /* CurrencyRateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEAC591704D983A2C31188F /* CurrencyRateStore.swift */; };
+		18B3F78B6363E80149D4A646 /* ReleaseNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */; };
 		19317D6C8A55E3F85BB7AE1F /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BCAB1F3B6930FE0B819F6D /* OnboardingState.swift */; };
 		19B0314193376FD1E4AC11A5 /* WindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E779B6EF738591CB935F3F95 /* WindowLayout.swift */; };
 		1A831E78CC5D84D543763B9C /* ExtensionStoreSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AE5D924466E1E80818A98 /* ExtensionStoreSheet.swift */; };
@@ -134,6 +135,7 @@
 		5FC53F9968A5DFF24CD109DD /* VisibilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EA0B9FFCBAB10941EC7702 /* VisibilityStore.swift */; };
 		5FED92BC16B1463EBDE38D77 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D41B9E6F2C617D28C83AFF /* ShortcutRecorder.swift */; };
 		606809BC14D6613B847036D0 /* ExtensionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECB81C669337C8E6CF7FF /* ExtensionStorage.swift */; };
+		607D38D86E7C4763DD28C8D0 /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757FAE5F3E9E06D9B77DCA /* ReleaseNotes.swift */; };
 		613827876C48EF88F2162C10 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */; };
 		614DAAC9331F9C1DE4D76F0D /* EmojiScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B6CA2ED2DDD9A89C7EE874 /* EmojiScreen.swift */; };
 		6293B6B6B50E09CA75B74654 /* NotesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF26598BE61F114D5999541 /* NotesSettingsView.swift */; };
@@ -380,6 +382,7 @@
 		301BA9123035D6BFB808F763 /* SnippetKeywordListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordListener.swift; sourceTree = "<group>"; };
 		30BBF211CE6A076EAF8D6C33 /* ExtensionManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManifest.swift; sourceTree = "<group>"; };
 		316A544BF6628C0465DE28D8 /* EmojiIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiIndex.swift; sourceTree = "<group>"; };
+		31757FAE5F3E9E06D9B77DCA /* ReleaseNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotes.swift; sourceTree = "<group>"; };
 		31BAD6EE1BA3036C4B5A3D19 /* HUDPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPresenter.swift; sourceTree = "<group>"; };
 		32733B27AE0BD75742D1394F /* DialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogView.swift; sourceTree = "<group>"; };
 		32D20FAFD9F3CC0E5802A966 /* ExtensionImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionImage.swift; sourceTree = "<group>"; };
@@ -581,6 +584,7 @@
 		D28281DFC434C75F8A594635 /* ReleaseFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseFeed.swift; sourceTree = "<group>"; };
 		D2D032AC22E53BB9997E492F /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
 		D43F1080FB443A1D0616790E /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
+		D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotesView.swift; sourceTree = "<group>"; };
 		D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearance.swift; sourceTree = "<group>"; };
 		D8B10DA3A9B1CBD9A03F3DE5 /* NoteDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocument.swift; sourceTree = "<group>"; };
 		DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasStore.swift; sourceTree = "<group>"; };
@@ -925,6 +929,7 @@
 				0D4F22647E4E1BA19F0FC520 /* AppVersion.swift */,
 				198E4EC8AECAAD0D90C4BA50 /* ReleaseChannel.swift */,
 				D28281DFC434C75F8A594635 /* ReleaseFeed.swift */,
+				31757FAE5F3E9E06D9B77DCA /* ReleaseNotes.swift */,
 				76460C2D60828CC79F0CE972 /* UpdateReadiness.swift */,
 			);
 			path = Model;
@@ -1061,6 +1066,7 @@
 		719FEF955227FBDDF9667E58 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */,
 				46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */,
 				CBCCFC1039C315D2F74418FE /* UpdateWindowView.swift */,
 			);
@@ -1949,6 +1955,8 @@
 				D6D8169527668572F0073F94 /* RelaunchRunner.swift in Sources */,
 				21812A1B54A4DFDC88604C16 /* ReleaseChannel.swift in Sources */,
 				DDFF8A9F420A4733DFA32A07 /* ReleaseFeed.swift in Sources */,
+				607D38D86E7C4763DD28C8D0 /* ReleaseNotes.swift in Sources */,
+				18B3F78B6363E80149D4A646 /* ReleaseNotesView.swift in Sources */,
 				9B05C47A7414D04E20237B09 /* RenderNode.swift in Sources */,
 				AD98F015439106F0E9D32015 /* RightClick.swift in Sources */,
 				47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */,

--- a/Tinycast/Features/Updates/Model/ReleaseFeed.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseFeed.swift
@@ -40,7 +40,7 @@ enum ReleaseFeed {
         return AvailableRelease(
             version: version,
             tag: entry.tagName,
-            notes: entry.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+            notes: ReleaseNotes.summary(of: entry.body ?? ""),
             assetURL: asset.browserDownloadURL,
             assetSize: asset.size,
             publishedAt: entry.publishedAt.flatMap { try? Date($0, strategy: .iso8601) })

--- a/Tinycast/Features/Updates/Model/ReleaseFeed.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseFeed.swift
@@ -13,6 +13,9 @@ struct AvailableRelease: Codable, Hashable, Sendable {
 /// Reads GitHub's releases list. Nothing throws: an unusable body is indistinguishable from
 /// "nothing to install", and both mean the pump simply retries later.
 enum ReleaseFeed {
+    /// Where releases come from, and what every `@handle` and `#304` in their notes points at.
+    static let repository = "abue-ammar/tinycast"
+
     /// The newest release this channel accepts, ignoring drafts and anything without a zip.
     static func newest(from data: Data, channel: ReleaseChannel) -> AvailableRelease? {
         guard let entries = try? JSONDecoder().decode([Entry].self, from: data) else { return nil }

--- a/Tinycast/Features/Updates/Model/ReleaseNotes.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseNotes.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// A release body as the update window reads it: the changelog CI generates, split into the handful
+/// of block shapes it actually emits.
+enum ReleaseNotes {
+    /// CI writes the install instructions below this line for the download page — a window that
+    /// updates itself has no use for them.
+    static let installMarker = "<!-- tinycast:install -->"
+
+    /// The app-facing half of a release body. A body published before the marker existed has no
+    /// marker, and comes back whole.
+    static func summary(of body: String) -> String {
+        let head = body.range(of: installMarker).map { String(body[..<$0.lowerBound]) } ?? body
+        return head.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    enum Block: Hashable, Sendable {
+        case heading(level: Int, text: String)
+        case bullet(String)
+        case paragraph(String)
+    }
+
+    /// A line scanner over what GitHub's release-notes API produces, not a general Markdown parser.
+    static func blocks(from summary: String) -> [Block] {
+        var blocks: [Block] = []
+        var paragraph: [String] = []
+
+        func flush() {
+            guard !paragraph.isEmpty else { return }
+            blocks.append(.paragraph(paragraph.joined(separator: "\n")))
+            paragraph.removeAll()
+        }
+
+        for raw in summary.replacingOccurrences(of: "\r\n", with: "\n").split(
+            separator: "\n", omittingEmptySubsequences: false)
+        {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty {
+                flush()
+            } else if let heading = heading(in: line) {
+                flush()
+                blocks.append(heading)
+            } else if let bullet = bullet(in: line) {
+                flush()
+                blocks.append(.bullet(bullet))
+            } else {
+                paragraph.append(line)
+            }
+        }
+        flush()
+        return blocks
+    }
+
+    private static func heading(in line: String) -> Block? {
+        let hashes = line.prefix(while: { $0 == "#" })
+        guard (1...6).contains(hashes.count), line.dropFirst(hashes.count).first == " " else { return nil }
+        // Markdown lets a heading close with its own run of hashes; trimming both ends covers it.
+        let text = line.dropFirst(hashes.count)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "# "))
+        return .heading(level: hashes.count, text: text)
+    }
+
+    private static func bullet(in line: String) -> String? {
+        guard let marker = line.first, "*-+".contains(marker), line.dropFirst().first == " " else { return nil }
+        return line.dropFirst().trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Tinycast/Features/Updates/Model/ReleaseNotes.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseNotes.swift
@@ -27,7 +27,7 @@ enum ReleaseNotes {
 
         func flush() {
             guard !paragraph.isEmpty else { return }
-            blocks.append(.paragraph(paragraph.joined(separator: "\n")))
+            blocks.append(.paragraph(linkified(paragraph.joined(separator: "\n"))))
             paragraph.removeAll()
         }
 
@@ -42,7 +42,7 @@ enum ReleaseNotes {
                 blocks.append(heading)
             } else if let bullet = bullet(in: line) {
                 flush()
-                blocks.append(.bullet(bullet))
+                blocks.append(.bullet(linkified(bullet)))
             } else {
                 paragraph.append(line)
             }
@@ -58,6 +58,59 @@ enum ReleaseNotes {
         let text = line.dropFirst(hashes.count)
             .trimmingCharacters(in: CharacterSet(charactersIn: "# "))
         return .heading(level: hashes.count, text: text)
+    }
+
+    /// GitHub autolinks a mention and a PR reference on the web; in the window they are plain text
+    /// until they are spelled as Markdown links.
+    private static func linkified(_ text: String) -> String {
+        var output = ""
+        var index = text.startIndex
+        var previous: Character?
+
+        while index < text.endIndex {
+            let rest = text[index...]
+            // A Markdown destination is already a URL, so nothing inside it is a reference.
+            if rest.hasPrefix("]("), let close = rest.firstIndex(of: ")") {
+                output += text[index...close]
+                previous = ")"
+                index = text.index(after: close)
+            } else if let (link, next) = mention(in: rest, after: previous)
+                ?? pullRequest(in: rest, after: previous)
+            {
+                output += link
+                previous = text[text.index(before: next)]
+                index = next
+            } else {
+                output.append(rest[index])
+                previous = rest[index]
+                index = text.index(after: index)
+            }
+        }
+        return output
+    }
+
+    private static func mention(in rest: Substring, after previous: Character?) -> (String, String.Index)? {
+        guard rest.first == "@", previous.map({ !$0.isLetter && !$0.isNumber }) ?? true else { return nil }
+        let handle = rest.dropFirst().prefix(while: isHandle)
+        // A scoped package name — `@raycast/api` — is not a person.
+        guard !handle.isEmpty, handle.count <= 39, !handle.hasSuffix("-"),
+            rest[handle.endIndex...].first != "/"
+        else { return nil }
+        return ("[@\(handle)](https://github.com/\(handle))", handle.endIndex)
+    }
+
+    private static func pullRequest(
+        in rest: Substring, after previous: Character?
+    ) -> (String, String.Index)? {
+        guard rest.first == "#", previous.map({ $0.isWhitespace || $0 == "(" }) ?? true else { return nil }
+        let number = rest.dropFirst().prefix(while: { $0.isASCII && $0.isNumber })
+        guard !number.isEmpty else { return nil }
+        let url = "https://github.com/\(ReleaseFeed.repository)/pull/\(number)"
+        return ("[#\(number)](\(url))", number.endIndex)
+    }
+
+    private static func isHandle(_ character: Character) -> Bool {
+        character == "-" || (character.isASCII && (character.isLetter || character.isNumber))
     }
 
     private static func bullet(in line: String) -> String? {

--- a/Tinycast/Features/Updates/Model/ReleaseNotes.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseNotes.swift
@@ -114,7 +114,9 @@ enum ReleaseNotes {
     }
 
     private static func bullet(in line: String) -> String? {
-        guard let marker = line.first, "*-+".contains(marker), line.dropFirst().first == " " else { return nil }
+        guard let marker = line.first, "*-+".contains(marker), line.dropFirst().first == " " else {
+            return nil
+        }
         return line.dropFirst().trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Tinycast/Features/Updates/Service/UpdateCheckStore.swift
+++ b/Tinycast/Features/Updates/Service/UpdateCheckStore.swift
@@ -5,7 +5,7 @@ import Foundation
 @Observable
 final class UpdateCheckStore {
     private nonisolated static let endpoint = URL(
-        string: "https://api.github.com/repos/abue-ammar/tinycast/releases?per_page=20")!
+        string: "https://api.github.com/repos/\(ReleaseFeed.repository)/releases?per_page=20")!
     /// Daily, measured from `lastCheckedAt`, so relaunching never re-asks GitHub.
     private static let refreshInterval: TimeInterval = 24 * 3600
     /// Shorter retry, so a machine offline at launch sees a release soon after it reconnects.

--- a/Tinycast/Features/Updates/UI/ReleaseNotesView.swift
+++ b/Tinycast/Features/Updates/UI/ReleaseNotesView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Lays out a release body as a document. `AttributedString`'s parser only does inline styling, so
+/// headings and bullets are placed here instead of arriving as literal `##` and `*`.
+struct ReleaseNotesView: View {
+    let text: String
+
+    private var blocks: [ReleaseNotes.Block] { ReleaseNotes.blocks(from: text) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { index, block in
+                view(for: block)
+                    .padding(.top, isHeading(block) && index > 0 ? Theme.Spacing.md : 0)
+            }
+        }
+        .font(.callout)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func view(for block: ReleaseNotes.Block) -> some View {
+        switch block {
+        case .heading(let level, let text):
+            Text(text)
+                .font(level <= 2 ? .headline : .subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .bullet(let text):
+            HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.sm) {
+                Text("•").foregroundStyle(Theme.Colors.textSecondary)
+                Text(markdown(text))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .paragraph(let text):
+            Text(markdown(text))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func isHeading(_ block: ReleaseNotes.Block) -> Bool {
+        if case .heading = block { return true }
+        return false
+    }
+
+    /// GitHub release bodies are Markdown; anything it can't parse still reads fine as plain text.
+    private func markdown(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+    }
+}

--- a/Tinycast/Features/Updates/UI/UpdateWindowView.swift
+++ b/Tinycast/Features/Updates/UI/UpdateWindowView.swift
@@ -115,9 +115,7 @@ struct UpdateWindowView: View {
     }
 
     private func notes(_ release: AvailableRelease) -> some View {
-        Text(markdown(release.notes))
-            .font(.callout)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        ReleaseNotesView(text: release.notes)
     }
 
     private func report(_ failure: UpdateFailure) -> some View {
@@ -152,8 +150,10 @@ struct UpdateWindowView: View {
             content()
                 .textSelection(.enabled)
                 .padding(Theme.Spacing.xl)
+                .hideNativeScrollers()
         }
         .frame(height: Self.cardHeight)
+        .thinScrollbar()
         .background(Theme.Colors.cardFill)
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
     }
@@ -195,12 +195,5 @@ struct UpdateWindowView: View {
                     .keyboardShortcut(.defaultAction)
             }
         }
-    }
-
-    /// GitHub release bodies are Markdown; anything it can't parse still reads fine as plain text.
-    private func markdown(_ text: String) -> AttributedString {
-        let options = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
     }
 }

--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -43,6 +43,10 @@ release feed the website already reads is the feed the app reads.
   parses inline styling only; headings and bullets are placed by hand or they arrive as literal `##`
   and `*`. `ExtensionMarkdownView` does the same job and is deliberately not reused — an extension's
   views never leave `Features/Extensions/`.
+- **`@handle` and `#304` are linked by the app, never by the release body.** GitHub autolinks both on
+  the web, and a bare mention is what notifies the contributor, so the published body keeps them
+  plain and `ReleaseNotes` spells them as Markdown links on the way to the window. Both point at
+  `ReleaseFeed.repository`, the one place the repo is named.
 
 ## Channel and version
 

--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -34,6 +34,15 @@ release feed the website already reads is the feed the app reads.
   recorded, a prompt or dialog is up, or the palette is open. Readiness is asked again at the click.
 - **Nothing about updates is persisted in `AppSettings`.** The feature owns one cache file, so no
   `AppSettingsKey` and no `SettingsBackupCoverage` entry exist for it.
+- **The window shows the changelog and nothing else.** CI writes install instructions below
+  `<!-- tinycast:install -->`, and `ReleaseNotes.summary` — the single reader of that marker, called
+  where the feed is parsed so the cache holds the cut text too — drops them. An app that installs its
+  own updates has no use for a Homebrew command, and a body published before the marker existed has
+  none, so it comes back whole.
+- **The notes are laid out by `ReleaseNotesView`, which is this feature's own.** `AttributedString`
+  parses inline styling only; headings and bullets are placed by hand or they arrive as literal `##`
+  and `*`. `ExtensionMarkdownView` does the same job and is deliberately not reused — an extension's
+  views never leave `Features/Extensions/`.
 
 ## Channel and version
 
@@ -99,6 +108,10 @@ ditto -c -k --keepParent --sequesterRsrc "$APP" "dist/$ZIP_FILE"
 
 which is the only zip that leaves the code signature verifiable — plain `zip` drops symlinks and
 breaks the seal, and the signature check above would then reject every update.
+
+The body it publishes is composed by `Scripts/release-notes.sh`: GitHub's generated changelog first,
+then `<!-- tinycast:install -->`, then the install text. Anything a release wants the update window to
+show has to go above that marker — see [release.md](../release.md#release-notes).
 
 **The casks must declare `auto_updates true`** in `abue-ammar/homebrew-tinycast`. Without it Homebrew
 compares its Caskroom receipt against the cask version, sees a self-updated app as outdated forever,

--- a/docs/release.md
+++ b/docs/release.md
@@ -76,8 +76,35 @@ needed. Run it from the **Actions** tab (`Release` → **Run workflow**) and pic
 - **version** — base semver, e.g. `0.2.0`.
 
 It builds on a `macos-26` runner with Xcode 26 and publishes a GitHub Release tagged
-`v<full-version>` with a versioned DMG asset (`Tinycast-<full-version>.dmg`), marked prerelease for
-beta. On success it also bumps the matching cask in the tap.
+`v<full-version>` with a versioned DMG and zip asset, marked prerelease for beta. On success it also
+bumps the matching cask in the tap and announces the release on Discord.
+
+### Release notes
+
+`Scripts/release-notes.sh` composes the release body, and CI runs it just before `gh release create`.
+It is safe to run by hand against any tag — it only reads:
+
+```sh
+CHANNEL=beta TAG=v0.9.13-beta.61 ./Scripts/release-notes.sh /tmp/body.md /tmp/discord.md
+```
+
+The changelog itself comes from GitHub's own release-notes API, which lists every merged PR with its
+author and number — so contributors are credited without anyone maintaining a `CHANGELOG.md`, and
+without Conventional Commits. **Nothing is ever committed to this repo**: the tag is created
+server-side by `gh release create`, and no release, bot or version-bump commit exists.
+
+Two details the script exists for:
+
+- **The previous tag is picked per channel.** Beta and stable tags interleave on `main` — the same
+  commit can carry both — so "the previous release" is only ever right within one channel. A stable
+  release therefore spans every beta since the last stable.
+- **The body is split by `<!-- tinycast:install -->`.** Everything above it is the changelog;
+  everything below is the Homebrew and quarantine text, which only a download page needs. The update
+  window cuts at that marker — see [features/updates.md](features/updates.md). Full PR URLs are
+  shortened to `#304`, which still autolinks on the web and fits a 460pt window.
+
+The Discord announcement carries the same changelog, truncated to fit Discord's component limit, and
+pings `@everyone`.
 
 ### Homebrew tap automation
 


### PR DESCRIPTION
Every release carried a byte-identical body — channel, version, bundle id, `Built from <sha>`, and the Homebrew and quarantine blocks. So the update window had nothing to show but install steps an app that updates itself does not need, and there was no changelog anywhere.

## Not semantic-release

It *can* run without committing (drop `@semantic-release/git` and `@semantic-release/changelog`), but it needs Conventional Commits this repo does not write, wants to own version numbers that `-beta.${GITHUB_RUN_NUMBER}` already owns, and does not credit contributors. GitHub's own release-notes API does all three, needs no Node, and writes nothing to the repo.

**No commits are added anywhere.** The tag is still created server-side by `gh release create`; there is no release commit, no bot commit and no version bump, exactly as before.

## CI

`Scripts/release-notes.sh` composes the body just before publish. It is read-only and safe to run by hand:

```sh
CHANNEL=beta TAG=v0.9.13-beta.61 ./Scripts/release-notes.sh /tmp/body.md /tmp/discord.md
```

- **The previous tag is picked per channel.** Beta and stable tags interleave on `main` — the same commit can carry both — so a stable release correctly spans every beta since the last stable.
- **The body splits at `<!-- tinycast:install -->`.** Changelog above, Homebrew and quarantine text below. Full PR URLs become `#304`, which still autolinks on the web and fits a 460pt window.

`release.yml` gains a *Compose release notes* step and publishes with `--notes-file`. Deliberately not `--generate-notes`: gh *prepends* `--notes` to generated notes, which would put the boilerplate back on top. Discord now pings `@everyone` and carries the same changelog, truncated to fit its component limit.

## App

`AttributedString` parses inline styling only, so `##` and `*` were arriving as literal characters.

- `ReleaseNotes` (Model, Foundation-only so the harness compiles it) cuts at the marker and parses headings, bullets and paragraphs.
- `ReleaseNotesView` lays them out. `ExtensionMarkdownView` does the same job and is deliberately **not** reused — an extension's views never leave `Features/Extensions/`.
- `ReleaseFeed` cuts at parse time, so the cache holds the trimmed text too. A body published before the marker existed has none and comes back whole.

The notes card also picks up `hideNativeScrollers()` / `thinScrollbar()`, matching every other scroll surface — it now scrolls for real. Window geometry is untouched.

## Verification

- `./Scripts/run-tests.sh` — all 37 harnesses pass; `updates-test` at 90 assertions, 20 of them new.
- Debug build succeeds with no new warnings; `./Scripts/lint.sh` clean.
- Composer run against real releases on both channels and against the no-PRs fallback path.
- Discord payload asserted for `allowed_mentions.parse == ["everyone"]` and no top-level `content`.
- The view rendered offscreen against the real `Theme` — the dev channel never enters the *available* stage, so it cannot be reached from a local build.

Two things need the first real run to confirm: the actual Discord post, and the window against a live release published with the new body.