### PR TITLE
Join the meeting you are about to be late for, from the palette or a chord

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -74,6 +74,7 @@ run ranking-test           $L/SearchRelevance.swift $L/LauncherRankingStore.swif
 run scopes-test            $L/SearchScopes.swift
 run favorites-test         $L/FavoriteSlots.swift
 run calc-test              Tinycast/Features/Calculator/Model/*.swift
+run calendar-test          Tinycast/Features/Calendar/Model/*.swift
 run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
 run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \

--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -1,0 +1,282 @@
+// Standalone test for meeting-link detection, the join window and the day buckets.
+import Foundation
+
+@main
+@MainActor
+struct CalendarTests {
+    static var failures = 0
+    static var passes = 0
+
+    /// Injected everywhere a date is built, so no assertion depends on the machine's zone.
+    static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    static func main() {
+        providerDetection()
+        rejectsNonMeetingPages()
+        fieldPrecedence()
+        linkScanning()
+        appURLRewrites()
+        agendaFiltering()
+        cardWindow()
+        chordFallsBackWiderThanTheCard()
+        countdownStrings()
+        dayBuckets()
+
+        print("\(passes)/\(passes + failures) passed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Provider detection
+
+    static func providerDetection() {
+        expect(provider("https://us02web.zoom.us/j/8901234567") == .zoom, "a Zoom /j/ link is Zoom")
+        expect(provider("https://zoom.us/w/123?pwd=xy") == .zoom, "a Zoom webinar link is Zoom")
+        expect(provider("https://acme.zoomgov.com/j/55") == .zoom, "zoomgov is Zoom")
+        expect(
+            provider("https://meet.google.com/abc-defg-hij") == .googleMeet,
+            "a Meet code is Google Meet")
+        expect(
+            provider("https://teams.microsoft.com/l/meetup-join/19%3ameeting_Zm8") == .teams,
+            "a Teams meetup-join link is Teams")
+        expect(provider("https://teams.live.com/meet/9312") == .teams, "a Teams personal link is Teams")
+        expect(provider("https://acme.webex.com/acme/j.php?MTID=m1") == .webex, "a Webex site is Webex")
+        expect(provider("https://meet.jit.si/DailyStandup") == .jitsi, "meet.jit.si is Jitsi")
+        expect(provider("https://8x8.vc/room") == .jitsi, "8x8.vc is Jitsi")
+        expect(provider("https://whereby.com/acme") == .whereby, "whereby.com is Whereby")
+        expect(provider("https://chime.aws/1234567890") == .chime, "chime.aws is Amazon Chime")
+        expect(
+            provider("https://global.gotomeeting.com/join/123456789") == .gotoMeeting,
+            "gotomeeting.com is GoTo Meeting")
+        expect(provider("https://app.goto.com/meeting/xy") == .gotoMeeting, "app.goto.com is GoTo")
+        expect(provider("https://bluejeans.com/123456") == .blueJeans, "bluejeans.com is BlueJeans")
+        expect(provider("https://join.skype.com/abcdef") == .skype, "join.skype.com is Skype")
+        expect(
+            provider("https://example.com/rooms/standup") == .generic,
+            "an unknown host is still a joinable link")
+        expect(MeetingLink.detect(in: "no links here at all") == nil, "plain prose has no link")
+        expect(
+            MeetingLink.detect(in: "mailto:someone@example.com") == nil,
+            "a mailto address is not a join link")
+    }
+
+    static func rejectsNonMeetingPages() {
+        expect(
+            MeetingLink.detect(in: "https://zoom.us/download") == nil,
+            "a Zoom download page is not a meeting, and does not fall back to a bare link")
+        expect(
+            MeetingLink.detect(in: "https://meet.google.com/tel/123") == nil,
+            "a Meet dial-in helper is not a meeting")
+        expect(
+            MeetingLink.detect(in: "https://teams.microsoft.com/downloads") == nil,
+            "a Teams download page is not a meeting")
+        expect(
+            MeetingLink.detect(in: "Join: https://zoom.us/download or https://zoom.us/j/42")?.provider
+                == .zoom,
+            "a rejected page does not stop the real link being found")
+    }
+
+    // MARK: - Where the link comes from
+
+    static func fieldPrecedence() {
+        let link = MeetingLink.detect(fields: [
+            "https://example.com/first", "https://meet.google.com/abc-defg-hij"
+        ])
+        expect(link?.provider == .googleMeet, "a named provider beats a bare link found earlier")
+        let bare = MeetingLink.detect(fields: [nil, "https://example.com/room", "https://other.test/x"])
+        expect(
+            bare?.url.absoluteString == "https://example.com/room",
+            "with no named provider the earliest bare link wins")
+        expect(MeetingLink.detect(fields: [nil, nil]) == nil, "empty fields yield no link")
+    }
+
+    static func linkScanning() {
+        expect(
+            MeetingLink.detect(in: "Dial in (https://whereby.com/acme).")?.url.absoluteString
+                == "https://whereby.com/acme",
+            "trailing punctuation is not part of the URL")
+        expect(
+            MeetingLink.detect(in: "<a href=\"https://whereby.com/acme\">join</a>")?.url
+                .absoluteString == "https://whereby.com/acme",
+            "a quoted href yields the URL alone")
+        expect(
+            MeetingLink.detect(in: "line one\nhttps://whereby.com/acme\nline three")?.url
+                .absoluteString == "https://whereby.com/acme",
+            "a newline ends the URL")
+        expect(
+            MeetingLink.detect(in: "HTTPS://WHEREBY.COM/Acme")?.provider == .whereby,
+            "the scheme and host match case-insensitively")
+    }
+
+    static func appURLRewrites() {
+        expect(
+            link("https://us02web.zoom.us/j/8901234567")?.appURL?.absoluteString
+                == "zoommtg://zoom.us/join?confno=8901234567",
+            "a Zoom link rewrites to the desktop app")
+        expect(
+            link("https://us02web.zoom.us/j/89?pwd=SeCrEt")?.appURL?.absoluteString
+                == "zoommtg://zoom.us/join?confno=89&pwd=SeCrEt",
+            "the Zoom passcode travels with the rewrite")
+        expect(
+            link("https://teams.microsoft.com/l/meetup-join/19%3ameeting_Zm8?x=1")?.appURL?
+                .absoluteString == "msteams:/l/meetup-join/19%3ameeting_Zm8?x=1",
+            "a Teams link rewrites to msteams:, path and query intact")
+        expect(
+            link("https://meet.google.com/abc-defg-hij")?.appURL == nil,
+            "a provider with no unambiguous scheme opens the web instead")
+        expect(link("https://example.com/room")?.appURL == nil, "a bare link opens the web")
+    }
+
+    // MARK: - The join window
+
+    static func agendaFiltering() {
+        let events = [
+            event(id: "late", start: 60), event(id: "early", start: 0),
+            event(id: "allday", start: 30, isAllDay: true),
+            event(id: "declined", start: 30, isDeclined: true)
+        ]
+        let agenda = UpcomingWindow.agenda(from: events)
+        expect(agenda.map(\.id) == ["early", "late"], "the agenda is timed, accepted and in start order")
+    }
+
+    static func cardWindow() {
+        let window = UpcomingWindow(leadMinutes: 5)
+        let meeting = event(id: "standup", start: 60, minutes: 30)
+        let start = at(60)
+        expect(
+            window.carded(from: [meeting], now: start.addingTimeInterval(-300))?.id == "standup",
+            "the card appears exactly five minutes out")
+        expect(
+            window.carded(from: [meeting], now: start.addingTimeInterval(-301)) == nil,
+            "one second earlier it is not there yet")
+        expect(
+            window.carded(from: [meeting], now: start.addingTimeInterval(299))?.id == "standup",
+            "it survives almost five minutes past the start, because everyone joins late")
+        expect(
+            window.carded(from: [meeting], now: start.addingTimeInterval(300)) == nil,
+            "the grace period ends five minutes past the start")
+
+        let brief = event(id: "brief", start: 60, minutes: 3)
+        expect(
+            window.carded(from: [brief], now: at(60).addingTimeInterval(179))?.id == "brief",
+            "a three-minute meeting is carded until it ends")
+        expect(
+            window.carded(from: [brief], now: at(60).addingTimeInterval(180)) == nil,
+            "the grace period never outlives the meeting")
+
+        let linkless = event(id: "linkless", start: 60, link: nil)
+        expect(
+            window.carded(from: [linkless], now: start) == nil,
+            "a meeting with no link is never carded")
+        expect(
+            UpcomingWindow.agenda(from: [linkless]).map(\.id) == ["linkless"],
+            "but it stays on the agenda, so it is still listed and searchable")
+    }
+
+    static func chordFallsBackWiderThanTheCard() {
+        let window = UpcomingWindow(leadMinutes: 5)
+        let running = event(id: "running", start: 0, minutes: 60)
+        let next = event(id: "next", start: 120)
+        let now = at(0).addingTimeInterval(1800)
+
+        expect(window.carded(from: [running], now: now) == nil, "half an hour in, the card is gone")
+        expect(
+            window.joinable(from: [running], now: now)?.id == "running",
+            "the chord still joins the call that is running")
+        expect(
+            window.joinable(from: [next], now: now)?.id == "next",
+            "with nothing running it offers the next one")
+        expect(
+            window.joinable(from: [running, next], now: at(120).addingTimeInterval(-120))?.id
+                == "next",
+            "inside the card window the chord joins what is on screen")
+        expect(
+            window.joinable(from: [], now: now) == nil, "an empty day offers nothing to join")
+        expect(
+            window.joinable(from: [event(id: "past", start: -120)], now: now) == nil,
+            "a meeting that is over is not offered")
+    }
+
+    static func countdownStrings() {
+        let start = at(60)
+        expect(
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(-240)) == "in 4 min",
+            "four minutes out reads as in 4 min")
+        expect(
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(-60)) == "in 1 min",
+            "one minute out reads as in 1 min")
+        expect(
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(-1)) == "in 1 min",
+            "a partial minute rounds up rather than reading as now")
+        expect(UpcomingWindow.countdown(to: start, now: start) == "now", "the start reads as now")
+        expect(
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(59)) == "now",
+            "the first minute after the start still reads as now")
+        expect(
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(120)) == "2 min ago",
+            "past the start it counts up")
+    }
+
+    // MARK: - Day buckets
+
+    static func dayBuckets() {
+        let now = date(year: 2026, month: 8, day: 23, hour: 22)
+        expect(
+            MeetingDay(for: now.addingTimeInterval(3600), now: now, calendar: calendar) == .today,
+            "an hour before midnight is still today")
+        expect(
+            MeetingDay(for: now.addingTimeInterval(2 * 3600), now: now, calendar: calendar)
+                == .tomorrow,
+            "an hour past midnight is tomorrow")
+        expect(
+            MeetingDay(for: now.addingTimeInterval(48 * 3600), now: now, calendar: calendar) == nil,
+            "the day after tomorrow has no bucket")
+        expect(
+            MeetingDay(for: now.addingTimeInterval(-24 * 3600), now: now, calendar: calendar) == nil,
+            "yesterday has no bucket")
+    }
+
+    // MARK: - Helpers
+
+    static let epoch = Date(timeIntervalSinceReferenceDate: 0)
+
+    static func at(_ minutes: Int) -> Date {
+        epoch.addingTimeInterval(TimeInterval(minutes * 60))
+    }
+
+    static func date(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        calendar.date(
+            from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+
+    static func link(_ text: String) -> MeetingLink? { MeetingLink.detect(in: text) }
+
+    static func provider(_ text: String) -> MeetingLink.Provider? { link(text)?.provider }
+
+    static func event(
+        id: String, start minutes: Int, minutes duration: Int = 30, isAllDay: Bool = false,
+        isDeclined: Bool = false, link: MeetingLink? = MeetingLink.detect(in: "https://example.com/x")
+    ) -> MeetingEvent {
+        MeetingEvent(
+            id: id, title: id, start: at(minutes),
+            end: at(minutes).addingTimeInterval(TimeInterval(duration * 60)),
+            isAllDay: isAllDay, isDeclined: isDeclined, calendarID: "cal", calendarName: "Work",
+            calendarItemID: id, link: link)
+    }
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition {
+            passes += 1
+        } else {
+            fail(label)
+        }
+    }
+
+    static func fail(_ label: String) {
+        print("FAIL: \(label)")
+        failures += 1
+    }
+}

--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -92,6 +92,7 @@ struct DoubleTapDetectorTests {
             (.clipboardHistory, .toggleClipboard, "hotkey.toggleClipboard"),
             (.searchEmoji, .toggleEmoji, "hotkey.toggleEmoji"),
             (.searchFiles, .searchFiles, "hotkey.searchFiles"),
+            (.joinNextMeeting, .joinNextMeeting, "hotkey.joinNextMeeting"),
             (.showNotes, .showNotes, "hotkey.showNotes"),
             (.createNote, .createNote, "hotkey.createNote"),
             (.searchNotes, .searchNotes, "hotkey.searchNotes")

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		303FC5342B61A7862EBC1C32 /* FocusRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9A0079D05A5D9B21A1CFCE /* FocusRelease.swift */; };
 		309320CB6B5424EA558A4823 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BE90FB09366A3518C2D4E5 /* EmojiData.generated.swift */; };
 		309B1313B6B40D1342362492 /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7817B7A8760B36FDA43F48FC /* CalcEngine.swift */; };
+		30C5B58F3876A5B85BFBBDDF /* ScheduleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590A432CC25ED6372B453BFA /* ScheduleScreen.swift */; };
 		312BCD2850AFD26E8B532937 /* ExtensionInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = F023729C84682E9231F3D73B /* ExtensionInstaller.swift */; };
 		3155DE3A2195764DDEA97F26 /* ClipboardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201FCD08ACA933378876385B /* ClipboardStore.swift */; };
 		31E0E4E0782A79504CEB588D /* ScrollIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622E1F1C01B954DCA2199BCD /* ScrollIntent.swift */; };
@@ -87,6 +88,7 @@
 		3917193B62450F226297B3F1 /* SelectionReveal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648F0F43FEEE537F6451756B /* SelectionReveal.swift */; };
 		39F5A11DD9D7C31AC720D4C0 /* QuicklinksSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC68E042182F7068220BB3 /* QuicklinksSettingsView.swift */; };
 		3A22313E903883E55046F207 /* AppSettingsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384485BD1794D25503534525 /* AppSettingsKey.swift */; };
+		3A2B91CE53DD84DE9EF5ECB8 /* UpcomingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F97240A718D95DFD9343DB /* UpcomingWindow.swift */; };
 		3B02D6CE68E0E488955A19B5 /* SnippetTemplateEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58E564E6181EB15497E51CD /* SnippetTemplateEngine.swift */; };
 		3BC6CC35889FFC77D640C7CA /* SnippetsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2EF66267B0141279A43613 /* SnippetsSettingsView.swift */; };
 		3E2E0C5B564C828D7ECA2759 /* RegionCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */; };
@@ -136,6 +138,7 @@
 		5FED92BC16B1463EBDE38D77 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D41B9E6F2C617D28C83AFF /* ShortcutRecorder.swift */; };
 		606809BC14D6613B847036D0 /* ExtensionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECB81C669337C8E6CF7FF /* ExtensionStorage.swift */; };
 		607D38D86E7C4763DD28C8D0 /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757FAE5F3E9E06D9B77DCA /* ReleaseNotes.swift */; };
+		60A1949A691168B535B562C8 /* MeetingCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E475F373557FD3524086CE19 /* MeetingCalendar.swift */; };
 		613827876C48EF88F2162C10 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */; };
 		614DAAC9331F9C1DE4D76F0D /* EmojiScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B6CA2ED2DDD9A89C7EE874 /* EmojiScreen.swift */; };
 		6293B6B6B50E09CA75B74654 /* NotesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF26598BE61F114D5999541 /* NotesSettingsView.swift */; };
@@ -159,11 +162,14 @@
 		6FC9F74D9119AC25D178D748 /* ExtensionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */; };
 		71AA40FC4B8C57FFDE5F8DFC /* SystemAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE72CE02F853ACE956627347 /* SystemAction.swift */; };
 		7320E4B2ABFAE8C1D76A3526 /* ExtensionArgumentsAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154222C91EFDB4D4490B6CE2 /* ExtensionArgumentsAccessory.swift */; };
+		743C70ACA40F61F635DB0B55 /* CalendarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0A2005448E6F88C3F78489 /* CalendarStore.swift */; };
 		74ACDD85B9F03C36E9258695 /* SettingsSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AA1305D43303E055DEE1E9 /* SettingsSplitViewController.swift */; };
 		74BE9E8319C8302EF525E6B2 /* QuicklinkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685FB7FD7E4E5BE6606440D0 /* QuicklinkStore.swift */; };
 		75AED41394E66D6E9CBDA7EA /* NotesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F84B7743B803F55C41D5C4A /* NotesRepository.swift */; };
 		75EF3CFF00A2215D57A4FBFF /* FavoriteSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE591549F24AE554C13CD0C /* FavoriteSlots.swift */; };
+		77A82B4F0CC09E7248DC5706 /* MeetingLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = B117F11E9B15D1B1919B7FB1 /* MeetingLink.swift */; };
 		7833FD6E0A6036954FE285CE /* FrequentEmojiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D35CA0655717E1798AFDA7B /* FrequentEmojiStore.swift */; };
+		791AC049B6CA16C7D86EEBEF /* MeetingLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C117C966BC2990F19E00AB /* MeetingLauncher.swift */; };
 		7BDB7CF7F1352015F6AC96C3 /* SnippetsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375734577C888260A8023181 /* SnippetsStore.swift */; };
 		7CC503824FDF49F788C85BB3 /* SettingsBackupCoverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5FFE395B9164BDC77B3470 /* SettingsBackupCoverage.swift */; };
 		7FDE88F4E065FF80DCB92445 /* NotesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B77DA46386E7E459406E4 /* NotesStore.swift */; };
@@ -201,6 +207,7 @@
 		9B05C47A7414D04E20237B09 /* RenderNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D354C1785923E612848C /* RenderNode.swift */; };
 		9B3BC1DCC478DA7517F04182 /* CalculatorHistoryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86545F54669A075FBDA5D1F1 /* CalculatorHistoryScreen.swift */; };
 		9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387BE675F580496656E72559 /* SymbolCatalog.swift */; };
