### PR TITLE
Re-offer an update prompt the app was too busy to show

### DIFF
--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -184,7 +184,7 @@ final class AppCore {
             Task { await emojiIndex.load() }
             currencyRates.start()
             updateChecker.onUpdateAvailable = { [weak self] release in
-                self?.updateCoordinator.presentIfAvailable(release)
+                self?.updateCoordinator.presentIfAvailable(release) ?? true
             }
             updateChecker.start()
 

--- a/Tinycast/Features/Updates/Service/UpdateCheckStore.swift
+++ b/Tinycast/Features/Updates/Service/UpdateCheckStore.swift
@@ -10,6 +10,9 @@ final class UpdateCheckStore {
     private static let refreshInterval: TimeInterval = 24 * 3600
     /// Shorter retry, so a machine offline at launch sees a release soon after it reconnects.
     private static let retryInterval: TimeInterval = 2 * 3600
+    /// A withheld prompt is re-offered this often, this many times, then left to the daily check.
+    private static let withheldInterval: TimeInterval = 120
+    private static let withheldRetryLimit = 15
     /// Keeps the first check, and any window it raises, clear of the login rush.
     private static let startupDelay = Duration.seconds(30)
 
@@ -21,13 +24,14 @@ final class UpdateCheckStore {
     private(set) var lastCheckedAt: Date?
     private(set) var isChecking = false
 
-    /// Raised when a check turns up something unskipped; the coordinator decides what to show.
-    @ObservationIgnored var onUpdateAvailable: (@MainActor (AvailableRelease) -> Void)?
+    /// Raised on an unskipped release; `false` answers that the prompt was withheld and is owed.
+    @ObservationIgnored var onUpdateAvailable: (@MainActor (AvailableRelease) -> Bool)?
 
     private let fileURL: URL
     private var skippedVersion: AppVersion?
     /// At most one uninvited appearance per version per launch; after that the window is the user's.
     @ObservationIgnored private var announcedVersion: AppVersion?
+    @ObservationIgnored private var withheldRetries = 0
     @ObservationIgnored private var pump: Task<Void, Never>?
 
     init() {
@@ -42,6 +46,8 @@ final class UpdateCheckStore {
         lastCheckedAt = cache.lastCheckedAt
         skippedVersion = cache.skippedVersion
     }
+
+    deinit { pump?.cancel() }
 
     /// Newer than what is running. What the window offers, including a version already skipped.
     var update: AvailableRelease? {
@@ -61,17 +67,10 @@ final class UpdateCheckStore {
         pump?.cancel()
         pump = Task { [weak self] in
             try? await Task.sleep(for: Self.startupDelay)
-            while !Task.isCancelled, let self {
-                // Clamped, so a future-stamped check can't park the loop past one interval.
-                let age = max(0, self.lastCheckedAt.map { Date().timeIntervalSince($0) } ?? .infinity)
-                guard age >= Self.refreshInterval else {
-                    self.announce()
-                    try? await Task.sleep(for: .seconds(Self.refreshInterval - age))
-                    continue
-                }
-                let ok = await self.check()
-                self.announce()
-                try? await Task.sleep(for: .seconds(ok ? Self.refreshInterval : Self.retryInterval))
+            while !Task.isCancelled {
+                // Optional-chained: the sleep must not retain the store, or nothing can release it.
+                guard let wait = await self?.advance() else { return }
+                try? await Task.sleep(for: .seconds(wait))
             }
         }
     }
@@ -95,10 +94,30 @@ final class UpdateCheckStore {
         persist()
     }
 
-    private func announce() {
-        guard let release = unskippedUpdate, announcedVersion != release.version else { return }
+    /// One turn of the pump: check if due, offer what is pending, and answer how long to wait.
+    private func advance() async -> TimeInterval {
+        // Clamped, so a future-stamped check can't park the loop past one interval.
+        let age = max(0, lastCheckedAt.map { Date().timeIntervalSince($0) } ?? .infinity)
+        var wait = Self.refreshInterval - age
+        if wait <= 0 {
+            wait = await check() ? Self.refreshInterval : Self.retryInterval
+        }
+        if announce() {
+            withheldRetries = 0
+        } else if withheldRetries < Self.withheldRetryLimit {
+            // A launch straight into the palette must not spend the day's only announcement.
+            withheldRetries += 1
+            wait = min(wait, Self.withheldInterval)
+        }
+        return wait
+    }
+
+    /// `false` only when a pending release was withheld, so the pump comes back for it.
+    private func announce() -> Bool {
+        guard let release = unskippedUpdate, announcedVersion != release.version else { return true }
+        guard onUpdateAvailable?(release) ?? true else { return false }
         announcedVersion = release.version
-        onUpdateAvailable?(release)
+        return true
     }
 
     private func persist() {

--- a/Tinycast/Features/Updates/UI/UpdateCoordinator.swift
+++ b/Tinycast/Features/Updates/UI/UpdateCoordinator.swift
@@ -81,12 +81,18 @@ final class UpdateCoordinator {
         }
     }
 
-    /// The automatic path. It may interrupt the user, so it defers to whatever they are doing.
-    func presentIfAvailable(_ release: AvailableRelease) {
-        guard UpdateReadiness.evaluate(activity) == nil else { return }
-        if case .installing = stage { return }
-        stage = .available(release)
-        present()
+    /// The automatic path: `false` answers that it withheld the prompt, so the store re-offers it.
+    func presentIfAvailable(_ release: AvailableRelease) -> Bool {
+        switch stage {
+        // Already in hand: re-offering would throw away a download or the relaunch it earned.
+        case .installing, .readyToRelaunch:
+            return true
+        case .checking, .upToDate, .localBuild, .available, .blocked, .failed:
+            guard UpdateReadiness.evaluate(activity) == nil else { return false }
+            stage = .available(release)
+            present()
+            return true
+        }
     }
 
     // MARK: - Actions

--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -29,9 +29,16 @@ release feed the website already reads is the feed the app reads.
   on the expanded copy before `replaceItemAt` runs, and the running app survives any failure untouched.
 - **Relaunching goes through `NSApp.terminate`, never `exit`.** That is what flushes a pending note
   draft and hands back the Hyper Key's HID-level caps remap, which outlives the process.
-- **An automatic prompt defers to whatever the user is doing.** `UpdateReadiness` withholds it while a
-  snippet is expanding, an extension command is running, an uninstall is trashing, a shortcut is being
-  recorded, a prompt or dialog is up, or the palette is open. Readiness is asked again at the click.
+- **An automatic prompt defers to whatever the user is doing, and is never spent unshown.**
+  `UpdateReadiness` withholds it while a snippet is expanding, an extension command is running, an
+  uninstall is trashing, a shortcut is being recorded, a prompt or dialog is up, or the palette is
+  open. A withheld prompt is still owed: `presentIfAvailable` answers `false`, the version is left
+  unannounced, and the pump re-offers it every two minutes for half an hour before falling back to
+  the daily rhythm. That is what a hand-launched copy depends on — its one announcement falls 30 s
+  in, straight into the palette the user opened the app to use, where a launch-at-login copy would
+  have found the desktop idle. The window itself still appears at most once per version per launch:
+  `announcedVersion` is set the moment an offer lands, so re-offering can never turn into nagging.
+  Readiness is asked again at the click.
 - **Nothing about updates is persisted in `AppSettings`.** The feature owns one cache file, so no
   `AppSettingsKey` and no `SettingsBackupCoverage` entry exist for it.
 - **The window shows the changelog and nothing else.** CI writes install instructions below


### PR DESCRIPTION
## Related issue

None filed — found while investigating a report that the update window never appears on a copy that
is not set to launch at login, while the same build prompts reliably when it is.

## What changed

`UpdateCheckStore.onUpdateAvailable` returned `Void`, but its one receiver was free to refuse:
`presentIfAvailable` bailed when `UpdateReadiness` said the app was busy, or when an install was
already under way. `announce()` set `announcedVersion` *before* calling the closure, so a refused
prompt counted as delivered. The pump then slept a full `refreshInterval`, and the release was never
offered again that launch.

That is deterministic for a hand-launched copy. The first announcement lands 30 s after launch —
`startupDelay`, tuned to clear the login rush — which for a manual launch is exactly when the palette
the user opened the app to use is on screen. `isPaletteVisible` is a blocker, so the offer was
withheld and spent. A launch-at-login copy finds the desktop idle at that same moment, prompts
normally, and then stays running long enough for later cycles to land. Same build, opposite outcome.

- `onUpdateAvailable` is now `(AvailableRelease) -> Bool`, and `announce()` sets `announcedVersion`
  only once an offer actually lands. A withheld one stays owed.
- A withheld prompt is re-offered every two minutes for half an hour (`withheldInterval`,
  `withheldRetryLimit`), then falls back to the daily rhythm. Bounded on purpose — it must not
  become a timer that wakes forever.
- `presentIfAvailable` switches exhaustively over `Stage`, so a future case is a compile error rather
  than another silent drop. `.installing` and `.readyToRelaunch` answer `true`: re-offering there
  would clobber a download or the relaunch it earned.

Non-obvious in the diff, and the reason the loop was restructured rather than patched: the pump was
`while !Task.isCancelled, let self` with the sleep **inside** the body, so it held the store strongly
across a 24-hour `Task.sleep`. The store could never be released and a `deinit` could never run. The
turn is now an optional-chained `await self?.advance()`, so the strong reference lives only for the
call and the sleep holds nothing — a released store ends the loop, and `deinit { pump?.cancel() }` is
reachable and ends it at once. Extracting `advance()` also removed the duplicated
`announce()`/sleep pair the old two-branch loop carried.

The freshness gate is deliberately untouched: a launch inside 24 h still does not re-ask GitHub, per
the existing invariant. That adds latency for short manual sessions but self-heals on the next launch
past the boundary, and changing it would trade a documented design decision for a smaller win.

## Memory footprint

Debug build (`Tinycast Dev.app`), measured with `footprint -p`. Palette driven via reopen, dismissed
by activating Finder.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 23 MB  |
| Palette open            | 39 MB  |
| Feature in use (peak)   | 41 MB  |
| Palette closed, settled | 39 MB  |

Leak-tested: five open/close palette cycles held flat at 40 MB with no growth, settling to 39 MB
(peak 41 MB). Two notes on honesty here. The pump does not run on this channel at all —
`com.tinycast.app.dev` is `.development`, so `start()` returns before the task is created — so these
numbers show no regression rather than exercising the changed code. And the update window itself is
not reachable on the dev channel (`applyEnabled` hides Check for Updates), so the peak row is the
palette peak; the window is one `AppWindowController` that tears its SwiftUI tree down on close,
unchanged by this PR.

The ownership change moves in the safe direction: the pump previously pinned the store for the
process lifetime, and now retains it only for the duration of each turn.

## Demo

Nothing visual changed — same window, same copy, same stages. What changed is whether the existing
window is shown at all.

## Drawbacks

- The re-offer is a bounded poll, not an event. Observing every blocker (palette, dialog, snippet
  expansion, extension run, uninstall, recorder) to fire the instant one clears would be exact, but
  it would wire the update feature into six unrelated coordinators. A 2-minute silent tick that costs
  one timer wake buys the same outcome for none of that coupling.
- If the app stays continuously busy for the full half-hour grace, the prompt waits for the next
  daily cycle. That is the pre-change behaviour, so it degrades to today rather than below it.
- `withheldRetries` resets only on a successful offer, not per check cycle. Exhausting the grace and
  then receiving a newer release within the same launch leaves that release on the slow path. Cheap
  to fix with a reset in `advance()`; left out because it needs a 30-minute busy window to reach and
  the extra line muddied the one place the pacing is decided. Flagging it rather than hiding it.

## Tests & validation

- `./Scripts/run-tests.sh` — all 39 harnesses pass, `updates-test` 98 passed / 0 failed.
- Debug build compiles with zero new warnings; `./Scripts/lint.sh` reports `lint-clean`.
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` — clean.
- Ran the Debug app: launches clean, palette opens and closes normally, no regression from the
  `AppCore` closure change.
- The exhaustive `Stage` switch is enforced by the compiler, so the `.installing` /
  `.readyToRelaunch` cases cannot silently regress.

**Not verified, and worth a reviewer's attention:** no live end-to-end prompt. The announce path
cannot run in a Debug build (`.development` never self-updates), and I did not want to run a second
`com.tinycast.app.beta` instance against the real cache and TCC grant to force one. The fix is
established by inspection and compilation, not by an observed pop-up.

To confirm by hand on the next beta: quit Beta, `rm ~/Library/Caches/com.tinycast.app.beta/update-check.json`,
launch by hand, open the palette immediately and hold it past the 30-second mark. Before this change
the prompt is gone for the whole session; after it, it should arrive within ~2 minutes of the palette
closing.

No new harness case: `UpdateCheckStore` lives in `Service/`, depends on `AppPaths` and `Bundle.main`,
and gates on a channel a CLI binary cannot report, so the harnesses (which compile
`Features/Updates/Model/*.swift`) cannot reach `announce()` without adding a test seam to shipped
code. `UpdateReadiness` — the pure decision this builds on — stays covered by `blocksWhileBusy()`.
