### PR TITLE
Draw extension icons carried as a data: URL, and tint them

### DIFF
--- a/Tests/ext-icon-test.swift
+++ b/Tests/ext-icon-test.swift
@@ -39,6 +39,35 @@ struct ExtensionIconTests {
         expect(icon.size.width > 0, "a missing icon falls back to the puzzle-piece tile")
     }
 
+    /// Extensions that render their own artwork hand it over as a `data:` URL rather than a file,
+    /// in either encoding, and Detail markdown appends Raycast's sizing query to it.
+    static func inlineDataURLsDecode() async {
+        let svg = """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" \
+            fill="none" stroke="currentColor"><path d="M2 12 L22 12"/></svg>
+            """
+        let escaped = CharacterSet(charactersIn: "<>\"# %{}|\\^~[]`").inverted
+        guard let encoded = svg.addingPercentEncoding(withAllowedCharacters: escaped) else {
+            return expect(false, "the fixture encodes")
+        }
+
+        for suffix in ["", "?raycast-width=200&raycast-height=200"] {
+            let url = URL(string: "data:image/svg+xml,\(encoded)\(suffix)")!
+            let image = await ExtensionIconCache.loadInlineAsync(url)
+            expect(image?.size == NSSize(width: 24, height: 24), "percent-encoded SVG\(suffix)")
+        }
+
+        let png = writePNG("inline", inset: 0).flatMap { try? Data(contentsOf: $0) }
+        guard let png else { return expect(false, "the PNG fixture writes") }
+        let base64 = URL(string: "data:image/png;base64,\(png.base64EncodedString())")!
+        let decoded = await ExtensionIconCache.loadInlineAsync(base64)
+        expect(decoded != nil, "base64 payload decodes")
+
+        let broken = URL(string: "data:image/png;base64,not-base-64")!
+        let rejected = await ExtensionIconCache.loadInlineAsync(broken)
+        expect(rejected == nil, "a broken payload is nil")
+    }
+
     /// A red square on a transparent canvas, `inset` pixels in from each edge.
     static func writePNG(_ name: String, inset: Int) -> URL? {
         let side = 512
@@ -92,9 +121,10 @@ struct ExtensionIconTests {
         return CGFloat(max(maxX - minX + 1, maxY - minY + 1)) / CGFloat(side)
     }
 
-    static func main() {
+    static func main() async {
         artworkIsNormalized()
         missingFileFallsBack()
+        await inlineDataURLsDecode()
 
         print(failures == 0 ? "Extension icon tests passed" : "\(failures) tests failed")
         exit(failures == 0 ? 0 : 1)

--- a/Tinycast/Features/Extensions/Service/ExtensionIconCache.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionIconCache.swift
@@ -54,6 +54,29 @@ enum ExtensionIconCache {
         return image
     }
 
+    // MARK: - Carried inline by the extension
+
+    /// The bytes a `data:` URL holds. Uncached and unfitted: the payload is already resident, and an
+    /// extension that draws its own SVG has already sized it.
+    static func loadInlineAsync(_ url: URL) async -> NSImage? {
+        guard let data = inlineData(url) else { return nil }
+        return await Task.detached(priority: .userInitiated) {
+            Decoded(image: NSImage(data: data))
+        }.value.image
+    }
+
+    /// `data:[<mediatype>][;base64],<payload>`, minus any query — Detail markdown appends Raycast's
+    /// `?raycast-width=…` sizing hints, and neither encoding can produce a `?` of its own.
+    private static func inlineData(_ url: URL) -> Data? {
+        let text = url.absoluteString
+        guard let comma = text.firstIndex(of: ",") else { return nil }
+        let payload = String(text[text.index(after: comma)...].prefix { $0 != "?" })
+        guard text[..<comma].hasSuffix(";base64") else {
+            return payload.removingPercentEncoding.map { Data($0.utf8) }
+        }
+        return Data(base64Encoded: payload, options: .ignoreUnknownCharacters)
+    }
+
     // MARK: - Fetched by the extension
 
     /// A failure caches nothing, so a transient error retries; `asIcon` is off for markdown images.

--- a/Tinycast/Features/Extensions/UI/ExtensionDetailView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionDetailView.swift
@@ -357,7 +357,9 @@ struct ExtensionMarkdownView: View {
         }
         let inner = line[line.index(after: open)..<line.index(before: line.endIndex)]
         let target = inner.split(separator: " ").first.map(String.init) ?? String(inner)
-        guard let url = URL(string: target), url.scheme?.hasPrefix("http") == true else { return nil }
+        guard let url = URL(string: target), let scheme = url.scheme,
+            scheme.hasPrefix("http") || scheme == "data"
+        else { return nil }
         return url
     }
 }
@@ -373,7 +375,7 @@ extension String {
     }
 }
 
