### PR TITLE
Add vim-style context menu navigation

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -96,6 +96,7 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift
+run palette-menu-nav-test  Tinycast/Palette/MenuNavigation.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
                            Tinycast/Features/HotKeys/Model/HyperKey.swift \

--- a/Tests/palette-menu-nav-test.swift
+++ b/Tests/palette-menu-nav-test.swift
@@ -1,0 +1,36 @@
+import Carbon.HIToolbox
+import Foundation
+
+@main
+@MainActor
+struct PaletteMenuNavigationTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func main() {
+        expect(MenuNavigation.handles(kVK_UpArrow), "up arrow is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_DownArrow), "down arrow is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_Return), "return is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_ANSI_KeypadEnter), "keypad enter is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_Escape), "escape is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_Tab), "tab is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_ANSI_J), "J is a menu-nav key")
+        expect(MenuNavigation.handles(kVK_ANSI_K), "K is a menu-nav key")
+
+        expect(!MenuNavigation.handles(kVK_ANSI_A), "plain typing stays frozen while a menu is open")
+        expect(!MenuNavigation.handles(kVK_ANSI_M), "an unrelated letter is not a menu-nav key")
+        expect(!MenuNavigation.handles(kVK_ANSI_X), "another unrelated letter is not a menu-nav key")
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		CC984C9647779469629461E7 /* LauncherItemsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A2ACAEC4D2D25D3112634 /* LauncherItemsSection.swift */; };
 		CC9A286B77E32C22B21A22BE /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */; };
 		CCC775255627E23DC5B567AE /* CustomCommandEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40049CE320BEE3A4388CDFF /* CustomCommandEditorSheet.swift */; };
+		CCF4FFCD9A81D5D2140D5137 /* MenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A06B3DF59571B6515BCA70C /* MenuNavigation.swift */; };
 		CD04C9CA00C002C0EC82756A /* AccessibilityText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEA89E08994378FB044B4BB /* AccessibilityText.swift */; };
 		CE15888F3C15EE2706E108A0 /* AppDisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */; };
 		CEE0B612FFDB0AFFEF23A8A1 /* SearchScopesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC45597561DCD90F51506F7 /* SearchScopesSection.swift */; };
@@ -399,6 +400,7 @@
 		28D1A69B721AA863AFFE176F /* FileSearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchScope.swift; sourceTree = "<group>"; };
 		296F67E23BF91CFBC6D66385 /* SystemActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionCoordinator.swift; sourceTree = "<group>"; };
 		29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideController.swift; sourceTree = "<group>"; };
+		2A06B3DF59571B6515BCA70C /* MenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigation.swift; sourceTree = "<group>"; };
 		2AEDBB526AB2C0406D8226D5 /* SystemActionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionRunner.swift; sourceTree = "<group>"; };
 		2B0D967615846F9C4EC3E44F /* ExtensionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDetailView.swift; sourceTree = "<group>"; };
 		2B0F5891A80B604FBE21897B /* CalcCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcCurrency.swift; sourceTree = "<group>"; };
@@ -1533,6 +1535,7 @@
 			isa = PBXGroup;
 			children = (
 				9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */,
+				2A06B3DF59571B6515BCA70C /* MenuNavigation.swift */,
 				C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */,
 				29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */,
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
@@ -2029,6 +2032,7 @@
 				AAFD2C9276D38719E85B675F /* Memo.swift in Sources */,
 				9E257392434C62CCC26C9B04 /* MenuBarLabel.swift in Sources */,
 				E6E929E9284E8AC361D64D6A /* MenuBarSummary.swift in Sources */,
+				CCF4FFCD9A81D5D2140D5137 /* MenuNavigation.swift in Sources */,
 				43DBCE7B5A84D0D6322124F5 /* MessageHUDController.swift in Sources */,
 				8D529C8F3AB579941067FE98 /* MessageHUDView.swift in Sources */,
 				8D20CD7B6918873960F84291 /* NoteDocument.swift in Sources */,

--- a/Tinycast/Palette/MenuNavigation.swift
+++ b/Tinycast/Palette/MenuNavigation.swift
@@ -1,0 +1,15 @@
+import Carbon.HIToolbox
+import Foundation
+
+enum MenuNavigation {
+    /// Keys a frozen search field must still pass through to menu navigation.
+    static let keyCodes: Set<Int> = [
+        kVK_UpArrow, kVK_DownArrow, kVK_LeftArrow, kVK_RightArrow,
+        kVK_Return, kVK_ANSI_KeypadEnter, kVK_Escape, kVK_Tab,
+        kVK_ANSI_J, kVK_ANSI_K
+    ]
+
+    static func handles(_ keyCode: Int) -> Bool {
+        keyCodes.contains(keyCode)
+    }
+}

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -52,12 +52,6 @@ final class PalettePanel: NSPanel {
         compositionObserver = NotificationToken(token, center: center)
     }
 
