### PR TITLE
Add First / Last Three Fourths to window management

### DIFF
--- a/Tests/window-command-test.swift
+++ b/Tests/window-command-test.swift
@@ -71,7 +71,7 @@ struct WindowCommandTests {
 
     static func testCatalog() {
         let commands = WindowCommandCatalog.all
-        expect(commands.count == 32, "catalog contains all 32 agreed commands")
+        expect(commands.count == 34, "catalog contains all 34 agreed commands")
         expect(commands.map(\.id) == WindowCommand.ID.allCases, "catalog covers every ID once")
         expect(
             Set(commands.map { $0.name.lowercased() }).count == commands.count, "names are unique")
@@ -131,6 +131,7 @@ struct WindowCommandTests {
             "every group is represented, in declaration order")
         expect(grouped.first { $0.group == .halves }?.commands.count == 4, "four halves")
         expect(grouped.first { $0.group == .quarters }?.commands.count == 4, "four quarters")
+        expect(grouped.first { $0.group == .fourths }?.commands.count == 2, "two fourths")
         expect(grouped.first { $0.group == .thirds }?.commands.count == 5, "five thirds")
         expect(grouped.first { $0.group == .sizing }?.commands.count == 10, "ten sizing commands")
         expect(grouped.first { $0.group == .moving }?.commands.count == 6, "six moving commands")
@@ -199,6 +200,19 @@ struct WindowCommandTests {
         }
         expect(!overlapping, "quarters never overlap")
 
+        expectRect(
+            frame(.firstThreeFourths)!, CGRect(x: 0, y: 0, width: 1080, height: 900),
+            "first three fourths")
+        expectRect(
+            frame(.lastThreeFourths)!, CGRect(x: 360, y: 0, width: 1080, height: 900),
+            "last three fourths")
+        expect(
+            frame(.firstThreeFourths)!.union(frame(.lastThreeFourths)!) == mainScreen.visibleFrame,
+            "the two three-fourths cover the screen between them")
+        expect(
+            frame(.firstThreeFourths)!.intersection(frame(.lastThreeFourths)!) == frame(.centerHalf)!,
+            "they overlap on exactly the centre half, so all three share the quarter grid")
+
         expectRect(frame(.firstThird)!, CGRect(x: 0, y: 0, width: 480, height: 900), "first third")
         expectRect(
             frame(.centerThird)!, CGRect(x: 480, y: 0, width: 480, height: 900), "center third")
@@ -252,7 +266,8 @@ struct WindowCommandTests {
     // MARK: - Non-divisible widths
 
     static func testNonDivisible() {
-        for width in [1441, 1000, 1367] as [CGFloat] {
+        // 1366 is the tie case for fourths: a quarter of it lands exactly on .5.
+        for width in [1441, 1000, 1367, 1366] as [CGFloat] {
             let screen = WindowLayout.Screen(
                 id: 9, frame: CGRect(x: 0, y: 0, width: width, height: 901),
                 visibleFrame: CGRect(x: 0, y: 0, width: width, height: 901))
@@ -274,6 +289,18 @@ struct WindowCommandTests {
             let top = frame(.topHalf, on: screen)!
             let bottom = frame(.bottomHalf, on: screen)!
             expect(top.maxY == bottom.minY, "\(width): vertical halves share an edge exactly")
+
+            let firstFourths = frame(.firstThreeFourths, on: screen)!
+            let lastFourths = frame(.lastThreeFourths, on: screen)!
+            expect(
+                abs(firstFourths.width - lastFourths.width) <= 1,
+                "\(width): the two three-fourths differ by at most a point")
+            expect(
+                abs(firstFourths.width - width * 0.75) <= 1,
+                "\(width): three fourths is three quarters of the screen")
+            expect(
+                firstFourths.union(lastFourths) == screen.visibleFrame,
+                "\(width): the two three-fourths still cover the screen")
         }
     }
 
@@ -340,6 +367,14 @@ struct WindowCommandTests {
             quarters.allSatisfy {
                 $0.minX >= 10 && $0.minY >= 10 && $0.maxX <= 1430 && $0.maxY <= 890
             }, "quarters stay inset from every screen edge")
+
+        // Fourths: the outer edge takes the full gap, the interior one half of it.
+        expectRect(
+            frame(.firstThreeFourths, gap: 10)!, CGRect(x: 10, y: 10, width: 1065, height: 880),
+            "first three fourths with a 10pt gap")
+        expectRect(
+            frame(.lastThreeFourths, gap: 10)!, CGRect(x: 365, y: 10, width: 1065, height: 880),
+            "last three fourths with a 10pt gap")
 
         // Thirds: two gutters, both exact.
         expect(

--- a/Tinycast/Features/WindowManagement/WindowCommand.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommand.swift
@@ -10,6 +10,8 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case topRightQuarter = "top-right-quarter"
         case bottomLeftQuarter = "bottom-left-quarter"
         case bottomRightQuarter = "bottom-right-quarter"
+        case firstThreeFourths = "first-three-fourths"
+        case lastThreeFourths = "last-three-fourths"
         case firstThird = "first-third"
         case centerThird = "center-third"
         case lastThird = "last-third"
@@ -52,6 +54,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
     enum Group: String, CaseIterable, Sendable {
         case halves
         case quarters
+        case fourths
         case thirds
         case sizing
         case moving
@@ -62,6 +65,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
             switch self {
             case .halves: return "Halves"
             case .quarters: return "Quarters"
+            case .fourths: return "Fourths"
             case .thirds: return "Thirds"
             case .sizing: return "Sizing"
             case .moving: return "Moving"
@@ -124,6 +128,8 @@ enum WindowCommandCatalog {
         case .topRightQuarter: return "Top Right Quarter"
         case .bottomLeftQuarter: return "Bottom Left Quarter"
         case .bottomRightQuarter: return "Bottom Right Quarter"
+        case .firstThreeFourths: return "First Three Fourths"
+        case .lastThreeFourths: return "Last Three Fourths"
         case .firstThird: return "First Third"
         case .centerThird: return "Center Third"
         case .lastThird: return "Last Third"
@@ -161,6 +167,8 @@ enum WindowCommandCatalog {
         case .topRightQuarter: return "rectangle.inset.toptrailing.filled"
         case .bottomLeftQuarter: return "rectangle.inset.bottomleading.filled"
         case .bottomRightQuarter: return "rectangle.inset.bottomtrailing.filled"
+        case .firstThreeFourths: return "rectangle.lefthalf.inset.filled"
+        case .lastThreeFourths: return "rectangle.righthalf.inset.filled"
         case .firstThird, .firstTwoThirds: return "rectangle.leadingthird.inset.filled"
         case .centerThird: return "rectangle.center.inset.filled"
         case .lastThird, .lastTwoThirds: return "rectangle.trailingthird.inset.filled"
@@ -201,6 +209,8 @@ enum WindowCommandCatalog {
             return .halves
         case .topLeftQuarter, .topRightQuarter, .bottomLeftQuarter, .bottomRightQuarter:
             return .quarters
+        case .firstThreeFourths, .lastThreeFourths:
+            return .fourths
         case .firstThird, .centerThird, .lastThird, .firstTwoThirds, .lastTwoThirds:
             return .thirds
         case .maximize, .almostMaximize, .reasonableSize, .maximizeHeight, .maximizeWidth, .center,

--- a/Tinycast/Features/WindowManagement/WindowLayout.swift
+++ b/Tinycast/Features/WindowManagement/WindowLayout.swift
@@ -310,6 +310,12 @@ enum WindowLayout {
             return Fractions(
                 x0: 0.5, x1: 1, y0: 0.5, y1: 1, anchor: Anchor(horizontal: .max, vertical: .max))
 
+        case .firstThreeFourths:
+            return Fractions(x0: 0, x1: 0.75, y0: 0, y1: 1, anchor: .topLeading)
+        case .lastThreeFourths:
+            return Fractions(
+                x0: 0.25, x1: 1, y0: 0, y1: 1, anchor: Anchor(horizontal: .max, vertical: .min))
+
         case .firstThird:
             return Fractions(x0: 0, x1: oneThird, y0: 0, y1: 1, anchor: .topLeading)
         case .centerThird:

--- a/docs/features/window-management.md
+++ b/docs/features/window-management.md
@@ -1,8 +1,8 @@
 # Window Management
 
-Rectangle-style window actions — halves, quarters, thirds, sizing, nudging, display moves, native
-fullscreen and Space switching — searchable in the palette and bindable to global shortcuts. 32
-commands, no new dependencies and no new permission: they reuse the Accessibility grant clipboard
+Rectangle-style window actions — halves, quarters, fourths, thirds, sizing, nudging, display moves,
+native fullscreen and Space switching — searchable in the palette and bindable to global shortcuts.
+34 commands, no new dependencies and no new permission: they reuse the Accessibility grant clipboard
 paste already needs.
 
 Ships **off**. Settings › Window Management is the switch, and while it is off there are no launcher
@@ -43,7 +43,8 @@ overlay rather than in Foundation.
 
 Adding a command is four edits in `WindowCommand.swift` (a case in `ID`, plus `name`, `symbol` and
 `group` arms), an arm in `WindowLayout.placement` or `tileFractions`, and bumping
-`commands.count == 32` and its group count in the harness.
+`commands.count == 34` and its group count in the harness. A command opening a new family also needs
+a `Group` case and its `title` arm; `ID.allCases` stays in group order.
 
 ## Coordinate space
 
@@ -248,7 +249,7 @@ quantize to zero and the gesture would do nothing.
 
 ## Testing
 
-`Tests/window-command-test.swift` (319 assertions) covers the catalog, the AX-space convention lock,
+`Tests/window-command-test.swift` (357 assertions) covers the catalog, the AX-space convention lock,
 tiling on divisible and non-divisible screens, off-origin and negative-coordinate displays, gap
 arithmetic including degenerate values, sizing, the Make Larger/Smaller round trip, nudges, display
 moves and wrapping, restore recovery, every `WindowActionMemory` rule, and a fuzz sweep over every

--- a/website/content/docs/features/window-management.md
+++ b/website/content/docs/features/window-management.md
@@ -1,6 +1,6 @@
 ---
 title: Window management
-description: 32 commands — halves, quarters, thirds, nudges, display moves and instant Space switching.
+description: 34 commands — halves, quarters, fourths, thirds, nudges, display moves and instant Space switching.
 ---
 
 Move and resize the window you were last in, without installing anything else.
@@ -16,6 +16,8 @@ launcher entries and a still-registered shortcut moves nothing.
 **Halves** — Left · Right · Top · Bottom
 
 **Quarters** — Top Left · Top Right · Bottom Left · Bottom Right
+
+**Fourths** — First Three Fourths · Last Three Fourths
 
 **Thirds** — First Third · Center Third · Last Third · First Two Thirds · Last Two Thirds
 


### PR DESCRIPTION
Closes #323.

The catalog could tile a window to a half, a third, two thirds or a corner quarter, but nothing between a half and the full width. A 3:1 split — a browser on three quarters, a terminal or chat on the last one — was the one common layout it could not express.

### The change

- **`WindowCommand.swift`** — two `ID` cases (`first-three-fourths`, `last-three-fourths`) declared after the quarters so `allCases` stays in group order, plus their `name`, `symbol` and `group` arms.
- **`WindowLayout.swift`** — one arm in `tileFractions`: `0 → 0.75` anchored leading, `0.25 → 1` anchored trailing. That is the whole geometry change. The shared gap rule, edge rounding and `isTileCommand` (so a display move re-derives the tile rather than scaling it) all apply as-is, and the anchors keep an app that refuses to shrink pinned to the side it was sent to instead of drifting centre.

Nothing else needed editing: the launcher entries, hotkey slots, Settings rows, per-command visibility and settings-backup coverage are all derived from `WindowCommandCatalog.all`.

### Two judgement calls

They open a new **`Group.fourths`** section rather than joining `.quarters`, which leaves the existing Quarters heading alone.

They take `rectangle.lefthalf.inset.filled` / `rectangle.righthalf.inset.filled` rather than sharing the leading/trailing third glyphs the way First and Last Two Thirds already do. No SF Symbol depicts a three-quarter fill, and a third launcher row wearing an identical icon stops being scannable.

### Testing

`Tests/window-command-test.swift` pins both rects on the reference display, at a 10 pt gap, and asserts their union is the visible frame and their intersection is exactly `Center Half` — which locks all three commands to one quarter grid. The non-divisible sweep gains 1366, the tie width where a quarter lands on `.5` and edge rounding could hand the two sides different widths. The fuzz sweep picks both commands up from `allCases` and needs no exclusion, since they are idempotent.

`./Scripts/run-tests.sh` — 39/39 harnesses pass, `window-command-test` at 357 assertions. Debug builds with no new warnings, `./Scripts/lint.sh` clean.

**Not covered automatically:** `WindowMover` has no harness, so the AX write path still wants a manual pass — both commands from the palette, the new Fourths section in Settings, and a **Move to Next Display** round trip on a second monitor to confirm the tile is re-derived at three quarters of the new screen.