+		9E4497ECAD183E5C2B49475B /* MeetingDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0599199132DAFBE12C59FBD /* MeetingDay.swift */; };
 		9E514EA8EB0408653AC3D1D9 /* BundleSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E30EFA3197FC5EF1E85C21 /* BundleSignature.swift */; };
 		9E5B694969D3F99BF7D0D9E1 /* ExtensionImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D20FAFD9F3CC0E5802A966 /* ExtensionImage.swift */; };
 		9F82DA5A46BB39A6C6DD075D /* DialogRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D150930C930F1FB5E2A31B /* DialogRequest.swift */; };
@@ -218,12 +225,14 @@
 		A64891F5587F2C11E4A2E2D2 /* ClipboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197035E213BEBA67DDA3377B /* ClipboardManager.swift */; };
 		A6514CA79A45918109A65514 /* UpdateCheckStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2A1ECA5667B8FD1B1F9FD8 /* UpdateCheckStore.swift */; };
 		A6A8CD2B71A15625F47498EA /* WindowMover.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA99178E0DCF6CBB521FB098 /* WindowMover.swift */; };
+		A70176F7F17CB4FF521634A4 /* MeetingCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2FAC737503B853DE6B5ED4 /* MeetingCardView.swift */; };
 		A769FFB50D3ED9E458028255 /* SettingsBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52998BAB1D8287CF14E46EF0 /* SettingsBackup.swift */; };
 		A7CEBFBFBB46554ACAD73CFB /* QuicklinkArgumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3044106BC42824C79E1803 /* QuicklinkArgumentsView.swift */; };
 		A7D7F8F64B0937D20D97F428 /* ExtensionAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */; };
 		A7F4CD74AEBEFF9F07103CD7 /* EmojiIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316A544BF6628C0465DE28D8 /* EmojiIndex.swift */; };
 		AAFD2C9276D38719E85B675F /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB76FDBFE1E306C2A5B1A29B /* Memo.swift */; };
 		AB500AC3DEBFF6EB1CE42812 /* DialogController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94507F8F095D3EBD1A9B3007 /* DialogController.swift */; };
+		ABFC92E6F22D8D6715081D9F /* CalendarAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F82845FDA307DF71676352 /* CalendarAccess.swift */; };
 		ACB45791BFE60896455293B4 /* FileSearchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC86115B040B8C574EAD0B5 /* FileSearchPolicy.swift */; };
 		ACD8CAE659B1C49EC8652576 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AD346C8FD5F2D4F00FF2B6 /* HotKeyCenter.swift */; };
 		ACE645630E536C93CA102050 /* VolumeHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90559D7DB9F6F3874CAFCDE /* VolumeHUDView.swift */; };
@@ -238,8 +247,10 @@
 		B56F252262AA1BD3E2631F0C /* FileSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391B8024E8719506361B45F7 /* FileSearchQuery.swift */; };
 		B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0F5891A80B604FBE21897B /* CalcCurrency.swift */; };
 		B8CECD85524BCCCBC0CDC2B5 /* ExtensionCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */; };
+		BAD4BEF8041665ACCF1CE460 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */; };
 		BBAB44C0E70AABE70A048889 /* QuicklinkArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */; };
 		BC755BD99ECA1F2D382D5C94 /* SettingsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */; };
+		BCA7E1C4BCF6F77634E54CA7 /* MeetingClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474E6D9830E336752C79F461 /* MeetingClock.swift */; };
 		BD45A99F26C015BF00AC77D5 /* ApplicationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289FC415E1D1776DD1C4EB9E /* ApplicationsSettingsView.swift */; };
 		BE1540DC6EE5F095F89CED5F /* EmojiGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0966995230FE7B7072C0018B /* EmojiGridGeometry.swift */; };
 		BEA4A58DE854DC330E90B5B9 /* ExtensionAppearanceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA26F487C06DC6F03F78B13 /* ExtensionAppearanceStore.swift */; };
@@ -272,6 +283,7 @@
 		D3F07F4AEBEAA489EDCD0763 /* FileSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FE27F894A8777C8ACCF1D /* FileSearchList.swift */; };
 		D44E20726F1EB11C8C297C4D /* WindowActionMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */; };
 		D4A45373662D6658706E4DA4 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27773F8955543E8A24CC0D28 /* ClipboardSettingsView.swift */; };
+		D4AC94686EEEF4B792B58593 /* CalendarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0AA95CA13E86370661D01C /* CalendarSettingsView.swift */; };
 		D68E7585496722BEC72E788C /* AliasStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */; };
 		D6D8169527668572F0073F94 /* RelaunchRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01488803F8025B0523D44BA /* RelaunchRunner.swift */; };
 		D736A0FE574A343AA0FD3911 /* AppIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E58EBB08450BA3426DF0565 /* AppIndex.swift */; };
@@ -288,12 +300,14 @@
 		E268D74F0DEFFA598E2D02AA /* OnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6972F177922B1EB8831735 /* OnboardingCard.swift */; };
 		E457BC709D195B8F5D0C2A79 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6DAC3B9FF387367C3FAB4 /* UninstallSession.swift */; };
 		E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E25B87C692D5FEE1FBF994 /* PanelTransition.swift */; };
+		E4E1403AA9A8ACE4A3D3581C /* MeetingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B330ABFC83721904159DDF2 /* MeetingEvent.swift */; };
 		E58AB83C608F8BBF99EAEB7E /* QuicklinkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856F65245B10433A230194E6 /* QuicklinkListView.swift */; };
 		E63AA3E7A400CB81FBFC3214 /* RaycastFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09A0608AC763EBC26216118 /* RaycastFormat.swift */; };
 		E6E8E3E2ECD0CD9A982115F3 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAA05D695590C4B654E5BF /* OnboardingCoordinator.swift */; };
 		E7DCBF503DDEF223C6BE71E5 /* LegacyHotKeyRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F375AF988B0DA844E2473DA /* LegacyHotKeyRecords.swift */; };
 		E8AD3FBDA8B150790643A2F5 /* NotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E2E570E54DEEF29FF2B65E /* NotesView.swift */; };
 		E8CB7624CCA5905AF1A4FAD9 /* AppCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BECF24B674F9458E4A876DA /* AppCore.swift */; };
+		EA077323DE71DAF8FE17693C /* CalendarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC504A12A2D9CC00B502D9E /* CalendarCoordinator.swift */; };
 		EA2587800F2CA347788C6F8C /* UninstallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0508EBDFD6E59370AB2E5B7 /* UninstallScreen.swift */; };
 		EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C045C66BB654E4CB407A673 /* AppActionsMenu.swift */; };
 		EBCDF88CD59A4B6F21F945C6 /* Quicklink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3385A84985A52E2DA3596 /* Quicklink.swift */; };
@@ -332,6 +346,7 @@
 		0966995230FE7B7072C0018B /* EmojiGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridGeometry.swift; sourceTree = "<group>"; };
 		0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowActionMemory.swift; sourceTree = "<group>"; };
 		0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPackageManager.swift; sourceTree = "<group>"; };
+		0B2FAC737503B853DE6B5ED4 /* MeetingCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCardView.swift; sourceTree = "<group>"; };
 		0C3B9645DB2293FA144B5AA2 /* Paster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paster.swift; sourceTree = "<group>"; };
 		0D4F22647E4E1BA19F0FC520 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 		0DFEBE220187043060F7F286 /* ToolRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRunner.swift; sourceTree = "<group>"; };
@@ -354,6 +369,7 @@
 		198E4EC8AECAAD0D90C4BA50 /* ReleaseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChannel.swift; sourceTree = "<group>"; };
 		1AA26F487C06DC6F03F78B13 /* ExtensionAppearanceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearanceStore.swift; sourceTree = "<group>"; };
 		1B865FF16D3C395A8D509B94 /* QuicklinkLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkLauncher.swift; sourceTree = "<group>"; };
+		1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
 		201FCD08ACA933378876385B /* ClipboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardStore.swift; sourceTree = "<group>"; };
 		209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
 		2258D4A6B6C22AB7C5D421BE /* DoubleTapMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapMonitor.swift; sourceTree = "<group>"; };
@@ -415,9 +431,11 @@
 		45EB979ECD44738BCD9E2F90 /* EmojiCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCoordinator.swift; sourceTree = "<group>"; };
 		463FE27F894A8777C8ACCF1D /* FileSearchList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchList.swift; sourceTree = "<group>"; };
 		46762A28D73339953019C0AA /* ExtensionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsSettingsView.swift; sourceTree = "<group>"; };
+		46C117C966BC2990F19E00AB /* MeetingLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingLauncher.swift; sourceTree = "<group>"; };
 		46CECB81C669337C8E6CF7FF /* ExtensionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStorage.swift; sourceTree = "<group>"; };
 		46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCoordinator.swift; sourceTree = "<group>"; };
 		471E1C3C250FD0A89E2C6430 /* ExtensionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionListView.swift; sourceTree = "<group>"; };
+		474E6D9830E336752C79F461 /* MeetingClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingClock.swift; sourceTree = "<group>"; };
 		4AA61A2FAF4E49E466DA8F37 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCurrency.swift; sourceTree = "<group>"; };
 		4DA7B926405DAC632C056418 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -434,6 +452,8 @@
 		5392500F86E23C099D33561D /* Tinycast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tinycast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardScreen.swift; sourceTree = "<group>"; };
 		54E48A8D5E2BC00E9E1CD5BF /* QuicklinkArgumentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentSession.swift; sourceTree = "<group>"; };
+		590A432CC25ED6372B453BFA /* ScheduleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleScreen.swift; sourceTree = "<group>"; };
+		5B330ABFC83721904159DDF2 /* MeetingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEvent.swift; sourceTree = "<group>"; };
 		5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDisplayName.swift; sourceTree = "<group>"; };
 		5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCommandView.swift; sourceTree = "<group>"; };
 		5D3044106BC42824C79E1803 /* QuicklinkArgumentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsView.swift; sourceTree = "<group>"; };
@@ -497,6 +517,7 @@
 		8F088EC0B4D97B3C9D0D0569 /* NoteTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTextView.swift; sourceTree = "<group>"; };
 		8F1545635C1E94D5E7DFECF1 /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
 		8F6F59F3C88C49BDED945F25 /* EdgeDissolve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeDissolve.swift; sourceTree = "<group>"; };
+		8FC504A12A2D9CC00B502D9E /* CalendarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCoordinator.swift; sourceTree = "<group>"; };
 		8FC86115B040B8C574EAD0B5 /* FileSearchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchPolicy.swift; sourceTree = "<group>"; };
 		8FEAC591704D983A2C31188F /* CurrencyRateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRateStore.swift; sourceTree = "<group>"; };
 		90E23F92F4B4DEEE55077C7C /* AppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconView.swift; sourceTree = "<group>"; };
@@ -518,6 +539,7 @@
 		9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommand.swift; sourceTree = "<group>"; };
 		9BD81541882CBCC5B06F718F /* UpdateDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDownloader.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		9D0A2005448E6F88C3F78489 /* CalendarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarStore.swift; sourceTree = "<group>"; };
 		9D134673CB1B563A3758FC37 /* UninstallRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRunner.swift; sourceTree = "<group>"; };
 		9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverArming.swift; sourceTree = "<group>"; };
 		9F9A0A3867D1B8E1D3284471 /* ExtensionNodeShims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionNodeShims.swift; sourceTree = "<group>"; };
@@ -544,6 +566,7 @@
 		AE35B5E7B1CC94F759116097 /* CurrencyFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFeed.swift; sourceTree = "<group>"; };
 		AEEB022D080E6DAF703D8132 /* SystemActionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionsSettingsView.swift; sourceTree = "<group>"; };
 		B0ABE4AF80DD5F5F8E91F63E /* SpotlightNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightNames.swift; sourceTree = "<group>"; };
+		B117F11E9B15D1B1919B7FB1 /* MeetingLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingLink.swift; sourceTree = "<group>"; };
 		B21678BAD7BA4A4E300FDA2C /* WindowManagementSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagementSettingsView.swift; sourceTree = "<group>"; };
 		B235DFF451FF4D52A8E44D00 /* ShortcutCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureSession.swift; sourceTree = "<group>"; };
 		B3C7D17F97002FD58E8A5F53 /* PermissionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsSettingsView.swift; sourceTree = "<group>"; };
@@ -558,12 +581,14 @@
 		B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherScreen.swift; sourceTree = "<group>"; };
 		B9F568F2F6EF857274F1A9D8 /* ExtensionIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionIconCache.swift; sourceTree = "<group>"; };
 		BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePanel.swift; sourceTree = "<group>"; };
+		BC0AA95CA13E86370661D01C /* CalendarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSettingsView.swift; sourceTree = "<group>"; };
 		BDB241B179A08518424F7C1B /* DialogPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogPanel.swift; sourceTree = "<group>"; };
 		BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		BE6972F177922B1EB8831735 /* OnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
 		BEDDA8820165672AF8464E25 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
 		BFB023D167225228757CC4B2 /* HealthTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthTicker.swift; sourceTree = "<group>"; };
 		C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteCoordinator.swift; sourceTree = "<group>"; };
+		C0599199132DAFBE12C59FBD /* MeetingDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDay.swift; sourceTree = "<group>"; };
 		C3E30EFA3197FC5EF1E85C21 /* BundleSignature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSignature.swift; sourceTree = "<group>"; };
 		C45190564C9D9F1722E83943 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C54C4540AD6F188A2455473F /* ExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRuntime.swift; sourceTree = "<group>"; };
@@ -583,6 +608,7 @@
 		D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
 		D28281DFC434C75F8A594635 /* ReleaseFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseFeed.swift; sourceTree = "<group>"; };
 		D2D032AC22E53BB9997E492F /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
+		D3F82845FDA307DF71676352 /* CalendarAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccess.swift; sourceTree = "<group>"; };
 		D43F1080FB443A1D0616790E /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
 		D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotesView.swift; sourceTree = "<group>"; };
 		D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearance.swift; sourceTree = "<group>"; };
@@ -599,6 +625,7 @@
 		E01488803F8025B0523D44BA /* RelaunchRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaunchRunner.swift; sourceTree = "<group>"; };
 		E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		E27FB790A72ACD75DFCDFDDF /* VolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSlider.swift; sourceTree = "<group>"; };
+		E475F373557FD3524086CE19 /* MeetingCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCalendar.swift; sourceTree = "<group>"; };
 		E54932083F6BC197453EA0C8 /* UninstallSearchRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSearchRoot.swift; sourceTree = "<group>"; };
 		E582B93EFB1A2AA85B048A87 /* CalcFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcFormatter.swift; sourceTree = "<group>"; };
 		E5B89168050723B7221F04A2 /* ClipboardCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardCoordinator.swift; sourceTree = "<group>"; };
@@ -614,6 +641,7 @@
 		F023729C84682E9231F3D73B /* ExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstaller.swift; sourceTree = "<group>"; };
 		F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		F097C9983DF27A99694C8BC5 /* Zlib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zlib.swift; sourceTree = "<group>"; };
+		F3F97240A718D95DFD9343DB /* UpcomingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingWindow.swift; sourceTree = "<group>"; };
 		F524FA7B33C0F861995EB1E6 /* QuicklinkArgumentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsScreen.swift; sourceTree = "<group>"; };
 		F58E564E6181EB15497E51CD /* SnippetTemplateEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplateEngine.swift; sourceTree = "<group>"; };
 		F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArchive.swift; sourceTree = "<group>"; };
@@ -662,6 +690,7 @@
 				5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */,
 				8E5F9675F2090C3AA9EEBF65 /* Appearance.swift */,
 				B6A96350EBE68EC79497FA2D /* AppPaths.swift */,
+				D3F82845FDA307DF71676352 /* CalendarAccess.swift */,
 				BFB023D167225228757CC4B2 /* HealthTicker.swift */,
 				2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */,
 				3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */,
@@ -1023,6 +1052,28 @@
 			path = Quicklinks;
 			sourceTree = "<group>";
 		};
