### PR TITLE
Clear query on first Escape

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -96,6 +96,9 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift
+run palette-escape-test    Tinycast/Palette/PaletteMode.swift \
+                           Tinycast/Palette/PaletteEscapeAction.swift \
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
                            Tinycast/Features/HotKeys/Model/HyperKey.swift \

--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@main
+@MainActor
+struct PaletteEscapeTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ actual: PaletteEscapeAction, _ expected: PaletteEscapeAction, _ message: String) {
+        if actual == expected {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message) — got \(actual), want \(expected)")
+        }
+    }
+
+    static func main() {
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: true, query: "notes", mode: .launcher),
+            .closeMenu,
+            "an open menu closes before anything else")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "notes", mode: .launcher),
+            .clearQuery,
+            "a typed launcher query clears before the palette hides")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "notes", mode: .extensionCommand),
+            .clearQuery,
+            "a typed extension query clears before the extension screen exits")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .extensionCommand),
+            .exitExtensionScreen,
+            "an empty extension query exits the extension screen")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .launcher),
+            .hidePalette,
+            "an empty launcher query hides the palette")
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Drives the real Escape precedence, so one press can never skip a step the user can still see —
+/// an open menu, typed text — and land on the one that throws work away.
 @main
 @MainActor
 struct PaletteEscapeTests {
@@ -36,6 +38,23 @@ struct PaletteEscapeTests {
             PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .launcher),
             .hidePalette,
             "an empty launcher query hides the palette")
+        // The two modes where the field is not a search field: an argument answer and a chat draft.
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "blue", mode: .quicklinkArguments),
+            .clearQuery,
+            "a half-typed argument clears before the pending quicklink is abandoned")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .quicklinkArguments),
+            .hidePalette,
+            "an empty argument field hides the palette, which cancels the pending quicklink")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "why is the sky", mode: .ai),
+            .clearQuery,
+            "an unsent chat draft clears before the palette hides")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: true, query: "", mode: .extensionCommand),
+            .closeMenu,
+            "a menu outranks the extension screen it is drawn over")
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		8D20CD7B6918873960F84291 /* NoteDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B10DA3A9B1CBD9A03F3DE5 /* NoteDocument.swift */; };
 		8D529C8F3AB579941067FE98 /* MessageHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976A1F05AD82DB8A04B3C3F9 /* MessageHUDView.swift */; };
 		8DCF330D30E59FFEE8C8E8CF /* PaletteDropGuideController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */; };
+		8E30C461429C894907FAD94D /* PaletteEscapeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */; };
 		8F5A6E0EFDBC4E4C54D8AA62 /* NoteSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D594CB90475093D58A2AB1E /* NoteSearch.swift */; };
 		8F66949F8518CF6F1878AEEF /* QuicklinkDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */; };
 		8FDF7F20B5FBA1B4D4FF563D /* ExtensionOAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE7A7AC9AEE81BAB9DA87FB /* ExtensionOAuthKeychain.swift */; };
