### PR TITLE
Keep the menu click-away catcher mounted

### DIFF
--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -169,13 +169,13 @@ struct RootPaletteView: View {
         // The panel has no title bar, so this thin top margin is the only place left to grab it.
         .overlay(alignment: .top) { topDragStrip }
         .modifier(ExtensionToastOverlay(extensions: extensions, showing: vm.mode == .extensionCommand))
-        // In-window overlays, so a menu stays clipped inside the panel.
+        // Never conditionally mounted: unmounting strands SwiftUI's hover target and eats clicks.
         .overlay {
-            if menuOpen {
-                Color.black.opacity(0.001)
-                    .contentShape(Rectangle())
-                    .onTapGesture(perform: closeMenus)
-            }
+            Color.black.opacity(0.001)
+                .contentShape(Rectangle())
+                // Not a tap: a drifting press must still dismiss, the way a native menu's does.
+                .gesture(DragGesture(minimumDistance: 0).onEnded { _ in closeMenus() })
+                .allowsHitTesting(menuOpen)
         }
         .overlay(alignment: .bottomLeading) {
             if openMenu == .app {


### PR DESCRIPTION
## Related issue

No issue. Found while building the AI model picker and noticed the same thing on the clipboard filter dropdown.

## What changed

Opening a header menu (the clipboard type filter today) and closing it, then clicking the button again, intermittently did nothing: the click reached AppKit, but neither the button nor the click-away catcher saw it until an unrelated render or a window exit/re-enter recomputed hover.

The catcher was inserted on open and removed on close, which could strand SwiftUI's hover target on the button underneath. It is now mounted permanently and only toggles `allowsHitTesting` with the open menu. It also dismisses on a `DragGesture(minimumDistance: 0)` rather than a tap, so a press that drifts a few points still closes the menu, the way a native menu's click-away does.

One file, `RootPaletteView.swift`, +6/−6.

## Memory footprint

Not applicable: a single always-present transparent overlay replaces a conditionally inserted one; no allocation, no new state.

Leak-tested: no new objects to leak.

## Demo

Before: the first clip, on `main` — filter menu opened, dismissed, button clicked again, nothing happens until the pointer leaves and re-enters the window. After: the second clip, on this branch, same window size and the same clicks.

## Drawbacks

The bug is intermittent, so the after clip shows it not happening rather than proves it can't. The change removes the condition the failure needs — a catcher unmounted under the pointer mid-interaction — and that reasoning is the evidence for the fix.

## Tests & validation

No harness covers this layer. Ran `./Scripts/run-tests.sh` (all pass), a Debug build with zero warnings, and `./Scripts/format.sh --check`. Exercised by hand: filter button open, dismiss and reopen in quick succession, click-away right beside the button and far from it, a press that drifts before release, Escape, and the footer Actions menu.
