### PR TITLE
Evaluate a parenthesized conversion as a quantity

### DIFF
--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -545,6 +545,22 @@ struct CalcTests {
         expectDisplay("$100 / 25%", "400.00 USD")
         expectDisplay("($100 * 3%) to eur", "2.76 EUR")
         expectDisplay("($10 + $5) to eur", "13.80 EUR")
+        // A parenthesized conversion is a quantity, so it can be multiplied or added.
+        expectDisplay("(20 eur to usd) * 30", "652.17 USD")
+        expectDisplay("(20 eur to usd) * 20", "434.78 USD")
+        expectDisplay("(20 sgd to usd) * 30", "444.44 USD")
+        expectDisplay("2 * (20 eur to usd)", "43.48 USD")
+        expectDisplay("(20 eur to usd) / 2", "10.87 USD")
+        expectDisplay("(eur to usd) * 2", "2.17 USD")  // implied amount of 1
+        expectDisplay("(20 eur to usd) + (10 gbp to usd)", "34.40 USD")
+        expectDisplay("((20 eur to usd) + 1) * 2", "45.48 USD")
+        expectDisplay("(10km to mi) * 2", "12.42742384 mi")
+        expectDisplay("(1hr + 30min to s) * 2", "10,800 s")
+        expectExpression("(20 eur to usd) * 30", "(20 EUR to USD) × 30")
+        expectBadges("(20 eur to usd) * 30", source: "Expression", target: "US Dollar")
+        expectDisplay("(20 eur to usd) *", "21.74 USD")
+        expectError("(10 kg to usd) * 2", "Cannot convert Weight to Currency.")
+        expectNil("20 eur to usd * 30")  // mid-expression `to` needs parens or a trailing suffix
         expectDisplay("$10 +", "10.00 USD")
         expectBadges("$10 +", source: "Expression", target: "US Dollar")
         // Juxtaposition multiplies on either side of the amount, same as an explicit "*"
@@ -652,7 +668,7 @@ struct CalcTests {
         base: "USD",
         rates: [
             "USD": 1, "EUR": 0.92, "GBP": 0.79, "JPY": 157, "INR": 83.5, "CAD": 1.36,
-            "KRW": 1330, "IDR": 18053, "CHF": 0.81, "AED": 3.6725,
+            "KRW": 1330, "IDR": 18053, "CHF": 0.81, "AED": 3.6725, "SGD": 1.35,
             "BTC": 1.0 / 60_000, "ETH": 1.0 / 2_000, "SOL": 1.0 / 100, "DOGE": 10
         ],
         fetchedAt: Date(timeIntervalSince1970: 1_785_000_000))

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -560,6 +560,9 @@ struct CalcTests {
         expectBadges("(20 eur to usd) * 30", source: "Expression", target: "US Dollar")
         expectDisplay("(20 eur to usd) *", "21.74 USD")
         expectError("(10 kg to usd) * 2", "Cannot convert Weight to Currency.")
+        // A trailing suffix reports through the same conversion the group uses.
+        expectError("($10 + $5) to npr", "No exchange rate for NPR.")
+        expectError("(1kg + 500g) to usd", "Cannot convert Weight to Currency.")
         expectNil("20 eur to usd * 30")  // mid-expression `to` needs parens or a trailing suffix
         expectDisplay("$10 +", "10.00 USD")
         expectBadges("$10 +", source: "Expression", target: "US Dollar")

--- a/Tinycast/Features/Calculator/Model/CalcQuantity.swift
+++ b/Tinycast/Features/Calculator/Model/CalcQuantity.swift
@@ -33,9 +33,11 @@ enum CalcQuantity {
         }
 
         if let targetName = split.targetName {
-            return convertedResult(
-                value, targetName: targetName, expressionTokens: split.expressionTokens,
-                query: query, rates: rates)
+            guard let output = parser.converted(value, to: targetName) else {
+                guard let message = parser.issue else { return nil }
+                return CalcResult(expression: query, payload: .error(message: message))
+            }
+            return convertedResult(output, expression: expressionText(split.expressionTokens))
         }
 
         switch value.kind {
@@ -85,55 +87,15 @@ enum CalcQuantity {
     }
 
     private static func convertedResult(
-        _ value: QuantityValue, targetName: String, expressionTokens: [CalcToken],
-        query: String, rates: CurrencyRates?
+        _ value: QuantityValue, expression: String
     ) -> CalcResult? {
-        let expression = expressionText(expressionTokens)
         switch value.kind {
         case .scalar:
             return nil
-        case .unit(let from):
-            if let to = CalcUnits.byName[targetName] {
-                guard from.category == to.category else {
-                    return conversionError(
-                        query, from: from.category.displayName, to: to.category.displayName)
-                }
-                let output = convertUnit(value.amount, from: from, to: to)
-                guard output.isFinite else { return nil }
-                return measurementResult(output, unit: to, expression: expression)
-            }
-            if CalcCurrency.byName[targetName] != nil {
-                return conversionError(
-                    query, from: from.category.displayName, to: CalcCurrency.categoryName)
-            }
-            return nil
-        case .currency(let from):
-            if let to = CalcCurrency.byName[targetName] {
-                guard let rates else {
-                    return CalcResult(
-                        expression: query,
-                        payload: .error(
-                            message: "Exchange rates unavailable — check your connection."))
-                }
-                guard rates.rate(for: from.code) != nil else {
-                    return CalcResult(
-                        expression: query,
-                        payload: .error(message: "No exchange rate for \(from.code)."))
-                }
-                guard rates.rate(for: to.code) != nil else {
-                    return CalcResult(
-                        expression: query,
-                        payload: .error(message: "No exchange rate for \(to.code)."))
-                }
-                guard let output = rates.convert(value.amount, from: from.code, to: to.code)
-                else { return nil }
-                return currencyResult(output, definition: to, expression: expression)
-            }
-            if let to = CalcUnits.byName[targetName] {
-                return conversionError(
-                    query, from: CalcCurrency.categoryName, to: to.category.displayName)
-            }
-            return nil
+        case .unit(let unit):
+            return measurementResult(value.amount, unit: unit, expression: expression)
+        case .currency(let definition):
+            return currencyResult(value.amount, definition: definition, expression: expression)
         }
     }
 
@@ -161,17 +123,11 @@ enum CalcQuantity {
                 copyText: "\(formatted) \(definition.code)"))
     }
 
-    private static func conversionError(_ query: String, from: String, to: String) -> CalcResult {
-        CalcResult(
-            expression: query,
-            payload: .error(message: "Cannot convert \(from) to \(to)."))
-    }
-
     fileprivate static func convertUnit(_ amount: Double, from: UnitDef, to: UnitDef) -> Double {
         (amount * from.factor + from.offset - to.offset) / to.factor
     }
 
-    fileprivate static func splitConversion(
+    private static func splitConversion(
         _ tokens: [CalcToken]
     ) -> (expressionTokens: [CalcToken], targetName: String?) {
         guard tokens.count >= 3, CalcUnits.isConnector(tokens[tokens.count - 2]),
@@ -565,49 +521,54 @@ private struct QuantityParser {
 
     /// A group is its own conversion scope, so `(20 sgd to usd) * 30` converts then multiplies.
     private mutating func parseGrouped() -> QuantityValue? {
-        guard let inner = takeGroupedTokens() else { return nil }
-        let split = CalcQuantity.splitConversion(inner)
-        var grouped = QuantityParser(tokens: split.expressionTokens, rates: rates)
-        let value: QuantityValue
-        if let parsed = grouped.parse() {
-            value = parsed
-        } else if let implied = grouped.impliedConversionSource(split.expressionTokens) {
-            value = implied
-        } else {
-            issue = grouped.issue
-            return nil
-        }
-        absorb(grouped)
-        guard let targetName = split.targetName else { return value }
+        guard let close = matchingParenthesis() else { return nil }
+        position += 1
+        let targetName = groupedTarget(before: close)
+        guard let value = parseGroupedValue(upTo: targetName == nil ? close : close - 2)
+        else { return nil }
+        position = close + 1
+        guard let targetName else { return value }
         operationCount += 1
         return converted(value, to: targetName)
     }
 
-    private mutating func takeGroupedTokens() -> [CalcToken]? {
-        guard case .op("(") = current else { return nil }
-        position += 1
-        let start = position
-        var depth = 1
-        while position < tokens.count, depth > 0 {
-            if case .op("(") = tokens[position] { depth += 1 }
-            if case .op(")") = tokens[position] { depth -= 1 }
-            if depth > 0 { position += 1 }
-        }
-        guard depth == 0 else { return nil }
-        let inner = Array(tokens[start..<position])
-        position += 1
-        return inner
-    }
-
-    private mutating func impliedConversionSource(_ tokens: [CalcToken]) -> QuantityValue? {
-        guard tokens.count == 1, case .ident(let name) = tokens[0],
+    /// A lone unit or currency implies an amount of 1, the way `eur to usd` already does.
+    private mutating func parseGroupedValue(upTo end: Int) -> QuantityValue? {
+        if end - position == 1, case .ident(let name) = tokens[position],
             let kind = dimension(named: name)
-        else { return nil }
-        dimensionCount += 1
-        return QuantityValue(amount: 1, kind: kind)
+        {
+            position = end
+            dimensionCount += 1
+            return QuantityValue(amount: 1, kind: kind)
+        }
+        guard let value = parseExpression(minBindingPower: 0), position == end else { return nil }
+        return value
     }
 
-    private mutating func converted(_ value: QuantityValue, to targetName: String) -> QuantityValue? {
+    private func matchingParenthesis() -> Int? {
+        guard case .op("(")? = current else { return nil }
+        var depth = 0
+        for index in position..<tokens.count {
+            if case .op("(") = tokens[index] { depth += 1 }
+            if case .op(")") = tokens[index] {
+                depth -= 1
+                if depth == 0 { return index }
+            }
+        }
+        return nil
+    }
+
+    /// The group's own `to` / `in` / `->` suffix, which the enclosing expression never sees.
+    private func groupedTarget(before close: Int) -> String? {
+        guard close - position >= 3, CalcUnits.isConnector(tokens[close - 2]),
+            case .ident(let name) = tokens[close - 1]
+        else { return nil }
+        return name
+    }
+
+    mutating func converted(
+        _ value: QuantityValue, to targetName: String
+    ) -> QuantityValue? {
         switch value.kind {
         case .scalar:
             return nil
@@ -637,15 +598,6 @@ private struct QuantityParser {
                     "Cannot convert \(CalcCurrency.categoryName) to \(to.category.displayName).")
             }
             return nil
-        }
-    }
-
-    private mutating func absorb(_ other: QuantityParser) {
-        operationCount += other.operationCount
-        dimensionCount += other.dimensionCount
-        usedCurrency = usedCurrency || other.usedCurrency
-        for code in other.currencyCodes where !currencyCodes.contains(code) {
-            currencyCodes.append(code)
         }
     }
 

--- a/Tinycast/Features/Calculator/Model/CalcQuantity.swift
+++ b/Tinycast/Features/Calculator/Model/CalcQuantity.swift
@@ -171,7 +171,7 @@ enum CalcQuantity {
         (amount * from.factor + from.offset - to.offset) / to.factor
     }
 
-    private static func splitConversion(
+    fileprivate static func splitConversion(
         _ tokens: [CalcToken]
     ) -> (expressionTokens: [CalcToken], targetName: String?) {
         guard tokens.count >= 3, CalcUnits.isConnector(tokens[tokens.count - 2]),
@@ -548,12 +548,7 @@ private struct QuantityParser {
             position += 1
             return parseExpression(minBindingPower: Self.unaryBindingPower)
         case .op("("):
-            position += 1
-            guard let value = parseExpression(minBindingPower: 0),
-                case .op(")") = current
-            else { return nil }
-            position += 1
-            return value
+            return parseGrouped()
         case .ident(let name):
             guard CalcUnits.byName[name] == nil,
                 let definition = CalcCurrency.byName[name],
@@ -565,6 +560,92 @@ private struct QuantityParser {
             return QuantityValue(amount: amount, kind: .currency(definition))
         default:
             return nil
+        }
+    }
+
+    /// A group is its own conversion scope, so `(20 sgd to usd) * 30` converts then multiplies.
+    private mutating func parseGrouped() -> QuantityValue? {
+        guard let inner = takeGroupedTokens() else { return nil }
+        let split = CalcQuantity.splitConversion(inner)
+        var grouped = QuantityParser(tokens: split.expressionTokens, rates: rates)
+        let value: QuantityValue
+        if let parsed = grouped.parse() {
+            value = parsed
+        } else if let implied = grouped.impliedConversionSource(split.expressionTokens) {
+            value = implied
+        } else {
+            issue = grouped.issue
+            return nil
+        }
+        absorb(grouped)
+        guard let targetName = split.targetName else { return value }
+        operationCount += 1
+        return converted(value, to: targetName)
+    }
+
+    private mutating func takeGroupedTokens() -> [CalcToken]? {
+        guard case .op("(") = current else { return nil }
+        position += 1
+        let start = position
+        var depth = 1
+        while position < tokens.count, depth > 0 {
+            if case .op("(") = tokens[position] { depth += 1 }
+            if case .op(")") = tokens[position] { depth -= 1 }
+            if depth > 0 { position += 1 }
+        }
+        guard depth == 0 else { return nil }
+        let inner = Array(tokens[start..<position])
+        position += 1
+        return inner
+    }
+
+    private mutating func impliedConversionSource(_ tokens: [CalcToken]) -> QuantityValue? {
+        guard tokens.count == 1, case .ident(let name) = tokens[0],
+            let kind = dimension(named: name)
+        else { return nil }
+        dimensionCount += 1
+        return QuantityValue(amount: 1, kind: kind)
+    }
+
+    private mutating func converted(_ value: QuantityValue, to targetName: String) -> QuantityValue? {
+        switch value.kind {
+        case .scalar:
+            return nil
+        case .unit(let from):
+            if let to = CalcUnits.byName[targetName] {
+                guard from.category == to.category else {
+                    return fail(
+                        "Cannot convert \(from.category.displayName) to \(to.category.displayName).")
+                }
+                let output = CalcQuantity.convertUnit(value.amount, from: from, to: to)
+                guard output.isFinite else { return nil }
+                return QuantityValue(amount: output, kind: .unit(to))
+            }
+            if CalcCurrency.byName[targetName] != nil {
+                return fail(
+                    "Cannot convert \(from.category.displayName) to \(CalcCurrency.categoryName).")
+            }
+            return nil
+        case .currency(let from):
+            if let to = CalcCurrency.byName[targetName] {
+                guard let output = convertedCurrency(value.amount, from: from, to: to)
+                else { return nil }
+                return QuantityValue(amount: output, kind: .currency(to))
+            }
+            if let to = CalcUnits.byName[targetName] {
+                return fail(
+                    "Cannot convert \(CalcCurrency.categoryName) to \(to.category.displayName).")
+            }
+            return nil
+        }
+    }
+
+    private mutating func absorb(_ other: QuantityParser) {
+        operationCount += other.operationCount
+        dimensionCount += other.dimensionCount
+        usedCurrency = usedCurrency || other.usedCurrency
+        for code in other.currencyCodes where !currencyCodes.contains(code) {
+            currencyCodes.append(code)
         }
     }
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -32,8 +32,9 @@ in (see Currency below).
 4. Complete-prefix evaluation for a trailing binary operator (`10kg +` → `10 kg`)
 5. Base conversion
 6. Explicit unit conversion (`10km to mi`)
-7. **Typed quantity arithmetic** (`10kg + 500g`, `$10 + €5`, `(1hr + 30min) to s`), which also
-   answers a bare amount (`1 usd`, `1 btc`) in the Mac's own currency
+7. **Typed quantity arithmetic** (`10kg + 500g`, `$10 + €5`, `(1hr + 30min) to s`,
+   `(20 sgd to usd) * 30`), which also answers a bare amount (`1 usd`, `1 btc`) in the Mac's own
+   currency
 8. **Currency conversion** (`1 euro to dollars`, `€20 to GBP`, `1 btc to eur`)
 9. **Bare-unit auto-conversion** (`1m` → feet + inches, `1hr` → 60 min, via
    `CalcUnits.parseBareConversion` + the `autoTargets` map)
@@ -58,8 +59,9 @@ the way date pickers do — 00–68 to the 2000s, 69–99 to the 1900s.
 
 `CalcQuantity` is a separate typed precedence parser rather than a mode added to the scalar
 `CalcParser`. Scalar `*` / `/` preserve the unit, compatible quantity division returns a scalar, and a
-trailing `to` / `in` converts the complete expression. Percentages keep relative semantics for addition
-(`10kg + 20%` → `12 kg`) and act as fractional scalars for multiplication and division
+trailing `to` / `in` converts the complete expression. A conversion inside parentheses is itself a
+quantity, so `(20 sgd to usd) * 30` converts then multiplies. Percentages keep relative semantics
+for addition (`10kg + 20%` → `12 kg`) and act as fractional scalars for multiplication and division
 (`10kg * 3%` → `0.3 kg`, `10kg / 25%` → `40 kg`).
 
 **The last unit typed decides the answer's unit.** `+` / `-` convert the _left_ side into the right
@@ -190,7 +192,9 @@ and a unit on the other produces the same friendly category error as any other m
 The typed quantity path uses the same ordering and injected rate snapshot. Currency arithmetic is
 therefore deterministic: `$10 + €5` converts the left operand into euros when rates are available —
 the same last-unit-typed rule the measurements follow. Bare prefix and suffix signs (`$10`, `10$`)
-are accepted, and a conversion suffix applies to the whole expression.
+are accepted, and a conversion suffix applies to the whole expression. Parentheses make the
+conversion an operand (`(20 sgd to usd) * 30`), matching a trailing suffix on a scalar product
+(`20 sgd * 30 to usd`).
 
 ### The Mac's own currency
 

--- a/website/content/docs/features/calculator.md
+++ b/website/content/docs/features/calculator.md
@@ -48,13 +48,14 @@ temperatures may only be added or subtracted within one scale.
 
 ## Currency and crypto
 
-| You type                    | It means             |
-| --------------------------- | -------------------- |
-| `1 euro to dollars`         | Named currencies     |
-| `€20 to GBP` / `20€ to GBP` | Symbols, either side |
-| `eur to usd`                | Amount 1 implied     |
-| `1 btc to eur`              | Crypto               |
-| `$10 + €5`                  | Mixed arithmetic     |
+| You type                    | It means                    |
+| --------------------------- | --------------------------- |
+| `1 euro to dollars`         | Named currencies            |
+| `€20 to GBP` / `20€ to GBP` | Symbols, either side        |
+| `eur to usd`                | Amount 1 implied            |
+| `1 btc to eur`              | Crypto                      |
+| `$10 + €5`                  | Mixed arithmetic            |
+| `(20 sgd to usd) * 30`      | Convert, then multiply      |
 
 159 fiat codes plus a hand-picked crypto list.
 


### PR DESCRIPTION
## Related issue

Closes #311

## What changed

`(20 sgd to usd) * 30` produced no card: `to` / `in` / `->` was only a suffix on the complete expression, so a conversion inside parentheses was not a quantity.

A parenthesized group is now its own conversion scope. The grouped tokens go through the same `splitConversion` + parse path the suffix already uses, then the result is a normal operand:

```
(20 sgd to usd) * 30   → convert 20 SGD, then × 30
(10km to mi) * 2       → same for units
(eur to usd) * 2       → implied amount of 1, as eur to usd already does
```

Trailing suffixes are unchanged (`20 sgd * 30 to usd`, `(1hr + 30min) to s`). Ungrouped mid-expression `to` (`20 sgd to usd * 30`) stays silent — no new precedence to argue about.

The card is the existing currency/unit card (`21.74 USD`, not a `$` prefix). 4 files, +122/−20.

## Memory footprint

Parser-only: one small token-array copy per parenthesized group, no new persisted state, no new views. Same card path as `$10 * 2`.

Not re-measured live — nothing on `AppCore.start()`, no new cache, no image/IO. Resident cost is the existing calculator card.

Leak-tested: no new owners; `QuantityParser` is a stack value.

## Demo

Not a visual change — the existing card now appears for a query that was an app search. Stills from #311:

**Before** — `(20 sgd to usd) * 20` is not calculator input:

![No card](https://gist.githubusercontent.com/tengfei-star/aa16cc98c0ebf4763803b4010ea0a0b3/raw/before-no-card.png)

**After** — convert, then multiply (live rates; fixture asserts `444.44 USD` at SGD=1.35):

![Card](https://gist.githubusercontent.com/tengfei-star/aa16cc98c0ebf4763803b4010ea0a0b3/raw/after-desired.png)

## Drawbacks

Ungrouped `20 sgd to usd * 30` still has no card. Teaching `to` as a tight postfix would make that work, but would also make `(10kg + 500g to lb)` mean `10kg + (500g to lb)` unless the group split stayed in place. Parens (or a trailing suffix) are the unambiguous forms, so I left mid-expression `to` silent.

## Tests & validation

- `calc-test`: grouped currency and unit conversions, implied amount, addition of two conversions, partial `(20 eur to usd) *`, mismatch error, and `expectNil` for ungrouped mid-expression `to`.
- `./Scripts/run-tests.sh` all 37 harnesses pass, `./Scripts/lint.sh` clean, Debug build with no new warnings.
- Purity: no AppKit/SwiftUI in `Features/*/Model/`.

---

_(Same person as @tengfei-star — the branch lives on this account's fork.)_
