### PR TITLE
Fix extension item click activation

### DIFF
--- a/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
@@ -67,7 +67,7 @@ struct ExtensionCommandScreen: PaletteScreen {
                 assetsPath: assetsPath,
                 scroll: scroll,
                 onSelect: { vm.selection = $0 },
-                onActivate: { activate(at: selection) },
+                onActivate: { activate(at: $0) },
                 onActions: { index in
                     vm.selection = index
                     openActions()

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
@@ -8,7 +8,7 @@ struct ExtensionCommandView: View {
     let assetsPath: String?
     let scroll: ScrollIntent
     let onSelect: (Int) -> Void
-    let onActivate: () -> Void
+    let onActivate: (Int) -> Void
     let onActions: (Int) -> Void
     let onFieldChange: (RenderNode, Any) -> Void
 
@@ -41,7 +41,7 @@ struct ExtensionCommandView: View {
             case .form:
                 ExtensionFormView(
                     screen: screen, assetsPath: assetsPath, onChange: onFieldChange,
-                    onSubmit: onActivate)
+                    onSubmit: { onActivate(selection) })
             case .unsupported(let type):
                 if type.isEmpty {
                     // A commit arrived but the command rendered nothing — it returned null, usually

--- a/Tinycast/Features/Extensions/UI/ExtensionListView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListView.swift
@@ -10,7 +10,7 @@ struct ExtensionListView: View {
     /// Changes only when the list should scroll, so mouse selection never yanks it.
     let scroll: ScrollIntent
     let onSelect: (Int) -> Void
-    let onActivate: () -> Void
+    let onActivate: (Int) -> Void
     let onActions: (Int) -> Void
 
     var body: some View {
@@ -77,7 +77,7 @@ struct ExtensionListView: View {
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 onSelect(item.index)
-                                onActivate()
+                                onActivate(item.index)
                             }
                             .onRightClick { onActions(item.index) }
                             .selectionFrame(item.index == selection)
@@ -118,7 +118,7 @@ struct ExtensionListView: View {
                         .contentShape(Rectangle())
                         .onTapGesture {
                             onSelect(item.index)
-                            onActivate()
+                            onActivate(item.index)
                         }
                         .onRightClick { onActions(item.index) }
                         .selectionFrame(item.index == selection)


### PR DESCRIPTION
## Related issue

Closes #316

## What changed

Extension list and grid taps now pass the tapped item index through the activation callback. This prevents clicks from activating the previously selected GIF while preserving keyboard activation and form submission behavior.

## Memory footprint

No new retained state, allocations, timers, or resources were added. Memory was not separately measured because the change only adjusts callback data flow.

Leak-tested: Not separately measured; no new resource-owning path was introduced.

## Drawbacks

None known.

## Tests & validation

- ./Scripts/run-tests.sh — all 38 harnesses passed.
- ./Scripts/lint.sh — passed with existing repository warnings.
- xcodebuild Debug build — passed.
- xcodebuild Release build — passed.
- git diff --check — passed.
- GUI click verification was not available in this environment; the stale-selection callback path was reproduced deterministically and corrected at its source.