### PR TITLE
feat: add shared shortcuts for launcher favorites and pinned clipboard items

### DIFF
--- a/Tests/clipboard-test.swift
+++ b/Tests/clipboard-test.swift
@@ -13,6 +13,7 @@ struct ClipboardTests {
         pasteLeavesPinsAlone()
         pinsSurvivePruningAndTheWindow()
         pinsLeadFilteredSearches()
+        pinnedSlotResolutionUsesVisiblePins()
         textFormClassification()
         typeFilterSplitsTheHistory()
         typeFilterJoinsTheSearchMemo()
@@ -140,6 +141,44 @@ struct ClipboardTests {
             expect(
                 short.first?.text == "needle in the haystack",
                 "the pinned match leads the fallback search too")
+        }
+    }
+
+    /// Slot picks are taken from the visible pinned block after query/filter, not from all pins.
+    static func pinnedSlotResolutionUsesVisiblePins() {
+        withStore { store, _ in
+            store.addText("alpha one", sourceBundleID: nil)
+            store.addText("beta two", sourceBundleID: nil)
+            store.addText("beta three", sourceBundleID: nil)
+            store.addText("plain text", sourceBundleID: nil)
+
+            store.togglePinned(item(store, "alpha one"))
+            store.togglePinned(item(store, "beta two"))
+            store.togglePinned(item(store, "beta three"))
+
+            expect(
+                store.pinnedItem(at: 0, in: "", filter: .all)?.text == "alpha one",
+                "slot 1 maps to the first pinned row")
+            expect(
+                store.pinnedItem(at: 2, in: "", filter: .all)?.text == "beta three",
+                "slot 3 maps to the third pinned row")
+            expect(
+                store.pinnedItem(at: 3, in: "", filter: .all) == nil,
+                "missing pinned slot returns nil")
+
+            expect(
+                store.pinnedItem(at: 0, in: "beta", filter: .all)?.text == "beta two",
+                "query narrows the pinned block before slot mapping")
+            expect(
+                store.pinnedItem(at: 1, in: "beta", filter: .all)?.text == "beta three",
+                "slot mapping follows visible pinned order under query")
+            expect(
+                store.pinnedItem(at: 2, in: "beta", filter: .all) == nil,
+                "query can remove pinned slots from reach")
+
+            expect(
+                store.pinnedItem(at: 0, in: "", filter: .link) == nil,
+                "filter applies before pinned slot mapping")
         }
     }
 

