### PR TITLE
Give every turn a system prompt, redact the signed-in address, and make a long table's end reachable

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -116,6 +116,8 @@ run palette-placement-test Tinycast/Platform/Appearance.swift \
                            Tinycast/Palette/PalettePlacement.swift
 run scroll-reveal-test     Tinycast/DesignSystem/Scrolling/SelectionReveal.swift
 run redaction-test         Tinycast/DesignSystem/RedactedPlaceholder.swift
+run ai-instructions-test   Tinycast/Features/AI/Model/AIInstructions.swift \
+                           Tinycast/Features/AI/Model/AIPreamble.swift
 run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Palette/PaletteState.swift \
                            Tinycast/Palette/PaletteMode.swift \

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -115,6 +115,7 @@ run palette-placement-test Tinycast/Platform/Appearance.swift \
                            Tinycast/DesignSystem/Theme.swift \
                            Tinycast/Palette/PalettePlacement.swift
 run scroll-reveal-test     Tinycast/DesignSystem/Scrolling/SelectionReveal.swift
+run redaction-test         Tinycast/DesignSystem/RedactedPlaceholder.swift
 run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Palette/PaletteState.swift \
                            Tinycast/Palette/PaletteMode.swift \

--- a/Tests/ai-instructions-test.swift
+++ b/Tests/ai-instructions-test.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pins `AIInstructions`: the preamble always rides along, the user's text lands after it, and
+/// whitespace alone never counts as a prompt. The preamble's own content is pinned too, since it
+/// ships to every model on every turn.
+@main
+struct AIInstructionsTest {
+    static func main() {
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        check(
+            "no user prompt still sends the preamble",
+            AIInstructions.compose(userPrompt: nil) == AIPreamble.text)
+        check(
+            "an empty prompt sends the preamble alone",
+            AIInstructions.compose(userPrompt: "") == AIPreamble.text)
+        check(
+            "whitespace is not a prompt",
+            AIInstructions.compose(userPrompt: "   \n\t ") == AIPreamble.text)
+
+        let composed = AIInstructions.compose(userPrompt: "  Answer only in haiku.  ")
+        check("the preamble comes first", composed.hasPrefix(AIPreamble.text))
+        check("the user's text comes last", composed.hasSuffix("Answer only in haiku."))
+        check("the user's text is trimmed", !composed.hasSuffix(" "))
+        check("the two are separated by a blank line", composed.contains("\n\nAnswer only in haiku."))
+
+        check(
+            "the preamble names the app so the model can answer for it",
+            AIPreamble.text.contains("Tinycast"))
+        check(
+            "the preamble tells the model to be honest in comparisons",
+            AIPreamble.text.lowercased().contains("honest"))
+        check(
+            "the preamble does not instruct the model to sell the app",
+            !AIPreamble.text.lowercased().contains("prefer tinycast"))
+
+        check(
+            "the preamble refuses to guess another launcher's numbers",
+            AIPreamble.text.lowercased().contains("no measurements for any other launcher"))
+
+        // Every line is billed on every turn, so the preamble has to stay a preamble.
+        check("the preamble stays short", AIPreamble.text.count < 1_800)
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tests/ai-instructions-test.swift
+++ b/Tests/ai-instructions-test.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Pins `AIInstructions`: the preamble always rides along, the user's text lands after it, and
-/// whitespace alone never counts as a prompt. The preamble's own content is pinned too, since it
-/// ships to every model on every turn.
+/// Pins `AIInstructions`: enabled, the preamble always rides along, the user's text lands after it,
+/// and whitespace alone never counts as a prompt; disabled, a turn carries nothing at all. The
+/// preamble's own content is pinned too, since it ships to every model on every turn.
 @main
 struct AIInstructionsTest {
     static func main() {
@@ -19,19 +19,29 @@ struct AIInstructionsTest {
 
         check(
             "no user prompt still sends the preamble",
-            AIInstructions.compose(userPrompt: nil) == AIPreamble.text)
+            AIInstructions.compose(userPrompt: nil, isEnabled: true) == AIPreamble.text)
         check(
             "an empty prompt sends the preamble alone",
-            AIInstructions.compose(userPrompt: "") == AIPreamble.text)
+            AIInstructions.compose(userPrompt: "", isEnabled: true) == AIPreamble.text)
         check(
             "whitespace is not a prompt",
-            AIInstructions.compose(userPrompt: "   \n\t ") == AIPreamble.text)
+            AIInstructions.compose(userPrompt: "   \n\t ", isEnabled: true) == AIPreamble.text)
 
-        let composed = AIInstructions.compose(userPrompt: "  Answer only in haiku.  ")
-        check("the preamble comes first", composed.hasPrefix(AIPreamble.text))
-        check("the user's text comes last", composed.hasSuffix("Answer only in haiku."))
-        check("the user's text is trimmed", !composed.hasSuffix(" "))
-        check("the two are separated by a blank line", composed.contains("\n\nAnswer only in haiku."))
+        let composed = AIInstructions.compose(userPrompt: "  Answer only in haiku.  ", isEnabled: true)
+        check("the preamble comes first", composed?.hasPrefix(AIPreamble.text) == true)
+        check("the user's text comes last", composed?.hasSuffix("Answer only in haiku.") == true)
+        check("the user's text is trimmed", composed?.hasSuffix(" ") == false)
+        check(
+            "the two are separated by a blank line",
+            composed?.contains("\n\nAnswer only in haiku.") == true)
+
+        // Off has to reach the preamble too, or the setting only turns off the half the user typed.
+        check(
+            "turned off, a turn carries no instructions",
+            AIInstructions.compose(userPrompt: nil, isEnabled: false) == nil)
+        check(
+            "turned off, the user's own text is withheld as well",
+            AIInstructions.compose(userPrompt: "Answer only in haiku.", isEnabled: false) == nil)
 
         check(
             "the preamble names the app so the model can answer for it",

--- a/Tests/redaction-test.swift
+++ b/Tests/redaction-test.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Pins `RedactedPlaceholder`: the disguise has to be stable, shaped like the address it stands in
+/// for, and drawn from an alphabet that gives a squinting viewer nothing.
+@main
+struct RedactionTest {
+    static func main() {
+        var failures = 0
+
+        func check(_ description: String, _ condition: @autoclosure () -> Bool) {
+            if condition() {
+                print("PASS  \(description)")
+            } else {
+                print("FAIL  \(description)")
+                failures += 1
+            }
+        }
+
+        let email = "ashish.kumar@example.com"
+        let redacted = RedactedPlaceholder.forValue(email)
+
+        check(
+            "the same value always wears the same disguise",
+            redacted == RedactedPlaceholder.forValue(email))
+        check(
+            "a different value gets a different one",
+            RedactedPlaceholder.forValue("someone.else@example.com") != redacted)
+        check("length is preserved, so the row does not reflow", redacted.count == email.count)
+
+        func atOffset(_ text: String) -> Int? {
+            text.firstIndex(of: "@").map { text.distance(from: text.startIndex, to: $0) }
+        }
+        check("the @ stays put", atOffset(redacted) == atOffset(email))
+        check(
+            "every dot keeps its position",
+            zip(redacted, email).allSatisfy { left, right in (left == ".") == (right == ".") })
+        check(
+            "hyphens and underscores pass through",
+            RedactedPlaceholder.forValue("a-b_c@d.e").filter { "-_@.".contains($0) } == "-_@.")
+
+        let structural = Set("@._-")
+        // Not "every character differs": avoiding the real glyph would announce what it is not.
+        let content = zip(redacted, email).filter { !structural.contains($0.1) }
+        let moved = content.filter { $0.0 != $0.1 }.count
+        check("the disguise is not the value", redacted != email)
+        check(
+            "the overwhelming majority of characters moved",
+            Double(moved) / Double(content.count) > 0.8)
+        check(
+            "structural characters are the only ones guaranteed to match",
+            zip(redacted, email).allSatisfy { left, right in
+                structural.contains(right) ? left == right : true
+            })
+
+        let ambiguous = Set("ilo01")
+        check(
+            "the alphabet avoids look-alike glyphs",
+            redacted.filter { !structural.contains($0) }.allSatisfy { !ambiguous.contains($0) })
+
+        check("an empty value produces an empty disguise", RedactedPlaceholder.forValue("").isEmpty)
+        check(
+            "a value that is only structure is returned unchanged",
+            RedactedPlaceholder.forValue("@.") == "@.")
+
+        // A disguise that repeats one character would read as obviously fake.
+        let letters = redacted.filter { !structural.contains($0) }
+        check("the scramble is not a single repeated character", Set(letters).count > 1)
+
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		A2073E8EBBAAB620E27F0BD5 /* SnippetTextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725A38B32FDAA64D4A4A88DF /* SnippetTextInjector.swift */; };
 		A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B89168050723B7221F04A2 /* ClipboardCoordinator.swift */; };
 		A33EA048BC22D7313F4D480C /* EventDraftFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8553E1626E985013046C47 /* EventDraftFields.swift */; };
+		A41185C975CBF97A8C6EAC19 /* SystemPromptEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF36BDC9ACE867DCC2CCF746 /* SystemPromptEditor.swift */; };
 		A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */; };
 		A500AF3BF8910B335A7A936C /* HUDPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1752929BA1ACC0BC54865C /* HUDPanel.swift */; };
 		A5354210CDCB796D2D988B82 /* RaycastImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F474B4E9FD7738D97AB65E /* RaycastImport.swift */; };
