### PR TITLE
Run the harnesses in parallel, and stop paying for scrypt at -Onone

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -6,10 +6,36 @@
 # member, which is how CI reported success over a harness that had not compiled since phase 10.
 
 set -uo pipefail
+
+# Absolute: the workers re-enter this script after the cd, where a relative $0 would not resolve.
+SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")/.." || exit 1
 
 BIN="${TMPDIR:-/tmp}/tinycast-harness"
 mkdir -p "$BIN"
+
+# `--exec` is the worker half: xargs re-enters here once per queued harness.
+if [ "${1:-}" = "--exec" ]; then
+    shift
+    name=$1 opt=$2
+    shift 2
+    if ! swiftc -swift-version 6 "$opt" "$@" "Tests/$name.swift" -o "$BIN/$name" > "$BIN/$name.log" 2>&1; then
+        printf '\033[31mFAIL\033[0m  %-22s did not compile\n' "$name"
+        : > "$BIN/$name.failed"
+        exit 0
+    fi
+    if ! "$BIN/$name" > "$BIN/$name.log" 2>&1; then
+        printf '\033[31mFAIL\033[0m  %-22s assertion failed\n' "$name"
+        : > "$BIN/$name.failed"
+        exit 0
+    fi
+    printf '\033[32mok\033[0m    %-22s\n' "$name"
+    exit 0
+fi
+
+QUEUE="$BIN/queue"
+: > "$QUEUE"
+rm -f "$BIN"/*.failed
 
 failed=()
 ran=0
@@ -26,8 +52,16 @@ if [ "$only" = "--index" ]; then
     printf '[' > "$DB"
 fi
 
-# run <name> <source...> — compile the harness and run it, recording either kind of failure.
+# run [slow] [-O] <name> <source...> — queue the harness. `slow` dispatches it in the first wave.
 run() {
+    local opt=-Onone pri=1
+    while :; do
+        case "$1" in
+            slow) pri=0; shift;;
+            -O)   opt=-O; shift;;
+            *)    break;;
+        esac
+    done
     local name=$1
     shift
     if [ -n "$only" ] && [ "$name" != "$only" ]; then return 0; fi
@@ -49,21 +83,12 @@ run() {
         return 0
     fi
 
-    if ! swiftc -swift-version 6 "$@" "Tests/$name.swift" -o "$BIN/$name" 2>&1; then
-        printf '\033[31mFAIL\033[0m  %-22s did not compile\n' "$name"
-        failed+=("$name")
-        return 0
-    fi
-    if ! "$BIN/$name"; then
-        printf '\033[31mFAIL\033[0m  %-22s assertion failed\n' "$name"
-        failed+=("$name")
-        return 0
-    fi
-    printf '\033[32mok\033[0m    %-22s\n' "$name"
+    # xargs splits the queue on whitespace, so no harness source path may contain a space.
+    printf '%s %s %s %s\n' "$pri" "$name" "$opt" "$*" >> "$QUEUE"
 }
 
 L=Tinycast/Features/Launcher/Model
-run fuzz-test              $L/SearchRelevance.swift
+run slow -O fuzz-test      $L/SearchRelevance.swift
 run file-search-test       $L/SearchRelevance.swift \
                            Tinycast/Features/FileSearch/Model/*.swift
 run file-search-session-test Tinycast/Platform/Signposts.swift \
@@ -136,7 +161,7 @@ run quicklink-test         Tinycast/Features/Quicklinks/Model/Quicklink.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkStore.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkArchive.swift
-run snippets-test          Tinycast/Platform/NotificationToken.swift \
+run slow snippets-test     Tinycast/Platform/NotificationToken.swift \
                            Tinycast/Platform/HealthTicker.swift \
                            Tinycast/Platform/AccessibilityText.swift \
                            Tinycast/Features/Snippets/Model/*.swift \
@@ -151,7 +176,7 @@ run notes-editor-test      Tinycast/Platform/Signposts.swift \
                            Tinycast/Features/Notes/Model/NoteDocument.swift \
                            Tinycast/Features/Notes/UI/NoteTextView.swift \
                            Tinycast/Features/Notes/UI/NoteEditorView.swift
-run raycast-test           Tinycast/Features/Backup/Model/RaycastFormat.swift \
+run slow -O raycast-test   Tinycast/Features/Backup/Model/RaycastFormat.swift \
                            Tinycast/Features/Backup/Model/RaycastV1Decoder.swift \
                            Tinycast/Features/Backup/Service/RaycastV2Decoder.swift \
                            Tinycast/Features/Backup/Service/Scrypt.swift \
@@ -168,7 +193,7 @@ run ext-cleanup-test       $E/Service/ExtensionCleanup.swift \
 run ext-store-test         $E/Model/ExtensionRegistry.swift \
                            $E/Model/ExtensionPackageManager.swift \
                            $E/Model/ExtensionStoreResponse.swift
-run ext-test               -parse-as-library \
+run slow ext-test          -parse-as-library \
                            $E/Model/ExtensionBootConfig.swift \
                            $E/Model/ExtensionManifest.swift \
                            $E/Model/RenderNode.swift \
@@ -194,7 +219,7 @@ run ai-chat-test           Tinycast/Features/AI/Model/AIRequest.swift \
                            Tinycast/Features/AI/Service/AIProvider.swift \
                            Tinycast/Features/AI/Service/ChatHistoryStore.swift \
                            Tinycast/Features/AI/UI/AIChatState.swift
-run codex-turn-test        Tinycast/Platform/AppPaths.swift \
+run slow codex-turn-test   Tinycast/Platform/AppPaths.swift \
                            Tinycast/Features/AI/Model/*.swift \
                            Tinycast/Features/AI/Service/AIProvider.swift \
                            Tinycast/Features/AI/Service/ChatGPTSubscriptionManager.swift \
@@ -223,7 +248,20 @@ if [ "$ran" -eq 0 ]; then
     exit 2
 fi
 
+# `sort -s` is stable, so the slow harnesses lead and everything else keeps its declaration order.
+JOBS="${TINYCAST_TEST_JOBS:-$(sysctl -n hw.ncpu)}"
+sort -s -k1,1n "$QUEUE" | cut -d' ' -f2- | xargs -P "$JOBS" -L1 "$SELF" --exec
+
+# A compiler diagnostic is far longer than PIPE_BUF, so the workers log it and it is replayed here.
+while read -r _ name _; do
+    if [ -f "$BIN/$name.failed" ]; then failed+=("$name"); fi
+done < "$QUEUE"
+
 if [ ${#failed[@]} -gt 0 ]; then
+    for name in "${failed[@]}"; do
+        printf '\n\033[31m--- %s ---\033[0m\n' "$name"
+        cat "$BIN/$name.log"
+    done
     printf '\n%d harness(es) failed: %s\n' "${#failed[@]}" "${failed[*]}" >&2
     exit 1
 fi

--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -726,14 +726,14 @@ struct SnippetsTests {
         let externalURL = repository.snippetsDirectory.appendingPathComponent("external.md")
         try SnippetMarkdownSerializer.serialize(Snippet(name: "External", text: "One"))
             .write(to: externalURL, atomically: true, encoding: .utf8)
-        try await Task.sleep(for: .milliseconds(500))
+        await settle { store.snippets.contains { $0.id == externalURL.path && $0.snippet.text == "One" } }
         check(
             "watcher reloads an externally created file",
             store.snippets.contains { $0.id == externalURL.path && $0.snippet.text == "One" })
 
         try SnippetMarkdownSerializer.serialize(Snippet(name: "External", text: "Two"))
             .write(to: externalURL, atomically: true, encoding: .utf8)
-        try await Task.sleep(for: .milliseconds(500))
+        await settle { store.record(id: externalURL.path)?.snippet.text == "Two" }
         check(
             "watcher observes atomic file replacement",
             store.record(id: externalURL.path)?.snippet.text == "Two")
@@ -744,7 +744,7 @@ struct SnippetsTests {
         try handle.truncate(atOffset: 0)
         try handle.write(contentsOf: Data(inPlaceSource.utf8))
         try handle.close()
-        try await Task.sleep(for: .milliseconds(500))
+        await settle { store.record(id: externalURL.path)?.snippet.text == "Three" }
         check(
             "watcher observes same-inode truncate and write",
             store.record(id: externalURL.path)?.snippet.text == "Three")
@@ -761,8 +761,10 @@ struct SnippetsTests {
             withItemAt: replacementDirectory,
             backupItemName: nil,
             options: [])
-        try await Task.sleep(for: .milliseconds(700))
         let installedReplacementURL = repository.snippetsDirectory.appendingPathComponent("replacement.md")
+        await settle(within: .milliseconds(700)) {
+            store.snippets.count == 1 && store.snippets.first?.id == installedReplacementURL.path
+        }
         check(
             "watcher rearms after directory replacement",
             store.snippets.count == 1 && store.snippets.first?.id == installedReplacementURL.path)
@@ -775,7 +777,9 @@ struct SnippetsTests {
         let recreatedURL = repository.snippetsDirectory.appendingPathComponent("recreated.md")
         try SnippetMarkdownSerializer.serialize(Snippet(name: "Recreated", text: "Newest"))
             .write(to: recreatedURL, atomically: true, encoding: .utf8)
-        try await Task.sleep(for: .milliseconds(700))
+        await settle(within: .milliseconds(700)) {
+            store.snippets.count == 1 && store.record(id: recreatedURL.path)?.snippet.text == "Newest"
+        }
         check(
             "watcher rearms after an explicit rename-away and recreation",
             store.snippets.count == 1
@@ -783,7 +787,10 @@ struct SnippetsTests {
         try fm.removeItem(at: renamedDirectory)
 
         try fm.removeItem(at: repository.snippetsDirectory)
-        try await Task.sleep(for: .milliseconds(700))
+        await settle(within: .milliseconds(700)) {
+            store.state == .ready && store.snippets.isEmpty
+                && fm.fileExists(atPath: repository.snippetsDirectory.path)
+        }
         check(
             "watcher recreates a deleted initialized directory without samples",
             store.state == .ready && store.snippets.isEmpty
@@ -791,6 +798,7 @@ struct SnippetsTests {
         let afterDeleteURL = repository.snippetsDirectory.appendingPathComponent("after-delete.md")
         try SnippetMarkdownSerializer.serialize(Snippet(name: "After Delete", text: "Rearmed"))
             .write(to: afterDeleteURL, atomically: true, encoding: .utf8)
+        // Not a settle: the burst below counts snapshots, so this reload must be fully quiet first.
         try await Task.sleep(for: .milliseconds(500))
         check(
             "watcher continues after deleted-directory recovery",
@@ -804,6 +812,7 @@ struct SnippetsTests {
             )
             .write(to: fileURL, atomically: true, encoding: .utf8)
         }
+        // A poll would stop at the first snapshot and miss a second one arriving.
         try await Task.sleep(for: .milliseconds(500))
         check(
             "watcher debounces a burst into one published reload",
@@ -815,7 +824,7 @@ struct SnippetsTests {
             to: corruptURL,
             atomically: true,
             encoding: .utf8)
-        try await Task.sleep(for: .milliseconds(500))
+        await settle { store.issues.contains { $0.fileURL.lastPathComponent == "corrupt.md" } }
         check(
             "watcher publishes corrupt-file issues without dropping valid files",
             store.issues.contains { $0.fileURL.lastPathComponent == "corrupt.md" }
@@ -1578,6 +1587,17 @@ struct SnippetsTests {
             check(description, error.localizedDescription.contains(fileURL.path))
         } catch {
             check(description, false)
+        }
+    }
+
+    // The same budget a fixed sleep spent, but a prompt watcher costs milliseconds of it.
+    private static func settle(
+        within timeout: Duration = .milliseconds(500),
+        until condition: () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline, !condition() {
+            try? await Task.sleep(for: .milliseconds(10))
         }
     }
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,6 +26,23 @@ what you touched.
 ./Scripts/run-tests.sh calc-test    # just one, while iterating
 ```
 
+The suite runs in parallel, `hw.ncpu` harnesses at a time, which is what takes it from about 140
+seconds to about 15. `TINYCAST_TEST_JOBS=1` forces it back to one at a time. Parallelism is safe
+because each harness already roots its scratch state somewhere of its own — a UUID-suffixed
+`temporaryDirectory`, a `UserDefaults(suiteName:)`, or `NSPasteboard.withUniqueName()` — and a new
+harness must keep doing that rather than reach for a fixed path.
+
+Two consequences worth knowing. Status lines arrive in **completion order**, not the order the `run`
+lines are written; and a failing harness's compiler diagnostics or assertion output are replayed
+together at the bottom, under its name, rather than streamed where they happened. That is deliberate:
+a compiler diagnostic is far longer than `PIPE_BUF`, so eleven workers streaming at once would
+interleave into nonsense.
+
+A `run` line takes two optional markers before the harness name. `-O` compiles that harness optimised,
+which is worth it only where the run dominates the compile — `raycast-test` spends 47 seconds in
+scrypt at `-Onone` and one second at `-O`. `slow` dispatches it in the first wave, so the longest
+harnesses are not still running after everything else has finished.
+
 The script is the **only** place the harness set is written down — CI runs exactly this, so the two
 cannot drift. Adding a harness means adding one `run` line.
 
@@ -178,6 +195,7 @@ Measured at the end of the 2026 refactor, on `main`. Useful as orders of magnitu
 | `SettingsPaneScanner` warm scan | 0.014 ms (16.5 ms cold), 52 panes |
 | Largest view / owner | `RootPaletteView` 662 lines, `AppCore` 284 lines |
 | Comment density | 1,653 of 27,289 source lines (6.1%) |
+| The harness suite | ~15 s wall clock, 11-way parallel (~98 s serial, ~140 s before either) |
 | `palette-selection-test` | 111,684 assertions — a tripwire: a change in this count means the row-order model moved |
 | `SnippetKeywordPolicy` match | 7 µs/keystroke at 50 keywords, 59 µs at 1,000 — the `lowercased()` is 0.09 µs of it |
 | `ClipboardStore.pinnedItems` | 27–127 µs per uncached search, 1,000-row window — no cache earns its invalidation yet |


### PR DESCRIPTION
## Related issue

None.

## What changed

`./Scripts/run-tests.sh` took **141 seconds** and was entirely serial: 43 harnesses, each a compile followed by a run, one after another, on an 11-core machine. It now takes **~15 seconds**, with the same 43 harnesses and the same assertion counts.

**Parallel dispatch.** `run` queues instead of executing; `xargs -P $(sysctl -n hw.ncpu)` re-enters the script through an internal `--exec` worker that does the compile and the run — still as two separate statements, so the `&&`/`set -e` trap the header comment warns about stays avoided. `TINYCAST_TEST_JOBS=1` forces the old serial behaviour.

This is safe because every harness already roots its scratch state somewhere of its own — a UUID-suffixed `temporaryDirectory`, a `UserDefaults(suiteName:)`, or `NSPasteboard.withUniqueName()` — so no two share mutable state. I checked all 43 before doing this, and `testing.md` now states it as a requirement on new harnesses rather than leaving it an accident.

**Two markers on a `run` line.** `-O` for the two harnesses where the run dominates the compile, and `slow` to dispatch the five longest in the first wave so they aren't still going after everything else has finished. Both are consumed before `"$@"`, so `--index` never sees them.

**Output.** Status lines now arrive in completion order, and a failing harness's diagnostics are replayed together at the bottom under its name rather than streamed where they happened. That's deliberate: a compiler diagnostic is far longer than `PIPE_BUF`, so eleven workers streaming at once would interleave into nonsense.

**`snippets-test`.** Seven fixed `Task.sleep(500–700ms)` waits on the file watcher became `await settle { … }`, polling on the same timeout budget. Three sleeps stayed, each with a one-line reason: they assert *absence* or an exact snapshot count, where a poll would stop at the first event and miss a second.

Where the time went:

| | Before | After |
| --- | --- | --- |
| `raycast-test` | 47.4s — scrypt, a memory-hard KDF, at `-Onone` | 1.2s run, +5.9s compile |
| `fuzz-test` | 12.4s — 120,000 scoring iterations | 5.9s run, +2.1s compile |
| `snippets-test` | 11.7s — 5.5s of it fixed sleeps | ~8.7s |
| First-launch assessment | ~15s — 0.35s per fresh binary, 0.006s on re-run | overlapped away |
| **Whole suite** | **141s** | **~15s** (98s with `TINYCAST_TEST_JOBS=1`) |

## Memory footprint

Not applicable — nothing under `Tinycast/` changes. The diff is the test runner, one harness and one doc, so the app binary and its runtime behaviour are untouched.

## Drawbacks

- **Status lines lose declaration order.** They arrive as harnesses finish. Failures are still listed in declaration order in the summary and the replayed logs, so the thing you actually read when something breaks is unchanged.
- **The queue is whitespace-split by `xargs`**, so no harness source path may contain a space. There's a comment on the `printf` saying so. Nothing in the repo has one and nothing is likely to.
- **`-O` means two harnesses no longer compile at the default optimisation level.** `-O` keeps overflow checks — unlike `-Ounchecked` — so the assertions are the same ones. Worth knowing if a future bug ever turns out to be optimisation-dependent.
- **Peak load is higher**: 11 concurrent `swiftc` processes instead of one. Fine here and on CI runners, which size `hw.ncpu` to what they have.
- `slow` is a hand-maintained hint. If a harness gets much slower later, nothing tells you to mark it — you'd just see the tail grow. The cost of it being wrong is a few seconds, not a wrong result.

## Tests & validation

All against this branch:

- `./Scripts/run-tests.sh` — **43/43 pass**, five consecutive runs, 14.6–15.7s each.
- `TINYCAST_TEST_JOBS=1 ./Scripts/run-tests.sh` — 43/43, 98s.
- `./Scripts/run-tests.sh calc-test` — single-harness mode; `./Scripts/run-tests.sh no-such-test` — still exits 2.
- **Both failure kinds, injected deliberately.** A syntax error → `did not compile`; a flipped assertion → `assertion failed`. Both replay their output under the harness name and exit 1. Two broken at once → both listed, no interleaving.
- **`--index` is provably untouched.** Snapshotted `$TMPDIR/tinycast-compile-db.json` and `.compile` before any edit and diffed after every change: **byte-identical** each time. `Scripts/sync-lsp.sh` is unmodified.
- `./Scripts/lint.sh` clean; the purity grep returns nothing.
- `snippets-test` reports **190 assertions before and after** the sleep rewrite, verified by building the harness from `main` and from this branch.

No manual sweep — no app surface changes.