-    /// Keys driving an open menu; they reach `onKeyPress` even while editing is frozen.
-    private static let menuNavKeys: Set<Int> = [
-        kVK_UpArrow, kVK_DownArrow, kVK_LeftArrow, kVK_RightArrow,
-        kVK_Return, kVK_ANSI_KeypadEnter, kVK_Escape, kVK_Tab
-    ]
-
     /// ⌃N/⌃P/⌃F/⌃B respelled as their arrow, so the arrow handlers serve both spellings.
     private static func emacsArrow(for event: NSEvent) -> NSEvent? {
         guard event.modifierFlags.intersection([.command, .option, .control, .shift]) == .control
@@ -144,7 +138,7 @@ final class PalettePanel: NSPanel {
         if event.type == .keyDown,
             paletteState?.menuOpen == true,
             event.modifierFlags.isDisjoint(with: [.command, .control]),
-            !Self.menuNavKeys.contains(Int(event.keyCode))
+            !MenuNavigation.handles(Int(event.keyCode))
         {
             return
         }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -309,6 +309,20 @@ struct RootPaletteView: View {
             moveVertically(-1)
             return .handled
         }
+        .onKeyPress(keys: ["j", "J"], phases: [.down, .repeat]) { press in
+            guard menuOpen,
+                press.modifiers.isDisjoint(with: [.command, .control, .option])
+            else { return .ignored }
+            moveMenu(1)
+            return .handled
+        }
+        .onKeyPress(keys: ["k", "K"], phases: [.down, .repeat]) { press in
+            guard menuOpen,
+                press.modifiers.isDisjoint(with: [.command, .control, .option])
+            else { return .ignored }
+            moveMenu(-1)
+            return .handled
+        }
         // Horizontal arrows step the grid; elsewhere they stay with the caret.
         .onKeyPress(.leftArrow) {
             if menuOpen { return .handled }

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -251,24 +251,26 @@ the arrow outside it, and AppKit's own alternation over the field came straight 
 structural instead of a pair of `onChange` handlers pushing each other closed. Three cases today —
 the ⌘K Actions menu (`.bottomTrailing`), the app menu (`.bottomLeading`) and the clipboard type
 filter (`.topTrailing`, hung under its header button). `menuContent` resolves the open case to one
-`PopoverMenuContent`, which is what lets ↑/↓, plain ↵, Esc and the click-away catcher serve every
-menu without knowing which is up. Every open path goes through `open(_:highlighting:)` and states
-where the highlight starts: the first row, except the type filter, which opens on the active filter.
+`PopoverMenuContent`, which is what lets ↑/↓, J/K, plain ↵, Esc and the click-away catcher serve
+every menu without knowing which is up. Every open path goes through `open(_:highlighting:)` and
+states where the highlight starts: the first row, except the type filter, which opens on the active
+filter.
 
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.
 
 ## Menu-open input freeze
 
-While a popover menu (⌘K Actions / app menu / clipboard type filter) is open the search field reads as inert but
-**never resigns first responder** — resigning makes the `NSTextField` swap between its field-editor
-and cell rendering, shifting the text / placeholder a point or two, so focus stays put. Input is
-frozen instead:
+While a popover menu (⌘K Actions / app menu / clipboard type filter) is open the search field reads
+as inert but **never resigns first responder** — resigning makes the `NSTextField` swap between its
+field-editor and cell rendering, shifting the text / placeholder a point or two, so focus stays put.
+Input is frozen instead:
 
 - `RootPaletteView` mirrors the open state into `PaletteState.menuOpen`, whose `didSet` fires
   `onMenuOpenChanged`.
 - `PalettePanel.sendEvent` then swallows text-editing keystrokes while `menuOpen` (letting ⌘/⌃ chords
-  and menu-nav keys through to SwiftUI `onKeyPress`), which is how ⌘. and ⌃X still reach their rows.
+  and menu-nav keys through to SwiftUI `onKeyPress`), which is how ⌘., ⌃X and bare J/K still reach
+  their rows.
 - The caret is hidden by clearing SwiftUI's **own** live field editor's `insertionPointColor`. SwiftUI
   force-casts its field editor to a private subclass, so vending a custom one crashes — only the
   existing one can be tuned.


### PR DESCRIPTION
## Related issue

Closes #334

## What changed

Adds Vim-style menu navigation to Tinycast’s palette menus:

- Press `J` to move the highlighted menu item down.
- Press `K` to move the highlighted menu item up.
- Key repeat is supported.
- The bindings apply only while a palette menu is open.
- Command, Control, and Option-modified J/K remain available for shortcuts.

The menu-navigation key set was extracted into `MenuNavigation` so AppKit’s input freeze and SwiftUI’s key handlers share the same definition. Outside an open menu, J and K remain normal search input.

## Memory footprint

TODO

## Demo

TODO

## Drawbacks

n/a

## Tests & validation

- Added `Tests/palette-menu-nav-test.swift`.