@@ -513,6 +514,7 @@
 		52BD814D567DFEFD303B1750 /* PaletteRowIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteRowIndex.swift; sourceTree = "<group>"; };
 		5311551EDC3AE497384CDE89 /* NoteSwitcherWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSwitcherWindowController.swift; sourceTree = "<group>"; };
 		5392500F86E23C099D33561D /* Tinycast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tinycast.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteEscapeAction.swift; sourceTree = "<group>"; };
 		548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardScreen.swift; sourceTree = "<group>"; };
 		54E48A8D5E2BC00E9E1CD5BF /* QuicklinkArgumentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentSession.swift; sourceTree = "<group>"; };
 		570CE37C7133E28F7495ED91 /* MarkdownCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeView.swift; sourceTree = "<group>"; };
@@ -1654,6 +1656,7 @@
 				C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */,
 				29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */,
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
+				53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
@@ -2238,6 +2241,7 @@
 				86C36C0885D5820E70184CF6 /* PaletteCoordinator.swift in Sources */,
 				8DCF330D30E59FFEE8C8E8CF /* PaletteDropGuideController.swift in Sources */,
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
+				8E30C461429C894907FAD94D /* PaletteEscapeAction.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
 				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,

--- a/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
@@ -163,7 +163,7 @@ final class ExtensionCoordinator {
         return command.arguments
     }
 
-    /// Escape in an extension screen: pop the extension's own stack first, then leave the command.
+    /// Escape past an empty search field: pop the extension's own stack, then leave the command.
     func exitExtensionScreen() {
         Task {
             if await extensions.popNavigation() { return }

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Ordered like a bare backspace: a screen is only left once the search field is empty.
 enum PaletteEscapeAction: Equatable {
     case closeMenu
     case clearQuery
@@ -9,6 +10,7 @@ enum PaletteEscapeAction: Equatable {
     static func resolve(menuOpen: Bool, query: String, mode: PaletteMode) -> Self {
         if menuOpen { return .closeMenu }
         if !query.isEmpty { return .clearQuery }
+        // An extension pops its own navigation stack before the command is left.
         if mode == .extensionCommand { return .exitExtensionScreen }
         return .hidePalette
     }

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum PaletteEscapeAction: Equatable {
+    case closeMenu
+    case clearQuery
+    case exitExtensionScreen
+    case hidePalette
+
+    static func resolve(menuOpen: Bool, query: String, mode: PaletteMode) -> Self {
+        if menuOpen { return .closeMenu }
+        if !query.isEmpty { return .clearQuery }
+        if mode == .extensionCommand { return .exitExtensionScreen }
+        return .hidePalette
+    }
+}

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -353,16 +353,16 @@ struct RootPaletteView: View {
             return screen.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
         }
         .onKeyPress(.escape) {
-            if menuOpen {
+            switch PaletteEscapeAction.resolve(menuOpen: menuOpen, query: vm.query, mode: vm.mode) {
+            case .closeMenu:
                 closeMenus()
-                return .handled
-            }
-            // An extension pops its own navigation stack before the command is left.
-            if vm.mode == .extensionCommand {
+            case .clearQuery:
+                vm.query = ""
+            case .exitExtensionScreen:
                 core.extensionCoordinator.exitExtensionScreen()
-                return .handled
+            case .hidePalette:
+                core.paletteCoordinator.hidePalette()
             }
-            core.paletteCoordinator.hidePalette()
             return .handled
         }
         .onKeyPress(.tab) {

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -194,8 +194,10 @@ screens hold (see [palette.md](palette.md)).
   `NaN` for `undefined`, so omitting a blank argument silently corrupts whatever they compute — Coffee's
   "Caffeinate for…" spawned `caffeinate -t NaN`, which exits instantly.
 
-Escape and a bare backspace pop the extension's own navigation stack first, and only leave the command
-once it's at its root. Pushed screens stay mounted, so popping back restores their state.
+Escape clears a non-empty search field first, and dispatches `onSearchTextChange` as any other edit
+would, so a command that took the search text over sees the empty string. Only over an empty field do
+Escape and a bare backspace pop the extension's own navigation stack, and only leave the command once
+it's at its root. Pushed screens stay mounted, so popping back restores their state.
 
 ## Turning it on
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -82,7 +82,8 @@ The argument screen is the one mode where the search field is not a search field
 argument's input, so its placeholder names that argument and ↵ submits rather than activating a row.
 Its own state lives on `AppCore.quicklinkArguments`, the way `.uninstall`'s target lives on
 `UninstallSession`, and leaving the mode cancels the pending open. A bare backspace steps back an
-argument before it falls through to the usual exit-to-launcher.
+argument before it falls through to the usual exit-to-launcher; Escape erases the half-typed answer
+first, and a second press hides the palette, which ends the pending open with it.
 
 ### Inline command arguments
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -75,7 +75,8 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab cycles launcher ↔
 clipboard and nothing else** unless the selected row declares arguments, in which case it walks those
 fields first (see below); the rest are reached by a command or a global hotkey, and Uninstall only
-from a launcher app's Actions menu, scoped to that app.
+from a launcher app's Actions menu, scoped to that app. **Escape clears a non-empty query before it
+hides the palette or exits an extension screen**, so one press clears and the next leaves.
 
 The argument screen is the one mode where the search field is not a search field: it _is_ the current
 argument's input, so its placeholder names that argument and ↵ submits rather than activating a row.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -197,7 +197,8 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 
 ### Core
 
-- Palette hotkey opens the launcher; pressing it again closes it; Escape closes it; clicking away closes it
+- Palette hotkey opens the launcher; pressing it again closes it; Escape clears a non-empty query,
+  then hides on a second press; clicking away closes it
 - Reopening focuses the search field with an empty query, in the same position and at the same size
 - Compact mode: typing expands it, and the search bar does **not** shift vertically during the swap
 - With a CJK IME: the placeholder clears as soon as composition starts and the composing text never


### PR DESCRIPTION
## Related issue

Closes #337

## What changed

Escape now clears a non-empty search query before closing the main window. Pressing Escape a second time then closes it.

The decision was extracted into the Foundation-only `PaletteEscapeAction` policy so the precedence can be tested without constructing the SwiftUI menu.

## Memory footprint

TODO

## Demo

TODO

## Drawbacks

Closing the palette with Escape now requires two presses when a query is present. This is intentional: the first press provides a quick way to reset the search without reopening the palette.

## Tests & validation

- Added `Tests/palette-escape-test.swift`.