@@ -275,6 +276,7 @@
 		ACE645630E536C93CA102050 /* VolumeHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90559D7DB9F6F3874CAFCDE /* VolumeHUDView.swift */; };
 		AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */; };
 		AD98F015439106F0E9D32015 /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */; };
+		ADC43E68C1B617D098C71D6E /* AIInstructions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6420FE45699DC3E53907CAE3 /* AIInstructions.swift */; };
 		ADE29D44A9504AC24FC17E72 /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A97022BE0F95B5D19F0C26 /* CalcDateTime.swift */; };
 		AE16EC9C7B4C75871A67187D /* MarkdownTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D14B02D3FE262EADFD3404 /* MarkdownTableView.swift */; };
 		AE3144FCC55FADC48955D17A /* KeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E16AEF81320A101E384098E /* KeyShortcut.swift */; };
@@ -285,6 +287,7 @@
 		B566FC125D9D193F234EC1AB /* ExtensionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988EA3698EA86BA53590C24E /* ExtensionFetcher.swift */; };
 		B56F252262AA1BD3E2631F0C /* FileSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391B8024E8719506361B45F7 /* FileSearchQuery.swift */; };
 		B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0F5891A80B604FBE21897B /* CalcCurrency.swift */; };
+		B72F17539405522E63D266F3 /* AIPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5861814F16B18935FBF034C /* AIPreamble.swift */; };
 		B8CECD85524BCCCBC0CDC2B5 /* ExtensionCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */; };
 		BAD4BEF8041665ACCF1CE460 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */; };
 		BBAB44C0E70AABE70A048889 /* QuicklinkArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */; };
@@ -538,6 +541,7 @@
 		622E1F1C01B954DCA2199BCD /* ScrollIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollIntent.swift; sourceTree = "<group>"; };
 		628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitcher.swift; sourceTree = "<group>"; };
 		62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
+		6420FE45699DC3E53907CAE3 /* AIInstructions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInstructions.swift; sourceTree = "<group>"; };
 		648F0F43FEEE537F6451756B /* SelectionReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReveal.swift; sourceTree = "<group>"; };
 		64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolImage.swift; sourceTree = "<group>"; };
 		658C57A4CE41C0FA80BBE41D /* RaycastImportV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV1.swift; sourceTree = "<group>"; };
@@ -677,6 +681,7 @@
 		BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetMarkdownSerializer.swift; sourceTree = "<group>"; };
 		BE6972F177922B1EB8831735 /* OnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
 		BEDDA8820165672AF8464E25 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
+		BF36BDC9ACE867DCC2CCF746 /* SystemPromptEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptEditor.swift; sourceTree = "<group>"; };
 		BFB023D167225228757CC4B2 /* HealthTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthTicker.swift; sourceTree = "<group>"; };
 		C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteCoordinator.swift; sourceTree = "<group>"; };
 		C0599199132DAFBE12C59FBD /* MeetingDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDay.swift; sourceTree = "<group>"; };
@@ -726,6 +731,7 @@
 		E475F373557FD3524086CE19 /* MeetingCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCalendar.swift; sourceTree = "<group>"; };
 		E54932083F6BC197453EA0C8 /* UninstallSearchRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSearchRoot.swift; sourceTree = "<group>"; };
 		E582B93EFB1A2AA85B048A87 /* CalcFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcFormatter.swift; sourceTree = "<group>"; };
+		E5861814F16B18935FBF034C /* AIPreamble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPreamble.swift; sourceTree = "<group>"; };
 		E5B89168050723B7221F04A2 /* ClipboardCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardCoordinator.swift; sourceTree = "<group>"; };
 		E5C7F0C39D24F068A8F84864 /* CurrencyData.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyData.generated.swift; sourceTree = "<group>"; };
 		E5CBCCE63360E4590CF5884A /* IconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconCache.swift; sourceTree = "<group>"; };
@@ -1193,7 +1199,9 @@
 			children = (
 				DB02E0EF46285235AD81C181 /* AIBrand.swift */,
 				1DE1B6753513C787B3FFE423 /* AIConnection.swift */,
