### PR TITLE
Stop the harnesses leaving files behind, and delete a dead rendezvous

### DIFF
--- a/Tests/ai-provider-test.swift
+++ b/Tests/ai-provider-test.swift
@@ -427,9 +427,9 @@ struct AIProviderTests {
     }
 
     static func settingsPersistAndRepairSelections() {
-        let suite = "AIProviderTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let suite = "AIProviderTests.persistence"
+        let defaults = isolatedDefaults(suite)
+        defer { discardSuite(suite, defaults) }
         let firstID = UUID()
         let secondID = UUID()
 
@@ -460,9 +460,9 @@ struct AIProviderTests {
     }
 
     static func subscriptionSelectionsReconcile() {
-        let suite = "AIProviderTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let suite = "AIProviderTests.subscription"
+        let defaults = isolatedDefaults(suite)
+        defer { discardSuite(suite, defaults) }
         let store = AISettingsStore(defaults: defaults)
         let model = ChatGPTSubscription.Model(
             id: "gpt", name: "GPT",
@@ -477,4 +477,21 @@ struct AIProviderTests {
         store.reconcile(chatGPTModels: [], isSignedOut: true)
         expect(store.defaultModel == nil, "signing out clears an unusable subscription default")
     }
+}
+
+/// `removePersistentDomain` only empties the domain; cfprefsd still leaves the plist on disk.
+private func discardSuite(_ name: String, _ defaults: UserDefaults) {
+    defaults.removePersistentDomain(forName: name)
+    UserDefaults.standard.removeSuite(named: name)
+    CFPreferencesAppSynchronize(name as CFString)
+    try? FileManager.default.removeItem(
+        at: URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Preferences/\(name).plist"))
+}
+
+/// A fixed suite name stops cfprefsd accumulating a plist per run; the domain is cleared at both ends.
+private func isolatedDefaults(_ name: String) -> UserDefaults {
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
 }

--- a/Tests/app-name-test.swift
+++ b/Tests/app-name-test.swift
@@ -6,7 +6,6 @@ struct AppNameTest {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
             .appendingPathComponent("tinycast-app-name-\(UUID().uuidString)")
-        defer { try? fm.removeItem(at: root) }
 
         var failures = 0
 
@@ -76,6 +75,7 @@ struct AppNameTest {
             "two blank keys still fall back to the filename",
             blankBoth?.installedAppName == "Ghost")
 
+        try? fm.removeItem(at: root)
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)
     }

--- a/Tests/custom-command-test.swift
+++ b/Tests/custom-command-test.swift
@@ -5,13 +5,8 @@ import Foundation
 struct CustomCommandTests {
     @MainActor
     static func main() async {
-        let suiteName = "com.tinycast.custom-command-tests.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            print("FAIL  could not create an isolated UserDefaults suite")
-            exit(1)
-        }
-        defaults.removePersistentDomain(forName: suiteName)
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let suiteName = "com.tinycast.custom-command-tests"
+        let defaults = isolatedDefaults(suiteName)
 
         var failures = 0
 
@@ -103,7 +98,6 @@ struct CustomCommandTests {
         let zdotdir = FileManager.default.temporaryDirectory
             .appendingPathComponent("tinycast-zdotdir-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: zdotdir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: zdotdir) }
         try? Data("alias tinycast_probe=true\n".utf8).write(
             to: zdotdir.appendingPathComponent(".zshrc"))
         setenv("ZDOTDIR", zdotdir.path, 1)
@@ -129,7 +123,26 @@ struct CustomCommandTests {
 
         unsetenv("ZDOTDIR")
 
+        try? FileManager.default.removeItem(at: zdotdir)
+        discardSuite(suiteName, defaults)
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)
     }
+}
+
+/// `removePersistentDomain` only empties the domain; cfprefsd still leaves the plist on disk.
+private func discardSuite(_ name: String, _ defaults: UserDefaults) {
+    defaults.removePersistentDomain(forName: name)
+    UserDefaults.standard.removeSuite(named: name)
+    CFPreferencesAppSynchronize(name as CFString)
+    try? FileManager.default.removeItem(
+        at: URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Preferences/\(name).plist"))
+}
+
+/// A fixed suite name stops cfprefsd accumulating a plist per run; the domain is cleared at both ends.
+private func isolatedDefaults(_ name: String) -> UserDefaults {
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
 }

--- a/Tests/ext-icon-test.swift
+++ b/Tests/ext-icon-test.swift
@@ -57,7 +57,9 @@ struct ExtensionIconTests {
             expect(image?.size == NSSize(width: 24, height: 24), "percent-encoded SVG\(suffix)")
         }
 
-        let png = writePNG("inline", inset: 0).flatMap { try? Data(contentsOf: $0) }
+        let pngURL = writePNG("inline", inset: 0)
+        defer { pngURL.map { try? FileManager.default.removeItem(at: $0.deletingLastPathComponent()) } }
+        let png = pngURL.flatMap { try? Data(contentsOf: $0) }
         guard let png else { return expect(false, "the PNG fixture writes") }
         let base64 = URL(string: "data:image/png;base64,\(png.base64EncodedString())")!
         let decoded = await ExtensionIconCache.loadInlineAsync(base64)

--- a/Tests/notes-test.swift
+++ b/Tests/notes-test.swift
@@ -20,16 +20,9 @@ struct NotesTests {
         let root = temporaryRoot("repository")
         defer { try? FileManager.default.removeItem(at: root) }
         let support = root.appendingPathComponent("com.tinycast.app")
-        let trash = root.appendingPathComponent("Trash", isDirectory: true)
-        try FileManager.default.createDirectory(at: trash, withIntermediateDirectories: true)
-        let stable = NotesRepository(
-            applicationSupportDirectory: support,
-            trashOperation: { url in
-                try FileManager.default.moveItem(
-                    at: url, to: trash.appendingPathComponent(url.lastPathComponent))
-            })
-        let development = NotesRepository(
-            applicationSupportDirectory: root.appendingPathComponent("com.tinycast.app.dev"))
+        let stable = try repository(in: root, support: support)
+        let development = try repository(
+            in: root, support: root.appendingPathComponent("com.tinycast.app.dev"))
 
         try FileManager.default.createDirectory(
             at: stable.notesDirectory, withIntermediateDirectories: true)
@@ -104,7 +97,7 @@ struct NotesTests {
         check(
             "deletion moves the file through the injected Trash operation",
             FileManager.default.fileExists(
-                atPath: trash.appendingPathComponent(plan.id.rawValue).path))
+                atPath: trashDirectory(in: root).appendingPathComponent(plan.id.rawValue).path))
 
         let outside = root.appendingPathComponent("outside.md")
         try Data("outside".utf8).write(to: outside)
@@ -125,8 +118,8 @@ struct NotesTests {
             "symlinked Markdown files are absent from enumeration",
             !(try stable.list()).contains { $0.id == symlinkID })
 
-        let empty = NotesRepository(
-            applicationSupportDirectory: root.appendingPathComponent("com.tinycast.app.empty"))
+        let empty = try repository(
+            in: root, support: root.appendingPathComponent("com.tinycast.app.empty"))
         let emptyLoad = try empty.load(preferredID: nil)
         check("an empty collection loads no document", emptyLoad.0.isEmpty && emptyLoad.1 == nil)
         check(
@@ -174,14 +167,7 @@ struct NotesTests {
     private static func testStoreCollectionAndAutosave() async throws {
         let root = temporaryRoot("store")
         defer { try? FileManager.default.removeItem(at: root) }
-        let trash = root.appendingPathComponent("Trash", isDirectory: true)
-        try FileManager.default.createDirectory(at: trash, withIntermediateDirectories: true)
-        let repository = NotesRepository(
-            applicationSupportDirectory: root,
-            trashOperation: { url in
-                try FileManager.default.moveItem(
-                    at: url, to: trash.appendingPathComponent(url.lastPathComponent))
-            })
+        let repository = try repository(in: root)
         let selection = SelectionBox()
         let store = NotesStore(
             repository: repository,
@@ -244,7 +230,7 @@ struct NotesTests {
         check(
             "trashing another note moves it through the injected Trash operation",
             FileManager.default.fileExists(
-                atPath: trash.appendingPathComponent(projectID.rawValue).path))
+                atPath: trashDirectory(in: root).appendingPathComponent(projectID.rawValue).path))
         check("trashing another note keeps the active note", store.activeID == firstID)
 
         for summary in store.summaries {
@@ -264,7 +250,7 @@ struct NotesTests {
     private static func testCollectionMutationsFlushTheDraft() async throws {
         let root = temporaryRoot("mutation-flush")
         defer { try? FileManager.default.removeItem(at: root) }
-        let repository = NotesRepository(applicationSupportDirectory: root)
+        let repository = try repository(in: root)
         let store = NotesStore(repository: repository)
 
         _ = await store.create()
@@ -304,7 +290,7 @@ struct NotesTests {
     private static func testStoreRecoversFromFailures() async throws {
         let root = temporaryRoot("recovery")
         defer { try? FileManager.default.removeItem(at: root) }
-        let repository = NotesRepository(applicationSupportDirectory: root)
+        let repository = try repository(in: root)
         try FileManager.default.createDirectory(
             at: repository.notesDirectory, withIntermediateDirectories: true)
         let unreadable = repository.fileURL(for: NoteID(rawValue: "Unreadable.md"))
@@ -344,6 +330,22 @@ struct NotesTests {
             "an edit that lands during a write is not lost",
             try String(contentsOf: activeURL, encoding: .utf8) == "edit during the write")
         store.stop()
+    }
+
+    /// Deleting a note trashes it for real, so every harness repository redirects that inside the root.
+    private static func repository(in root: URL, support: URL? = nil) throws -> NotesRepository {
+        let trash = trashDirectory(in: root)
+        try FileManager.default.createDirectory(at: trash, withIntermediateDirectories: true)
+        return NotesRepository(
+            applicationSupportDirectory: support ?? root,
+            trashOperation: { url in
+                try FileManager.default.moveItem(
+                    at: url, to: trash.appendingPathComponent(url.lastPathComponent))
+            })
+    }
+
+    private static func trashDirectory(in root: URL) -> URL {
+        root.appendingPathComponent("Trash", isDirectory: true)
     }
 
     private static func temporaryRoot(_ name: String) -> URL {

--- a/Tests/ranking-test.swift
+++ b/Tests/ranking-test.swift
@@ -6,7 +6,6 @@ struct RankingTest {
     static func main() async {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("tinycast-ranking-\(UUID().uuidString).json")
-        defer { try? FileManager.default.removeItem(at: fileURL) }
 
         var clock = Date(timeIntervalSince1970: 2_000_000_000)
         let store = LauncherRankingStore(fileURL: fileURL) { clock }
@@ -138,6 +137,7 @@ struct RankingTest {
             "the observed boost cap stays under a band stride",
             maxBoost < SearchRelevance.bandStride - FuzzyMatch.maximumScore)
 
+        try? FileManager.default.removeItem(at: fileURL)
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)
     }

--- a/Tests/scopes-test.swift
+++ b/Tests/scopes-test.swift
@@ -6,7 +6,6 @@ struct ScopesTest {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
             .appendingPathComponent("tinycast-scopes-\(UUID().uuidString)")
-        defer { try? fm.removeItem(at: root) }
 
         var failures = 0
 
@@ -93,6 +92,7 @@ struct ScopesTest {
             "defaults are already normalized",
             SearchScopes.normalize(SearchScopes.defaults) == SearchScopes.defaults)
 
+        try? fm.removeItem(at: root)
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)
     }

--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -450,19 +450,12 @@ struct SnippetsTests {
         var aliasCoordinationHeld = true
         for index in 0..<20 where aliasCoordinationHeld {
             let bundleIdentifier = "com.example.symlink-save-\(index)"
-            let revalidation = RevalidationRendezvous()
-            let hooks = SnippetRepository.MutationHooks(afterRevalidation: { mutation, _ in
-                guard case .save = mutation else { return }
-                revalidation.arriveAndWait()
-            })
             let directRepository = SnippetRepository(
                 bundleIdentifier: bundleIdentifier,
-                applicationSupportRoot: physicalSupport,
-                mutationHooks: hooks)
+                applicationSupportRoot: physicalSupport)
             let symlinkedRepository = SnippetRepository(
                 bundleIdentifier: bundleIdentifier,
-                applicationSupportRoot: symlinkedSupport,
-                mutationHooks: hooks)
+                applicationSupportRoot: symlinkedSupport)
             let symlinkedRecord = try symlinkedRepository.create(
                 Snippet(name: "Alias Race", text: "Original"))
             guard
@@ -1609,23 +1602,6 @@ struct SnippetsTests {
             print("FAIL  \(description)")
             failures += 1
         }
-    }
-}
-
-private final class RevalidationRendezvous: @unchecked Sendable {
-    private let condition = NSCondition()
-    private var arrivals = 0
-
-    func arriveAndWait() {
-        condition.lock()
-        arrivals += 1
-        if arrivals == 2 {
-            condition.broadcast()
-        } else {
-            let deadline = Date().addingTimeInterval(0.25)
-            while arrivals < 2, condition.wait(until: deadline) {}
-        }
-        condition.unlock()
     }
 }
 

--- a/Tinycast/Features/Snippets/Model/SnippetRepository.swift
+++ b/Tinycast/Features/Snippets/Model/SnippetRepository.swift
@@ -58,7 +58,6 @@ struct SnippetRepository: Sendable {
 
     struct MutationHooks: Sendable {
         var beforeRevalidation: @Sendable (Mutation, URL) -> Void = { _, _ in }
-        var afterRevalidation: @Sendable (Mutation, URL) -> Void = { _, _ in }
     }
 
     struct Snapshot: Sendable, Equatable {
@@ -202,7 +201,6 @@ struct SnippetRepository: Sendable {
                             expected: expectedRevision,
                             actual: actualRevision)
                     }
-                    mutationHooks.afterRevalidation(.save, mutationURL)
                     try Data(content.utf8).write(to: mutationURL, options: .atomic)
                     return StoredSnippet(
                         fileURL: fileURL,
@@ -230,7 +228,6 @@ struct SnippetRepository: Sendable {
                             expected: expectedRevision,
                             actual: actualRevision)
                     }
-                    mutationHooks.afterRevalidation(.delete, mutationURL)
                     try FileManager.default.removeItem(at: mutationURL)
                 }
             }


### PR DESCRIPTION
Two harness fixes, one per commit. No production behaviour changes; the only shipped-source edit removes a test seam that no longer has callers.

## 1. `snippets-test` sat idle for 5 seconds per run

The harness took 8.2s to run but used 0.3s of CPU — it was sleeping, not testing. Per-section timing put 8.0s of that in two sections; the other eleven, roughly 190 assertions, totalled 0.12s.

The cost was `RevalidationRendezvous`, a two-party `NSCondition` barrier on `afterRevalidation` meant to force the symlinked-alias save race open. It never completed once: across 20 iterations it logged 20 arrivals, never 40, and `arrivals` never reached 2.

Both reasons are structural, not flaky:

- the losing saver throws `.conflict` before reaching `afterRevalidation`, so it never arrives;
- the hook runs inside `coordinatedMutation` — mutually exclusive access — so the loser cannot enter until the winner leaves.

Moving the barrier to `beforeRevalidation` would not help. A rendezvous inside coordinated access cannot complete by construction. So every iteration sat out its full 250ms deadline for nothing, and the assertion passed anyway because file coordination alone provides the serialization it checks.

Removing it left `afterRevalidation` with no callers, so that seam goes too. The loop keeps all 20 iterations — the race coverage is real and now nearly free.

**8.15s → 2.85s, all 190 assertions passing, stable over 10 consecutive runs.**

## 2. The harnesses were leaving files on disk

A full suite run left 15 paths behind, checked by snapshotting `$TMPDIR`, `~/Library/{Application Support,Caches,Preferences}` and `$HOME` before and after.

**The visible one:** `notes-test` put a real `.md` in the developer's Trash on every run. `NotesRepository` deletes through `FileManager.trashItem` — correct for the app, since deleting a note should be undoable — and it takes an injectable `trashOperation` so tests can redirect it. Two of five construction sites did; the one that trashes did not. All five now go through a single helper, which also folds away two copies of the redirect closure.

**The rest:** one bug repeated across five harnesses — a `defer` in a function ending in `exit()` never runs, so the cleanup was dead code.

| Harness | Was leaking |
| --- | --- |
| `custom-command-test` | a plist holding real test data — **389 had accumulated** |
| `ai-provider-test` | two empty plists per run (76 accumulated) |
| `app-name-test`, `scopes-test`, `ranking-test` | temp fixtures |
| `ext-icon-test` | separate cause: `writePNG` mints a directory per call, and `inlineDataURLsDecode` never removed its own |

**On the preference suites:** deleting the plist in-process does not work. `removePersistentDomain` only empties the domain, and `cfprefsd` recreates the file after the process exits — even with `removeSuite` and `CFPreferencesAppSynchronize`, both of which I tried and measured. Rather than race the daemon's flush timing, the suites now use fixed names instead of per-run UUIDs, so three files are reused and always emptied rather than accumulating without bound.

**A full run now leaves zero new paths and zero Trash items.**

## Verification

- All 45 harnesses pass.
- `./Scripts/lint.sh` clean; warning count identical to baseline (60 before, 60 after).
- Debug build succeeds with no new warnings.
- Model-purity grep clean.
- No doc referenced the removed symbols.

The 465 stale plists already on my machine were deleted separately, after confirming the pattern excluded the three fixed-name files now in use.