### PR TITLE
Fold the search query once per sweep, and delete three dead declarations

### DIFF
--- a/Tinycast/Features/Emoji/Service/EmojiIndex.swift
+++ b/Tinycast/Features/Emoji/Service/EmojiIndex.swift
@@ -47,11 +47,12 @@ final class EmojiIndex {
         return searchMemo.value(for: SearchKey(query: q, revision: revision)) {
             // Penalized just under half a tier, so an equal-quality name match always wins.
             var scored: [ScoredEntry] = []
+            let query = FuzzyMatch.Query(q)
             for (order, entry) in entries.enumerated() {
-                let nameScore = FuzzyMatch.score(query: q, candidate: entry.name)
+                let nameScore = FuzzyMatch.score(query, candidate: entry.name)
                 var best = nameScore
                 if !entry.keywords.isEmpty,
-                    let keywordScore = FuzzyMatch.score(query: q, candidate: entry.keywords)
+                    let keywordScore = FuzzyMatch.score(query, candidate: entry.keywords)
                 {
                     best = max(best ?? Int.min, keywordScore - 500)
                 }

--- a/Tinycast/Features/Extensions/Service/ExtensionAppearanceStore.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionAppearanceStore.swift
@@ -34,12 +34,6 @@ final class ExtensionAppearanceStore {
         persist()
     }
 
-    /// Replace the whole map at once (used when importing a settings backup).
-    func replace(_ newOverrides: [String: ExtensionAppearance]) {
-        overrides = newOverrides
-        persist()
-    }
-
     private func persist() {
         guard let data = try? JSONEncoder().encode(overrides) else { return }
         defaults.set(data, forKey: key)

--- a/Tinycast/Features/Extensions/Service/ExtensionManager.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionManager.swift
@@ -142,12 +142,6 @@ final class ExtensionManager: ExtensionRuntimeDelegate, ExtensionHostContext {
         publishLauncherEntries()
     }
 
-    /// Bulk apply from a settings backup.
-    func replaceAppearances(_ overrides: [String: ExtensionAppearance]) {
-        appearances.replace(overrides)
-        publishLauncherEntries()
-    }
-
     /// An appearance wins, else the shipped artwork: the launcher is handed the answer, not the why.
     private func icon(
         for command: ExtensionCommand, in owner: InstalledExtension,

--- a/Tinycast/Features/Extensions/Service/ExtensionStoreClient.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionStoreClient.swift
@@ -76,10 +76,11 @@ struct ExtensionStoreClient: Sendable {
         -> [ExtensionListing]
     {
         let folders = try await folderNames(in: registry)
+        let folded = FuzzyMatch.Query(query)
         let ranked =
             folders
             .compactMap { folder -> (String, Int)? in
-                guard let score = FuzzyMatch.score(query: query, candidate: folder) else {
+                guard let score = FuzzyMatch.score(folded, candidate: folder) else {
                     return nil
                 }
                 return (folder, score)

--- a/Tinycast/Features/Extensions/UI/ExtensionScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionScreen.swift
@@ -114,7 +114,8 @@ struct ExtensionScreen: Equatable {
             let sectionType = root.type == "Grid" ? "Grid.Section" : "List.Section"
             let emptyType = root.type == "Grid" ? "Grid.EmptyView" : "List.EmptyView"
             emptyView = root.children.first { $0.type == emptyType }
-            let needle = filtersLocally ? query.trimmingCharacters(in: .whitespaces) : ""
+            let needle = FuzzyMatch.Query(
+                filtersLocally ? query.trimmingCharacters(in: .whitespaces) : "")
             var rows: [Row] = []
             var items: [Item] = []
             // Numbering as the rows are built is what keeps `selection` and the drawn order in step;
@@ -182,12 +183,12 @@ struct ExtensionScreen: Equatable {
 
     /// Local filtering mirrors Raycast: title, subtitle and keywords, ranked by the launcher's matcher
     /// so an extension list feels like the rest of the palette.
-    static func matches(_ item: RenderNode, _ needle: String) -> Bool {
+    static func matches(_ item: RenderNode, _ needle: FuzzyMatch.Query) -> Bool {
         guard !needle.isEmpty else { return true }
         var haystack = [item.string("title") ?? ""]
         if let subtitle = item.string("subtitle") { haystack.append(subtitle) }
         haystack.append(contentsOf: item.array("keywords").compactMap(\.stringValue))
-        return haystack.contains { FuzzyMatch.score(query: needle, candidate: $0) != nil }
+        return haystack.contains { FuzzyMatch.score(needle, candidate: $0) != nil }
     }
 
     private static func gridColumns(_ root: RenderNode) -> Int {

--- a/Tinycast/Features/FileSearch/Model/FileSearchQuery.swift
+++ b/Tinycast/Features/FileSearch/Model/FileSearchQuery.swift
@@ -22,9 +22,12 @@ enum FileSearchQuery {
     ) -> [FileSearchResult] {
         let terms = terms(in: query)
         guard !terms.isEmpty else { return [] }
+        // Folded once each: a thousand candidates would otherwise re-fold every term per result.
+        let whole = FuzzyMatch.Query(query)
+        let folded = terms.map(FuzzyMatch.Query.init)
         return results.filter { !isExcludedPath($0.id, ignoring: ignore) }.map { result in
-            let full = FuzzyMatch.score(query: query, candidate: result.name)
-            let termScore = terms.compactMap { FuzzyMatch.score(query: $0, candidate: result.name) }
+            let full = FuzzyMatch.score(whole, candidate: result.name)
+            let termScore = folded.compactMap { FuzzyMatch.score($0, candidate: result.name) }
                 .reduce(0, +)
             return (result, full, termScore)
         }

--- a/Tinycast/Features/Launcher/Model/SearchRelevance.swift
+++ b/Tinycast/Features/Launcher/Model/SearchRelevance.swift
@@ -61,6 +61,16 @@ enum FuzzyMatch {
         match(query: query, candidate: candidate)?.score
     }
 
+    /// The folded form, for a caller sweeping many candidates against one query.
+    static func score(_ query: Query, candidate: String) -> Int? {
+        match(query, candidate: candidate)?.score
+    }
+
+    /// Exact-only, for a caller that discards every weaker tier: skips the subsequence walk.
+    static func isExact(_ query: Query, candidate: String) -> Bool {
+        normalized(candidate) == query.text
+    }
+
     /// The widest score `match` returns; the bands are sized off it so they never overlap.
     static let maximumScore = 100_000
 
@@ -149,7 +159,11 @@ enum SearchRelevance {
 
     /// Base relevance from the strongest matching field, or nil when no field matches.
     static func score(query: String, fields: SearchFields) -> Int? {
-        let query = FuzzyMatch.Query(query)
+        score(FuzzyMatch.Query(query), fields: fields)
+    }
+
+    /// The folded form: an index ranking every entry against one query folds it once, not per entry.
+    static func score(_ query: FuzzyMatch.Query, fields: SearchFields) -> Int? {
         // Every entry is equally relevant to an empty query, so no field claims a band.
         guard !query.isEmpty else { return 0 }
         var best: Int?
@@ -177,8 +191,8 @@ enum SearchRelevance {
         if let bundleID = fields.bundleID {
             consider(identifyingPart(of: bundleID), literal: .bundleID, subsequence: nil)
             // A pasted identifier should still resolve, which the trimmed form alone can't do.
-            if let match = FuzzyMatch.match(query, candidate: bundleID), match.tier == .exact {
-                best = max(best ?? Int.min, Band.bundleID.offset + match.score)
+            if FuzzyMatch.isExact(query, candidate: bundleID) {
+                best = max(best ?? Int.min, Band.bundleID.offset + FuzzyMatch.maximumScore)
             }
         }
         if let executableName = fields.executableName {

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -463,11 +463,12 @@ final class AppIndex {
     private func rank(_ q: String, limit: Int) -> [AppEntry] {
         Signposts.interval("AppIndex.rank") {
             let learned = ranking.boosts(query: q)
+            let query = FuzzyMatch.Query(q)
             let scored = apps.compactMap { app -> (AppEntry, Int)? in
                 var fields = app.searchFields
                 fields.userAlias = aliases.alias(for: app.preferenceKey)
                 // Base relevance is the strongest field; the boost is added blind to it.
-                guard let score = SearchRelevance.score(query: q, fields: fields) else {
+                guard let score = SearchRelevance.score(query, fields: fields) else {
                     return nil
                 }
                 return (app, score + (learned[app.preferenceKey] ?? 0))

--- a/Tinycast/Features/Snippets/Model/SnippetRepository.swift
+++ b/Tinycast/Features/Snippets/Model/SnippetRepository.swift
@@ -299,15 +299,6 @@ struct SnippetRepository: Sendable {
         }
     }
 
-    private func nextAvailableFileURL(for name: String, in directory: URL) -> URL {
-        var suffix = 1
-        while true {
-            let candidate = uniqueFileURL(for: name, suffix: suffix, in: directory)
-            if !FileManager.default.fileExists(atPath: candidate.path) { return candidate }
-            suffix += 1
-        }
-    }
-
     private func uniqueFileURL(for name: String, suffix: Int, in directory: URL) -> URL {
         let base = SnippetMarkdownSerializer.slug(for: name)
         let filename = suffix == 1 ? "\(base).md" : "\(base)-\(suffix).md"

--- a/Tinycast/Platform/Permissions.swift
+++ b/Tinycast/Platform/Permissions.swift
@@ -55,15 +55,6 @@ enum Permissions {
     }
 
     @MainActor
-    static func openCameraSettings() {
-        guard
-            let url = URL(
-                string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera")
-        else { return }
-        NSWorkspace.shared.open(url)
-    }
-
-    @MainActor
     static func openCalendarSettings() {
         guard
             let url = URL(


### PR DESCRIPTION
## Related issue

Closes #

## What changed

Two unrelated cleanups found by sweeping the tree for confirmed-dead declarations and confirmed-wasted work. No behavior, UI or visual change in either.

**Fold the search query once per sweep.** `FuzzyMatch.Query` exists so a query is normalized and split into `[Character]` once rather than per candidate — but five call sites went through the `String` overloads inside their loops and paid that fold on every candidate. The hot one is `AppIndex.rank`, which does it for every indexed entry on every keystroke; `EmojiIndex.search` did it ~1,900 times against two fields each, and `FileSearchQuery.rank` up to 1,000 times per query plus once per term per result.

`FuzzyMatch.score(_:candidate:)` and `SearchRelevance.score(_:fields:)` are the new folded forms. The `String` spellings stay and delegate — one-shot callers still want them. The one signature change is `ExtensionScreen.matches`, which now takes a `Query` because it is called per item from the list build.

**Non-obvious bit:** the same sweep ran a full `FuzzyMatch.match` over every app's bundle ID and then discarded it unless the tier came back `.exact`. That is a `hasPrefix`, a `range(of:)` and the entire subsequence walk, to answer a question one string compare answers — so `FuzzyMatch.isExact` answers it directly. Scores are identical because the exact tier always scored `maximumScore`, which is the constant the branch now adds. This turned out to be the larger half of the win.

**Delete three unreferenced declarations.** `SnippetRepository.nextAvailableFileURL` (superseded by `createUnlocked`, which retries against a failed atomic create instead — the live path, and the one without the TOCTOU window), `Permissions.openCameraSettings` (the camera-denied state is a sentence with no button, unlike the calendar and accessibility panes that do link out), and `ExtensionManager.replaceAppearances` with the `ExtensionAppearanceStore.replace` it wrapped. See Drawbacks on that last pair. No doc referenced any of them.

## Memory footprint

**Not measured — this table needs filling before merge.** I did not run the footprint pass, so rather than guess I am flagging it rather than filling it in.

What can be said from the diff: the change is allocation-negative by construction and introduces no new storage. It removes per-candidate `String` normalizations and `[Character]` allocations from four sweeps and adds none; the folded `Query` values are stack-local to each call and outlive nothing. The deletions remove code without removing state — `ExtensionAppearanceStore`'s `overrides` map is still there, only its unused bulk setter is gone.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Drawbacks

**Deleting `replaceAppearances` documents a gap rather than closing one.** Its comment called it the settings-backup restore path, but no backup has ever carried extension appearances: `extensionAppearances` persists under its own key rather than through `AppSettings`, so `SettingsBackupCoverage` — the thing that makes `settings-backup-test` fail on an unconsidered key — never had it in scope. Export/import silently drops a user's custom extension icons today, and still will after this. Deleting the hook changes nothing a user sees; it removes a comment that claimed the wiring existed. Wiring it up for real is a feature and wants its own PR.

**`NoteSearch` has the same re-folding pattern and I left it.** Its `Query.terms` are also used as raw strings for the `source.range(of:)` fallback, so fixing it means carrying both forms per term. Note counts are small enough that the complexity isn't worth it.

`ExtensionScreen.matches` changing signature is a small API ripple, but it has exactly two call sites, both in the same file.

## Tests & validation

`./Scripts/run-tests.sh` — all 39 harnesses pass. The ranking semantics are pinned by `fuzz-test` and `ranking-test`, which cover the tier boundaries, the band ordering and the bundle-ID exact case specifically; both pass **unmodified**, which is the argument that the scoring is untouched. `emoji-test`, `file-search-test`, `ext-test`, `ext-store-test` and `snippets-test` also pass. No cases added — the point of the change is that existing cases keep passing.

Debug build compiles with no new warnings, `./Scripts/lint.sh` is clean, and the `Features/*/Model/` AppKit/SwiftUI import check returns nothing.

**Benchmark**, since "faster" needs a number. A standalone harness compiling the shipped `SearchRelevance.swift` at `-O`, scoring a 450-entry corpus against ten queries, 50 iterations, three runs:

| | per full keystroke sweep |
| --- | --- |
| baseline | 10.95 ms |
| bundle-ID fix only | 8.24 ms (−25%) |
| both | 7.79 ms (−29%) |

Not run by hand in the app — the harnesses and the benchmark are the evidence here.