+				6420FE45699DC3E53907CAE3 /* AIInstructions.swift */,
 				A68649D40F987D1CD24D1112 /* AIModelDiscovery.swift */,
+				E5861814F16B18935FBF034C /* AIPreamble.swift */,
 				106F9FEF3F0C36E0C5686DA7 /* AIRequest.swift */,
 				0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */,
 				D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */,
@@ -1908,6 +1916,7 @@
 				B5ABB8CDB1469F8755B12567 /* AICommandSection.swift */,
 				C975F928132D3DAB1BB569F0 /* AISettingsStore.swift */,
 				8DA2EC0303BFCB1212E69B54 /* AISettingsView.swift */,
+				BF36BDC9ACE867DCC2CCF746 /* SystemPromptEditor.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2020,8 +2029,10 @@
 				8696DC1B16B6618D22F804D5 /* AIChatState.swift in Sources */,
 				3DAB1821040DCA295BEB4437 /* AICommandSection.swift in Sources */,
 				753FEBB891DBCE13C4C59935 /* AIConnection.swift in Sources */,
+				ADC43E68C1B617D098C71D6E /* AIInstructions.swift in Sources */,
 				36A6FC9C41CDBD4ADA1F8E87 /* AIModelDiscovery.swift in Sources */,
 				F8E1B044D84E96FB455155CD /* AIModelDiscoveryService.swift in Sources */,
+				B72F17539405522E63D266F3 /* AIPreamble.swift in Sources */,
 				C7468FBE50BAEC5084D4DB17 /* AIProvider.swift in Sources */,
 				50300E827CBD0F54F0360111 /* AIProviderFactory.swift in Sources */,
 				914402CB38C5D09C611AA8F4 /* AIRequest.swift in Sources */,
@@ -2342,6 +2353,7 @@
 				A11EB7D1852FB3D56DDBE7C3 /* SystemActionCoordinator.swift in Sources */,
 				0047FE6A50E746CCF0FC6810 /* SystemActionRunner.swift in Sources */,
 				82D95EF7539498A9A484B3D1 /* SystemActionsSettingsView.swift in Sources */,
+				A41185C975CBF97A8C6EAC19 /* SystemPromptEditor.swift in Sources */,
 				410F1B5FFAA44378AC9EC2DB /* SystemSettingsSettingsView.swift in Sources */,
 				36968DFA1E201E681F0BCD42 /* Theme.swift in Sources */,
 				6A0C45313C7B73349C7B17E0 /* ThinScrollbar.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		DDFF8A9F420A4733DFA32A07 /* ReleaseFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28281DFC434C75F8A594635 /* ReleaseFeed.swift */; };
 		DEBCF434AB244DAD43DB8A6A /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */; };
 		DFB25A4CDD35071B745F2EF9 /* DoubleTapModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */; };
+		E1A4472391E5AD3EE828202E /* RedactedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEA1E122A8139A21E646FE2 /* RedactedText.swift */; };
 		E268D74F0DEFFA598E2D02AA /* OnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6972F177922B1EB8831735 /* OnboardingCard.swift */; };
 		E457BC709D195B8F5D0C2A79 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6DAC3B9FF387367C3FAB4 /* UninstallSession.swift */; };
 		E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E25B87C692D5FEE1FBF994 /* PanelTransition.swift */; };
@@ -362,6 +363,7 @@
 		F44DA0C81285A90138E13A7B /* ChatGPTSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */; };
 		F51785CF5A6EC0B87D6802C9 /* ExtensionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCBDD92DEAD780A1DC423CA /* ExtensionScreen.swift */; };
 		F71FC7195AC8D6626BEE8931 /* NotesPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91151402A1A4586B2496BF35 /* NotesPanel.swift */; };
+		F801D00F877421DC7045C5F3 /* RedactedPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131B15F5EF86A067FA6C36D7 /* RedactedPlaceholder.swift */; };
 		F85CE4CDCF7589ACAEF2CA20 /* AppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E23F92F4B4DEEE55077C7C /* AppIconView.swift */; };
 		F8D69CE2A8C04DEEC1810A1F /* UninstallRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D134673CB1B563A3758FC37 /* UninstallRunner.swift */; };
 		F8E1B044D84E96FB455155CD /* AIModelDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B27ECEB1C09B14C403FC8 /* AIModelDiscoveryService.swift */; };
@@ -409,6 +411,7 @@
 		106F9FEF3F0C36E0C5686DA7 /* AIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIRequest.swift; sourceTree = "<group>"; };
 		112551581ECF83B53D405334 /* BackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsView.swift; sourceTree = "<group>"; };
 		121A2ACAEC4D2D25D3112634 /* LauncherItemsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherItemsSection.swift; sourceTree = "<group>"; };
+		131B15F5EF86A067FA6C36D7 /* RedactedPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactedPlaceholder.swift; sourceTree = "<group>"; };
 		132C5A534C02305C1A29CC74 /* LauncherList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherList.swift; sourceTree = "<group>"; };
 		132FBA3F0A0B4F6C796B901B /* NoteSwitcherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSwitcherView.swift; sourceTree = "<group>"; };
 		14F474B4E9FD7738D97AB65E /* RaycastImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImport.swift; sourceTree = "<group>"; };
@@ -500,6 +503,7 @@
 		474E6D9830E336752C79F461 /* MeetingClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingClock.swift; sourceTree = "<group>"; };
 		4AA61A2FAF4E49E466DA8F37 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		4AEBAA9641BC6C279DB0123C /* CameraPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewController.swift; sourceTree = "<group>"; };
+		4BEA1E122A8139A21E646FE2 /* RedactedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactedText.swift; sourceTree = "<group>"; };
 		4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCurrency.swift; sourceTree = "<group>"; };
 		4D8553E1626E985013046C47 /* EventDraftFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDraftFields.swift; sourceTree = "<group>"; };
 		4DA7B926405DAC632C056418 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -924,6 +928,8 @@
 				08279257B0F5995E86FF2C03 /* EntryIconView.swift */,
 				C5BA06E4CC7E8D40E3285F16 /* KeyCapChip.swift */,
 				4FAE24CC14F7DFECD1BD7FB1 /* PopoverMenu.swift */,
