### PR TITLE
Name an app whose display name is blank

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -72,6 +72,7 @@ run file-search-session-test Tinycast/Platform/Signposts.swift \
                              Tinycast/Features/FileSearch/Service/*.swift
 run ranking-test           $L/SearchRelevance.swift $L/LauncherRankingStore.swift
 run scopes-test            $L/SearchScopes.swift
+run app-name-test          Tinycast/Platform/AppDisplayName.swift
 run favorites-test         $L/FavoriteSlots.swift
 run calc-test              Tinycast/Features/Calculator/Model/*.swift
 run calendar-test          Tinycast/Features/Calendar/Model/*.swift

--- a/Tests/app-name-test.swift
+++ b/Tests/app-name-test.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+@main
+struct AppNameTest {
+    static func main() {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("tinycast-app-name-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: root) }
+
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        /// A real bundle on disk: `installedAppName` reads the plist the way the scan does.
+        func makeApp(_ fileName: String, info: [String: Any]) -> Bundle? {
+            let url = root.appendingPathComponent(fileName)
+            let contents = url.appendingPathComponent("Contents")
+            try? fm.createDirectory(at: contents, withIntermediateDirectories: true)
+            let data = try? PropertyListSerialization.data(
+                fromPropertyList: info, format: .xml, options: 0)
+            try? data?.write(to: contents.appendingPathComponent("Info.plist"))
+            return Bundle(url: url)
+        }
+
+        check(
+            "a blank display name is not a name",
+            AppDisplayName.named("") == nil && AppDisplayName.named("   ") == nil
+                && AppDisplayName.named("\n\t") == nil)
+        check("a missing value is not a name", AppDisplayName.named(nil) == nil)
+        check("a non-string value is not a name", AppDisplayName.named(42) == nil)
+        check("a name is trimmed", AppDisplayName.named("  Paw  ") == "Paw")
+
+        check(
+            "a blank display name falls back to CFBundleName",
+            AppDisplayName.inInfo(["CFBundleDisplayName": "", "CFBundleName": "RapidAPI"])
+                == "RapidAPI")
+        check(
+            "a present display name still wins",
+            AppDisplayName.inInfo(["CFBundleDisplayName": "Shown", "CFBundleName": "Internal"])
+                == "Shown")
+        check(
+            "an info dictionary naming nothing yields nil",
+            AppDisplayName.inInfo(["CFBundleDisplayName": " ", "CFBundleName": ""]) == nil)
+
+        // RapidAPI 4.5.5 ships exactly this: blank display name, real `CFBundleName`, Paw's old id.
+        let rapidAPI = makeApp(
+            "RapidAPI.app",
+            info: [
+                "CFBundleDisplayName": "", "CFBundleName": "RapidAPI",
+                "CFBundleIdentifier": "com.luckymarmot.Paw"
+            ])
+        check(
+            "a bundle with a blank display name is named by CFBundleName",
+            rapidAPI?.installedAppName == "RapidAPI")
+
+        let unnamed = makeApp("Mystery.app", info: ["CFBundleIdentifier": "com.example.mystery"])
+        check(
+            "a bundle naming itself nowhere falls back to its filename",
+            unnamed?.installedAppName == "Mystery")
+
+        let blankBoth = makeApp(
+            "Ghost.app",
+            info: [
+                "CFBundleDisplayName": "  ", "CFBundleName": "",
+                "CFBundleIdentifier": "com.example.ghost"
+            ])
+        check(
+            "two blank keys still fall back to the filename",
+            blankBoth?.installedAppName == "Ghost")
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tinycast/Features/Extensions/Service/ExtensionHostBridge.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionHostBridge.swift
@@ -428,10 +428,7 @@ final class ExtensionHostBridge: ExtensionHostAPI {
 
     private func describe(application url: URL) -> [String: Any] {
         let bundle = Bundle(url: url)
-        let name =
-            (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
-            ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)
-            ?? url.deletingPathExtension().lastPathComponent
+        let name = bundle?.installedAppName ?? url.deletingPathExtension().lastPathComponent
         return [
             "name": name, "path": url.path, "bundleId": bundle?.bundleIdentifier ?? NSNull(),
             "localizedName": name

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -389,9 +389,7 @@ final class AppIndex {
                 if let bundleID, !seenBundleIDs.insert(bundleID).inserted { continue }
 
                 let name =
-                    (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
-                    ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)
-                    ?? url.deletingPathExtension().lastPathComponent
+                    bundle?.installedAppName ?? url.deletingPathExtension().lastPathComponent
                 let executable =
                     bundle?.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
                 result.append(

--- a/Tinycast/Features/Launcher/Service/SettingsPaneScanner.swift
+++ b/Tinycast/Features/Launcher/Service/SettingsPaneScanner.swift
@@ -65,7 +65,7 @@ enum SettingsPaneScanner {
     ) -> String? {
         if let override = nameOverrides[bundleID] { return override }
         if let localized = loctableName(appexURL: appexURL) { return localized }
-        return (info["CFBundleDisplayName"] as? String) ?? (info["CFBundleName"] as? String)
+        return AppDisplayName.inInfo(info)
     }
 
     /// Localized name from `InfoPlist.loctable`, preferred languages first, then English.
@@ -81,7 +81,7 @@ enum SettingsPaneScanner {
         codes.append("en")
         for code in codes {
             if let entry = table[code] as? [String: Any],
-                let name = entry["CFBundleDisplayName"] as? String
+                let name = AppDisplayName.named(entry["CFBundleDisplayName"])
             {
                 return name
             }

--- a/Tinycast/Features/Uninstall/Service/UninstallSession.swift
+++ b/Tinycast/Features/Uninstall/Service/UninstallSession.swift
@@ -116,7 +116,7 @@ final class UninstallSession {
         let info = Bundle(url: url)?.infoDictionary
         return UninstallTarget(
             bundleURL: url, bundleID: bundleID,
-            displayName: (info?["CFBundleDisplayName"] as? String) ?? name,
+            displayName: AppDisplayName.named(info?["CFBundleDisplayName"]) ?? name,
             bundleName: info?["CFBundleName"] as? String)
     }
 }

--- a/Tinycast/Platform/AppDisplayName.swift
+++ b/Tinycast/Platform/AppDisplayName.swift
@@ -1,10 +1,35 @@
 import Foundation
 
+/// How an app bundle's name is read. Apps ship `CFBundleDisplayName = ""` often enough that a blank
+/// value has to read as absent: the empty name it yields draws as nothing and matches no query.
+enum AppDisplayName {
+    /// The Info.plist value as a name, or nil when it is absent, not a string, or blank.
+    static func named(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The name a raw Info.plist carries, for callers holding one without a `Bundle` to open.
+    static func inInfo(_ info: [String: Any]) -> String? {
+        named(info["CFBundleDisplayName"]) ?? named(info["CFBundleName"])
+    }
+}
+
 extension Bundle {
     /// The channel-aware display name, from the generated Info.plist.
     var appDisplayName: String {
-        (object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
-            ?? (object(forInfoDictionaryKey: "CFBundleName") as? String)
-            ?? "Tinycast"
+        infoName("CFBundleDisplayName") ?? infoName("CFBundleName") ?? "Tinycast"
+    }
+
+    /// An installed app's name, in Finder's own order, ending at the `.app` filename.
+    var installedAppName: String {
+        infoName("CFBundleDisplayName") ?? infoName("CFBundleName")
+            ?? bundleURL.deletingPathExtension().lastPathComponent
+    }
+
+    /// Localized: `object(forInfoDictionaryKey:)` consults `InfoPlist.strings` where the bundle has one.
+    private func infoName(_ key: String) -> String? {
+        AppDisplayName.named(object(forInfoDictionaryKey: key))
     }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,6 +58,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `file-search-session-test` | serialized query execution, debounce coalescing and cancellation |
 | `ranking-test` | `Launcher/Model/LauncherRankingStore.swift` |
 | `scopes-test` | `Launcher/Model/SearchScopes.swift` |
+| `app-name-test` | `Platform/AppDisplayName.swift` — every path that names a scanned bundle |
 | `calc-test` | all of `Calculator/Model/` |
 | `calendar-test` | all of `Calendar/Model/` — link detection, the join window, the day buckets |
 | `clipboard-test` | `Clipboard/Model/ClipboardStore.swift` |


### PR DESCRIPTION
Fixes #103, fixes #324.

## The bug

RapidAPI ships `CFBundleDisplayName = ""` (Basalt, from #103, does the same):

```text
CFBundleDisplayName = ""
CFBundleName        = "RapidAPI"
CFBundleIdentifier  = "com.luckymarmot.Paw"
```

`AppIndex.scan` chained the two keys with `??`, which only falls through on `nil`. A present-but-empty string won, so the entry's `name` was `""`. That is worse than cosmetic: the row draws an icon and nothing else, empty names sort ahead of every real one on an empty query, and no query can ever match an empty candidate — the app is unreachable. #324's screenshot of three nameless rows at the top of Applications is the same bug, three times over, not a separate one.

#103 was closed because its reporter withdrew it, not because anything changed, so the chain was still as first described.

## The fix

`Platform/AppDisplayName.swift` becomes the one place that knows how a bundle is named. A blank value now reads as absent, so the chain carries on to `CFBundleName` and then the `.app` filename — the order Finder and Spotlight already resolve these apps by.

Four callers that each spelled the chain out now share it:

- `AppIndex.scan` — the launcher itself.
- `ExtensionHostBridge.describe` — what an extension sees for an app.
- `SettingsPaneScanner` — including the loctable read, where a blank entry for the preferred language now falls through to the next language instead of winning.
- `UninstallSession.makeTarget` — uninstall gets a real name to match support folders on, still gated by `safeNames`' three-character minimum.

Deliberately **not** `URLResourceKey.localizedNameKey`: it would match Finder exactly but rename every localized app to the system language and can carry `.app` depending on extension-hiding — a much wider change than this bug asks for.

## Blast radius

Nothing persisted is keyed by name — `preferenceKey` is `bundleID ?? id`, so ranking, favorites, aliases, visibility and hotkeys are untouched, and `SpotlightNames.Cache` is in-memory and rebuilt per scan. Two derived behaviors shift, both correctly: an executable matching the real name is now dropped as the redundant alias it is, and a Spotlight alternate name equal to the display name stops being indexed twice.

## Testing

New `app-name-test` harness — the pure helpers plus three real bundles written to a temp dir, one of them RapidAPI's exact shape. All 39 harnesses pass, Debug builds with no new warnings, `lint.sh` clean.