-/// A remote image inside a Detail's markdown, capped so a large asset can't push the layout around.
+/// An image inside a Detail's markdown, capped so a large asset can't push the layout around.
 private struct ExtensionMarkdownImage: View {
     let url: URL
     @State private var image: NSImage?
@@ -396,6 +398,11 @@ private struct ExtensionMarkdownImage: View {
                     .frame(height: 120)
             }
         }
-        .task(id: url) { image = await ExtensionIconCache.loadRemoteAsync(url, asIcon: false) }
+        .task(id: url) {
+            image =
+                url.scheme == "data"
+                ? await ExtensionIconCache.loadInlineAsync(url)
+                : await ExtensionIconCache.loadRemoteAsync(url, asIcon: false)
+        }
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -8,8 +8,8 @@ extension EnvironmentValues {
 }
 
 enum ExtensionImage {
-    /// A resolved icon: an SF Symbol, an image file, the Finder icon of a path, a remote URL, or a
-    /// bare emoji/text glyph.
+    /// A resolved icon: an SF Symbol, an image file, the Finder icon of a path, a URL — fetched or
+    /// carrying its own bytes — or a bare emoji/text glyph.
     enum Source: Equatable {
         case symbol(String)
         case file(String)
@@ -17,6 +17,8 @@ enum ExtensionImage {
         /// not an image to decode.
         case fileIcon(String)
         case remote(URL)
+        /// A `data:` URL — an extension that renders its own SVG hands over bytes rather than a path.
+        case inline(URL)
         case glyph(String)
     }
 
@@ -93,8 +95,9 @@ enum ExtensionImage {
             if let digits = numberGlyph(forIcon: text) { return .glyph(digits) }
             if let symbol = symbolName(forIcon: text) { return .symbol(symbol) }
         }
-        if let url = URL(string: text), let scheme = url.scheme, scheme.hasPrefix("http") {
-            return .remote(url)
+        if let url = URL(string: text), let scheme = url.scheme {
+            if scheme.hasPrefix("http") { return .remote(url) }
+            if scheme == "data" { return .inline(url) }
         }
         if text.hasPrefix("/") || text.hasPrefix("~") {
             return .file((text as NSString).expandingTildeInPath)
@@ -323,7 +326,7 @@ struct ExtensionIconView: View {
         content
             .frame(width: size, height: size)
             .clipShape(shape)
-            .task(id: cacheKey) { await load() }
+            .task(id: resolved?.source) { await load() }
     }
 
     @ViewBuilder
@@ -339,13 +342,18 @@ struct ExtensionIconView: View {
             Text(text)
                 .font(.system(size: size * 0.72))
                 .frame(width: size, height: size)
-        case .file, .fileIcon, .remote:
+        case .file, .fileIcon, .remote, .inline:
             if let loaded {
                 // Only a multi-frame image pays for `NSImageView`; a still stays on SwiftUI's path.
                 if animates, loaded.isAnimated {
                     AnimatedImageView(image: loaded)
                 } else {
-                    Image(nsImage: loaded).resizable().aspectRatio(contentMode: .fit)
+                    // A `tintColor` masks the artwork, which is what colours a `currentColor` SVG.
+                    Image(nsImage: loaded)
+                        .resizable()
+                        .renderingMode(resolved?.tint == nil ? .original : .template)
+                        .scaledToFit()
+                        .foregroundStyle(resolved?.tint ?? .primary)
                 }
             } else {
                 placeholder
@@ -366,15 +374,6 @@ struct ExtensionIconView: View {
             : AnyShape(RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous))
     }
 
-    private var cacheKey: String {
-        switch resolved?.source {
-        case .file(let path): return "file:" + path
-        case .fileIcon(let path): return "fileIcon:" + path
-        case .remote(let url): return "remote:" + url.absoluteString
-        default: return ""
-        }
-    }
-
     /// An animating tile takes the image as shipped; the fitted path would hand back one frame.
     private func load() async {
         switch resolved?.source {
@@ -389,6 +388,8 @@ struct ExtensionIconView: View {
             loaded = await IconCache.loadFittedAsync(forFile: path)
         case .remote(let url):
             loaded = await ExtensionIconCache.loadRemoteAsync(url, asIcon: !animates)
+        case .inline(let url):
+            loaded = await ExtensionIconCache.loadInlineAsync(url)
         default:
             loaded = nil
         }

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -158,8 +158,8 @@ screens hold (see [palette.md](palette.md)).
   too. `isShowingDetail` splits the screen into rows plus a detail pane. `ExtensionScreen.Item`
   carries both the flat `selection` index and the scroll id, and is the `ForEach` identity of the row
   and the grid cell alike — see the scroll-id rule in [ui.md](../ui.md#rows-selection-hover).
-- **Detail** — markdown rendered block-by-block (headings, lists, code fences, quotes, rules, remote
-  images) with `AttributedString` handling inline styling, plus `Detail.Metadata`.
+- **Detail** — markdown rendered block-by-block (headings, lists, code fences, quotes, rules, fetched
+  and inline images) with `AttributedString` handling inline styling, plus `Detail.Metadata`.
 - **Appearance** — `environment.appearance` reports the real one, so an extension that branches on it
   is told the truth. It is an injected field on `ExtensionLaunchContext` (a `Model/` type owns no
   environment), which means a **running command keeps the appearance it booted with**; a change
@@ -168,7 +168,10 @@ screens hold (see [palette.md](palette.md)).
   `\.isDarkAppearance` so the pick re-renders when the surface flips; either side stands in when an
   extension supplies only one. `{fileIcon: path}` is its own source: the path names a bundle or
   document whose Finder icon is wanted, so it goes to `NSWorkspace` rather than being decoded as an
-  image file — an `.app` has no bitmap to read. The feature's own fills live in `ExtensionColors` — never in `Theme`.
+  image file — an `.app` has no bitmap to read. A `data:` URL is a source of its own too: an extension
+  that renders its own SVG hands over the bytes, so they are decoded inline rather than fetched. A
+  `tintColor` on any of them draws the image as a template, which is what colours an SVG written
+  against `currentColor`. The feature's own fills live in `ExtensionColors` — never in `Theme`.
 - **Form** — label-left/control-right rows. Field values live in the extension (React owns them); every
   edit dispatches `onTinycastChange` and the resulting re-render is what updates the control, so
   `defaultValue`, a controlled `value`, and `ref.reset()` all behave.
@@ -464,10 +467,12 @@ Every macOS 26 app icon is a squircle with a glyph inside it, and the ground dis
 palette, so only the glyph reads. A Raycast icon is a flat, fully saturated tile,
 so every pixel of it reads. At equal geometry the extension shouts, and fitting it smaller is what
 makes the two match by eye. Shipped and fetched images take the same target, so an icon doesn't
-change size depending on where it came from.
+change size depending on where it came from. An inline `data:` image is the one exception and is never
+fitted: the extension that drew it has already sized it, and rasterizing would cost the vector.
 
 Change the number only against a rendered strip of real icons; it means nothing on its own.
-`ext-icon-test` guards the invariant: padding in the source cannot change the drawn size.
+`ext-icon-test` guards the invariant: padding in the source cannot change the drawn size, and a
+`data:` payload decodes in either encoding.
 
 - `ExtensionAppearance` (symbol + `ExtensionTint`) is stored per extension by manifest name in
   `ExtensionAppearanceStore`, and applies to **every command** of that extension — the same inheritance


### PR DESCRIPTION
## Related issue

Closes #331

Also covers the follow-up raised in that thread — Raycast `Color`s inside an SVG not resolving — since both are the same missing step in `ExtensionIconView`.

## What changed

**`data:` URL icons drew the placeholder.** An extension that renders its own artwork hands over the bytes rather than a path — Hugeicons builds every tile as `data:image/svg+xml,<percent-encoded svg>`. `ExtensionImage.source(from:assetsPath:)` only read a string as a URL when the scheme began with `http`, so a data URL fell past the path and `assets/` branches onto `return text.count <= 4 ? .glyph(text) : nil`, resolved to `nil`, and every cell drew `Theme.Colors.iconPlaceholder`.

`Source` gains `inline(URL)`, classified alongside `.remote`. `ExtensionIconCache.loadInlineAsync` decodes the payload off-main in either encoding (percent-encoded or `;base64`). It never caches — the bytes are already resident in the render tree — and never fits, because the extension that drew the SVG has already sized it and rasterizing would cost the vector. That exception is now written down in `docs/features/extensions.md` next to the `0.76` extent rule it departs from.

Non-obvious bit: **the decoder cuts the payload at `?`.** Detail markdown appends Raycast's sizing hints (`![…](data:image/svg+xml,…?raycast-width=200&raycast-height=200)`). Without the cut those characters percent-decode into trailing text after `</svg>` and `NSImage(data:)` returns nil — verified, not assumed. Neither encoding can produce a bare `?` of its own, so the cut is unambiguous.

`ExtensionMarkdownView.standaloneImageURL` carried the same `http`-only guard, so a `data:` image in a `Detail` block was dropped for the same reason — that's the Hugeicons **View All Styles** screen, one ↵ away from the broken grid. It now accepts `data:` too.

**`tintColor` was resolved but never applied to images.** Lucide passes `content: { source: "https://lucide.dev/api/icons/<name>", tintColor: Color.PrimaryText }`, and those SVGs are `stroke="currentColor"` — with no CSS context that resolves to black, which is what shipped. `ExtensionIconView` computed the tint but only used it on the `.symbol` branch. Raycast treats a tint on an image as a template fill, so a tinted image now renders `.template` over the tint and an untinted one stays explicitly `.original`.

Rendering the real view through `ImageRenderer` confirms the mechanism rather than the appearance: untinted gives `r=g=b=0.0` (the SVG's own black), red-tinted gives `r=1.0, g=0.149, b=0.0` at the same alpha.

`cacheKey` is deleted. It existed only to give `.task` an `Equatable` id, and `Source` already is one — so the id is now the source itself, which also removes the case where two different sources collapsed to the same `""` key.

## Memory footprint

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: **no** — not run.

I did not take these readings, so I'm not going to fill the table with numbers I don't have. What I can say about the shape of the change: the inline path adds no cache and no retained bitmap — `loadInlineAsync` decodes into the same `@State private var loaded` an `http` icon already used, and the `NSImage` is released with the cell. It removes one allocation per render pass (`cacheKey` built a `String` on every `body`). The one thing worth watching on a real run is a large Hugeicons result set, where each cell now holds a decoded `_NSSVGImageRep` where it previously held nothing at all — that is the fix working, but it is the only place the number can move.

## Demo

Not included — I don't have a before/after capture. The owner's screenshots in #331 show both grids rendering after the fix.

## Drawbacks

- **An untinted `currentColor` SVG still draws black.** That matches Raycast: an image with no `tintColor` is drawn as authored. Both extensions in the issue supply a colour — Hugeicons substitutes one into the SVG using `environment.appearance`, Lucide passes `tintColor` — so both are correct now, but an extension that supplies neither will look wrong on dark, and the fix for that is not ours to make.
- **An inline image isn't fitted**, so in a `List` row it draws at full extent while a shipped or fetched icon sits at `0.76`. Hugeicons only uses data URLs in a `Grid`, where it's right; a future extension that puts one in a list row would look marginally large next to file-backed neighbours. Fitting it would rasterize the vector at 48px for a 56pt tile, which is the worse trade.
- **`.task(id:)` now compares the full data URL** (a few KB per cell) instead of a short key. Sub-millisecond across a full grid, but it is a real change in what SwiftUI diffs each update.
- I verified the decode and tint mechanisms headlessly; **the grids themselves want a visual pass in a dev build**, particularly Hugeicons at grid size in both appearances.

## Tests & validation

- `./Scripts/run-tests.sh` — all 39 harnesses pass.
- `ext-icon-test` gains `inlineDataURLsDecode()`: a percent-encoded SVG, the same URL with Raycast's sizing query appended, a base64 payload, and a malformed one returning nil rather than throwing. The harness `main()` is now `async` to await it.
- Debug build compiles with no new warnings; `./Scripts/lint.sh` clean. The new draw uses `scaledToFit()`, so `ExtensionImage.swift` no longer trips `legacy_swiftui_aspect_ratio`.
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` returns nothing.
- By hand: read the installed Hugeicons and Lucide bundles to confirm the shapes each one actually emits (`content: {source: y1(svg, colour), tooltip}` and `content: {source: f.path, tintColor: t}`) rather than working from the issue text alone.