+				131B15F5EF86A067FA6C36D7 /* RedactedPlaceholder.swift */,
+				4BEA1E122A8139A21E646FE2 /* RedactedText.swift */,
 				BEDDA8820165672AF8464E25 /* SettingsComponents.swift */,
 				64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */,
 				A1306524F57602D90FCF153C /* Theme.swift */,
@@ -2276,6 +2282,8 @@
 				478500C6465327947EBD9D61 /* RaycastSnippetImport.swift in Sources */,
 				FE9CFF847072FAA9C7D5B660 /* RaycastV1Decoder.swift in Sources */,
 				05683E4BDBD1FD73FCECACB9 /* RaycastV2Decoder.swift in Sources */,
+				F801D00F877421DC7045C5F3 /* RedactedPlaceholder.swift in Sources */,
+				E1A4472391E5AD3EE828202E /* RedactedText.swift in Sources */,
 				3E2E0C5B564C828D7ECA2759 /* RegionCurrency.swift in Sources */,
 				D6D8169527668572F0073F94 /* RelaunchRunner.swift in Sources */,
 				21812A1B54A4DFDC88604C16 /* ReleaseChannel.swift in Sources */,

--- a/Tinycast/DesignSystem/RedactedPlaceholder.swift
+++ b/Tinycast/DesignSystem/RedactedPlaceholder.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// The stand-in a redacted value wears until someone asks for the real one. Derived from the value,
+/// so a redrawn row never reshuffles into a different disguise, and shaped like it — `@`, `.`, `-`
+/// and `_` survive — so an address still reads as an address behind the blur. The scramble is the
+/// redaction and the blur only signals it: a blurred real address can be read back off a paused
+/// frame, a blurred fake one has nothing to give up. Length survives too, so that much still leaks.
+enum RedactedPlaceholder {
+    /// No `i`, `l`, `o`, `0` or `1`: a half-blurred glyph should not be identifiable by elimination.
+    private static let alphabet = Array("abcdefghjkmnpqrstuvwxyz23456789")
+
+    /// The characters that carry an address's shape rather than its content.
+    private static let structural: Set<Character> = ["@", ".", "-", "_"]
+
+    /// Same input, same disguise, every time.
+    static func forValue(_ value: String) -> String {
+        var state = seed(value)
+        return String(
+            value.map { character in
+                guard !structural.contains(character) else { return character }
+                return alphabet[Int(next(&state) % UInt32(alphabet.count))]
+            })
+    }
+
+    /// FNV-1a over the value's UTF-8 — cheap and stable across launches, and no kind of boundary.
+    private static func seed(_ value: String) -> UInt32 {
+        var state: UInt32 = 0x811c_9dc5
+        for byte in value.utf8 {
+            state ^= UInt32(byte)
+            state = state &* 0x0100_0193
+        }
+        return state
+    }
+
+    /// One xorshift-multiply round, so neighbouring characters don't walk a visible pattern.
+    private static func next(_ state: inout UInt32) -> UInt32 {
+        state ^= state >> 13
+        state = state &* 0x85eb_ca6b
+        state ^= state >> 16
+        state = state &* 0xc2b2_ae35
+        return state
+    }
+}

--- a/Tinycast/DesignSystem/RedactedText.swift
+++ b/Tinycast/DesignSystem/RedactedText.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// A value the pane shows only on request: scrambled and blurred until clicked, plain after. A
+/// Settings pane gets screenshotted, screen-shared and recorded, and a signed-in account address is
+/// the one thing on this one that names a person. Monospaced in both states so the row keeps its
+/// width when the disguise drops, since `RedactedPlaceholder` matches only the value's length.
+struct RedactedText: View {
+    let value: String
+    var revealHelp = "Click to reveal"
+    var hideHelp = "Click to hide"
+
+    @State private var isRevealed = false
+
+    var body: some View {
+        Button {
+            withAnimation(.easeOut(duration: Theme.Duration.enter)) { isRevealed.toggle() }
+        } label: {
+            Text(isRevealed ? value : RedactedPlaceholder.forValue(value))
+                .monospaced()
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .blur(radius: isRevealed ? 0 : Theme.Blur.redaction)
+                .textSelection(.disabled)
+        }
+        .buttonStyle(.plain)
+        .help(isRevealed ? hideHelp : revealHelp)
+        // Reading a disguise aloud is worse than useless to someone who cannot see the blur.
+        .accessibilityLabel(isRevealed ? value : "Hidden: \(revealHelp.lowercased())")
+        .accessibilityAddTraits(.isButton)
+    }
+}

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -41,6 +41,12 @@ enum Theme {
         static let recorderKeyCap: CGFloat = 4
     }
 