+		62EF0A8EC65450D9B118D559 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				E475F373557FD3524086CE19 /* MeetingCalendar.swift */,
+				C0599199132DAFBE12C59FBD /* MeetingDay.swift */,
+				5B330ABFC83721904159DDF2 /* MeetingEvent.swift */,
+				B117F11E9B15D1B1919B7FB1 /* MeetingLink.swift */,
+				F3F97240A718D95DFD9343DB /* UpcomingWindow.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		677EE2B98DA29890F4BE354A /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				9D0A2005448E6F88C3F78489 /* CalendarStore.swift */,
+				474E6D9830E336752C79F461 /* MeetingClock.swift */,
+				46C117C966BC2990F19E00AB /* MeetingLauncher.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		6D9D85B5CE38DEAF33B64137 /* About */ = {
 			isa = PBXGroup;
 			children = (
@@ -1108,6 +1159,17 @@
 				91D0784E49BC5899A585F285 /* Scrypt.swift */,
 			);
 			path = Service;
+			sourceTree = "<group>";
+		};
+		7ABC8B1EF26E88F63B7DF160 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				8FC504A12A2D9CC00B502D9E /* CalendarCoordinator.swift */,
+				0B2FAC737503B853DE6B5ED4 /* MeetingCardView.swift */,
+				590A432CC25ED6372B453BFA /* ScheduleScreen.swift */,
+				1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */,
+			);
+			path = UI;
 			sourceTree = "<group>";
 		};
 		7CD438390F8FA4B3C2AE5F28 /* Snippets */ = {
@@ -1226,6 +1288,7 @@
 			children = (
 				4852DB90D637B9D8E0B2556C /* Backup */,
 				356F452DB0F8F9834817455B /* Calculator */,
+				AB3219F826C0EB84910B6AAD /* Calendar */,
 				005F026A8F7D5E209B1CE917 /* Clipboard */,
 				486F4CE5090E1ABA5AC16451 /* CustomCommands */,
 				15CFCD6B1429C5F0944CBCC4 /* Emoji */,
@@ -1376,6 +1439,17 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		AB3219F826C0EB84910B6AAD /* Calendar */ = {
+			isa = PBXGroup;
+			children = (
+				62EF0A8EC65450D9B118D559 /* Model */,
+				677EE2B98DA29890F4BE354A /* Service */,
+				D62A9A3E2CCA4CC188B8E3FB /* Settings */,
+				7ABC8B1EF26E88F63B7DF160 /* UI */,
+			);
+			path = Calendar;
+			sourceTree = "<group>";
+		};
 		B7F695C73111F7B44A3C240A /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -1501,6 +1575,14 @@
 				FC2B77DA46386E7E459406E4 /* NotesStore.swift */,
 			);
 			path = Service;
+			sourceTree = "<group>";
+		};
+		D62A9A3E2CCA4CC188B8E3FB /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				BC0AA95CA13E86370661D01C /* CalendarSettingsView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		DA2B58692CED3E980CCBEE18 /* Service */ = {
@@ -1779,6 +1861,10 @@
 				9B3BC1DCC478DA7517F04182 /* CalculatorHistoryScreen.swift in Sources */,
 				5FB708EC91426C41762AB96B /* CalculatorHistoryStore.swift in Sources */,
 				5E155BEE2FC62267F516A343 /* CalculatorHistoryView.swift in Sources */,
+				ABFC92E6F22D8D6715081D9F /* CalendarAccess.swift in Sources */,
+				EA077323DE71DAF8FE17693C /* CalendarCoordinator.swift in Sources */,
+				D4AC94686EEEF4B792B58593 /* CalendarSettingsView.swift in Sources */,
+				743C70ACA40F61F635DB0B55 /* CalendarStore.swift in Sources */,
 				279F586CC34205EBA8ACA892 /* CalloutPlacement.swift in Sources */,
 				80E77985425032856DEECDFD /* CalloutShape.swift in Sources */,
 				A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */,
@@ -1892,6 +1978,13 @@
 				633DCA2F00A274C375EB4423 /* LauncherRankingStore.swift in Sources */,
 				7FF6A0A4702E1C1365F2D76A /* LauncherScreen.swift in Sources */,
 				E7DCBF503DDEF223C6BE71E5 /* LegacyHotKeyRecords.swift in Sources */,
+				60A1949A691168B535B562C8 /* MeetingCalendar.swift in Sources */,
+				A70176F7F17CB4FF521634A4 /* MeetingCardView.swift in Sources */,
+				BCA7E1C4BCF6F77634E54CA7 /* MeetingClock.swift in Sources */,
+				9E4497ECAD183E5C2B49475B /* MeetingDay.swift in Sources */,
+				E4E1403AA9A8ACE4A3D3581C /* MeetingEvent.swift in Sources */,
+				791AC049B6CA16C7D86EEBEF /* MeetingLauncher.swift in Sources */,
+				77A82B4F0CC09E7248DC5706 /* MeetingLink.swift in Sources */,
 				AAFD2C9276D38719E85B675F /* Memo.swift in Sources */,
 				43DBCE7B5A84D0D6322124F5 /* MessageHUDController.swift in Sources */,
 				8D529C8F3AB579941067FE98 /* MessageHUDView.swift in Sources */,
@@ -1961,6 +2054,8 @@
 				AD98F015439106F0E9D32015 /* RightClick.swift in Sources */,
 				47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */,
 				9A80D2997DCF835AF225A586 /* RunningAppsMonitor.swift in Sources */,
+				30C5B58F3876A5B85BFBBDDF /* ScheduleScreen.swift in Sources */,
+				BAD4BEF8041665ACCF1CE460 /* ScheduleView.swift in Sources */,
 				00D813D3D99D0856E743168B /* ScreenTarget.swift in Sources */,
 				31E0E4E0782A79504CEB588D /* ScrollIntent.swift in Sources */,
 				07726F26DC68689F8984F467 /* Scrypt.swift in Sources */,
@@ -2024,6 +2119,7 @@
 				E457BC709D195B8F5D0C2A79 /* UninstallSession.swift in Sources */,
 				CAE4C44A9D2EC4AC51FD3150 /* UninstallTarget.swift in Sources */,
 				D9113113F828FD6983715D6B /* UninstallView.swift in Sources */,
+				3A2B91CE53DD84DE9EF5ECB8 /* UpcomingWindow.swift in Sources */,
 				A6514CA79A45918109A65514 /* UpdateCheckStore.swift in Sources */,
 				56E4958BCEF1FED10B4A796E /* UpdateCoordinator.swift in Sources */,
 				C396379DCAD85611D4C6F587 /* UpdateDownloader.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -29,6 +29,8 @@ final class AppCore {
     let aliases = AliasStore()
     let calcHistory = CalculatorHistoryStore()
     let currencyRates = CurrencyRateStore()
+    let calendarStore = CalendarStore()
+    let meetingClock = MeetingClock()
     let updateChecker = UpdateCheckStore()
     let emojiIndex = EmojiIndex()
     let frequentEmoji = FrequentEmojiStore()
@@ -98,6 +100,7 @@ final class AppCore {
         windowCommandCoordinator: windowCommandCoordinator,
         snippetExpansion: snippetExpansion, fileSearchCoordinator: fileSearchCoordinator,
         notesCoordinator: notesCoordinator, extensionCoordinator: extensionCoordinator,
+        calendarCoordinator: calendarCoordinator,
         core: self)
     @ObservationIgnored private(set) lazy var clipboardCoordinator = ClipboardCoordinator(
         clipboardStore: clipboardStore, palette: palette, windowController: windowController,
@@ -107,6 +110,9 @@ final class AppCore {
         paletteCoordinator: paletteCoordinator)
     @ObservationIgnored private(set) lazy var calculatorCoordinator = CalculatorCoordinator(
         calcHistory: calcHistory, paletteCoordinator: paletteCoordinator, core: self)
+    @ObservationIgnored private(set) lazy var calendarCoordinator = CalendarCoordinator(
+        store: calendarStore, clock: meetingClock, appIndex: appIndex, settings: settings,
+        paletteCoordinator: paletteCoordinator, core: self)
     @ObservationIgnored private(set) lazy var fileSearchCoordinator = FileSearchCoordinator(
         settings: settings, appIndex: appIndex, session: fileSearch, palette: palette,
         paletteCoordinator: paletteCoordinator, core: self)
@@ -173,6 +179,7 @@ final class AppCore {
             quicklinks.load()
             quicklinkCoordinator.applyQuicklinksPresence()
             updateCoordinator.applyEnabled()
+            calendarCoordinator.applyEnabled()
             Task { await appIndex.refresh() }
             Task { await emojiIndex.load() }
             currencyRates.start()
@@ -192,6 +199,9 @@ final class AppCore {
             hotKeys.onCreateNote = { [weak self] in self?.notesCoordinator.createNote() }
             hotKeys.onSearchNotes = { [weak self] in self?.notesCoordinator.searchNotes() }
             hotKeys.onSearchFiles = { [weak self] in self?.fileSearchCoordinator.show() }
+            hotKeys.onJoinNextMeeting = { [weak self] in
+                self?.calendarCoordinator.joinNextMeeting()
+            }
             hotKeys.onRunCustomCommand = { [weak self] id in
                 self?.customCommandCoordinator.runCustomCommand(id: id)
             }
@@ -268,7 +278,7 @@ final class AppCore {
         case .extensionCommand(let entryID):
             return appIndex.apps.first { $0.kind == .extensionCommand && $0.id == entryID }?.name
         case .togglePalette, .toggleClipboard, .toggleEmoji, .searchFiles, .systemAction,
-            .showNotes, .createNote, .searchNotes, .windowCommand:
+            .showNotes, .createNote, .searchNotes, .windowCommand, .joinNextMeeting:
             return nil
         }
     }
@@ -306,6 +316,11 @@ final class AppCore {
             }, reproject: { $0.quicklinkCoordinator.applyQuicklinksPresence() })
         track({ _ = $0.fileSearchEnabled }, reproject: { $0.fileSearchCoordinator.applyEnabled() })
         track({ _ = $0.notesEnabled }, reproject: { $0.notesCoordinator.applyEnabled() })
+        track(
+            {
+                _ = $0.calendarEnabled
+                _ = $0.calendarShowInLauncher
+            }, reproject: { $0.calendarCoordinator.applyEnabled() })
         track(
             {
                 _ = $0.fileSearchScopes

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -51,6 +51,9 @@ struct SettingsBackup: Codable {
         var quicklinkOpensNewWindow: Bool?
         var quicklinkSelectionFallback: String?
         var quicklinkConfirmsBeforeDelete: Bool?
+        // `calendarEnabled` is absent: an import must not grant calendar access.
+        var calendarShowInLauncher: Bool?
+        var joinWindowMinutes: Int?
     }
 
     /// Combos keep the legacy shape, so older files import. docs/features/hotkeys.md#persistence
@@ -62,6 +65,7 @@ struct SettingsBackup: Codable {
         var createNote: HotKeyBinding?
         var searchNotes: HotKeyBinding?
         var searchFiles: HotKeyBinding?
+        var joinNextMeeting: HotKeyBinding?
         var apps: [String: HotKeyBinding]?
         var panes: [String: HotKeyBinding]?
         var customCommands: [String: HotKeyBinding]?
@@ -122,7 +126,9 @@ extension SettingsBackup {
             extensionsShowInLauncher: s.extensionsShowInLauncher,
             quicklinkOpensNewWindow: s.quicklinkOpensNewWindow,
             quicklinkSelectionFallback: s.quicklinkSelectionFallback.rawValue,
-            quicklinkConfirmsBeforeDelete: s.quicklinkConfirmsBeforeDelete)
+            quicklinkConfirmsBeforeDelete: s.quicklinkConfirmsBeforeDelete,
+            calendarShowInLauncher: s.calendarShowInLauncher,
+            joinWindowMinutes: s.joinWindowMinutes.rawValue)
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
@@ -133,6 +139,7 @@ extension SettingsBackup {
         hotkeys.createNote = hk.binding(for: .createNote)
         hotkeys.searchNotes = hk.binding(for: .searchNotes)
         hotkeys.searchFiles = hk.binding(for: .searchFiles)
+        hotkeys.joinNextMeeting = hk.binding(for: .joinNextMeeting)
         hotkeys.apps = Dictionary(
             uniqueKeysWithValues: hk.boundBundleIDs.compactMap { id in
                 hk.binding(for: .app(bundleID: id)).map { (id, $0) }
@@ -333,6 +340,14 @@ extension SettingsBackup {
             settings.quicklinkConfirmsBeforeDelete = flag
             count += 1
         }
+        if let flag = s.calendarShowInLauncher {
+            settings.calendarShowInLauncher = flag
+            count += 1
+        }
+        if let raw = s.joinWindowMinutes, let window = JoinWindow(rawValue: raw) {
+            settings.joinWindowMinutes = window
+            count += 1
+        }
         return count
     }
 
@@ -352,6 +367,7 @@ extension SettingsBackup {
         if let b = hotkeys.createNote { apply(b, .createNote) }
         if let b = hotkeys.searchNotes { apply(b, .searchNotes) }
         if let b = hotkeys.searchFiles { apply(b, .searchFiles) }
+        if let b = hotkeys.joinNextMeeting { apply(b, .joinNextMeeting) }
         for (id, b) in hotkeys.apps ?? [:] { apply(b, .app(bundleID: id)) }
         for (id, b) in hotkeys.panes ?? [:] { apply(b, .settingsPane(bundleID: id)) }
         for (rawID, b) in hotkeys.customCommands ?? [:] {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -33,7 +33,9 @@ enum SettingsBackupCoverage {
         "quicklinkOpensNewWindow": .quicklinkOpensNewWindow,
         "quicklinkSelectionFallback": .quicklinkSelectionFallback,
         "quicklinkConfirmsBeforeDelete": .quicklinkConfirmsBeforeDelete,
-        "extensionsShowInLauncher": .extensionsShowInLauncher
+        "extensionsShowInLauncher": .extensionsShowInLauncher,
+        "calendarShowInLauncher": .calendarShowInLauncher,
+        "joinWindowMinutes": .joinWindowMinutes
     ]
 
     /// The `SettingsData` fields no `AppSettings` key stands behind, and what they read instead.
@@ -58,6 +60,8 @@ enum SettingsBackupCoverage {
         AppSettingsKey.palettePosition.rawValue:
             "Machine-local geometry: a point restored onto another display layout lands nowhere.",
         AppSettingsKey.autoSwitchInputSource.rawValue:
-            "Names a keyboard input source installed on this Mac; another Mac may not have it."
+            "Names a keyboard input source installed on this Mac; another Mac may not have it.",
+        AppSettingsKey.calendarEnabled.rawValue:
+            "Doubles as consent to read your calendar; an import must not grant calendar access."
     ]
 }

--- a/Tinycast/Features/Calendar/Model/MeetingCalendar.swift
+++ b/Tinycast/Features/Calendar/Model/MeetingCalendar.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// One calendar the user can switch off, flattened out of EventKit for the Settings list.
+struct MeetingCalendar: Identifiable, Hashable, Sendable {
+    let id: String
+    let title: String
+    /// The owning account, so two "Calendar" entries from different accounts stay tellable apart.
+    let accountName: String
+}

--- a/Tinycast/Features/Calendar/Model/MeetingDay.swift
+++ b/Tinycast/Features/Calendar/Model/MeetingDay.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// The two day buckets My Schedule groups by, mirroring the clipboard's `DateBucket`.
+enum MeetingDay: Sendable {
+    case today
+    case tomorrow
+
+    init?(for date: Date, now: Date, calendar: Calendar) {
+        if calendar.isDate(date, inSameDayAs: now) {
+            self = .today
+            return
+        }
+        guard let next = calendar.date(byAdding: .day, value: 1, to: now),
+            calendar.isDate(date, inSameDayAs: next)
+        else { return nil }
+        self = .tomorrow
+    }
+
+    var title: String {
+        switch self {
+        case .today: return "Today"
+        case .tomorrow: return "Tomorrow"
+        }
+    }
+}

--- a/Tinycast/Features/Calendar/Model/MeetingEvent.swift
+++ b/Tinycast/Features/Calendar/Model/MeetingEvent.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// One calendar occurrence, flattened out of EventKit so nothing EventKit-shaped reaches a view.
+struct MeetingEvent: Identifiable, Hashable, Sendable {
+    /// Unique per occurrence: a recurring series shares one event identifier across every instance.
+    let id: String
+    let title: String
+    let start: Date
+    let end: Date
+    let isAllDay: Bool
+    let isDeclined: Bool
+    let calendarID: String
+    let calendarName: String
+    /// EventKit's `calendarItemIdentifier` — the only handle Calendar.app's `ical://` URL accepts.
+    let calendarItemID: String
+    let link: MeetingLink?
+
+    private static let entryPrefix = "meeting:"
+
+    var entryID: String { Self.entryPrefix + id }
+
+    static func id(fromEntryID entryID: String) -> String? {
+        guard entryID.hasPrefix(entryPrefix) else { return nil }
+        return String(entryID.dropFirst(entryPrefix.count))
+    }
+
+    func isInProgress(now: Date) -> Bool { start <= now && now < end }
+}

--- a/Tinycast/Features/Calendar/Model/MeetingLink.swift
+++ b/Tinycast/Features/Calendar/Model/MeetingLink.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// A meeting's join link and the service behind it, read out of the event's own text.
+struct MeetingLink: Hashable, Sendable {
+    let provider: Provider
+    let url: URL
+
+    /// The desktop app's own URL, where one can be formed without guessing. Nil means open the web.
+    var appURL: URL? { provider.appURL(for: url) }
+
+    /// Fields in precedence order; a named provider anywhere beats a bare link found earlier.
+    static func detect(fields: [String?]) -> MeetingLink? {
+        var fallback: MeetingLink?
+        for field in fields.compactMap({ $0 }) {
+            for url in webURLs(in: field) {
+                guard let link = classify(url) else { continue }
+                if link.provider != .generic { return link }
+                if fallback == nil { fallback = link }
+            }
+        }
+        return fallback
+    }
+
+    static func detect(in text: String) -> MeetingLink? {
+        detect(fields: [text])
+    }
+
+    /// A URL on a known host that fails that provider's path rule is rejected, never demoted to
+    /// `.generic` — `zoom.us/download` sits in half the invites people are sent.
+    private static func classify(_ url: URL) -> MeetingLink? {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https",
+            let host = url.host()?.lowercased()
+        else { return nil }
+        guard let provider = Provider(host: host) else {
+            return MeetingLink(provider: .generic, url: url)
+        }
+        return provider.admits(path: url.path()) ? MeetingLink(provider: provider, url: url) : nil
+    }
+
+    private static let terminators: Set<Character> = [
+        " ", "\t", "\n", "\r", "\"", "'", "<", ">", "«", "»", "\u{00A0}"
+    ]
+    private static let trailingNoise: Set<Character> = [".", ",", ";", ":", ")", "]", "}", "!", "?"]
+
+    /// Hand-rolled rather than `NSDataDetector`: a detector is not `Sendable`, and rebuilding one
+    /// per event costs more than the scan it replaces.
+    private static func webURLs(in text: String) -> [URL] {
+        var found: [URL] = []
+        var cursor = text.startIndex
+        while cursor < text.endIndex,
+            let start = text.range(
+                of: "http", options: .caseInsensitive, range: cursor..<text.endIndex)?.lowerBound
+        {
+            let end = text[start...].firstIndex(where: terminators.contains) ?? text.endIndex
+            var candidate = text[start..<end]
+            while let last = candidate.last, trailingNoise.contains(last) {
+                candidate = candidate.dropLast()
+            }
+            let lowered = candidate.lowercased()
+            if lowered.hasPrefix("http://") || lowered.hasPrefix("https://"),
+                let url = URL(string: String(candidate))
+            {
+                found.append(url)
+            }
+            cursor = end > start ? end : text.index(after: start)
+        }
+        return found
+    }
+}
+
+extension MeetingLink {
+    enum Provider: String, CaseIterable, Sendable {
+        case zoom
+        case googleMeet
+        case teams
+        case webex
+        case jitsi
+        case whereby
+        case chime
+        case gotoMeeting
+        case blueJeans
+        case skype
+        /// Any other http(s) link the event carries — joinable, just not identifiable.
+        case generic
+
+        var title: String {
+            switch self {
+            case .zoom: return "Zoom"
+            case .googleMeet: return "Google Meet"
+            case .teams: return "Microsoft Teams"
+            case .webex: return "Webex"
+            case .jitsi: return "Jitsi"
+            case .whereby: return "Whereby"
+            case .chime: return "Amazon Chime"
+            case .gotoMeeting: return "GoTo Meeting"
+            case .blueJeans: return "BlueJeans"
+            case .skype: return "Skype"
+            case .generic: return "Meeting Link"
+            }
+        }
+
+        /// No brand artwork ships with the app, so the name carries the identity and the glyph only
+        /// says what kind of thing this is.
+        var sfSymbol: String { self == .generic ? "link" : "video.fill" }
+
+        /// Host suffixes, matched as the whole host or as a subdomain of it. Disjoint by construction.
+        private static let hostSuffixes: [Provider: [String]] = [
+            .zoom: ["zoom.us", "zoom.com", "zoomgov.com"],
+            .googleMeet: ["meet.google.com"],
+            .teams: ["teams.microsoft.com", "teams.microsoft.us", "teams.live.com"],
+            .webex: ["webex.com", "webex.com.cn"],
+            .jitsi: ["meet.jit.si", "8x8.vc"],
+            .whereby: ["whereby.com"],
+            .chime: ["chime.aws"],
+            .gotoMeeting: ["gotomeeting.com", "gotomeet.me", "app.goto.com"],
+            .blueJeans: ["bluejeans.com"],
+            .skype: ["join.skype.com"]
+        ]
+
+        init?(host: String) {
+            let match = Self.hostSuffixes.first { _, suffixes in
+                suffixes.contains { host == $0 || host.hasSuffix("." + $0) }
+            }
+            guard let match else { return nil }
+            self = match.key
+        }
+
+        /// Whether the path shape is a meeting rather than a download page or a dial-in helper.
+        func admits(path: String) -> Bool {
+            let segments = path.split(separator: "/").map { $0.lowercased() }
+            switch self {
+            case .zoom:
+                return segments.contains { ["j", "w", "s", "my"].contains($0) }
+            case .googleMeet:
+                return segments.count == 1 && segments[0] != "tel"
+            case .teams:
+                return segments.contains("meetup-join") || segments.contains("meet")
+            case .webex, .jitsi, .whereby, .chime, .gotoMeeting, .blueJeans, .skype, .generic:
+                return !segments.isEmpty
+            }
+        }
+
+        /// Only the two rewrites Apple's URL handlers make unambiguous; anything else opens the web.
+        func appURL(for url: URL) -> URL? {
+            switch self {
+            case .zoom: return zoomAppURL(for: url)
+            case .teams: return teamsAppURL(for: url)
+            default: return nil
+            }
+        }
+
+        private func zoomAppURL(for url: URL) -> URL? {
+            let segments = url.path().split(separator: "/")
+            guard let marker = segments.firstIndex(where: { ["j", "w", "s"].contains($0.lowercased()) }),
+                let conference = segments.dropFirst(marker + 1).first
+            else { return nil }
+            var components = URLComponents()
+            components.scheme = "zoommtg"
+            components.host = "zoom.us"
+            components.path = "/join"
+            var query = [URLQueryItem(name: "confno", value: String(conference))]
+            if let password = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "pwd" })?.value
+            {
+                query.append(URLQueryItem(name: "pwd", value: password))
+            }
+            components.queryItems = query
+            return components.url
+        }
+
+        private func teamsAppURL(for url: URL) -> URL? {
+            guard url.host()?.lowercased().hasSuffix("teams.microsoft.com") == true else { return nil }
+            let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?.query
+            return URL(string: "msteams:" + url.path() + (query.map { "?" + $0 } ?? ""))
+        }
+    }
+}

--- a/Tinycast/Features/Calendar/Model/UpcomingWindow.swift
+++ b/Tinycast/Features/Calendar/Model/UpcomingWindow.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Which meeting is worth showing, and whether it is time. Every clock read is an injected `now`.
+struct UpcomingWindow: Sendable {
+    let leadMinutes: Int
+
+    private var lead: TimeInterval { TimeInterval(leadMinutes * 60) }
+
+    /// The events any surface may show: timed, not declined, in start order. The one place that
+    /// rule lives, so the card, the chord, the schedule and the launcher cannot drift apart.
+    static func agenda(from events: [MeetingEvent]) -> [MeetingEvent] {
+        events
+            .filter { !$0.isAllDay && !$0.isDeclined }
+            .sorted { $0.start < $1.start }
+    }
+
+    /// The card's meeting: `now` inside `[start - lead, min(start + lead, end)]`, and joinable.
+    /// The grace period never outlives the meeting, so a three-minute stand-up clears at its end.
+    func carded(from events: [MeetingEvent], now: Date) -> MeetingEvent? {
+        Self.agenda(from: events).first {
+            $0.link != nil && now >= $0.start - lead && now < min($0.start + lead, $0.end)
+        }
+    }
+
+    /// The chord's meeting. It answers the card first so the shortcut always joins what is on
+    /// screen, then anything running, then the next one with a link.
+    func joinable(from events: [MeetingEvent], now: Date) -> MeetingEvent? {
+        if let carded = carded(from: events, now: now) { return carded }
+        let linked = Self.agenda(from: events).filter { $0.link != nil }
+        return linked.first { $0.isInProgress(now: now) } ?? linked.first { $0.start > now }
+    }
+
+    static func countdown(to start: Date, now: Date) -> String {
+        let delta = start.timeIntervalSince(now)
+        if delta > 0 { return "in \(Int((delta / 60).rounded(.up))) min" }
+        let elapsed = Int((-delta / 60).rounded(.down))
+        return elapsed == 0 ? "now" : "\(elapsed) min ago"
+    }
+}

--- a/Tinycast/Features/Calendar/Service/CalendarStore.swift
+++ b/Tinycast/Features/Calendar/Service/CalendarStore.swift
@@ -1,0 +1,161 @@
+import EventKit
+import Foundation
+
+/// Today's and tomorrow's meetings, read from EventKit. See docs/features/calendar.md.
+@MainActor
+@Observable
+final class CalendarStore {
+    /// Flattened occurrences over `[startOfToday, endOfTomorrow]`, newest query wins.
+    private(set) var events: [MeetingEvent] = []
+    private(set) var calendars: [MeetingCalendar] = []
+    private(set) var access: CalendarAccess = Permissions.calendarAccess()
+
+    /// Fired whenever `events` changes, so the launcher's meeting slice is republished.
+    @ObservationIgnored var onChange: (() -> Void)?
+
+    private let defaults = UserDefaults.standard
+    private let hiddenKey = "hiddenMeetingCalendars"
+    /// Exclusions, not inclusions, so a calendar added after this was written defaults to on.
+    private var hiddenCalendarIDs: Set<String>
+
+    /// Built on first use, so a Mac with the feature off never loads EventKit at launch.
+    @ObservationIgnored private var eventStore: EKEventStore?
+    @ObservationIgnored private var changeObserver: NotificationToken?
+
+    init() {
+        hiddenCalendarIDs = Set(defaults.stringArray(forKey: hiddenKey) ?? [])
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        access = Permissions.calendarAccess()
+        guard access == .granted else { return }
+        // Deferred: the first EventKit query pays for its XPC warm-up, and launch protects itself.
+        Task { reload() }
+    }
+
+    func stop() {
+        changeObserver = nil
+        eventStore = nil
+        publish([])
+        calendars = []
+    }
+
+    /// Tinycast's own consent dialog has already been accepted by the time this runs.
+    func requestAccess() async -> Bool {
+        let granted = await Permissions.requestCalendarAccess()
+        access = Permissions.calendarAccess()
+        guard granted else { return false }
+        // A store built before the grant never sees the new calendars; drop it and rebuild.
+        changeObserver = nil
+        eventStore = nil
+        reload()
+        return true
+    }
+
+    /// EventKit says when to reload, so nothing here polls. The palette adds one refresh per summon.
+    private func observeStoreChanges() {
+        guard changeObserver == nil, let eventStore else { return }
+        let center = NotificationCenter.default
+        let token = center.addObserver(
+            forName: .EKEventStoreChanged, object: eventStore, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.reload() }
+        }
+        changeObserver = NotificationToken(token, center: center)
+    }
+
+    // MARK: - Reading
+
+    /// Two days of events is a sub-millisecond query and `EKEventStore` is not `Sendable`, so this
+    /// stays on the main actor; only pure `MeetingEvent` values leave it.
+    func reload() {
+        access = Permissions.calendarAccess()
+        guard access == .granted else {
+            publish([])
+            return
+        }
+        let store = eventStore ?? EKEventStore()
+        eventStore = store
+        observeStoreChanges()
+
+        let sources = store.calendars(for: .event)
+        calendars =
+            sources
+            .map {
+                MeetingCalendar(
+                    id: $0.calendarIdentifier, title: $0.title, accountName: $0.source.title)
+            }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+
+        let selected = sources.filter { !hiddenCalendarIDs.contains($0.calendarIdentifier) }
+        guard !selected.isEmpty, let span = Self.span(from: Date()) else {
+            publish([])
+            return
+        }
+        // The predicate expands recurrence itself; fetching masters and rolling our own never works.
+        let predicate = store.predicateForEvents(
+            withStart: span.start, end: span.end, calendars: selected)
+        publish(store.events(matching: predicate).compactMap(Self.meeting(from:)))
+    }
+
+    private func publish(_ next: [MeetingEvent]) {
+        guard next != events else { return }
+        events = next
+        onChange?()
+    }
+
+    /// Midnight today through midnight the day after tomorrow, in the Mac's own zone.
+    private static func span(from now: Date) -> (start: Date, end: Date)? {
+        let calendar = Calendar.current
+        guard let start = calendar.dateInterval(of: .day, for: now)?.start,
+            let end = calendar.date(byAdding: .day, value: 2, to: start)
+        else { return nil }
+        return (start, end)
+    }
+
+    private static func meeting(from event: EKEvent) -> MeetingEvent? {
+        // A cancelled event is not happening, so it never reaches a surface.
+        guard event.status != .canceled, let start = event.startDate, let end = event.endDate,
+            let calendar = event.calendar
+        else { return nil }
+        let declined =
+            event.attendees?
+            .first { $0.isCurrentUser }?.participantStatus == .declined
+        return MeetingEvent(
+            id: (event.eventIdentifier ?? event.calendarItemIdentifier)
+                + "|\(start.timeIntervalSinceReferenceDate)",
+            title: event.title ?? "(No Title)",
+            start: start,
+            end: end,
+            isAllDay: event.isAllDay,
+            isDeclined: declined,
+            calendarID: calendar.calendarIdentifier,
+            calendarName: calendar.title,
+            calendarItemID: event.calendarItemIdentifier,
+            link: MeetingLink.detect(fields: [
+                event.url?.absoluteString, event.location, event.notes
+            ]))
+    }
+
+    func event(id: String) -> MeetingEvent? {
+        events.first { $0.id == id }
+    }
+
+    // MARK: - Per-calendar switches
+
+    func isEnabled(_ calendar: MeetingCalendar) -> Bool {
+        !hiddenCalendarIDs.contains(calendar.id)
+    }
+
+    func setEnabled(_ enabled: Bool, for calendar: MeetingCalendar) {
+        if enabled {
+            hiddenCalendarIDs.remove(calendar.id)
+        } else {
+            hiddenCalendarIDs.insert(calendar.id)
+        }
+        defaults.set(Array(hiddenCalendarIDs), forKey: hiddenKey)
+        reload()
+    }
+}

--- a/Tinycast/Features/Calendar/Service/MeetingClock.swift
+++ b/Tinycast/Features/Calendar/Service/MeetingClock.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Publishes the current minute so a countdown re-renders on the boundary rather than per keystroke.
+/// It runs only while the palette is up, so an idle Mac owns no timer at all.
+@MainActor
+@Observable
+final class MeetingClock {
+    private(set) var now = Date()
+
+    @ObservationIgnored private var tick: Task<Void, Never>?
+
+    func start() {
+        now = Date()
+        // Replace rather than bail: an exited loop leaves a non-nil task that would block restart.
+        tick?.cancel()
+        tick = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(Self.secondsToNextMinute()))
+                guard !Task.isCancelled, let self else { return }
+                self.now = Date()
+            }
+        }
+    }
+
+    func stop() {
+        tick?.cancel()
+        tick = nil
+    }
+
+    isolated deinit {
+        tick?.cancel()
+    }
+
+    /// The reference date is itself a minute boundary, so the remainder is the offset into one.
+    private static func secondsToNextMinute() -> TimeInterval {
+        60 - Date().timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 60)
+    }
+}

--- a/Tinycast/Features/Calendar/Service/MeetingLauncher.swift
+++ b/Tinycast/Features/Calendar/Service/MeetingLauncher.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+enum MeetingLauncher {
+
+    /// The desktop app where one claims the scheme, the web where it does not. Returns false only
+    /// when neither route exists, which is what the caller reports.
+    @MainActor
+    @discardableResult
+    static func join(_ link: MeetingLink) -> Bool {
+        if let appURL = link.appURL, NSWorkspace.shared.urlForApplication(toOpen: appURL) != nil {
+            return NSWorkspace.shared.open(appURL)
+        }
+        return NSWorkspace.shared.open(link.url)
+    }
+
+    /// Calendar.app's own handle. A recurring occurrence opens its series, which is all `ical://` takes.
+    @MainActor
+    @discardableResult
+    static func showInCalendar(_ event: MeetingEvent) -> Bool {
+        guard
+            let url = URL(
+                string: "ical://ekevent/\(event.calendarItemID)?method=show&options=more")
+        else { return false }
+        return NSWorkspace.shared.open(url)
+    }
+}

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct CalendarSettingsView: View {
+    @Environment(AppCore.self) private var core
+    @Environment(AppSettings.self) private var settings
+    @Environment(CalendarStore.self) private var store
+
+    var body: some View {
+        @Bindable var settings = settings
+        Form {
+            FeatureSwitchSection(
+                header: "Calendar",
+                enableTitle: "Join meetings from Tinycast",
+                enableSubtitle:
+                    "Reads today's and tomorrow's events to find join links. Nothing leaves this Mac.",
+                launcherSubtitle: "List individual meetings alongside apps and commands.",
+                isEnabled: enabledBinding,
+                showsInLauncher: $settings.calendarShowInLauncher)
+
+            if store.access == .denied {
+                Section {
+                    SettingsRow(
+                        title: "Calendar access is off",
+                        subtitle: "Turn Tinycast on under Privacy & Security ▸ Calendars."
+                    ) {
+                        Button("Open System Settings…") { Permissions.openCalendarSettings() }
+                    }
+                }
+            }
+
+            Section {
+                SettingsRow(title: "Join Next Meeting") {
+                    ShortcutRecorder(action: .joinNextMeeting)
+                }
+                Picker(selection: $settings.joinWindowMinutes) {
+                    ForEach(JoinWindow.allCases) { window in
+                        Text(window.title).tag(window)
+                    }
+                } label: {
+                    Text("Show the join card")
+                    Text("How early the card appears, and how long past the start it stays.")
+                }
+            } header: {
+                Text("Joining")
+            }
+            .settingsEnabled(settings.calendarEnabled)
+
+            CalendarPickerSection()
+                .settingsEnabled(settings.calendarEnabled)
+        }
+        .formStyle(.grouped)
+        .releasesFocusOnOutsideClick()
+    }
+
+    /// Routed through the coordinator so enabling, which is also consent, confirms first.
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { settings.calendarEnabled },
+            set: { core.calendarCoordinator.setCalendarEnabled($0) }
+        )
+    }
+}
+
+/// The per-calendar switches. Machine-local by nature, so they live on the store rather than
+/// `AppSettings`, and never travel in a settings backup.
+private struct CalendarPickerSection: View {
+    @Environment(CalendarStore.self) private var store
+    @State private var query = ""
+
+    private var calendars: [MeetingCalendar] {
+        guard !query.isEmpty else { return store.calendars }
+        return store.calendars.filter {
+            $0.title.localizedCaseInsensitiveContains(query)
+                || $0.accountName.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    var body: some View {
+        Section {
+            SettingsFilterField(prompt: "Search calendars…", query: $query)
+
+            if calendars.isEmpty {
+                Text(emptyMessage)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                // One row holding a lazy stack: a `Form` realizes every row it is handed.
+                LazyVStack(spacing: 0) {
+                    ForEach(calendars) { calendar in
+                        if calendar.id != calendars.first?.id { Divider() }
+                        CalendarRow(calendar: calendar)
+                            .padding(.vertical, Self.rowPadding)
+                    }
+                }
+                .padding(.vertical, -Self.rowPadding)
+            }
+        } header: {
+            Text("Calendars")
+        }
+    }
+
+    /// A grouped `Form` row's own vertical padding.
+    private static let rowPadding: CGFloat = 15
+
+    private var emptyMessage: String {
+        if !query.isEmpty { return "No matches for “\(query)”." }
+        return store.access == .granted ? "No calendars on this Mac." : "Nothing to show yet."
+    }
+}
+
+private struct CalendarRow: View {
+    let calendar: MeetingCalendar
+    @Environment(CalendarStore.self) private var store
+
+    var body: some View {
+        SettingsRow(title: calendar.title, subtitle: calendar.accountName) {
+            Toggle("", isOn: binding)
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .accessibilityLabel("Include \(calendar.title) in meetings")
+        }
+    }
+
+    private var binding: Binding<Bool> {
+        Binding(
+            get: { store.isEnabled(calendar) },
+            set: { store.setEnabled($0, for: calendar) }
+        )
+    }
+}

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -1,0 +1,199 @@
+import AppKit
+
+/// Owns joining a meeting: the consent gate, the card's and the chord's actions, feature presence.
+@MainActor
+final class CalendarCoordinator {
+    private let store: CalendarStore
+    private let clock: MeetingClock
+    private let appIndex: AppIndex
+    private let settings: AppSettings
+    private let paletteCoordinator: PaletteCoordinator
+    /// Dialogs and the HUD, so both stay owned by `AppCore`.
+    private unowned let core: AppCore
+
+    init(
+        store: CalendarStore,
+        clock: MeetingClock,
+        appIndex: AppIndex,
+        settings: AppSettings,
+        paletteCoordinator: PaletteCoordinator,
+        core: AppCore
+    ) {
+        self.store = store
+        self.clock = clock
+        self.appIndex = appIndex
+        self.settings = settings
+        self.paletteCoordinator = paletteCoordinator
+        self.core = core
+    }
+
+    /// The window every surface reads, so the card, the chord and the schedule cannot disagree.
+    var window: UpcomingWindow { UpcomingWindow(leadMinutes: settings.joinWindowMinutes.rawValue) }
+
+    /// The meeting the join card shows, or nil when none is due. `now` comes from the ticking clock.
+    var cardedMeeting: MeetingEvent? {
+        guard settings.calendarEnabled else { return nil }
+        return window.carded(from: store.events, now: clock.now)
+    }
+
+    /// Today and tomorrow, timed and accepted, in start order.
+    var agenda: [MeetingEvent] { UpcomingWindow.agenda(from: store.events) }
+
+    // MARK: - Feature switch
+
+    /// The switch funnels here so enabling, which is also consent, confirms first.
+    func setCalendarEnabled(_ enabled: Bool) {
+        guard enabled != settings.calendarEnabled else { return }
+        if !enabled {
+            settings.calendarEnabled = false
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        Task {
+            guard
+                await core.confirm(
+                    title: "Enable calendar?",
+                    message:
+                        "Tinycast reads today's and tomorrow's events to find join links. Nothing leaves this Mac.",
+                    symbol: "calendar", confirmTitle: "Continue", tone: .neutral,
+                    confirmRole: .standard)
+            else { return }
+
+            settings.calendarEnabled = true
+            // The one prompt for this feature, raised from the gesture that asked for it.
+            guard await store.requestAccess() else { return }
+            applyEnabled()
+        }
+    }
+
+    /// Publishes or withdraws everything the feature contributes to the launcher.
+    func applyEnabled() {
+        let enabled = settings.calendarEnabled
+        appIndex.setCommandsVisible(
+            [.joinNextMeeting, .copyMeetingLink, .mySchedule, .openInCalendar], enabled)
+        guard enabled else {
+            store.stop()
+            publishEntries()
+            return
+        }
+        store.onChange = { [weak self] in self?.publishEntries() }
+        store.start()
+        publishEntries()
+    }
+
+    private func publishEntries() {
+        guard settings.calendarEnabled, settings.calendarShowInLauncher else {
+            appIndex.setMeetings([])
+            return
+        }
+        appIndex.setMeetings(agenda.map(Self.entry(for:)))
+    }
+
+    private static func entry(for meeting: MeetingEvent) -> AppEntry {
+        AppEntry(
+            id: meeting.entryID, name: meeting.title,
+            url: URL(
+                string: "tinycast://meeting/"
+                    + (meeting.id.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+                        ?? ""))!,
+            bundleID: nil, kind: .meeting,
+            matchAliases: [meeting.calendarName],
+            symbolName: meeting.link?.provider.sfSymbol ?? "calendar")
+    }
+
+    // MARK: - Palette lifecycle
+
+    /// Both hooks the palette needs: events go stale while it is closed, and the countdown only
+    /// has to tick while someone can see it.
+    func paletteDidShow() {
+        guard settings.calendarEnabled else { return }
+        clock.start()
+        // Off the summon path: the card is observation-driven, so it can land a frame later.
+        Task { store.reload() }
+    }
+
+    func paletteDidHide() {
+        clock.stop()
+    }
+
+    // MARK: - Commands
+
+    func joinNextMeeting() {
+        guard let meeting = nextJoinable() else {
+            report("Nothing to join right now")
+            return
+        }
+        join(meeting)
+    }
+
+    func copyNextMeetingLink() {
+        guard let meeting = nextJoinable() else {
+            report("Nothing to join right now")
+            return
+        }
+        copyLink(meeting)
+    }
+
+    func openNextMeetingInCalendar() {
+        guard let meeting = window.joinable(from: store.events, now: Date()) ?? agenda.first else {
+            report("Nothing scheduled today or tomorrow")
+            return
+        }
+        openInCalendar(meeting)
+    }
+
+    /// Live rather than clock-driven: a chord fires without the palette, so nothing is ticking.
+    private func nextJoinable() -> MeetingEvent? {
+        guard settings.calendarEnabled else { return nil }
+        return window.joinable(from: store.events, now: Date())
+    }
+
+    // MARK: - Row actions
+
+    /// ↵ on a meeting row: join it, or hand a linkless one to Calendar.
+    func activateMeeting(id: String) {
+        guard let meeting = store.event(id: id) else { return }
+        join(meeting)
+    }
+
+    func join(_ meeting: MeetingEvent) {
+        guard let link = meeting.link else {
+            openInCalendar(meeting)
+            return
+        }
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        if MeetingLauncher.join(link) { return }
+        Task {
+            _ = await core.reportFailure(
+                title: "Couldn't open the meeting link",
+                message: "Nothing on this Mac would open \(link.url.absoluteString).",
+                symbol: "video.slash", recovery: nil)
+        }
+    }
+
+    func copyLink(_ meeting: MeetingEvent) {
+        guard let link = meeting.link else {
+            report("This meeting has no link")
+            return
+        }
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        Paster.copyPlainText(link.url.absoluteString)
+        core.showMessage("Meeting link copied")
+    }
+
+    func openInCalendar(_ meeting: MeetingEvent) {
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        MeetingLauncher.showInCalendar(meeting)
+    }
+
+    func showSchedule() {
+        paletteCoordinator.showPalette(mode: .schedule)
+    }
+
+    /// A miss is transient, so it reports through the HUD rather than a dialog needing dismissal.
+    private func report(_ message: String) {
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        core.showMessage(message, tone: .neutral)
+    }
+}

--- a/Tinycast/Features/Calendar/UI/MeetingCardView.swift
+++ b/Tinycast/Features/Calendar/UI/MeetingCardView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// The join card above the launcher results; selectable like a row, Enter joins.
+struct MeetingCard: View {
+    let meeting: MeetingEvent
+    let now: Date
+    let selected: Bool
+    @State private var hovered = false
+
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.xl) {
+            SymbolImage(
+                name: meeting.link?.provider.sfSymbol ?? "calendar",
+                size: Theme.Size.headerIconSlot
+            )
+            .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                Text(meeting.title)
+                    .font(Theme.Typography.calcResult.weight(.semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                Text(subtitle)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: Theme.Spacing.md)
+            Text(UpcomingWindow.countdown(to: meeting.start, now: now))
+                .font(Theme.Typography.rowTitle.weight(.medium))
+                .lineLimit(1)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.xxs)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Radius.keyCap, style: .continuous)
+                        .fill(Theme.Colors.controlSurface)
+                )
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+        .padding(.vertical, Theme.Spacing.xxl)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                .fill(Theme.Colors.cardFill)
+        )
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                .fill(fill)
+        )
+        .armedHover($hovered)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "\(meeting.title), \(UpcomingWindow.countdown(to: meeting.start, now: now))"
+        )
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var subtitle: String {
+        let time = MeetingTimeFormat.clock(meeting.start)
+        guard let provider = meeting.link?.provider else { return time }
+        return "\(time) · \(provider.title)"
+    }
+}
+
+/// The one place a meeting time becomes text, so the card and the schedule rows never diverge.
+@MainActor
+enum MeetingTimeFormat {
+    private static let formatter: Date.FormatStyle = .dateTime.hour().minute()
+
+    static func clock(_ date: Date) -> String { date.formatted(formatter) }
+}
+
+/// Actions for a meeting, shared by the card and every schedule row.
+@MainActor
+enum MeetingActionsMenu {
+    static func content(meeting: MeetingEvent, core: AppCore) -> PopoverMenuContent {
+        var items: [PopoverMenuItem] = []
+        if meeting.link != nil {
+            items.append(
+                PopoverMenuItem(title: "Join Meeting", systemImage: "video.fill", shortcut: "↵") {
+                    core.calendarCoordinator.join(meeting)
+                })
+            items.append(
+                PopoverMenuItem(title: "Copy Meeting Link", systemImage: "link", shortcut: "⌘↵") {
+                    core.calendarCoordinator.copyLink(meeting)
+                })
+        }
+        items.append(
+            PopoverMenuItem(
+                title: "Open in Calendar", systemImage: "calendar",
+                shortcut: meeting.link == nil ? "↵" : nil
+            ) {
+                core.calendarCoordinator.openInCalendar(meeting)
+            })
+        return PopoverMenuContent(header: meeting.title, items: items)
+    }
+}

--- a/Tinycast/Features/Calendar/UI/ScheduleScreen.swift
+++ b/Tinycast/Features/Calendar/UI/ScheduleScreen.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// My Schedule: today and tomorrow, filtered by the query. Enter joins, ⌘K carries the rest.
+struct ScheduleScreen: PaletteScreen {
+    let store: CalendarStore
+    let clock: MeetingClock
+    let core: AppCore
+    let vm: PaletteState
+    let openActions: () -> Void
+
+    var rows: [MeetingEvent] {
+        let query = vm.query.trimmingCharacters(in: .whitespaces)
+        let agenda = UpcomingWindow.agenda(from: store.events)
+        guard !query.isEmpty else { return agenda }
+        return agenda.filter {
+            $0.title.localizedCaseInsensitiveContains(query)
+                || $0.calendarName.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    /// A meeting with no link has nowhere to join, so the pill offers what it can instead.
+    var primaryActionTitle: String {
+        meeting(at: vm.selection)?.link == nil ? "Open in Calendar" : "Join Meeting"
+    }
+
+    private func meeting(at selection: Int) -> MeetingEvent? {
+        let rows = rows
+        return rows.indices.contains(selection) ? rows[selection] : nil
+    }
+
+    func actions(at selection: Int) -> PopoverMenuContent? {
+        guard let meeting = meeting(at: selection) else { return nil }
+        return MeetingActionsMenu.content(meeting: meeting, core: core)
+    }
+
+    func activate(at selection: Int) {
+        guard let meeting = meeting(at: selection) else { return }
+        core.calendarCoordinator.activateMeeting(id: meeting.id)
+    }
+
+    /// ⌘↵ — copy the link, for the "what's the link?" message rather than the call itself.
+    func secondary(at selection: Int) -> Bool {
+        guard let meeting = meeting(at: selection), meeting.link != nil else { return false }
+        core.calendarCoordinator.copyLink(meeting)
+        return true
+    }
+
+    func body(selection: Int, scroll: ScrollIntent) -> AnyView {
+        AnyView(content(selection: selection, scroll: scroll))
+    }
+
+    @ViewBuilder
+    private func content(selection: Int, scroll: ScrollIntent) -> some View {
+        let rows = rows
+        if rows.isEmpty {
+            EmptyResults(text: emptyMessage)
+        } else {
+            ScheduleList(
+                results: rows,
+                selectedID: meeting(at: selection)?.id,
+                now: clock.now,
+                scroll: scroll,
+                onActivate: { activate(at: rows.firstIndex(of: $0) ?? selection) },
+                onActions: { meeting in
+                    if let index = rows.firstIndex(of: meeting) { vm.selection = index }
+                    openActions()
+                }
+            )
+        }
+    }
+
+    /// Names why the list is empty: no access reads very differently from a free afternoon.
+    private var emptyMessage: String {
+        if store.access != .granted { return "Tinycast has no access to your calendar" }
+        if !vm.query.trimmingCharacters(in: .whitespaces).isEmpty { return "No matching meetings" }
+        return "Nothing scheduled today or tomorrow"
+    }
+}

--- a/Tinycast/Features/Calendar/UI/ScheduleView.swift
+++ b/Tinycast/Features/Calendar/UI/ScheduleView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// The My Schedule list, bucketed into Today and Tomorrow.
+struct ScheduleList: View {
+    let results: [MeetingEvent]
+    let selectedID: MeetingEvent.ID?
+    let now: Date
+    let scroll: ScrollIntent
+    let onActivate: (MeetingEvent) -> Void
+    let onActions: (MeetingEvent) -> Void
+
+    private enum Row: Identifiable {
+        case header(String)
+        case meeting(MeetingEvent)
+        var id: String {
+            switch self {
+            case .header(let title): return "header-" + title
+            case .meeting(let meeting): return meeting.id
+            }
+        }
+    }
+
+    /// `results` is already in start order, so a bucket change is where a header belongs.
+    private var rows: [Row] {
+        var rows: [Row] = []
+        var current: String?
+        for meeting in results {
+            let title =
+                MeetingDay(for: meeting.start, now: now, calendar: .current)?.title ?? "Later"
+            if title != current {
+                rows.append(.header(title))
+                current = title
+            }
+            rows.append(.meeting(meeting))
+        }
+        return rows
+    }
+
+    private var firstRowSelected: Bool {
+        selectedID != nil && selectedID == results.first?.id
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(rows) { row in
+                        switch row {
+                        case .header(let title):
+                            SectionHeader(title: title, isFirst: row.id == rows.first?.id)
+                        case .meeting(let meeting):
+                            MeetingRow(
+                                meeting: meeting, now: now, selected: meeting.id == selectedID
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture { onActivate(meeting) }
+                            .onRightClick { onActions(meeting) }
+                            .selectionFrame(meeting.id == selectedID)
+                        }
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.xs)
+                .padding(.bottom, Theme.Spacing.md)
+                .hideNativeScrollers()
+                .scrollOriginAnchor()
+            }
+            .edgeDissolve()
+            .thinScrollbar()
+            .scrollFollowsSelection(
+                scroll, row: selectedID, atOrigin: firstRowSelected, proxy: proxy)
+        }
+    }
+}
+
+private struct MeetingRow: View {
+    let meeting: MeetingEvent
+    let now: Date
+    let selected: Bool
+    @State private var hovered = false
+
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            SymbolImage(
+                name: meeting.link?.provider.sfSymbol ?? "calendar", size: Theme.Size.rowIcon * 0.7
+            )
+            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+            .foregroundStyle(meeting.isInProgress(now: now) ? Theme.Colors.brand : .secondary)
+            Text(meeting.title)
+                .font(Theme.Typography.rowTitle)
+                .lineLimit(1)
+            Spacer(minLength: Theme.Spacing.md)
+            Text(trailing)
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .fill(fill)
+        )
+        .armedHover($hovered)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(meeting.title), \(trailing)")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// A meeting under way says so; everything else reads as the clock time it starts.
+    private var trailing: String {
+        meeting.isInProgress(now: now) ? "Now" : MeetingTimeFormat.clock(meeting.start)
+    }
+}

--- a/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
+++ b/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
@@ -9,6 +9,7 @@ enum HotKeyAction: Hashable, Sendable {
     case createNote
     case searchNotes
     case searchFiles
+    case joinNextMeeting
     case app(bundleID: String)
     case settingsPane(bundleID: String)
     case customCommand(id: UUID)
@@ -29,6 +30,7 @@ enum HotKeyAction: Hashable, Sendable {
         case .createNote: "hotkey.createNote"
         case .searchNotes: "hotkey.searchNotes"
         case .searchFiles: "hotkey.searchFiles"
+        case .joinNextMeeting: "hotkey.joinNextMeeting"
         case .app(let bundleID): "hotkey.app." + bundleID
         case .settingsPane(let bundleID): "hotkey.pane." + bundleID
         case .customCommand(let id): "hotkey.customCommand." + id.uuidString.lowercased()
@@ -42,6 +44,6 @@ enum HotKeyAction: Hashable, Sendable {
     /// The fixed actions every install can bind; the per-item catalogs extend them at launch.
     static let builtInActions: [HotKeyAction] = [
         .togglePalette, .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes,
-        .searchFiles
+        .searchFiles, .joinNextMeeting
     ]
 }

--- a/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
+++ b/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
@@ -11,6 +11,7 @@ final class HotKeyManager {
     var onCreateNote: (() -> Void)?
     var onSearchNotes: (() -> Void)?
     var onSearchFiles: (() -> Void)?
+    var onJoinNextMeeting: (() -> Void)?
     var onRunCustomCommand: ((UUID) -> Void)?
     var onRunSystemAction: ((SystemAction.ID) -> Void)?
     var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
@@ -139,7 +140,7 @@ final class HotKeyManager {
             if binding == nil { set.remove(entryID) } else { set.insert(entryID) }
             UserDefaults.standard.set(Array(set), forKey: boundExtensionCommandKey)
         case .togglePalette, .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes,
-            .searchFiles, .systemAction, .windowCommand:
+            .searchFiles, .joinNextMeeting, .systemAction, .windowCommand:
             break
         }
         candidateActionsCache = nil
@@ -202,6 +203,8 @@ final class HotKeyManager {
             return CommandID.searchNotes.name
         case .searchFiles:
             return CommandID.searchFiles.name
+        case .joinNextMeeting:
+            return CommandID.joinNextMeeting.name
         case .app(let bundleID), .settingsPane(let bundleID):
             return displayName?(action) ?? bundleID
         case .customCommand:
@@ -244,6 +247,7 @@ final class HotKeyManager {
         case .createNote: onCreateNote?()
         case .searchNotes: onSearchNotes?()
         case .searchFiles: onSearchFiles?()
+        case .joinNextMeeting: onJoinNextMeeting?()
         case .app(let bundleID): AppLauncher.toggle(bundleID: bundleID)
         case .settingsPane(let bundleID): AppLauncher.openSettingsPane(bundleID: bundleID)
         case .customCommand(let id): onRunCustomCommand?(id)

--- a/Tinycast/Features/HotKeys/Service/LegacyHotKeyRecords.swift
+++ b/Tinycast/Features/HotKeys/Service/LegacyHotKeyRecords.swift
@@ -59,7 +59,7 @@ enum LegacyHotKeyRecords {
         case .quicklink(let id):
             "KeyboardShortcuts_quicklinkHotkey." + id.uuidString.lowercased()
         // Newer than the package it adopts records from, so there is nothing to adopt.
-        case .extensionCommand: nil
+        case .extensionCommand, .joinNextMeeting: nil
         }
     }
 }

--- a/Tinycast/Features/Launcher/Model/CommandID.swift
+++ b/Tinycast/Features/Launcher/Model/CommandID.swift
@@ -6,6 +6,10 @@ enum CommandID: String, CaseIterable, Sendable {
     case clipboardHistory = "command:clipboard-history"
     case searchEmoji = "command:search-emoji"
     case searchFiles = "command:search-files"
+    case joinNextMeeting = "command:join-next-meeting"
+    case copyMeetingLink = "command:copy-meeting-link"
+    case mySchedule = "command:my-schedule"
+    case openInCalendar = "command:open-in-calendar"
     case showNotes = "command:show-notes"
     case createNote = "command:create-note"
     case searchNotes = "command:search-notes"
@@ -27,6 +31,10 @@ enum CommandID: String, CaseIterable, Sendable {
         case .clipboardHistory: return "Clipboard History"
         case .searchEmoji: return "Search Emoji & Symbols"
         case .searchFiles: return "Search Files"
+        case .joinNextMeeting: return "Join Next Meeting"
+        case .copyMeetingLink: return "Copy Meeting Link"
+        case .mySchedule: return "My Schedule"
+        case .openInCalendar: return "Open in Calendar"
         case .showNotes: return "Show Notes"
         case .createNote: return "Create Note"
         case .searchNotes: return "Search Notes"
@@ -50,6 +58,10 @@ enum CommandID: String, CaseIterable, Sendable {
         case .clipboardHistory: return "doc.on.clipboard"
         case .searchEmoji: return "face.smiling"
         case .searchFiles: return "doc.text.magnifyingglass"
+        case .joinNextMeeting: return "video.fill"
+        case .copyMeetingLink: return "link"
+        case .mySchedule: return "calendar"
+        case .openInCalendar: return "calendar.badge.clock"
         case .showNotes: return "text.page"
         case .createNote: return "note.text.badge.plus"
         case .searchNotes: return "text.magnifyingglass"
@@ -76,6 +88,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .showNotes: return .showNotes
         case .createNote: return .createNote
         case .searchNotes: return .searchNotes
+        case .joinNextMeeting: return .joinNextMeeting
         default: return nil
         }
     }

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -11,6 +11,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case windowCommand
         case quicklink
         case extensionCommand
+        case meeting
 
         var descriptor: KindDescriptor {
             switch self {
@@ -51,6 +52,10 @@ struct AppEntry: Identifiable, Hashable, Sendable {
                 return KindDescriptor(
                     label: "Extension", sectionTitle: "Extensions",
                     openVerb: "Run Command", canRevealInFinder: false, isSymbolIcon: true)
+            case .meeting:
+                return KindDescriptor(
+                    label: "Meeting", sectionTitle: "Meetings",
+                    openVerb: "Join Meeting", canRevealInFinder: false, isSymbolIcon: true)
             }
         }
     }
@@ -110,7 +115,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
             return WindowCommandCatalog.command(forEntryID: id).map { .windowCommand(id: $0.id) }
         case .quicklink:
             return Quicklink.id(fromEntryID: id).map { .quicklink(id: $0) }
-        case .snippet, .extensionCommand:
+        case .snippet, .extensionCommand, .meeting:
             return nil
         }
     }
@@ -136,6 +141,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case .systemAction: return SystemActionCatalog.action(forEntryID: id)?.sfSymbol ?? "questionmark"
         case .windowCommand:
             return WindowCommandCatalog.command(forEntryID: id)?.sfSymbol ?? "questionmark"
+        case .meeting: return "video.fill"
         case .application, .systemSettings, .extensionCommand: return "questionmark"
         }
     }
@@ -215,6 +221,7 @@ final class AppIndex {
     private var windowCommandEntries: [AppEntry] = []
     private var quicklinkEntries: [AppEntry] = []
     private var extensionEntries: [AppEntry] = []
+    private var meetingEntries: [AppEntry] = []
     /// The catalog's commands a disabled feature hides; the Commands slice is recomputed from it.
     private var hiddenCommands: Set<CommandID> = []
     private var alternateNameCache = SpotlightNames.Cache()
@@ -277,6 +284,14 @@ final class AppIndex {
             }
         guard entries != quicklinkEntries else { return }
         quicklinkEntries = entries
+        publishEntries()
+    }
+
+    /// Replaces the meeting slice. Events move on their own, so this is called from the store's
+    /// change hook rather than from a user edit.
+    func setMeetings(_ entries: [AppEntry]) {
+        guard entries != meetingEntries else { return }
+        meetingEntries = entries
         publishEntries()
     }
 
@@ -402,7 +417,7 @@ final class AppIndex {
     private func publishEntries() {
         // Each slice arrives in its own display order; the slice order is the section order.
         let updated =
-            discoveredEntries + extensionEntries + quicklinkEntries + snippetEntries
+            meetingEntries + discoveredEntries + extensionEntries + quicklinkEntries + snippetEntries
             + Self.systemActionEntries + windowCommandEntries + customCommandEntries
             + commandEntries
         guard updated != apps else { return }

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -15,6 +15,7 @@ final class LauncherCoordinator {
     private let fileSearchCoordinator: FileSearchCoordinator
     private let notesCoordinator: NotesCoordinator
     private let extensionCoordinator: ExtensionCoordinator
+    private let calendarCoordinator: CalendarCoordinator
     /// The backup commands only, which need the live stores to gather from and apply to.
     private unowned let core: AppCore
 
@@ -31,6 +32,7 @@ final class LauncherCoordinator {
         fileSearchCoordinator: FileSearchCoordinator,
         notesCoordinator: NotesCoordinator,
         extensionCoordinator: ExtensionCoordinator,
+        calendarCoordinator: CalendarCoordinator,
         core: AppCore
     ) {
         self.ranking = ranking
@@ -45,6 +47,7 @@ final class LauncherCoordinator {
         self.fileSearchCoordinator = fileSearchCoordinator
         self.notesCoordinator = notesCoordinator
         self.extensionCoordinator = extensionCoordinator
+        self.calendarCoordinator = calendarCoordinator
         self.core = core
     }
 
@@ -82,6 +85,11 @@ final class LauncherCoordinator {
             extensionCoordinator.runExtensionCommand(app, arguments: arguments)
             return
         }
+        if app.kind == .meeting {
+            guard let id = MeetingEvent.id(fromEntryID: app.id) else { return }
+            calendarCoordinator.activateMeeting(id: id)
+            return
+        }
         // Before the palette hides: an unfilled quicklink stays up to ask first.
         if app.kind == .quicklink {
             guard let id = Quicklink.id(fromEntryID: app.id) else { return }
@@ -100,7 +108,7 @@ final class LauncherCoordinator {
             let snippetID = String(app.id.dropFirst("snippet:".count))
             snippetExpansion.expandSnippet(id: snippetID, targetApp: previous)
         case .command, .customCommand, .systemAction, .windowCommand, .quicklink,
-            .extensionCommand:
+            .extensionCommand, .meeting:
             break  // handled above
         }
     }
@@ -115,6 +123,14 @@ final class LauncherCoordinator {
             paletteCoordinator.showPalette(mode: .emoji)
         case .searchFiles:
             fileSearchCoordinator.show()
+        case .joinNextMeeting:
+            calendarCoordinator.joinNextMeeting()
+        case .copyMeetingLink:
+            calendarCoordinator.copyNextMeetingLink()
+        case .mySchedule:
+            calendarCoordinator.showSchedule()
+        case .openInCalendar:
+            calendarCoordinator.openNextMeetingInCalendar()
         case .showNotes:
             paletteCoordinator.hidePalette(restoreFocus: false)
             notesCoordinator.show()

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -7,47 +7,68 @@ struct LauncherList: View {
     let showSections: Bool
     /// Changes only when the list should scroll, so mouse selection never yanks it.
     let scroll: ScrollIntent
-    /// The inline answer, at flat index 0 when present; needs a non-empty query.
-    var calc: CalcResult?
-    var calcSelected = false
-    var onActivateCalc: () -> Void = {}
-    var onCalcActions: () -> Void = {}
+    /// The card at flat index 0, when one leads. At most one ever does.
+    var card: LeadCard?
+    var cardSelected = false
+    var onActivateCard: () -> Void = {}
+    var onCardActions: () -> Void = {}
     let onActivate: (AppEntry) -> Void
     let onActions: (AppEntry) -> Void
     @Environment(RunningAppsMonitor.self) private var runningApps
 
-    private nonisolated static let calcRowID = "calc-card"
+    /// The calculator answers a typed query and the join card an empty one, so they cannot both
+    /// lead — which is what keeps the flat selection index a single-row offset.
+    enum LeadCard: Equatable {
+        case calc(CalcResult)
+        case meeting(MeetingEvent, now: Date)
+
+        var sectionTitle: String {
+            switch self {
+            case .calc: return "Calculator"
+            case .meeting: return "Meeting"
+            }
+        }
+
+        var rowID: String {
+            switch self {
+            case .calc: return "calc-card"
+            case .meeting: return "meeting-card"
+            }
+        }
+    }
 
     private enum Row: Identifiable {
         case header(String)
-        case calc(CalcResult)
+        case card(LeadCard)
         /// `slot` is the row's ⌘-digit, carried from the section build so no row has to search for it.
         case app(AppEntry, slot: Character?)
         var id: String {
             switch self {
             case .header(let title): return "header-" + title
-            case .calc: return LauncherList.calcRowID
+            case .card(let card): return card.rowID
             case .app(let app, _): return app.id
             }
         }
     }
 
     /// Scroll target for the current selection.
-    private var selectedRowID: String? { calcSelected ? Self.calcRowID : selectedID }
+    private var selectedRowID: String? {
+        cardSelected ? card?.rowID : selectedID
+    }
 
-    /// Whether the selection sits on flat index 0: the calc card, else the first result.
+    /// Whether the selection sits on flat index 0: the card, else the first result.
     private var firstRowSelected: Bool {
-        calc != nil ? calcSelected : selectedID != nil && selectedID == results.first?.id
+        card != nil ? cardSelected : selectedID != nil && selectedID == results.first?.id
     }
 
     private var rows: [Row] {
-        var calcRows: [Row] = []
-        if let calc { calcRows = [.header("Calculator"), .calc(calc)] }
+        var cardRows: [Row] = []
+        if let card { cardRows = [.header(card.sectionTitle), .card(card)] }
         guard showSections else {
-            guard !results.isEmpty else { return calcRows }
-            return calcRows + [.header("Results")] + results.map { .app($0, slot: nil) }
+            guard !results.isEmpty else { return cardRows }
+            return cardRows + [.header("Results")] + results.map { .app($0, slot: nil) }
         }
-        var rows: [Row] = calcRows
+        var rows: [Row] = cardRows
         let favorites = results.prefix(favoriteCount)
         let rest = results.dropFirst(favoriteCount)
         var grouped: [AppEntry.Kind: [AppEntry]] = [:]
@@ -61,7 +82,7 @@ struct LauncherList: View {
         }
         // Publication order, so rows match the flat index.
         let kinds: [AppEntry.Kind] = [
-            .application, .systemSettings, .extensionCommand, .quicklink, .snippet,
+            .meeting, .application, .systemSettings, .extensionCommand, .quicklink, .snippet,
             .systemAction, .windowCommand, .customCommand, .command
         ]
         for kind in kinds {
@@ -81,7 +102,7 @@ struct LauncherList: View {
     var body: some View {
         let rows = rows
         return Group {
-            if results.isEmpty && calc == nil {
+            if results.isEmpty && card == nil {
                 EmptyResults(text: "No apps found")
             } else {
                 ScrollViewReader { proxy in
@@ -91,13 +112,13 @@ struct LauncherList: View {
                                 switch row {
                                 case .header(let title):
                                     SectionHeader(title: title, isFirst: row.id == rows.first?.id)
-                                case .calc(let result):
-                                    CalculatorCard(result: result, selected: calcSelected)
+                                case .card(let card):
+                                    LeadCardView(card: card, selected: cardSelected)
                                         .contentShape(Rectangle())
-                                        .onTapGesture(perform: onActivateCalc)
-                                        .onRightClick(perform: onCalcActions)
+                                        .onTapGesture(perform: onActivateCard)
+                                        .onRightClick(perform: onCardActions)
                                         .padding(.bottom, Theme.Spacing.xs)
-                                        .selectionFrame(calcSelected)
+                                        .selectionFrame(cardSelected)
                                 case .app(let app, let slot):
                                     AppRow(
                                         app: app,
@@ -125,6 +146,21 @@ struct LauncherList: View {
                         scroll, row: selectedRowID, atOrigin: firstRowSelected, proxy: proxy)
                 }
             }
+        }
+    }
+}
+
+/// Draws whichever card leads; each feature still owns how its own card looks.
+private struct LeadCardView: View {
+    let card: LauncherList.LeadCard
+    let selected: Bool
+
+    var body: some View {
+        switch card {
+        case .calc(let result):
+            CalculatorCard(result: result, selected: selected)
+        case .meeting(let meeting, let now):
+            MeetingCard(meeting: meeting, now: now, selected: selected)
         }
     }
 }

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -9,6 +9,9 @@ struct LauncherScreen: PaletteScreen {
     let vm: PaletteState
     /// Sampled by `openActions`, so the Quit row can't appear or vanish while the menu is up.
     let running: Bool
+    /// The join card's meeting, resolved by the coordinator; nil unless one is due.
+    let meeting: MeetingEvent?
+    let now: Date
     let openActions: () -> Void
     /// Called when an action reorders the list, so the highlight scrolls back into view.
     let scrollToFollow: () -> Void
@@ -28,6 +31,7 @@ struct LauncherScreen: PaletteScreen {
     init(
         appIndex: AppIndex, favorites: FavoritesStore, visibility: VisibilityStore,
         currencyRates: CurrencyRateStore, core: AppCore, vm: PaletteState, running: Bool,
+        meeting: MeetingEvent?, now: Date,
         openActions: @escaping () -> Void, scrollToFollow: @escaping () -> Void
     ) {
         self.appIndex = appIndex
@@ -36,6 +40,7 @@ struct LauncherScreen: PaletteScreen {
         self.core = core
         self.vm = vm
         self.running = running
+        self.now = now
         self.openActions = openActions
         self.scrollToFollow = scrollToFollow
 
@@ -44,22 +49,34 @@ struct LauncherScreen: PaletteScreen {
         let calc = CalcMemo.evaluate(vm.query, rates: currencyRates.rates)
         let entries = results.map(Row.entry)
         let pinsFavorites = vm.query.trimmingCharacters(in: .whitespaces).isEmpty
+        // The calculator only answers a typed query and the card only an empty one, so at most one
+        // of them ever leads, and the flat index keeps a single-row offset.
+        let meeting = pinsFavorites ? meeting : nil
+        self.meeting = meeting
         self.results = results
         self.calc = calc
         self.showSections = pinsFavorites || AppEntry.Kind.named(by: vm.query) != nil
         self.pinsFavorites = pinsFavorites
         self.favoriteCount = pinsFavorites ? results.prefix(while: favorites.isFavorite).count : 0
-        self.rows = calc.map { [.calc($0)] + entries } ?? entries
+        if let calc {
+            self.rows = [.calc(calc)] + entries
+        } else if let meeting {
+            self.rows = [.meeting(meeting)] + entries
+        } else {
+            self.rows = entries
+        }
     }
 
     /// The card is a row like any other, so the flat selection indexes `rows` with no offset.
     enum Row: Equatable, Identifiable {
         case calc(CalcResult)
+        case meeting(MeetingEvent)
         case entry(AppEntry)
 
         var id: String {
             switch self {
             case .calc: return "calc-card"
+            case .meeting: return "meeting-card"
             case .entry(let app): return app.id
             }
         }
@@ -74,6 +91,8 @@ struct LauncherScreen: PaletteScreen {
     var primaryActionTitle: String {
         switch row(at: clampedSelection) {
         case .calc: return "Copy Answer"
+        case .meeting(let meeting):
+            return meeting.link == nil ? "Open in Calendar" : "Join Meeting"
         case .entry(let app): return app.kind.descriptor.openVerb
         case nil: return "Open Application"
         }
@@ -118,8 +137,16 @@ struct LauncherScreen: PaletteScreen {
     }
 
     private func isCardSelected(_ selection: Int) -> Bool {
-        if case .calc = row(at: selection) { return true }
-        return false
+        switch row(at: selection) {
+        case .calc, .meeting: return true
+        case .entry, nil: return false
+        }
+    }
+
+    /// Whichever card leads, in the terms the list draws it in.
+    private var leadCard: LauncherList.LeadCard? {
+        if let calc { return .calc(calc) }
+        return meeting.map { .meeting($0, now: now) }
     }
 
     /// An error card is selectable but has no action: it must drive neither the pill nor ⌘K.
@@ -132,6 +159,8 @@ struct LauncherScreen: PaletteScreen {
         switch row(at: selection) {
         case .calc(let result):
             return result.isActionable ? CalcActionsMenu.content(result: result, core: core) : nil
+        case .meeting(let meeting):
+            return MeetingActionsMenu.content(meeting: meeting, core: core)
         case .entry(let app):
             return AppActionsMenu.content(
                 app: app, searchQuery: vm.query, core: core, running: running,
@@ -150,6 +179,7 @@ struct LauncherScreen: PaletteScreen {
         switch row(at: selection) {
         // Error cards no-op — copyCalculatorResult only acts on value payloads.
         case .calc(let result): core.calculatorCoordinator.copyCalculatorResult(result)
+        case .meeting(let meeting): core.calendarCoordinator.activateMeeting(id: meeting.id)
         case .entry(let app):
             core.launcherCoordinator.launch(
                 app, searchQuery: vm.query, arguments: argumentValues(for: app))
@@ -246,7 +276,7 @@ struct LauncherScreen: PaletteScreen {
     }
 
     private func select(row index: Int) {
-        vm.selection = index + (calc == nil ? 0 : 1)
+        vm.selection = index + (calc == nil && meeting == nil ? 0 : 1)
         scrollToFollow()
     }
 
@@ -274,14 +304,14 @@ struct LauncherScreen: PaletteScreen {
             favoriteCount: favoriteCount,
             showSections: showSections,
             scroll: scroll,
-            calc: calc,
-            calcSelected: isCardSelected(selection),
-            onActivateCalc: {
+            card: leadCard,
+            cardSelected: isCardSelected(selection),
+            onActivateCard: {
                 vm.selection = 0
                 activate(at: 0)
             },
-            onCalcActions: {
-                guard let calc, case .value = calc.payload else { return }
+            onCardActions: {
+                guard hasPrimaryAction(at: 0) else { return }
                 vm.selection = 0
                 openActions()
             },

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -24,6 +24,19 @@ enum PopToRootTimeout: Int, CaseIterable, Identifiable, Sendable {
     var interval: TimeInterval { TimeInterval(rawValue) }
 }
 
+/// How early the join card appears, and how long past the start it stays. See UpcomingWindow.
+enum JoinWindow: Int, CaseIterable, Identifiable, Sendable {
+    case one = 1
+    case two = 2
+    case five = 5
+    case ten = 10
+    case fifteen = 15
+
+    var id: Int { rawValue }
+
+    var title: String { rawValue == 1 ? "1 minute" : "\(rawValue) minutes" }
+}
+
 @MainActor
 @Observable
 final class AppSettings {
@@ -206,6 +219,21 @@ final class AppSettings {
         }
     }
 
+    /// Doubles as calendar-access consent, so only `CalendarCoordinator` may write it.
+    var calendarEnabled: Bool {
+        didSet { defaults.set(calendarEnabled, forKey: Key.calendarEnabled.rawValue) }
+    }
+
+    var calendarShowInLauncher: Bool {
+        didSet {
+            defaults.set(calendarShowInLauncher, forKey: Key.calendarShowInLauncher.rawValue)
+        }
+    }
+
+    var joinWindowMinutes: JoinWindow {
+        didSet { defaults.set(joinWindowMinutes.rawValue, forKey: Key.joinWindowMinutes.rawValue) }
+    }
+
     /// Off means fully off: no launcher entries, and a still-registered shortcut moves nothing.
     var windowManagementEnabled: Bool {
         didSet {
@@ -340,6 +368,13 @@ final class AppSettings {
             ?? ExtensionRegistry.defaults
         extensionCustomSearchPaths =
             defaults.stringArray(forKey: Key.extensionCustomSearchPaths.rawValue) ?? []
+        // Opt-in, like extensions: until it is asked for, EventKit is never loaded.
+        calendarEnabled = defaults.bool(forKey: Key.calendarEnabled.rawValue)
+        calendarShowInLauncher =
+            defaults.object(forKey: Key.calendarShowInLauncher.rawValue) == nil
+            || defaults.bool(forKey: Key.calendarShowInLauncher.rawValue)
+        joinWindowMinutes =
+            JoinWindow(rawValue: defaults.integer(forKey: Key.joinWindowMinutes.rawValue)) ?? .five
         windowManagementEnabled = defaults.bool(forKey: Key.windowManagementEnabled.rawValue)
         windowManagementShowInLauncher =
             defaults.object(forKey: Key.windowManagementShowInLauncher.rawValue) == nil

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -40,4 +40,7 @@ enum AppSettingsKey: String, CaseIterable {
     case extensionPackageManager = "extensionPackageManager"
     case extensionRegistries = "extensionRegistries"
     case extensionCustomSearchPaths = "extensionCustomSearchPaths"
+    case calendarEnabled = "calendarEnabled"
+    case calendarShowInLauncher = "calendarShowInLauncher"
+    case joinWindowMinutes = "joinWindowMinutes"
 }

--- a/Tinycast/Features/Settings/Panes/PermissionsSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/PermissionsSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PermissionsSettingsView: View {
     @State private var accessibilityTrusted = Permissions.isAccessibilityTrusted()
+    @State private var calendarAccess = Permissions.calendarAccess()
     private let refreshTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -35,12 +36,44 @@ struct PermissionsSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Section {
+                LabeledContent {
+                    Label(calendarStatus.title, systemImage: calendarStatus.symbol)
+                        .foregroundStyle(calendarStatus.tint)
+                } label: {
+                    Text("Calendars")
+                    Text("Lets Tinycast find the join link for the meeting you are about to be in.")
+                }
+
+                LabeledContent {
+                    Button("Open…") { Permissions.openCalendarSettings() }
+                } label: {
+                    Text("Manage in System Settings")
+                    // Only the Calendar pane's own switch may ask for this, so this never prompts.
+                    Text("Opens Privacy & Security › Calendars.")
+                }
+            } header: {
+                Text("Calendars")
+            }
         }
         .formStyle(.grouped)
-        .onAppear { accessibilityTrusted = Permissions.isAccessibilityTrusted() }
-        .onReceive(refreshTimer) { _ in
-            let trusted = Permissions.isAccessibilityTrusted()
-            if trusted != accessibilityTrusted { accessibilityTrusted = trusted }
+        .onAppear(perform: refresh)
+        .onReceive(refreshTimer) { _ in refresh() }
+    }
+
+    private var calendarStatus: (title: String, symbol: String, tint: Color) {
+        switch calendarAccess {
+        case .granted: return ("Granted", "checkmark.circle.fill", .green)
+        case .notDetermined: return ("Not asked yet", "questionmark.circle.fill", .secondary)
+        case .denied: return ("Not granted", "exclamationmark.triangle.fill", .orange)
         }
+    }
+
+    private func refresh() {
+        let trusted = Permissions.isAccessibilityTrusted()
+        if trusted != accessibilityTrusted { accessibilityTrusted = trusted }
+        let access = Permissions.calendarAccess()
+        if access != calendarAccess { calendarAccess = access }
     }
 }

--- a/Tinycast/Features/Settings/SettingsCoordinator.swift
+++ b/Tinycast/Features/Settings/SettingsCoordinator.swift
@@ -44,6 +44,7 @@ final class SettingsCoordinator {
             .environment(core.customCommands)
             .environment(core.snippetsStore)
             .environment(core.quicklinks)
+            .environment(core.calendarStore)
             // Propagates down so the window's materials show through, not each list's backing.
             .scrollContentBackground(.hidden)
     }

--- a/Tinycast/Features/Settings/SettingsDetailView.swift
+++ b/Tinycast/Features/Settings/SettingsDetailView.swift
@@ -20,6 +20,7 @@ struct SettingsDetailView: View {
             case .windowManagement: WindowManagementSettingsView()
             case .clipboard: ClipboardSettingsView()
             case .emoji: EmojiSettingsView()
+            case .calendar: CalendarSettingsView()
             case .extensions: ExtensionsSettingsView()
             case .permissions: PermissionsSettingsView()
             case .backup: BackupSettingsView()

--- a/Tinycast/Features/Settings/SettingsTab.swift
+++ b/Tinycast/Features/Settings/SettingsTab.swift
@@ -1,6 +1,7 @@
 enum SettingsTab: CaseIterable, Identifiable {
     case general, applications, systemSettings, systemActions, commands, quicklinks, fileSearch,
-        notes, snippets, windowManagement, clipboard, emoji, extensions, permissions, backup, about
+        notes, snippets, windowManagement, clipboard, emoji, calendar, extensions, permissions,
+        backup, about
     /// The case, never an index: a selectable `List` flattens section and row IDs together.
     var id: Self { self }
 
@@ -18,6 +19,7 @@ enum SettingsTab: CaseIterable, Identifiable {
         case .windowManagement: return "Window Management"
         case .clipboard: return "Clipboard"
         case .emoji: return "Emoji & Symbols"
+        case .calendar: return "Calendar"
         case .extensions: return "Extensions"
         case .permissions: return "Permissions"
         case .backup: return "Backup"
@@ -39,6 +41,7 @@ enum SettingsTab: CaseIterable, Identifiable {
         case .windowManagement: return "macwindow"
         case .clipboard: return "doc.on.clipboard"
         case .emoji: return "face.smiling"
+        case .calendar: return "calendar"
         case .extensions: return "puzzlepiece.extension"
         case .permissions: return "lock.shield"
         case .backup: return "arrow.up.arrow.down.circle"
@@ -69,7 +72,8 @@ enum SettingsSection: CaseIterable, Identifiable {
             return [.applications, .systemSettings, .systemActions, .commands, .quicklinks]
         case .features:
             return [
-                .fileSearch, .notes, .snippets, .windowManagement, .clipboard, .emoji, .extensions
+                .fileSearch, .notes, .snippets, .windowManagement, .clipboard, .emoji, .calendar,
+                .extensions
             ]
         case .advanced: return [.backup, .about]
         }

--- a/Tinycast/Info.plist
+++ b/Tinycast/Info.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Tinycast uses automation to perform system actions you explicitly run.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Tinycast reads today's and tomorrow's events so you can join a meeting from the palette.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Tinycast uses Bluetooth access only when you run the Toggle Bluetooth action.</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Tinycast/Palette/PaletteMode.swift
+++ b/Tinycast/Palette/PaletteMode.swift
@@ -6,6 +6,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     case calculatorHistory
     case emoji
     case fileSearch
+    case schedule
     case uninstall
     case quicklinks
     /// Collects a quicklink's `{argument}` values; the request lives on the session.
@@ -21,6 +22,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "Calculator History"
         case .emoji: return "Emoji & Symbols"
         case .fileSearch: return "Search Files"
+        case .schedule: return "My Schedule"
         case .uninstall: return "Uninstall Application"
         case .quicklinks: return "Quicklinks"
         case .quicklinkArguments: return "Open Quicklink"
@@ -34,6 +36,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "plus.forwardslash.minus"
         case .emoji: return "face.smiling"
         case .fileSearch: return "doc.text.magnifyingglass"
+        case .schedule: return "calendar"
         case .uninstall: return "trash"
         case .quicklinks, .quicklinkArguments: return Quicklink.sfSymbol
         case .extensionCommand: return "puzzlepiece.extension"
@@ -46,6 +49,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "Do math, convert units, or search your past calculations…"
         case .emoji: return "Search emoji and symbols…"
         case .fileSearch: return "Search files and folders…"
+        case .schedule: return "Search today and tomorrow…"
         case .uninstall: return "Filter files and folders by name…"
         case .quicklinks: return "Search quicklinks…"
         // Replaced by the pending argument's name; only reached if the session vanished mid-render.

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -57,6 +57,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             panel.contentView?.layoutSubtreeIfNeeded()
             core.inputSourceSwitcher.beginSession(
                 preferredInputSourceID: core.settings.autoSwitchInputSourceID)
+            // Events go stale while the palette is closed, and the countdown only ticks while up.
+            core.calendarCoordinator.paletteDidShow()
             // Non-activating, so summoning never raises our own aux windows behind it.
             panel.makeKeyAndOrderFront(nil)
             panel.orderFrontRegardless()
@@ -71,6 +73,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     func hide(restoreFocus: Bool) {
         panel?.orderOut(nil)
         core.inputSourceSwitcher.endSession()
+        core.calendarCoordinator.paletteDidHide()
         // Drop the anchor, so the next summon re-resolves for the screen in use then.
         anchor = nil
         // The guides must never outlive the panel they point at.
@@ -225,6 +228,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             .environment(core.quicklinks)
             .environment(core.quicklinkArguments)
             .environment(core.extensions)
+            .environment(core.calendarStore)
+            .environment(core.meetingClock)
         let panel = PalettePanel(rootView: root)
         panel.delegate = self
         panel.paletteState = core.palette

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -13,6 +13,9 @@ struct RootPaletteView: View {
     @Environment(EmojiIndex.self) private var emojiIndex
     @Environment(FrequentEmojiStore.self) private var frequentEmoji
     @Environment(FileSearchSession.self) private var fileSearch
+    @Environment(CalendarStore.self) private var calendarStore
+    /// Observed so the join card's countdown redraws on the minute boundary.
+    @Environment(MeetingClock.self) private var meetingClock
     @Environment(UninstallSession.self) private var uninstall
     @Environment(QuicklinkStore.self) private var quicklinks
     @Environment(QuicklinkArgumentSession.self) private var quicklinkArguments
@@ -40,6 +43,7 @@ struct RootPaletteView: View {
             return LauncherScreen(
                 appIndex: appIndex, favorites: favorites, visibility: visibility,
                 currencyRates: currencyRates, core: core, vm: vm, running: selectionIsRunning,
+                meeting: core.calendarCoordinator.cardedMeeting, now: meetingClock.now,
                 openActions: openActions,
                 scrollToFollow: { scroll = ScrollIntent(kind: .follow) })
         case .uninstall:
@@ -59,6 +63,10 @@ struct RootPaletteView: View {
         case .fileSearch:
             return FileSearchScreen(
                 session: fileSearch, core: core, vm: vm, openActions: openActions)
+        case .schedule:
+            return ScheduleScreen(
+                store: calendarStore, clock: meetingClock, core: core, vm: vm,
+                openActions: openActions)
         case .clipboard:
             return ClipboardScreen(
                 store: store, core: core, vm: vm, openActions: openActions,

--- a/Tinycast/Platform/CalendarAccess.swift
+++ b/Tinycast/Platform/CalendarAccess.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// What the Mac will let Tinycast read of the user's calendar.
+enum CalendarAccess: Sendable {
+    case notDetermined
+    case granted
+    /// Denied or restricted: only System Settings can undo it, so both read the same to us.
+    case denied
+}

--- a/Tinycast/Platform/Permissions.swift
+++ b/Tinycast/Platform/Permissions.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EventKit
 // `@preconcurrency` downgrades AX diagnostics: the option key is a constant C global.
 @preconcurrency import ApplicationServices
 
@@ -20,6 +21,30 @@ enum Permissions {
             let url = URL(
                 string:
                     "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+        else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    static func calendarAccess() -> CalendarAccess {
+        switch EKEventStore.authorizationStatus(for: .event) {
+        case .fullAccess: return .granted
+        case .notDetermined: return .notDetermined
+        // Write-only is the same as nothing here: Tinycast only ever reads.
+        default: return .denied
+        }
+    }
+
+    /// The one prompt for the calendar, raised from the gesture that asked for it. The store is
+    /// built and dropped here: a grant is process-wide, so nothing non-`Sendable` has to travel.
+    nonisolated static func requestCalendarAccess() async -> Bool {
+        (try? await EKEventStore().requestFullAccessToEvents()) ?? false
+    }
+
+    @MainActor
+    static func openCalendarSettings() {
+        guard
+            let url = URL(
+                string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
         else { return }
         NSWorkspace.shared.open(url)
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ open with an `## Invariants` section; read it before changing anything in that a
 [launcher](features/launcher.md) ·
 [clipboard](features/clipboard.md) ·
 [calculator](features/calculator.md) ·
+[calendar](features/calendar.md) ·
 [emoji](features/emoji.md) ·
 [file search](features/file-search.md) ·
 [notes](features/notes.md) ·

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ Independently of the folder tree, every mature subsystem has converged on the sa
 │ Quicklink{,Destination,Store,Archive} · Notes/Model/* · Snippets/Model/* · │
 │ ShellCommandRunner · DoubleTap{Modifier,Detector} · ClipboardStore ·       │
 │ RaycastFormat · RaycastV1Decoder · AppSettingsKey · SettingsBackupCoverage │
+│ MeetingLink · MeetingEvent · UpcomingWindow · MeetingDay                   │
 └──────────────────────────────────┬─────────────────────────────────────────┘
                                    │ consumed by
 ┌─ EFFECT ─────────────────────────▼─────────────────────────────────────────┐
@@ -30,11 +31,12 @@ Independently of the folder tree, every mature subsystem has converged on the sa
 │ IconCache · WindowMover · UninstallScanner · UninstallRunner ·             │
 │ SystemActionRunner · QuicklinkLauncher · SnippetTextInjector ·             │
 │ SnippetKeywordListener · NotesRepository · CurrencyRateStore · Paster ·    │
-│ HotKeyCenter · HyperKeyTap · DoubleTapMonitor · RunningAppsMonitor         │
+│ HotKeyCenter · HyperKeyTap · DoubleTapMonitor · RunningAppsMonitor ·       │
+│ CalendarStore · MeetingLauncher · MeetingClock                             │
 └──────────────────────────────────┬─────────────────────────────────────────┘
                                    │ published through
 ┌─ OBSERVABLE STATE ───────────────▼─────────────────────────────────────────┐
-│ 32 @MainActor @Observable stores, sessions, indices and State types        │
+│ 38 @MainActor @Observable stores, sessions, indices and State types        │
 └──────────────────────────────────┬─────────────────────────────────────────┘
                                    │ rendered by
 ┌─ VIEW ───────────────────────────▼─────────────────────────────────────────┐
@@ -73,10 +75,12 @@ the shared primitives and system shims every feature draws on. Neither may depen
 `AppCore.shared` (`App/AppCore.swift`) is a `@MainActor` singleton owning every long-lived thing in the
 app: the stores (`AppIndex`, `ClipboardStore`, `SnippetsStore`, `QuicklinkStore`, `CustomCommandStore`,
 `FavoritesStore`, `VisibilityStore`, `AliasStore`, `LauncherRankingStore`, `CalculatorHistoryStore`,
-`CurrencyRateStore`, `FrequentEmojiStore`), the managers and monitors (`ClipboardManager`,
+`CurrencyRateStore`, `FrequentEmojiStore`, `CalendarStore`), the managers, monitors and clocks
+(`ClipboardManager`,
 `HotKeyManager`, `HyperKeyTap`, `RunningAppsMonitor`, `SnippetKeywordListener`), the shared state
 (`AppSettings`, `PaletteState`, `FileSearchSession`, `UninstallSession`,
-`QuicklinkArgumentSession`), `NotesStore`, the fifteen feature coordinators, and the window controllers.
+`QuicklinkArgumentSession`, `MeetingClock`), `NotesStore`, the eighteen feature coordinators, and the
+window controllers.
 
 `AppDelegate.applicationDidFinishLaunching` calls `AppCore.shared.start()` and nothing else. That is the
 one wiring point, and `start()` reads as the app's whole boot sequence in one screen.
@@ -130,7 +134,7 @@ macOS by itself. Nothing else in the app sets an appearance.
 
 ## Observation
 
-32 types are `@MainActor @Observable`. Nothing uses `ObservableObject` or `@Published`, and views read
+38 types are `@MainActor @Observable`. Nothing uses `ObservableObject` or `@Published`, and views read
 state through `@Environment` rather than `@EnvironmentObject`.
 
 Three things about this model are easy to get wrong:
@@ -187,8 +191,9 @@ Tinycast/
   Assets.xcassets/  the app icon and the bundled image sets some catalog symbols resolve to
   Features/
     PaletteRowIndex.swift   the flat selection index — palette-owned, so it sits at the top
-    Launcher/ Clipboard/ Calculator/ Emoji/ FileSearch/ Notes/ Quicklinks/ Snippets/ Uninstall/
-    SystemActions/ CustomCommands/ HotKeys/ Backup/ WindowManagement/ Onboarding/ Extensions/
+    Launcher/ Clipboard/ Calculator/ Calendar/ Emoji/ FileSearch/ Notes/ Quicklinks/ Snippets/
+    Uninstall/ SystemActions/ CustomCommands/ HotKeys/ Backup/ WindowManagement/ Onboarding/
+    Extensions/
         Model/      pure — the harness inputs
         Service/    effects — stores, monitors, runners, AppKit glue
         UI/         screens, views, and the feature's coordinator

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -1,0 +1,134 @@
+# Calendar and meeting join
+
+Two surfaces over the Mac's own calendar: a **join card** at the top of an empty launcher, and a
+**Join Next Meeting** global shortcut that never opens the palette at all. Around them sit four
+launcher commands, a `My Schedule` sub-screen, and individual events as searchable launcher entries.
+
+## Invariants
+
+- **Nothing polls.** `.EKEventStoreChanged` is the reload signal, held through the RAII
+  `NotificationToken`. The only timer is `MeetingClock`, which ticks on the minute boundary and only
+  while the palette is up. Its `Task` is stored and cancelled in `stop()` and in an `isolated deinit`.
+- **The card's window is `[start - lead, min(start + lead, end)]`.** The grace period exists because
+  everyone joins late; the `min` is why it never outlives a meeting shorter than the lead.
+- **Recurrence comes from `predicateForEvents(withStart:end:calendars:)`**, which expands occurrences
+  itself. Masters are never fetched and recurrence is never hand-rolled.
+- **`UpcomingWindow.agenda` is the only place that says which events count** — timed, not declined,
+  in start order. The card, the chord, the schedule and the launcher slice all go through it, so they
+  cannot drift apart.
+- **`calendarEnabled` doubles as consent**, so it is in `SettingsBackupCoverage.deliberatelyExcluded`
+  and only `CalendarCoordinator.setCalendarEnabled` may write it. Tinycast's own dialog comes first,
+  the macOS prompt second, and only from the gesture that asked.
+- **Per-calendar toggles live on `CalendarStore`, not `AppSettings`.** Calendar identifiers are
+  machine-specific, so they are deliberately outside the backup mirror — the same reasoning as
+  `palettePosition`.
+- **`Model/` stays Foundation-only**; `calendar-test` compiles the shipped sources. EventKit lives in
+  `Service/CalendarStore.swift` and nothing EventKit-shaped leaves it.
+
+## The pure layer
+
+`Model/` holds the whole decision, with every clock read injected:
+
+- **`MeetingLink`** — the join link plus its `Provider`. Ten named services, plus `.generic` for any
+  other `http(s)` link the event carries.
+- **`MeetingEvent`** — one occurrence, flattened out of `EKEvent`.
+- **`UpcomingWindow`** — `agenda`, `carded`, `joinable` and `countdown`.
+- **`MeetingDay`** — the Today / Tomorrow buckets, mirroring the clipboard's `DateBucket`.
+
+### Finding the link
+
+`MeetingLink.detect(fields:)` is handed `[event.url, event.location, event.notes]` in that order and
+scans each for `http(s)` runs. **A named provider anywhere beats a bare link found earlier**, so a
+"reset your password" URL at the top of an invite never wins over the Meet link below it.
+
+Link extraction is hand-rolled rather than `NSDataDetector`: a detector is not `Sendable`, and
+rebuilding one per event costs more than the scan it replaces. A URL ends at whitespace or a quote,
+and trailing punctuation is trimmed, so `(https://whereby.com/acme).` yields the URL alone.
+
+**A URL on a known host that fails that provider's path rule is rejected outright, not demoted to
+`.generic`** — `zoom.us/download` sits in half the invites people are sent, and `meet.google.com/tel/…`
+is a dial-in helper rather than a meeting.
+
+### Opening it
+
+`MeetingLauncher.join` prefers the desktop app: `MeetingLink.appURL` rewrites a Zoom link to
+`zoommtg://zoom.us/join?confno=…` (carrying `pwd` when present) and a `teams.microsoft.com` link to
+`msteams:` plus its path and query. Nothing else is rewritten — the rest of the table has no
+unambiguous scheme, and guessing one would open the wrong thing. If no app claims the scheme, the
+plain `https` link opens instead.
+
+No brand artwork ships with the app, so every named provider draws `video.fill` and the **name**
+carries the identity; `.generic` draws `link`.
+
+## The card
+
+The card is `LauncherScreen.Row.meeting`, prepended the way the calculator card is. The two can never
+both lead: **the calculator only answers a typed query and the card only an empty one**, which is what
+keeps the flat selection index a single-row offset. `LauncherList.LeadCard` is that fact made
+structural — one optional card, one selected flag, one activate closure, whichever feature owns it.
+
+The countdown re-renders from `MeetingClock.now`, not from a keystroke, so `in 4 min` becomes
+`in 3 min` on the boundary. A partial minute rounds **up** (`in 1 min` at 20 seconds out), and the
+first minute past the start reads `now` rather than `0 min ago`.
+
+Like the calculator card, a card appearing while the palette is already open shifts the highlight down
+by one row. That is the existing behaviour of the row above it and is left alone.
+
+## The chord
+
+`UpcomingWindow.joinable` is deliberately wider than `carded`, and answers in this order:
+
+1. Whatever the card is showing — so the chord always joins what is on screen.
+2. Anything currently running, however long ago it started.
+3. The next meeting with a link.
+
+It reads the live clock rather than `MeetingClock`, because a chord fires with the palette closed and
+nothing ticking.
+
+## Commands
+
+`Join Next Meeting` is the only one with a `HotKeyAction`; the other three are launcher rows and ⌘K
+actions. All four leave the launcher when the feature is off, through
+`CalendarCoordinator.applyEnabled`, the `applyQuicklinksPresence` twin.
+
+| Command | Does |
+| --- | --- |
+| Join Next Meeting | Opens the link for the carded, running, or next meeting. Bindable. |
+| Copy Meeting Link | The same meeting's link, to the pasteboard. |
+| My Schedule | Opens the `.schedule` palette mode. |
+| Open in Calendar | Hands the meeting to Calendar.app. |
+
+A miss reports through the HUD (`Nothing to join right now`), not a dialog: it is transient and there
+is nothing to acknowledge.
+
+## Reading the store
+
+`CalendarStore` queries `[startOfToday, endOfTomorrow + 1 day)` in the Mac's own zone. **The fetch
+stays on the main actor**: two days of events is a sub-millisecond query and `EKEventStore` is not
+`Sendable`, so pushing it off-main would be a fight with no measurable gain. Both the launch-time load
+and the per-summon refresh are deferred into a `Task`, because the first EventKit query pays for its
+XPC warm-up and both of those paths are protected.
+
+The `EKEventStore` itself is built on first use, so a Mac with the feature off never loads EventKit.
+After a grant the store is dropped and rebuilt — one built before the grant does not see the new
+calendars.
+
+`MeetingEvent.id` is the event identifier plus the occurrence's start, because a recurring series
+shares one identifier across every instance. `calendarItemID` is kept separately: it is the only
+handle `ical://ekevent/…` accepts, and a recurring occurrence opens its series.
+
+A cancelled event never reaches a surface. A declined one is dropped by `agenda`, and an all-day one
+with it.
+
+## Settings
+
+The Calendar pane carries the master switch (routed through the coordinator so the consent gate cannot
+be bypassed), the `Join Next Meeting` recorder, the join-window picker, and the per-calendar checkbox
+list — `LauncherItemsSection`'s shape, including the one `Form` row holding a `LazyVStack`, because a
+`Form` realizes every row it is handed.
+
+The hidden-calendar set stores **exclusions**, so a calendar added after the setting was written
+defaults to on. Holidays and Birthdays are what people switch off.
+
+The Permissions pane shows calendar access alongside Accessibility, but only ever opens System
+Settings: the Calendar pane's own switch is the one place that may prompt.

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -57,8 +57,8 @@ export → import within one build is guaranteed to round-trip.
 migration key it never wrote. It is scheduled for deletion.
 
 `hotkey.searchFiles`, `hotkey.toggleClipboard`, `hotkey.toggleEmoji`, `hotkey.showNotes`,
-`hotkey.createNote` and `hotkey.searchNotes` are the built-in launcher commands with an action of their
-own, alongside `hotkey.togglePalette`, which has no command row. They are the only `CommandID`s whose
+`hotkey.createNote`, `hotkey.searchNotes` and `hotkey.joinNextMeeting` are the built-in launcher
+commands with an action of their own, alongside `hotkey.togglePalette`, which has no command row. They are the only `CommandID`s whose
 `hotKeyAction` is non-nil — which is what puts a recorder on their rows in Settings ▸ Commands, and a
 keycap on their launcher rows. Each is also reachable from its own feature pane, so it is one binding
 from two places, not two settings. `HotKeyManager` names them all through `CommandID`, so a conflict

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -66,6 +66,7 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 | `.calculatorHistory` | `CalculatorHistoryScreen` | `CalculatorHistoryList` |
 | `.emoji` | `EmojiScreen` | `EmojiGridView` |
 | `.fileSearch` | `FileSearchScreen` | `FileSearchList` (see [file-search.md](file-search.md)) |
+| `.schedule` | `ScheduleScreen` | `ScheduleList` (see [calendar.md](calendar.md)) |
 | `.uninstall` | `UninstallScreen` | `UninstallList` (see [uninstall.md](uninstall.md)) |
 | `.quicklinks` | `QuicklinkListScreen` | `QuicklinkList` |
 | `.quicklinkArguments` | `QuicklinkArgumentsScreen` | `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt)) |
@@ -100,8 +101,8 @@ The typed values live on `PaletteState.commandArguments`, keyed by
 `PaletteState.argumentKey(entryID, name)`, and are cleared with the rest of the screen.
 
 The flat `selection` index is the single source of truth for highlight / activation and **must always
-match the visible row order**, including the inline calculator card at index 0 when present (see
-[calculator.md](calculator.md)).
+match the visible row order**, including the card at index 0 when present — the calculator's (see
+[calculator.md](calculator.md)) or the meeting join card (see [calendar.md](calendar.md)), never both.
 
 ## Window placement
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -149,7 +149,7 @@ Two gotchas worth knowing before they cost an afternoon:
 
 ### Observation
 
-28 types use `@Observable`; nothing uses `ObservableObject` or `@Published`. Migrating anything new into
+38 types use `@Observable`; nothing uses `ObservableObject` or `@Published`. Migrating anything new into
 this model:
 
 - `@ObservationIgnored` on memo caches and lazily-built collaborators. Without it, reading a memo

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,6 +59,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `ranking-test` | `Launcher/Model/LauncherRankingStore.swift` |
 | `scopes-test` | `Launcher/Model/SearchScopes.swift` |
 | `calc-test` | all of `Calculator/Model/` |
+| `calendar-test` | all of `Calendar/Model/` — link detection, the join window, the day buckets |
 | `clipboard-test` | `Clipboard/Model/ClipboardStore.swift` |
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
@@ -335,6 +336,19 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - A bare amount (`1 usd`) answers in the Mac's region currency, and follows a change to
   System Settings ▸ General ▸ Language & Region without a relaunch — and nothing prompts for location
 - A crypto query (`1 btc`, `0.5 sol to eur`) answers, and `1 usd to btc` stays in plain notation
+
+### Calendar and meetings
+
+- With Calendar **off**: no launcher entries, no card, no permission prompt at launch
+- Enabling shows the consent dialog **before** the macOS prompt; declining prompts for nothing
+- With a meeting four minutes out, an empty palette shows the card on top, provider glyph and all
+- The countdown steps on the minute boundary rather than on a keystroke
+- ↵ joins: a Zoom link opens the Zoom app, and the browser where no app claims the scheme
+- Typing a character swaps the card for the calculator's; ↑/↓ never lands on a phantom row
+- Unchecking a calendar drops its events from the launcher and My Schedule, and survives a relaunch
+- Adding or deleting an event in Calendar.app updates an open palette without a reopen
+- A meeting with no link is listed and searchable, and answers Open in Calendar rather than Join
+- Import a backup taken with Calendar on: it comes back **off**, and no calendar toggle travels
 
 ### System actions and window management
 


### PR DESCRIPTION
Adds `Features/Calendar`: a join card at the top of an empty launcher, a `Join Next Meeting` global shortcut, three more launcher commands, a `My Schedule` sub-screen, and individual events as searchable launcher entries under their own category.

ref #43

## The two surfaces

**The card.** Open the palette with an empty query and, if a meeting is inside the join window, the top row is a card — title, countdown (`in 4 min`), provider — and ↵ joins it. Nothing to type.

**The chord.** `Join Next Meeting` is the only one of the four commands with a `HotKeyAction`, so the link opens without the palette appearing at all.

`UpcomingWindow.joinable` is deliberately wider than `carded`, and answers in this order: whatever the card is showing, then anything currently running however long ago it started, then the next meeting with a link. Answering the card first is what makes the chord always join what is on screen.

## The window

The card lives over `[start - lead, min(start + lead, end)]`, `lead` being `joinWindowMinutes` (default 5). The grace period exists because everyone joins late; the `min` is why it never outlives a meeting shorter than the lead — a three-minute stand-up clears at its end, not five minutes past its start.

`UpcomingWindow.agenda` is the single place that says which events count: timed, not declined, in start order. The card, the chord, the schedule and the launcher slice all go through it, so they cannot drift apart. A linkless event is still listed and searchable — it just answers **Open in Calendar** rather than **Join**.

## Nothing polls

`.EKEventStoreChanged` is the reload signal, held through the RAII `NotificationToken`. The only timer in the feature is `MeetingClock`: one tick on the minute boundary, running solely while the palette is up, its `Task` stored and cancelled in `stop()` and in an `isolated deinit`. An idle Mac owns no timer at all.

Recurring events expand through `predicateForEvents(withStart:end:calendars:)`. Masters are never fetched and recurrence is never hand-rolled.

**The EventKit query stays on the main actor**, deliberately. Two days of events is a sub-millisecond query and `EKEventStore` is not `Sendable`, so pushing it off-main would be a fight with no measurable gain — `EKEvent`s become pure `MeetingEvent` values immediately and nothing EventKit-shaped leaves the store. Both the launch-time load and the per-summon refresh defer into a `Task`, because the first query pays for EventKit's XPC warm-up and both of those paths are protected. The `EKEventStore` itself is built on first use, so a Mac with the feature off never loads EventKit.

## Finding and opening the link

`MeetingLink.detect(fields:)` is handed `[event.url, event.location, event.notes]` in that order. **A named provider anywhere beats a bare link found earlier**, so the "reset your password" URL at the top of an invite never wins over the Meet link below it.

Ten services are known by name — Zoom, Google Meet, Teams, Webex, Jitsi, Whereby, Amazon Chime, GoTo Meeting, BlueJeans, Skype — and any other `http(s)` link still joins under a neutral glyph. **A URL on a known host that fails that provider's path rule is rejected outright rather than demoted to generic**: `zoom.us/download` sits in half the invites people are sent, and `meet.google.com/tel/…` is a dial-in helper.

Extraction is hand-rolled rather than `NSDataDetector` — a detector is not `Sendable`, and rebuilding one per event costs more than the scan it replaces.

`MeetingLauncher.join` prefers the desktop app: Zoom rewrites to `zoommtg://zoom.us/join?confno=…` carrying `pwd`, and `teams.microsoft.com` to `msteams:` plus path and query. **Nothing else is rewritten** — the rest of the table has no unambiguous scheme, and guessing one opens the wrong thing. Where no app claims the scheme, the plain `https` link opens.

No brand artwork ships with the app, so every named provider draws `video.fill` and the *name* carries the identity.

## Consent

The feature ships **off**. The Settings switch routes through `CalendarCoordinator.setCalendarEnabled`, which raises Tinycast's own dialog **before** the macOS prompt and only from the gesture that asked — the `setSnippetsEnabled` shape. Turning it off never prompts. A fresh install sees no system dialog it did not ask for.

`calendarEnabled` therefore doubles as consent and sits in `SettingsBackupCoverage.deliberatelyExcluded`: **an imported backup restores Calendar off.** `settings-backup-test` enforces that. `calendarShowInLauncher` and `joinWindowMinutes` are mirrored normally.

Per-calendar toggles live on `CalendarStore` rather than `AppSettings`, as an *exclusion* set keyed by calendar identifier — machine-specific, so deliberately outside the backup mirror for the same reason as `palettePosition`, and a calendar added later defaults to on. Holidays and Birthdays are what people switch off.

## One refactor

`LauncherList` carried `calc` / `calcSelected` / `onActivateCalc` / `onCalcActions`. A second parallel set for meetings would have meant eight card parameters, so it now takes one `LeadCard?` enum instead — same four parameters, no growth.

That also makes an invariant structural instead of a comment: **the calculator only answers a typed query and the join card only an empty one**, so at most one ever leads and the flat selection index keeps a single-row offset. Existing calculator-card behaviour is unchanged.

## Verification

| Check | Result |
| --- | --- |
| `./Scripts/run-tests.sh` | all 38 harnesses pass, `calendar-test` at 59 assertions |
| `./Scripts/lint.sh` | clean |
| Purity grep over `Features/*/Model/` | empty |
| Debug build | succeeds, no new warnings |
| Docs | `features/calendar.md` added; README, architecture, palette, hotkeys, standards, testing updated |

`calendar-test` compiles the four pure `Model/` sources and covers every provider pattern, the rejected non-meeting pages, field precedence, URL scanning out of prose and HTML, both app-scheme rewrites, each edge of the card window, all-day and declined skipping, the chord's wider fallback, the countdown strings and the day buckets across midnight.

> [!NOTE]
> The timing behaviour needs a real calendar and a human: the consent ordering, the card appearing at T-5, the countdown stepping on the boundary, and a Zoom link actually reaching the Zoom app. `docs/testing.md` gains a **Calendar and meetings** sweep section with those ten checks. The Debug build was launched and is stable; nothing past launch was driven automatically.