--- a/Tests/favorites-test.swift
+++ b/Tests/favorites-test.swift
@@ -23,6 +23,14 @@ struct FavoritesTest {
         check("⌘0 is the tenth, not the first", FavoriteSlots.index(for: "0") == 9)
         check("a letter is not a slot", FavoriteSlots.index(for: "a") == nil)
 
+        let numberRowKeyCodes: [UInt16] = [18, 19, 20, 21, 23, 22, 26, 28, 25, 29]
+        for (index, keyCode) in numberRowKeyCodes.enumerated() {
+            check(
+                "physical number-row keycode \(keyCode) maps to slot \(index)",
+                FavoriteSlots.index(forKeyCode: keyCode) == index)
+        }
+        check("unknown keycode is not a slot", FavoriteSlots.index(forKeyCode: 0) == nil)
+
         check("the first row shows 1", FavoriteSlots.digit(at: 0) == "1")
         check("the tenth row shows 0", FavoriteSlots.digit(at: 9) == "0")
         check("the eleventh row shows nothing", FavoriteSlots.digit(at: 10) == nil)

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -299,6 +299,12 @@ final class ClipboardStore {
         search(query, filter: filter).firstIndex { $0.id == item.id }
     }
 
+    /// The Nth visible pinned entry under `query` and `filter`, where 0 is the first pinned row.
+    func pinnedItem(at index: Int, in query: String, filter: ClipboardFilter) -> ClipboardItem? {
+        guard index >= 0 else { return nil }
+        return search(query, filter: filter).prefix(while: \.isPinned).dropFirst(index).first
+    }
+
     private func unfiltered(_ q: String) -> [ClipboardItem] {
         guard !q.isEmpty else { return orderedItems }
         // Pins are matched in memory: all resident, and the LIMIT would otherwise drop one.

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -28,6 +28,15 @@ struct ClipboardScreen: PaletteScreen {
         core.clipboardCoordinator.paste(item)
     }
 
+    /// ⌘1…⌘0 — paste the Nth visible pinned entry (Pinned section order), if present.
+    func activatePinned(at index: Int) -> Bool {
+        guard let item = store.pinnedItem(at: index, in: vm.query, filter: vm.clipboardFilter) else {
+            return false
+        }
+        core.clipboardCoordinator.paste(item)
+        return true
+    }
+
     /// ⌘↵ — copy without pasting, leaving the frontmost app's own clipboard use alone.
     func secondary(at selection: Int) -> Bool {
         guard let item = item(at: selection) else { return false }

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -13,11 +13,11 @@ struct ClipboardList: View {
 
     private enum Row: Identifiable {
         case header(String)
-        case item(ClipboardItem)
+        case item(ClipboardItem, slot: Character?)
         var id: String {
             switch self {
             case .header(let title): return "header-" + title
-            case .item(let item): return item.id.uuidString
+            case .item(let item, _): return item.id.uuidString
             }
         }
     }
@@ -31,13 +31,16 @@ struct ClipboardList: View {
     private var rows: [Row] {
         var rows: [Row] = []
         var currentTitle: String?
+        var pinnedSlot = 0
         for item in results {
             let title = item.isPinned ? "Pinned" : DateBucket(for: item.createdAt).title
             if title != currentTitle {
                 rows.append(.header(title))
                 currentTitle = title
             }
-            rows.append(.item(item))
+            let slot = item.isPinned ? FavoriteSlots.digit(at: pinnedSlot) : nil
+            if item.isPinned { pinnedSlot += 1 }
+            rows.append(.item(item, slot: slot))
         }
         return rows
     }
@@ -51,10 +54,10 @@ struct ClipboardList: View {
                         switch row {
                         case .header(let title):
                             SectionHeader(title: title, isFirst: row.id == rows.first?.id)
-                        case .item(let item):
+                        case .item(let item, let slot):
                             ClipboardRow(
                                 item: item, selected: item.id == selectedID,
-                                imageURL: store.imageURL(for: item)
+                                imageURL: store.imageURL(for: item), slot: slot
                             )
                             .selectionFrame(item.id == selectedID)
                             .contentShape(Rectangle())
@@ -118,6 +121,9 @@ private struct ClipboardRow: View {
     let item: ClipboardItem
     let selected: Bool
     let imageURL: URL?
+    /// This row's ⌘-digit, or nil when it is not among the first ten visible pins.
+    let slot: Character?
+    @Environment(PaletteState.self) private var palette
     @State private var hovered = false
 
     /// Selection wins over hover when a row is both; otherwise hover shows its fainter layer.
@@ -135,6 +141,12 @@ private struct ClipboardRow: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
+            if let slot, palette.commandHeld {
+                HStack(spacing: Theme.Spacing.xxs) {
+                    KeyCapChip(text: "⌘", style: .outline)
+                    KeyCapChip(text: String(slot), style: .outline)
+                }
+            }
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)

--- a/Tinycast/Features/Launcher/Model/FavoriteSlots.swift
+++ b/Tinycast/Features/Launcher/Model/FavoriteSlots.swift
@@ -5,8 +5,16 @@ import Foundation
 enum FavoriteSlots {
     static let digits: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]
 
+    /// ANSI number-row key codes in visual order 1…9,0. This is layout-independent.
+    private static let numberRowKeyCodes: [UInt16] = [18, 19, 20, 21, 23, 22, 26, 28, 25, 29]
+
     /// The favorite a digit launches, or nil when that key is not a slot.
     static func index(for digit: Character) -> Int? { digits.firstIndex(of: digit) }
+
+    /// The favorite a physical number-row key launches, or nil when that key is not a slot.
+    static func index(forKeyCode keyCode: UInt16) -> Int? {
+        numberRowKeyCodes.firstIndex(of: keyCode)
+    }
 
     /// The digit shown on the row at `index`, or nil past the last slot.
     static func digit(at index: Int) -> Character? {

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -20,6 +20,10 @@ final class PaletteState {
     /// Bumped when the panel intercepts ⌘.. AppKit binds that chord to `cancelOperation:`, so the
     /// field editor eats it before `onKeyPress`; the screen still owns which row it pins.
     private(set) var pinChordToken = UUID()
+    /// Bumped when AppKit resolves ⌘1…⌘0 to a slot index from the physical number row.
+    private(set) var favoriteSlotToken = UUID()
+    /// The last slot index from `noteFavoriteSlot`, consumed by the SwiftUI layer.
+    private(set) var favoriteSlotIndex: Int?
     /// Set by the compact bar's overflow to expand without a query; cleared by `prepare`.
     var forceExpanded = false
     /// The paste target, mirrored on every show; `prepare` resets the screen, not this.
@@ -64,6 +68,11 @@ final class PaletteState {
 
     func notePinChord() {
         pinChordToken = UUID()
+    }
+
+    func noteFavoriteSlot(_ index: Int) {
+        favoriteSlotIndex = index
+        favoriteSlotToken = UUID()
     }
 
     func noteCommandHeld(_ held: Bool) {

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -267,6 +267,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             guard let self, !event.isARepeat,
                 event.modifierFlags.intersection([.command, .option, .control, .shift]) == .command
             else { return false }
+            if self.core.palette.mode == .launcher || self.core.palette.mode == .clipboard,
+                let index = FavoriteSlots.index(forKeyCode: event.keyCode)
+            {
+                self.core.palette.noteFavoriteSlot(index)
+                return true
+            }
             // Escape has no character, so it matches by key code.
             if Int(event.keyCode) == kVK_Escape {
                 self.core.palette.prepare(mode: .launcher)

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -292,6 +292,8 @@ struct RootPaletteView: View {
         }
         // ⌘. arrives as a token rather than a key press. See `PaletteState.pinChordToken`.
         .onChange(of: vm.pinChordToken) { pinSelection() }
+        // ⌘1…⌘0 arrives as a slot index from AppKit keyCode matching.
+        .onChange(of: vm.favoriteSlotToken) { activateFavoriteSlotShortcut() }
         // One optional makes "exactly one menu" structural; this only mirrors it for the panel.
         .onChange(of: openMenu) {
             vm.menuOpen = menuOpen
@@ -300,15 +302,6 @@ struct RootPaletteView: View {
         // Several paths flip `paletteIsCollapsed`, so resize the window to match.
         .onChange(of: core.paletteCoordinator.paletteIsCollapsed) {
             core.paletteCoordinator.syncPaletteSize()
-        }
-        // ⌘1–⌘9/⌘0 launch favorites by position, in both palette sizes.
-        .onKeyPress(keys: Self.favoriteSlotKeys, phases: .down) { press in
-            guard press.modifiers.contains(.command),
-                !isCollapsed || settings.showFavoritesInCompactMode,
-                let index = FavoriteSlots.index(for: press.key.character),
-                let launcher = screen as? LauncherScreen
-            else { return .ignored }
-            return launcher.launchFavorite(at: index) ? .handled : .ignored
         }
         // Repeat included: holding the key must keep stepping, as the bare-key form does by default.
         .onKeyPress(keys: [.downArrow], phases: [.down, .repeat]) { press in
@@ -721,10 +714,6 @@ struct RootPaletteView: View {
         withAnimation(Self.menuAnimation) { openMenu = nil }
     }
 
-    /// SwiftUI wants a Set; built once so the palette isn't allocating one per render.
-    private static let favoriteSlotKeys: Set<KeyEquivalent> =
-        Set(FavoriteSlots.digits.map { KeyEquivalent($0) })
-
     /// Inset from the bottom corners, so the menu's own corner isn't clipped.
     private static let menuInset: CGFloat = 8
     private static let menuAnimation: Animation = .easeOut(duration: 0.14)
@@ -802,6 +791,18 @@ struct RootPaletteView: View {
             _ = clipboard.pin(at: selection)
         } else if let quicklinks = screen as? QuicklinkListScreen {
             _ = quicklinks.pin(at: selection)
+        }
+    }
+
+    /// Dispatches the Cmd+number slot action to the active screen.
+    private func activateFavoriteSlotShortcut() {
+        guard let index = vm.favoriteSlotIndex else { return }
+        if let launcher = screen as? LauncherScreen {
+            _ = launcher.launchFavorite(at: index)
+            return
+        }
+        if let clipboard = screen as? ClipboardScreen {
+            _ = clipboard.activatePinned(at: index)
         }
     }
 

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -108,6 +108,10 @@ Pasting a pinned entry deliberately does **not** promote it: it holds its place 
 section, so `promote` skips pinned rows instead of rewriting the row and its FTS entry for no
 visible change.
 
+The ten palette slots shared with launcher favorites address this visible Pinned block too. A slot
+uses the current query and type filter, so its first entry is the first visible pin; a missing slot is
+a no-op. They are fixed to the physical number row, with ⌘1…⌘9 then ⌘0 as their labels.
+
 `load` reads every pinned row plus the newest 1000 unpinned ones as two indexed branches over a
 partial index on `pinned_at` (`Tests/clipboard-test.swift` covers the shape). The single
 `pinned_at IS NOT NULL OR rowid >= ?` form reads better but cannot be driven from an index while

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -298,10 +298,10 @@ across the list — the top of Favorites on add, the neighbour above the one tha
 
 ### ⌘-digit slots
 
-`FavoriteSlots` (`Launcher/Model/FavoriteSlots.swift`) is the whole rule: **⌘1…⌘9 then ⌘0 for the
-tenth**, ten digit keys being the physical ceiling — there is no ⌘10. The eleventh favorite is still
-listed and reorderable, and simply has no chord and no number. Three places read that table — the key
-handler, the row's number, the compact tooltip — so none of them can invent an eleventh slot.
+`FavoriteSlots` (`Launcher/Model/FavoriteSlots.swift`) defines ten local palette slots: **⌘1…⌘9 then
+⌘0**. They match the physical number row, not the character produced by the current keyboard layout,
+so the same positions work on QWERTY and AZERTY. The same slots address pinned Clipboard entries in
+that screen; the eleventh favorite is still listed and reorderable, and simply has no slot.
 
 Both palette sizes serve the chords from the same prefix, because `paletteIsCollapsed` already
 requires an empty query: **compact implies empty implies `favoriteCount` is the pinned prefix**. That

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -280,6 +280,10 @@ Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and a
 
 - **A bare backspace** — the field editor consumes it as an edit (`onBareBackspace`).
 - **Chords with no main menu item** — ⌘, and ⌘w, which an app with a menu bar would never see here.
+- **The physical number-row slots.** `FavoriteSlots` matches ⌘1…⌘0 by key code before fixed command
+  chords, then publishes the resolved position to the active screen. Only the launcher and clipboard
+  screens intercept these slots; other screens keep their own ⌘-number shortcuts. The launcher's
+  compact visibility setting is visual only and does not disable its favorite slots.
 - **Chords AppKit has already bound to a selector.** `⌘.` is the one that bites: AppKit binds it to
   `cancelOperation:` alongside Escape, so `interpretKeyEvents` hands it to the field editor and
   `onKeyPress(keys: ["."])` never fires. Pin (⌘.) therefore arrives through `onCommandShortcut`,


### PR DESCRIPTION
## Related issue

Close #291 #292 

Related to #315 (previous PR)

## What changed

This PR adds a shared `⌘`-number shortcut system for both launcher favorites and pinned clipboard entries.

### 1. Physical number-row shortcut mapping

`FavoriteSlots` now maps physical macOS number-row key codes to ten slots:

- `⌘1` through `⌘9`
- `⌘0` as the tenth slot

The mapping uses hardware key codes rather than the character produced by the keyboard layout. This makes the shortcuts work consistently on layouts such as QWERTY and AZERTY.

The existing digit-based mapping remains responsible for displaying slot labels, while the new key-code mapping resolves actual keyboard events.

### 2. AppKit handles the shortcuts

The shortcut detection was moved from SwiftUI's `onKeyPress` handling into `PaletteWindowController`.

When a non-repeated command-only number-row event is received:

1. The key code is converted into a favorite slot index.
2. The event is consumed by the palette window.
3. The resolved index is published through `PaletteState`.

This avoids keyboard-layout-dependent behavior and ensures the shortcuts are intercepted before AppKit or the field editor handles them.

### 3. `PaletteState` forwards shortcut events

`PaletteState` now contains:

- `favoriteSlotToken`, a change token used to notify SwiftUI.
- `favoriteSlotIndex`, the resolved slot index.
- `noteFavoriteSlot(_:)`, which stores the index and generates a new token.

`RootPaletteView` observes that token and dispatches the action to the currently active screen.

This preserves the existing architecture: AppKit captures the low-level keyboard event, while the active SwiftUI screen decides what the slot means.

### 4. Launcher favorite behavior

On `LauncherScreen`, `⌘1…⌘0` still launches favorites by position.

The previous SwiftUI key handler was removed. The behavior remains available in both palette sizes, subject to the existing rule that favorites must be enabled in compact mode.

Favorites beyond the tenth item remain visible and reorderable, but do not receive a keyboard slot.

### 5. Pinned clipboard shortcuts

`ClipboardScreen` now supports the same ten shortcuts through `activatePinned(at:)`.

A new `ClipboardStore.pinnedItem(at:in:filter:)` method resolves the requested item from the visible result set:

- The current search query is applied.
- The current clipboard type filter is applied.
- Only the visible pinned section is considered.
- Slot numbering follows the visible pinned order.
- Missing slots are ignored without producing an action.

For example, after filtering for `beta`, `⌘1` selects the first visible pinned result containing `beta`, rather than the first pinned item in the entire history.

### 6. Clipboard row UI

Pinned clipboard rows now receive an optional slot label. When the Command key is held, the first ten visible pinned rows display shortcuts such as:

- `⌘ 1`
- `⌘ 2`
- …
- `⌘ 0`

The labels are hidden otherwise, so the normal clipboard list remains visually compact.

## Memory footprint

<!-- Required. Under 100 MB always, and back to baseline after the palette closes. -->

| Step | Memory |
| --- | ---: |
| Idle after launch | 34.4 MB |
| Palette open | 40.1 MB |
| Feature in use (peak) | 44.3 MB |
| Palette closed, settled | 41.8 MB |

Leak-tested:

## Demo

<!-- Visual change: add a side-by-side before/after video with the same window size and actions. -->

### Before

<img width="1484" height="930" alt="2026-08-22 at 23 57 35" src="https://github.com/user-attachments/assets/c0a4fedc-d865-4de1-a032-425669ed3b53" />

https://github.com/user-attachments/assets/19acd787-ee49-4d8b-a892-465dec193538

As you can see the previous version was not compatible with multiple keyboard layout (espacially with French Layout (Azerty).

### After : using AppKit instead of SwiftUI's `onKeyPress`

The mapping uses hardware key codes rather than the character produced by the keyboard layout. This makes the shortcuts work consistently on layouts such as QWERTY and AZERTY.

https://github.com/user-attachments/assets/2f993a91-f453-4908-942a-391850bcc829

## Drawbacks

None known.

## Tests & validation

### Added tests

The commit adds coverage in two standalone harnesses.

#### `Tests/favorites-test.swift`

The favorites harness now verifies that:

- Physical key code `18` resolves to the first slot.
- Physical key code `25` resolves to the ninth slot.
- Physical key code `29` resolves to the tenth slot (`⌘0`).
- An unknown key code does not resolve to a slot.

The existing tests still verify the ten-slot limit, the `1…9,0` display order, the absence of an eleventh slot, negative-index handling, and the round-trip agreement between displayed digits and slot indices.

#### `Tests/clipboard-test.swift`

The new `pinnedSlotResolutionUsesVisiblePins()` case verifies that:

- The first and third slots resolve to the corresponding pinned rows.
- A slot beyond the visible pinned rows returns `nil`.
- A search query is applied before slot numbering.
- The visible order is preserved after filtering.
- A type filter is applied before slot numbering.
- Filtering can make a previously available slot unreachable.

Together, these tests protect the contract that shortcuts operate on the visible pinned block, rather than on the complete unfiltered clipboard history.

### Commands

```sh
./Scripts/run-tests.sh favorites-test
./Scripts/run-tests.sh clipboard-test
./Scripts/lint.sh
```

The tests exercise the shipped model sources through the repository's standalone harnesses. Manual validation should also confirm that `⌘1…⌘0` launches the expected favorite or pastes the expected visible pinned clipboard item, including with a query active and with the palette in compact mode.


I have taken your comments into account (https://github.com/abue-ammar/tinycast/pull/315#pullrequestreview-5001884414).

I made all those tests and it worked with both AZERTY and QWERTY.

## Manual Keyboard Validation

Run every keyboard test with both layouts:

- QWERTY: `Cmd+1` through `Cmd+9`, then `Cmd+0`
- AZERTY: the same physical number-row keys, including `Shift` where required

The physical key position must determine the slot, not the character produced by the layout.

### 1. Launcher Favorites

- [x] Create 10 launcher favorites.
- [x] QWERTY: physical keys 1 through 9 launch favorites 1 through 9.
- [x] QWERTY: physical key 0 launches favorite 10.
- [x] AZERTY: the same physical keys launch the same favorites.
- [x] The displayed labels are `1` through `9`, then `0`.
- [x] With fewer than 10 favorites, unused slots do nothing.
- [x] With 10 favorites, `Add to Favorites` is disabled.
- [x] Remove a favorite, then confirm a new favorite can be added.
- [x] Reorder favorites and confirm the slots follow the new order.

### 2. Launcher Compact Mode

- [x] Enable `Show favorites in compact mode`.
- [x] Open the launcher in compact mode.
- [x] QWERTY: test all 10 physical number-row keys.
- [x] AZERTY: test the same 10 physical keys.
- [x] Confirm visible favorites launch correctly.
- [x] Confirm slots 6 through 0 launch favorites not visible in the compact bar.
- [x] Disable `Show favorites in compact mode` while keeping favorites configured.
- [x] Repeat all 10 physical keys on QWERTY and AZERTY.
- [x] Confirm favorites still launch even though they are hidden.
- [x] Expand the palette and confirm the slot mapping is unchanged.

### 3. Clipboard Pinned Slots

- [x] Add and pin at least 3 clipboard entries.
- [x] QWERTY: each physical slot pastes the matching pinned entry.
- [x] AZERTY: the same physical keys paste the same entries.
- [x] Confirm slot order matches visible pin order.
- [x] Search for a subset of pinned entries and retest the slots.
- [x] Test text, link, image, and mixed clipboard filters.
- [x] Test an unavailable slot and confirm nothing unrelated is pasted.
- [x] Confirm pasting does not reorder pinned entries.
- [x] Hold `Cmd` and confirm the slot labels appear; release it and confirm they disappear.

### 4. Other Palette Screens

For each screen below, test all 10 physical number-row keys with QWERTY and AZERTY:

- [x] Snippets
- [x] Quicklinks
- [x] Quicklink argument form
- [x] Emoji picker
- [x] Calculator history
- [x] File search
- [x] Uninstall screen

### 5. Modifier and Existing Shortcut Behavior

- [x] QWERTY: test `Cmd+Shift+1`.
- [x] AZERTY: test the equivalent physical combination.
- [x] Confirm `Shift` does not prevent a favorite slot from working.
- [x] Test `Cmd+Option+1` and `Cmd+Control+1`; neither launches a favorite.
- [x] Hold a slot key and confirm key repeat does not cause unwanted repeated launches.
- [x] Test `Cmd+,` and confirm Settings opens.
- [x] Test `Cmd+.` and confirm the selected item is pinned where applicable.
- [x] Test `Cmd+W` and confirm the palette closes.
- [x] Test `Escape` and confirm existing escape behavior is unchanged.
- [x] Switch between QWERTY and AZERTY without restarting Tinycast.
- [x] Repeat a launcher slot and clipboard slot after switching layouts.

### 7. Final Regression and Shell Smoke Tests

- [x] Close and reopen Tinycast, then retest one launcher slot in both layouts.
- [x] Confirm favorite persistence after relaunch.
- [x] Confirm clipboard pin persistence after relaunch.

I found a bug during those tests (idk if it's intended) :
1. when you open a note, and use the clipboard history to paste something in a window, it's always pasted into the note (the Note always has the focus)