+    enum Blur {
+        /// Enough to make a redacted address unreadable at full size without turning the row into a
+        /// smear; the scramble underneath is what actually hides it.
+        static let redaction: CGFloat = 3
+    }
+
     enum Size {
         static let panelWidth: CGFloat = 750
         static let panelHeight: CGFloat = 475

--- a/Tinycast/Features/AI/Model/AIInstructions.swift
+++ b/Tinycast/Features/AI/Model/AIInstructions.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// What every chat request carries ahead of the transcript: `AIPreamble`, then whatever the user
+/// has written in Settings. The preamble is not shown in the pane — it is the app talking about
+/// itself, not a setting — and `AIPreamble.swift` is the single copy of it.
+enum AIInstructions {
+    /// The user's own text goes last, so it can qualify the preamble rather than fight it.
+    static func compose(userPrompt: String?) -> String {
+        let trimmed = userPrompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? AIPreamble.text : AIPreamble.text + "\n\n" + trimmed
+    }
+}

--- a/Tinycast/Features/AI/Model/AIInstructions.swift
+++ b/Tinycast/Features/AI/Model/AIInstructions.swift
@@ -3,9 +3,13 @@ import Foundation
 /// What every chat request carries ahead of the transcript: `AIPreamble`, then whatever the user
 /// has written in Settings. The preamble is not shown in the pane — it is the app talking about
 /// itself, not a setting — and `AIPreamble.swift` is the single copy of it.
+///
+/// Turned off, a turn carries no instructions at all. The preamble is billed on every turn and
+/// shapes every answer, so opting out has to reach it too, not only the half the user typed.
 enum AIInstructions {
     /// The user's own text goes last, so it can qualify the preamble rather than fight it.
-    static func compose(userPrompt: String?) -> String {
+    static func compose(userPrompt: String?, isEnabled: Bool) -> String? {
+        guard isEnabled else { return nil }
         let trimmed = userPrompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? AIPreamble.text : AIPreamble.text + "\n\n" + trimmed
     }

--- a/Tinycast/Features/AI/Model/AIPreamble.swift
+++ b/Tinycast/Features/AI/Model/AIPreamble.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// What Tinycast tells a model about itself, ahead of every message in every chat. This file holds
+/// nothing else, so editing the prompt means opening one file and changing prose — no logic to read
+/// past, and no second copy anywhere to keep in step.
+///
+/// Two things to keep in mind when editing. Every line is billed again on every turn, so length has
+/// a running cost; and the figures below are deliberately rough — re-measure with
+/// `docs/measure-footprint.sh` and round them off again whenever they have drifted enough to
+/// mislead, rather than chasing each build.
+enum AIPreamble {
+    static let text = """
+        You are the assistant built into Tinycast, a native macOS menu-bar launcher and an \
+        open-source alternative to Raycast that also runs Raycast extensions natively.
+
+        You are reached from Tinycast's command palette: its search field is your composer, Return \
+        sends a message and stops a streaming reply, and ⌘K opens actions including New Chat.
+
+        Tinycast also provides a fuzzy app launcher, global and per-app hotkeys, clipboard history \
+        for text and images, an inline calculator, a floating note, snippets, quicklinks, window \
+        management, file search and an emoji picker.
+
+        It is written in SwiftUI and AppKit against the current macOS only, with no third-party \
+        dependencies and no bundled web runtime, and it runs as a menu-bar accessory with no Dock \
+        icon. That is why it stays around 8 MB on disk and uses tens of megabytes of memory rather \
+        than hundreds. Treat those two figures as approximate.
+
+        Answer questions about Tinycast from this. Say so when you do not know rather than \
+        inventing a feature, and compare Tinycast with other tools honestly — you are not here to \
+        sell it. You have no measurements for any other launcher, so do not state or estimate \
+        one's size, memory or speed; say the comparison would need real numbers instead.
+        """
+}

--- a/Tinycast/Features/AI/Settings/AISettingsStore.swift
+++ b/Tinycast/Features/AI/Settings/AISettingsStore.swift
@@ -20,6 +20,12 @@ final class AISettingsStore {
     var systemPrompt: String {
         didSet { defaults.set(systemPrompt, forKey: AppSettingsKey.aiSystemPrompt.rawValue) }
     }
+    /// On by default: without it a model has no idea what app it is answering for.
+    var systemPromptEnabled: Bool {
+        didSet {
+            defaults.set(systemPromptEnabled, forKey: AppSettingsKey.aiSystemPromptEnabled.rawValue)
+        }
+    }
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -30,6 +36,8 @@ final class AISettingsStore {
         webSearchEnabled =
             defaults.object(forKey: AppSettingsKey.aiWebSearch.rawValue) as? Bool ?? false
         systemPrompt = defaults.string(forKey: AppSettingsKey.aiSystemPrompt.rawValue) ?? ""
+        systemPromptEnabled =
+            defaults.object(forKey: AppSettingsKey.aiSystemPromptEnabled.rawValue) as? Bool ?? true
         if case .api(let connection, let model) = defaultModel,
             !connections.contains(where: { $0.id == connection && $0.models.contains(model) })
         {

--- a/Tinycast/Features/AI/Settings/AISettingsStore.swift
+++ b/Tinycast/Features/AI/Settings/AISettingsStore.swift
@@ -16,6 +16,10 @@ final class AISettingsStore {
     var webSearchEnabled: Bool {
         didSet { defaults.set(webSearchEnabled, forKey: AppSettingsKey.aiWebSearch.rawValue) }
     }
+    /// Appended to `AIInstructions.preamble` on every turn, so it is billed on every turn.
+    var systemPrompt: String {
+        didSet { defaults.set(systemPrompt, forKey: AppSettingsKey.aiSystemPrompt.rawValue) }
+    }
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -25,6 +29,7 @@ final class AISettingsStore {
             defaults.data(forKey: AppSettingsKey.aiDefaultModel.rawValue))
         webSearchEnabled =
             defaults.object(forKey: AppSettingsKey.aiWebSearch.rawValue) as? Bool ?? false
+        systemPrompt = defaults.string(forKey: AppSettingsKey.aiSystemPrompt.rawValue) ?? ""
         if case .api(let connection, let model) = defaultModel,
             !connections.contains(where: { $0.id == connection && $0.models.contains(model) })
         {

--- a/Tinycast/Features/AI/Settings/AISettingsView.swift
+++ b/Tinycast/Features/AI/Settings/AISettingsView.swift
@@ -31,6 +31,7 @@ struct AISettingsView: View {
             Group {
                 defaultModelSection
                 chatSection
+                systemPromptSection
                 chatGPTSection
                 apiConnectionsSection
             }
@@ -121,6 +122,21 @@ struct AISettingsView: View {
             Text("Images pasted into the chat go to any model that accepts them; others never see one.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    private var systemPromptSection: some View {
+        @Bindable var settings = settings
+        return Section {
+            SystemPromptEditor(text: $settings.systemPrompt)
+        } header: {
+            Text("System prompt")
+        } footer: {
+            Text(
+                "Sent ahead of every message in every chat, on top of what Tinycast already tells the model about itself — so it is billed again on each turn."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
     }
 

--- a/Tinycast/Features/AI/Settings/AISettingsView.swift
+++ b/Tinycast/Features/AI/Settings/AISettingsView.swift
@@ -128,12 +128,17 @@ struct AISettingsView: View {
     private var systemPromptSection: some View {
         @Bindable var settings = settings
         return Section {
+            Toggle(isOn: $settings.systemPromptEnabled) {
+                Text("Send a system prompt")
+                Text("Off sends nothing ahead of your message, not even what Tinycast says about itself.")
+            }
             SystemPromptEditor(text: $settings.systemPrompt)
+                .disabled(!settings.systemPromptEnabled)
         } header: {
             Text("System prompt")
         } footer: {
             Text(
-                "Sent ahead of every message in every chat, on top of what Tinycast already tells the model about itself — so it is billed again on each turn."
+                "Your text is sent ahead of every message in every chat, after what Tinycast already tells the model about itself — so both are billed again on each turn."
             )
             .font(.caption)
             .foregroundStyle(.secondary)

--- a/Tinycast/Features/AI/Settings/AISettingsView.swift
+++ b/Tinycast/Features/AI/Settings/AISettingsView.swift
@@ -176,7 +176,14 @@ struct AISettingsView: View {
                     Button("Refresh") { subscription.refresh() }
                     Button("Disconnect", role: .destructive) { subscription.logout() }
                 } label: {
-                    Text(account.email ?? "Connected to ChatGPT")
+                    if let email = account.email {
+                        RedactedText(
+                            value: email,
+                            revealHelp: "Click to reveal the signed-in account",
+                            hideHelp: "Click to hide the signed-in account")
+                    } else {
+                        Text("Connected to ChatGPT")
+                    }
                     Text("ChatGPT \(account.planTitle)")
                 }
             }

--- a/Tinycast/Features/AI/Settings/SystemPromptEditor.swift
+++ b/Tinycast/Features/AI/Settings/SystemPromptEditor.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// The user's own addition to every request. Hidden behind a blur when it already has content, so
+/// opening Settings on a stream or in a screenshot does not spill whatever someone told the model
+/// to do; an empty one opens plain, because there is nothing yet to give away and a blurred empty
+/// box is only a puzzle. The card keeps its edges — only the text goes soft.
+struct SystemPromptEditor: View {
+    @Binding var text: String
+
+    @State private var isRevealed: Bool
+
+    init(text: Binding<String>) {
+        _text = text
+        _isRevealed = State(initialValue: text.wrappedValue.isBlank)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text(text.isBlank ? "Nothing added" : "Added to every message")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: Theme.Spacing.lg)
+                Button {
+                    withAnimation(.easeOut(duration: Theme.Duration.enter)) { isRevealed.toggle() }
+                } label: {
+                    Image(systemName: isRevealed ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.plain)
+                .help(isRevealed ? "Hide the prompt" : "Show the prompt")
+                .disabled(text.isBlank)
+                .accessibilityLabel(isRevealed ? "Hide the system prompt" : "Show the system prompt")
+            }
+            TextEditor(text: $text)
+                .font(.body)
+                .scrollContentBackground(.hidden)
+                .blur(radius: isRevealed ? 0 : Theme.Blur.redaction)
+                .disabled(!isRevealed)
+                .padding(Theme.Spacing.sm)
+                .frame(height: Theme.Size.editorTextHeight)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                        .fill(Theme.Colors.cardFill)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                        .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
+                )
+        }
+    }
+}
+
+extension String {
+    fileprivate var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -50,7 +50,9 @@ final class AIChatCoordinator {
         guard settings.aiEnabled else { return false }
         do {
             let webSearch = core.aiSettings.webSearchEnabled && capabilities.webSearch
-            return chat.send(input, using: try core.aiProvider(), webSearch: webSearch)
+            return chat.send(
+                input, using: try core.aiProvider(), webSearch: webSearch,
+                instructions: AIInstructions.compose(userPrompt: core.aiSettings.systemPrompt))
         } catch {
             chat.report(error.localizedDescription)
             return false

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -52,7 +52,9 @@ final class AIChatCoordinator {
             let webSearch = core.aiSettings.webSearchEnabled && capabilities.webSearch
             return chat.send(
                 input, using: try core.aiProvider(), webSearch: webSearch,
-                instructions: AIInstructions.compose(userPrompt: core.aiSettings.systemPrompt))
+                instructions: AIInstructions.compose(
+                    userPrompt: core.aiSettings.systemPrompt,
+                    isEnabled: core.aiSettings.systemPromptEnabled))
         } catch {
             chat.report(error.localizedDescription)
             return false

--- a/Tinycast/Features/AI/UI/AIChatState.swift
+++ b/Tinycast/Features/AI/UI/AIChatState.swift
@@ -32,13 +32,17 @@ final class AIChatState {
     }
 
     @discardableResult
-    func send(_ input: String, using provider: any AIProvider, webSearch: Bool = false) -> Bool {
+    func send(
+        _ input: String, using provider: any AIProvider, webSearch: Bool = false,
+        instructions: String? = nil
+    ) -> Bool {
         let text = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty || !pendingImages.isEmpty, !isStreaming else { return false }
         notice = nil
         session.append(ChatMessage(role: .user, text: text, images: pendingImages.map(\.image)))
         clearStaging()
-        let request = AIRequest(messages: session.requestMessages, webSearch: webSearch)
+        let request = AIRequest(
+            instructions: instructions, messages: session.requestMessages, webSearch: webSearch)
         session.append(ChatMessage(role: .assistant, text: "", state: .streaming))
         isStreaming = true
         isThinking = false

--- a/Tinycast/Features/AI/UI/ChatTranscriptView.swift
+++ b/Tinycast/Features/AI/UI/ChatTranscriptView.swift
@@ -21,7 +21,9 @@ struct ChatTranscriptView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: Theme.Spacing.xl) {
+                // Not lazy: a transcript is a few tall rows, and an estimated height is what every
+                // anchored jump and the end test are measured against.
+                VStack(spacing: Theme.Spacing.xl) {
                     ForEach(messages) { message in
                         ChatMessageView(
                             message: message,
@@ -50,7 +52,10 @@ struct ChatTranscriptView: View {
             .onScrollGeometryChange(for: ScrollMark.self) { geometry in
                 ScrollMark(
                     offset: geometry.contentOffset.y,
+                    // The offset rests at `-insetTop`, so the end sits that much past a raw
+                    // offset plus the band — without it the true bottom never reads as the end.
                     atEnd: geometry.contentOffset.y + geometry.containerSize.height
+                        + geometry.contentInsets.top
                         >= geometry.contentSize.height - Theme.Spacing.chatFollowTailSlack)
             } action: { old, new in
                 // A plain wheel reports no ScrollPhase, so the offset is the only signal every

--- a/Tinycast/Features/AI/UI/MarkdownTableView.swift
+++ b/Tinycast/Features/AI/UI/MarkdownTableView.swift
@@ -32,6 +32,9 @@ struct MarkdownTableView: View {
                 }
             }
         }
+        // Given only a width, Grid measures a wrapping row a line short of what it draws, and the
+        // transcript's scroll view then stops above the message's own end.
+        .fixedSize(horizontal: false, vertical: true)
         .padding(Theme.Spacing.xl)
         .background(
             RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -82,6 +82,9 @@ enum SettingsBackupCoverage {
             "Whether prompts may reach a search engine is a choice each Mac makes for itself.",
         AppSettingsKey.aiSystemPrompt.rawValue:
             "Standing instructions to a model are the one AI setting that changes every answer; an "
-            + "import must not carry them onto another Mac unseen."
+            + "import must not carry them onto another Mac unseen.",
+        AppSettingsKey.aiSystemPromptEnabled.rawValue:
+            "Governs whether a turn carries standing instructions at all, so it changes every answer "
+            + "the same way the prompt it gates does."
     ]
 }

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -79,6 +79,9 @@ enum SettingsBackupCoverage {
         AppSettingsKey.aiDefaultModel.rawValue:
             "The default model names an external AI destination; importing must not choose one.",
         AppSettingsKey.aiWebSearch.rawValue:
-            "Whether prompts may reach a search engine is a choice each Mac makes for itself."
+            "Whether prompts may reach a search engine is a choice each Mac makes for itself.",
+        AppSettingsKey.aiSystemPrompt.rawValue:
+            "Standing instructions to a model are the one AI setting that changes every answer; an "
+            + "import must not carry them onto another Mac unseen."
     ]
 }

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -54,4 +54,5 @@ enum AppSettingsKey: String, CaseIterable {
     case aiDefaultModel = "aiDefaultModel"
     case aiWebSearch = "aiWebSearch"
     case aiSystemPrompt = "aiSystemPrompt"
+    case aiSystemPromptEnabled = "aiSystemPromptEnabled"
 }

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -53,4 +53,5 @@ enum AppSettingsKey: String, CaseIterable {
     case aiConnections = "aiConnections"
     case aiDefaultModel = "aiDefaultModel"
     case aiWebSearch = "aiWebSearch"
+    case aiSystemPrompt = "aiSystemPrompt"
 }

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -17,7 +17,8 @@ AI Chat is the first consumer, but the provider layer does not depend on it.
   where it is running and what the app can do, then whatever Settings → AI holds. The preamble
   states capabilities and asks for honest comparisons; it does not instruct the model to favour
   Tinycast over anything else. It is not shown in the pane, and `AIPreamble.swift` holds the only
-  copy of it — edit the prompt there, not here.
+  copy of it — edit the prompt there, not here. `compose` returns `nil` when the user has turned
+  the system prompt off, and every transport drops a nil instruction, so a turn then carries none.
 - **API keys live only in the login Keychain.** `AIConnection` persists the provider, endpoint and
   model identifiers in `UserDefaults`; it never contains a key. Keys are addressed by connection UUID
   through `APIKeyStore`, and never enter logs, errors or settings backups. A key is issued for one
@@ -273,7 +274,16 @@ already holds something — a Settings pane is exactly what ends up in a screens
 opens plain when it is empty, since a blurred empty box is only a puzzle. The footer says the text
 rides along on every turn, because it is billed on every turn and nothing else in the pane is.
 
-`aiConnections`, `aiDefaultModel` and `aiSystemPrompt` are deliberately excluded from settings
-backups. The first is meaningless without machine-local Keychain items; the second names an external destination and must
-not silently redirect AI traffic after an import; the third is standing instructions that change
-every answer, and must not arrive on another Mac unread.
+`Send a system prompt` governs the whole instruction, not just the half the user typed. Clearing the
+box already withholds their own text, so a switch that spared the preamble would add nothing; the
+preamble is the part that is billed on every turn for every user and has no other way off. Off
+disables the editor rather than hiding it, so what is being withheld stays readable. One thing it
+deliberately cannot reach: the Codex route always prepends its own instruction never to invoke
+tools, run commands or touch files. That is a sandbox boundary on a local CLI, not Tinycast
+describing itself, and a user switch must not be able to lift it.
+
+`aiConnections`, `aiDefaultModel`, `aiSystemPrompt` and `aiSystemPromptEnabled` are deliberately
+excluded from settings backups. The first is meaningless without machine-local Keychain items; the
+second names an external destination and must not silently redirect AI traffic after an import; the
+last two are standing instructions and the switch that sends them, both of which change every
+answer and must not arrive on another Mac unread.

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -253,6 +253,14 @@ Settings → AI is a normal grouped `Form` inside Tinycast's existing Settings w
 separate settings window or palette overlay. The pane edits multiple API connections, manages the
 ChatGPT login and chooses the one default model shared by future features.
 
+The signed-in ChatGPT address is the one thing on the pane that names a person, and a Settings pane
+is what gets screenshotted into a bug report or left on screen in a recording, so `RedactedText`
+shows it scrambled and blurred until it is clicked. `RedactedPlaceholder` derives the stand-in from
+the address itself — stable across redraws, same length, `@ . - _` left in place — because a blurred
+real address can be recovered from a still frame while a blurred fake one cannot. It hides an
+address from a camera, not a secret from an attacker: the length still shows and one click undoes
+it. The scramble is not selectable, since dragging it out would only ever yield the stand-in.
+
 `aiConnections` and `aiDefaultModel` are deliberately excluded from settings backups. The first is
 meaningless without machine-local Keychain items; the second names an external destination and must
 not silently redirect AI traffic after an import.

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -12,6 +12,12 @@ AI Chat is the first consumer, but the provider layer does not depend on it.
   `.ai`. Turning it off cancels a streaming reply and drops the transcript, but touches neither the
   saved conversations in `ai-chats.sqlite3` nor a Keychain key. `aiEnabled` is excluded from settings
   backups like every other AI key, so an import can never arm a feature it cannot configure.
+- **Every request carries Tinycast's own preamble, and the user's text goes after it.**
+  `AIInstructions.compose` builds `AIRequest.instructions`: a fixed preamble that tells the model
+  where it is running and what the app can do, then whatever Settings → AI holds. The preamble
+  states capabilities and asks for honest comparisons; it does not instruct the model to favour
+  Tinycast over anything else. It is not shown in the pane, and `AIPreamble.swift` holds the only
+  copy of it — edit the prompt there, not here.
 - **API keys live only in the login Keychain.** `AIConnection` persists the provider, endpoint and
   model identifiers in `UserDefaults`; it never contains a key. Keys are addressed by connection UUID
   through `APIKeyStore`, and never enter logs, errors or settings backups. A key is issued for one
@@ -261,6 +267,13 @@ real address can be recovered from a still frame while a blurred fake one cannot
 address from a camera, not a secret from an attacker: the length still shows and one click undoes
 it. The scramble is not selectable, since dragging it out would only ever yield the stand-in.
 
-`aiConnections` and `aiDefaultModel` are deliberately excluded from settings backups. The first is
-meaningless without machine-local Keychain items; the second names an external destination and must
-not silently redirect AI traffic after an import.
+The System prompt box appends to the preamble rather than replacing it, so the model never loses
+the ground truth about where it is. `SystemPromptEditor` opens blurred and non-editable whenever it
+already holds something — a Settings pane is exactly what ends up in a screenshot or a stream — and
+opens plain when it is empty, since a blurred empty box is only a puzzle. The footer says the text
+rides along on every turn, because it is billed on every turn and nothing else in the pane is.
+
+`aiConnections`, `aiDefaultModel` and `aiSystemPrompt` are deliberately excluded from settings
+backups. The first is meaningless without machine-local Keychain items; the second names an external destination and must
+not silently redirect AI traffic after an import; the third is standing instructions that change
+every answer, and must not arrive on another Mac unread.


### PR DESCRIPTION
## Related issue

Discussed directly — three follow-ups on top of #319, each self-contained and reviewable on its own.

## What changed

1. **Tell the model where it is running, and let the user add to it** — `AIRequest.instructions` already reached both transports (the HTTP route inserts it as a system message and lifts it into Anthropic's own `system` field; the Codex runner prepends it), but chat never set it, so every model answered with no idea what it was inside. `AIInstructions.compose` fills it: `AIPreamble` first, then whatever the user has written in Settings, theirs last so it qualifies the preamble rather than fights it. `AIPreamble.swift` holds that prose and nothing else — no second copy in the docs to fall out of step. The preamble states capabilities and asks for honest comparisons; it does **not** instruct the model to favour Tinycast over anything else, since the app would be spending the user's own API budget to argue its case, and it forbids guessing another launcher's numbers, which a model will otherwise invent on request. `SystemPromptEditor` opens blurred and non-editable whenever it already holds something; an empty one opens plain. `aiSystemPrompt` is excluded from settings backups — standing instructions change every answer and must not arrive on another Mac unread.

2. **Hide the signed-in ChatGPT address behind a blur until it is asked for** — a Settings pane is what ends up in a screenshot, a screen share or a recording, and the signed-in account address is the one thing on this one that names a person. `RedactedPlaceholder` derives a stand-in from the address itself, so it is stable across redraws and keeps the address's shape — the at sign, dot, hyphen and underscore all survive — while every other character comes from an alphabet without the look-alike glyphs. The scramble is the redaction and the blur only signals it: a blurred real address can be recovered from a still frame, a blurred stand-in has nothing to give up.

3. **Report a wrapping table's real height, so a reply's end stays reachable** — a reply ending in a long markdown table could not be scrolled to its own end: at the maximum offset the trailing paragraph, the copy button and the timestamp sat below the footer with no way to bring them up. `Grid` was the cause. Offered only a width, it measures a wrapping row a line shorter than it goes on to draw — a flat ~14pt a row, whatever the column count — so a 100-row table reported 5558 where it drew 7071, and everything past that fell outside the scrollable range. Fixing the vertical axis makes the grid resolve its columns against the width it was actually offered and report the height it draws. Two things in the transcript go with it: the stack is no longer lazy, because a lazy one only ever hands the scroll view an estimated height and that is what every anchored jump and the end test are measured against; and the end test now normalizes by the top inset, since a slack of 44 against an inset of 54 could not fire at the true bottom at all, so scrolling down by hand never resumed following and Jump to Latest never stood down.

Non-obvious in the diff:

- **The scroll geometry was never at fault**, which is worth stating because it looks like the obvious suspect. The panel is 475 tall and `containerSize.height` is the 369pt band between the bars, so the resting maximum is `contentSize - containerSize - insetTop` — exactly where the last content point meets the footer's top edge, which is where the scroll view was already stopping. Nothing in `EdgeDissolve` or `ThinScrollbar` is touched.
- **A wide table now renders differently.** Resolving columns against the offered width means a table that used to squeeze and wrap now uses the panel's width and wraps less. A table that already fit is unchanged, pixel for pixel.
- `Theme` gains `Blur.redaction`; `AppSettingsKey` gains `aiSystemPrompt`, excluded through `SettingsBackupCoverage` like every other AI key.

## Drawbacks

- **The visual change and the fix are the same modifier.** Making the grid report its real height is what also makes it use the width properly, so a wide table's new look cannot be declined separately. If the old squeeze is preferred, the alternative that keeps it is measuring the drawn height and feeding it back through a `@State` — a second layout pass on every render of a streaming transcript, which seems the worse trade.
- **`.fixedSize` on the grid is a workaround for a SwiftUI measurement bug**, not a statement about the design. If a future SwiftUI measures `Grid` honestly the modifier becomes redundant, though it stays harmless.
- **The transcript stack is no longer lazy**, so every message is realized up front. A transcript is a few tall rows rather than many short ones, so this is cheap here — but a very long conversation pays for it on open rather than as it scrolls.
- **The preamble is billed on every turn**, in every model's context, for every user.

## Tests & validation

- `./Scripts/run-tests.sh` — all 45 harnesses pass. New here: `ai-instructions-test` (12 assertions, pinning that the preamble always ships, that the user's text lands last and trimmed, and that whitespace is not a prompt) and `redaction-test` (13, pinning that a value always wears the same disguise, that length and `@ . - _` positions survive, and that the disguise is never the value).
- Release build succeeds with **zero warnings**.
- The scroll fix was measured rather than eyeballed, with a headless harness that reproduces the palette's own geometry (750×475, 54/52 bars, so `containerSize` lands on the real 369pt band) and renders the shipped `MarkdownView` → `MarkdownTableView`. Before: a 100-row wrapping table reports 5558 and draws 7071. After: reported covers drawn for 3-, 5- and 8-column wrapping tables and for cells with no break opportunity at all, with the card never exceeding the available width (~663 of 678) and non-wrapping tables identical at 165×925.
- By hand, in an installed Release build: a reply ending in a 100-row table scrolls to its trailing paragraph, copy button and timestamp; other chats show no trailing gap.
- `Scripts/lint.sh` did not run — swiftlint is not installed on this machine.
