### PR TITLE
Tint an extension action's icon in the ⌘K panel

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -197,15 +197,21 @@ run ext-store-test         $E/Model/ExtensionRegistry.swift \
                            $E/Model/ExtensionPackageManager.swift \
                            $E/Model/ExtensionStoreResponse.swift
 run slow ext-test          -parse-as-library \
+                           Tinycast/Platform/Appearance.swift \
+                           Tinycast/Platform/Images/IconCache.swift \
+                           Tinycast/DesignSystem/Theme.swift \
                            $E/Model/ExtensionBootConfig.swift \
                            $E/Model/ExtensionManifest.swift \
                            $E/Model/RenderNode.swift \
                            $E/Service/ExtensionCatalog.swift \
                            $E/Service/ExtensionFetcher.swift \
+                           $E/Service/ExtensionIconCache.swift \
                            $E/Service/ExtensionNodeShims.swift \
                            $E/Service/ExtensionOAuthKeychain.swift \
                            $E/Service/ExtensionOAuthSession.swift \
                            $E/Service/ExtensionRuntime.swift \
+                           $E/UI/ExtensionAnimatedImage.swift \
+                           $E/UI/ExtensionImage.swift \
                            $E/UI/ExtensionScreen.swift \
                            $L/SearchRelevance.swift \
                            Tinycast/Platform/Compression/Zlib.swift

--- a/Tests/ext-test.swift
+++ b/Tests/ext-test.swift
@@ -11,7 +11,9 @@
 //
 //   /tmp/ext-test ~/.config/raycast/extensions/<uuid> [command-name]
 
+import AppKit
 import Foundation
+import SwiftUI
 
 @main
 struct ExtensionTests {
@@ -196,6 +198,7 @@ struct ExtensionTests {
         manifestChecks()
         renderNodeChecks()
         screenChecks()
+        actionIconChecks()
         oauthUnitChecks()
         await runtimeChecks()
 
@@ -459,6 +462,53 @@ struct ExtensionTests {
         check("item panel wins", panels.actionPanel(forItemAt: 0)?.id == 9)
         check("screen panel is the fallback", panels.actionPanel(forItemAt: 1)?.id == 8)
         check("out-of-range selection falls back", panels.actionPanel(forItemAt: 99)?.id == 8)
+    }
+
+    /// An `Action`'s icon is a full `ImageLike`, so the ⌘K panel has to keep its tint: a picker built
+    /// from `{Icon.Circle, tintColor}` rows is one grey column without it. See docs/features/extensions.md.
+    @MainActor
+    static func actionIconChecks() {
+        func icon(
+            _ json: String, isDestructive: Bool = false, assets: String? = nil
+        ) -> ExtensionImage.Resolved {
+            let wrapped = Data(#"{"icon": \#(json)}"#.utf8)
+            let props = (try? JSONSerialization.jsonObject(with: wrapped)) as? [String: Any]
+            return ExtensionImage.actionIcon(
+                props?["icon"].map(RenderValue.init(json:)), assetsPath: assets, isDark: true,
+                isDestructive: isDestructive)
+        }
+
+        let tinted = icon(#"{"source":"circle-16","tintColor":"raycast-green"}"#)
+        check("a tinted symbol keeps its source", tinted.source == .symbol("circle"))
+        check("a tinted symbol keeps its tint", tinted.tint == .green)
+
+        // Doubled delimiters: the hex tint contains `"#`, which closes a single-# raw string.
+        check(
+            "raw hex tints too",
+            icon(##"{"source":"circle-16","tintColor":"#FF3B30"}"##).tint
+                == Color(red: 1, green: 0x3B / 255, blue: 0x30 / 255))
+        check(
+            "a themed tint picks the dark side",
+            icon(#"{"source":"circle-16","tintColor":{"light":"raycast-red","dark":"raycast-blue"}}"#)
+                .tint == .blue)
+
+        let bare = icon(#""checkmark-circle-16""#)
+        check("a bare icon still resolves", bare.source == .symbol("checkmark.circle"))
+        check("and carries no tint", bare.tint == nil)
+
+        let asset = icon(#""logo.png""#, assets: "/tmp/demo/assets")
+        check(
+            "an asset name resolves against assets/", asset.source == .file("/tmp/demo/assets/logo.png"),
+            String(describing: asset.source))
+
+        check("no icon falls back to a glyph", icon("null").source == .symbol("bolt"))
+        let destructive = icon("null", isDestructive: true)
+        check("a destructive fallback is a trash glyph", destructive.source == .symbol("trash"))
+        check("and takes red", destructive.tint == .red)
+        check(
+            "a destructive action's own tint wins",
+            icon(#"{"source":"circle-16","tintColor":"raycast-yellow"}"#, isDestructive: true).tint
+                == .yellow)
     }
 
     private final class MockTokenStore: ExtensionOAuthTokenStore, @unchecked Sendable {

--- a/Tests/ext-test.swift
+++ b/Tests/ext-test.swift
@@ -509,6 +509,12 @@ struct ExtensionTests {
             "a destructive action's own tint wins",
             icon(#"{"source":"circle-16","tintColor":"raycast-yellow"}"#, isDestructive: true).tint
                 == .yellow)
+        // A tint masks artwork rather than colouring it, so a destructive PNG must stay untinted.
+        let destructiveArtwork = icon(#""danger.png""#, isDestructive: true, assets: "/tmp/a")
+        check(
+            "a destructive artwork icon keeps its own colours",
+            destructiveArtwork.source == .file("/tmp/a/danger.png") && destructiveArtwork.tint == nil,
+            String(describing: destructiveArtwork))
     }
 
     private final class MockTokenStore: ExtensionOAuthTokenStore, @unchecked Sendable {

--- a/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
@@ -11,10 +11,26 @@ private enum Metrics {
     static var maxHeight: CGFloat { visibleRows * (rowHeight + rowSpacing) }
 }
 
+/// One row of a running command's ⌘K panel. Its own type, not `PopoverMenuItem`: an extension names
+/// any icon and tints it, and the palette's menu row carries neither.
+struct ExtensionActionItem {
+    let title: String
+    let icon: ExtensionImage.Resolved
+    var shortcut: String?
+    var isDestructive = false
+    let action: () -> Void
+}
+
+/// A panel's header and rows, built once and consumed by render and keyboard alike.
+struct ExtensionActionsContent {
+    var header: String?
+    let items: [ExtensionActionItem]
+}
+
 /// The ⌘K panel of a running command. Not `PopoverMenu`: an extension's panel is long, so it scrolls.
 struct ExtensionActionsPanel: View {
     var header: String?
-    let items: [PopoverMenuItem]
+    let items: [ExtensionActionItem]
     @Binding var selection: Int
     let onActivate: (Int) -> Void
 
@@ -77,7 +93,7 @@ struct ExtensionActionsPanel: View {
 
 /// Its own row, not the palette's: that one is file-private, and this one may grow its own trimmings.
 private struct ExtensionActionRow: View {
-    let item: PopoverMenuItem
+    let item: ExtensionActionItem
     let selected: Bool
     /// Fired on enter, so the owner can move selection and share one highlight.
     let onHover: () -> Void
@@ -113,24 +129,18 @@ private struct ExtensionActionRow: View {
         .onHover { if $0 { onHover() } }
     }
 
+    /// A symbol is drawn here rather than handed to `ExtensionIconView`: the row's glyph is sized to
+    /// the menu's 20pt slot, which that view's own scale would shrink. Everything else it draws better.
     @ViewBuilder
     private var icon: some View {
-        switch item.icon {
-        case .symbol(let name):
+        if case .symbol(let name) = item.icon.source {
             Image(systemName: name)
                 .font(Theme.Typography.menuIcon)
-                .symbolRenderingMode(.hierarchical)
-                .foregroundStyle(item.isDestructive ? Color.red : Color.secondary)
+                .symbolRenderingMode(item.icon.tint == nil ? .hierarchical : .monochrome)
+                .foregroundStyle(item.icon.tint ?? Color.secondary)
                 .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
-        case .asset(let name):
-            Image(name)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .foregroundStyle(item.isDestructive ? Color.red : Color.secondary)
-                .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
-        case .file(let path):
-            ExtensionIconView(
-                resolved: ExtensionImage.Resolved(source: .file(path)), size: Theme.Size.menuIcon)
+        } else {
+            ExtensionIconView(resolved: item.icon, size: Theme.Size.menuIcon)
         }
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
@@ -12,19 +12,13 @@ private enum Metrics {
 }
 
 /// One row of a running command's ⌘K panel. Its own type, not `PopoverMenuItem`: an extension names
-/// any icon and tints it, and the palette's menu row carries neither.
+/// any icon and tints it, and the palette's menu row carries neither. Drawing only — a row's handler
+/// stays on `PaletteMenuContent`, so the panel and the keyboard fire the same one.
 struct ExtensionActionItem {
     let title: String
     let icon: ExtensionImage.Resolved
     var shortcut: String?
     var isDestructive = false
-    let action: () -> Void
-}
-
-/// A panel's header and rows, built once and consumed by render and keyboard alike.
-struct ExtensionActionsContent {
-    var header: String?
-    let items: [ExtensionActionItem]
 }
 
 /// The ⌘K panel of a running command. Not `PopoverMenu`: an extension's panel is long, so it scrolls.

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
@@ -50,6 +50,25 @@ struct ExtensionCommandScreen: PaletteScreen {
     /// through `ExtensionActionsMenu.content` and draws `ExtensionActionsPanel` instead of the menu.
     func actions(at selection: Int) -> PopoverMenuContent? { nil }
 
+    func menuContent(
+        at selection: Int, selection menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
+    ) -> PaletteMenuContent? {
+        guard
+            let content = ExtensionActionsMenu.content(
+                screen: screen, selection: selection, assetsPath: assetsPath, core: core)
+        else { return nil }
+        return PaletteMenuContent(
+            rowCount: content.items.count,
+            view: AnyView(
+                ExtensionActionsPanel(
+                    header: content.header, items: content.items, selection: menuSelection,
+                    onActivate: onActivate)),
+            activate: { index in
+                guard content.items.indices.contains(index) else { return }
+                content.items[index].action()
+            })
+    }
+
     func activate(at selection: Int) {
         guard let handler = primaryAction(at: selection)?.handler else { return }
         extensions.dispatch(handler: handler)

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
@@ -7,7 +7,6 @@ import SwiftUI
 struct ExtensionCommandScreen: PaletteScreen {
     let screen: ExtensionScreen
     let extensions: ExtensionManager
-    let core: AppCore
     let vm: PaletteState
     let openActions: () -> Void
 
@@ -46,26 +45,28 @@ struct ExtensionCommandScreen: PaletteScreen {
 
     func hasPrimaryAction(at selection: Int) -> Bool { primaryAction(at: selection) != nil }
 
-    /// Nil by design: a command's rows carry tinted, extension-owned icons, so the palette reads them
-    /// through `ExtensionActionsMenu.content` and draws `ExtensionActionsPanel` instead of the menu.
-    func actions(at selection: Int) -> PopoverMenuContent? { nil }
-
+    /// The whole menu rather than `actions(at:)`: a command's rows carry tinted, extension-owned
+    /// icons, and its panel scrolls — neither of which the palette's own menu row can express.
     func menuContent(
-        at selection: Int, selection menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
+        at selection: Int, menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
     ) -> PaletteMenuContent? {
-        guard
-            let content = ExtensionActionsMenu.content(
-                screen: screen, selection: selection, assetsPath: assetsPath, core: core)
-        else { return nil }
+        let actions = ExtensionScreen.actions(in: screen.actionPanel(forItemAt: selection))
+        guard !actions.isEmpty else { return nil }
+        let screen = screen
+        let assetsPath = assetsPath
+        let extensions = extensions
         return PaletteMenuContent(
-            rowCount: content.items.count,
-            view: AnyView(
-                ExtensionActionsPanel(
-                    header: content.header, items: content.items, selection: menuSelection,
-                    onActivate: onActivate)),
+            rowCount: actions.count,
+            view: {
+                AnyView(
+                    ExtensionActionsPanel(
+                        header: ExtensionActionsMenu.header(screen: screen, selection: selection),
+                        items: ExtensionActionsMenu.rows(actions, assetsPath: assetsPath),
+                        selection: menuSelection, onActivate: onActivate))
+            },
             activate: { index in
-                guard content.items.indices.contains(index) else { return }
-                content.items[index].action()
+                guard let handler = actions[index].handler else { return }
+                extensions.dispatch(handler: handler)
             })
     }
 

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
@@ -46,10 +46,9 @@ struct ExtensionCommandScreen: PaletteScreen {
 
     func hasPrimaryAction(at selection: Int) -> Bool { primaryAction(at: selection) != nil }
 
-    func actions(at selection: Int) -> PopoverMenuContent? {
-        ExtensionActionsMenu.content(
-            screen: screen, selection: selection, assetsPath: assetsPath, core: core)
-    }
+    /// Nil by design: a command's rows carry tinted, extension-owned icons, so the palette reads them
+    /// through `ExtensionActionsMenu.content` and draws `ExtensionActionsPanel` instead of the menu.
+    func actions(at selection: Int) -> PopoverMenuContent? { nil }
 
     func activate(at selection: Int) {
         guard let handler = primaryAction(at: selection)?.handler else { return }

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
@@ -156,40 +156,35 @@ struct ExtensionFeedbackOverlay: View {
     }
 }
 
-/// Actions menu content for the running command's current selection.
+/// The ⌘K panel's content for the running command's current selection.
 @MainActor
 enum ExtensionActionsMenu {
+    /// Rows carry a resolved `ExtensionImage` rather than a symbol name: an `Action`'s icon is an
+    /// `ImageLike`, so it can name any source and tint it, which `PopoverMenuItem` cannot express.
     static func content(
         screen: ExtensionScreen, selection: Int, assetsPath: String?, core: AppCore
-    ) -> PopoverMenuContent? {
+    ) -> ExtensionActionsContent? {
         let actions = ExtensionScreen.actions(in: screen.actionPanel(forItemAt: selection))
         guard !actions.isEmpty else { return nil }
         let header =
             screen.items.indices.contains(selection)
             ? screen.items[selection].node.string("title") : screen.navigationTitle
-        return PopoverMenuContent(
+        return ExtensionActionsContent(
             header: header,
             items: actions.map { action in
-                PopoverMenuItem(
+                ExtensionActionItem(
                     title: action.title,
-                    systemImage: symbolName(for: action),
-                    shortcut: action.shortcutCaps?.joined()
+                    icon: ExtensionImage.actionIcon(
+                        action.iconValue, assetsPath: assetsPath,
+                        // Read rather than injected: a panel is rebuilt each time it opens.
+                        isDark: NSApp.effectiveAppearance.isDark,
+                        isDestructive: action.isDestructive),
+                    shortcut: action.shortcutCaps?.joined(),
+                    isDestructive: action.isDestructive
                 ) {
                     guard let handler = action.handler else { return }
                     core.extensions.dispatch(handler: handler)
                 }
             })
-    }
-
-    /// The popover menu draws SF Symbols, so an extension icon resolves to one; a file-based icon falls
-    /// back to a neutral glyph rather than an empty slot.
-    private static func symbolName(for action: ExtensionAction) -> String {
-        // Read rather than injected: a menu is rebuilt each time it opens, so it never goes stale.
-        guard
-            let resolved = ExtensionImage.resolve(
-                action.iconValue, assetsPath: nil, isDark: NSApp.effectiveAppearance.isDark),
-            case .symbol(let name) = resolved.source
-        else { return action.isDestructive ? "trash" : "bolt" }
-        return name
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
@@ -159,32 +159,26 @@ struct ExtensionFeedbackOverlay: View {
 /// The ⌘K panel's content for the running command's current selection.
 @MainActor
 enum ExtensionActionsMenu {
+    /// What the panel belongs to: the selected row, or the screen when the selection has outrun it.
+    static func header(screen: ExtensionScreen, selection: Int) -> String? {
+        screen.items.indices.contains(selection)
+            ? screen.items[selection].node.string("title") : screen.navigationTitle
+    }
+
     /// Rows carry a resolved `ExtensionImage` rather than a symbol name: an `Action`'s icon is an
     /// `ImageLike`, so it can name any source and tint it, which `PopoverMenuItem` cannot express.
-    static func content(
-        screen: ExtensionScreen, selection: Int, assetsPath: String?, core: AppCore
-    ) -> ExtensionActionsContent? {
-        let actions = ExtensionScreen.actions(in: screen.actionPanel(forItemAt: selection))
-        guard !actions.isEmpty else { return nil }
-        let header =
-            screen.items.indices.contains(selection)
-            ? screen.items[selection].node.string("title") : screen.navigationTitle
-        return ExtensionActionsContent(
-            header: header,
-            items: actions.map { action in
-                ExtensionActionItem(
-                    title: action.title,
-                    icon: ExtensionImage.actionIcon(
-                        action.iconValue, assetsPath: assetsPath,
-                        // Read rather than injected: a panel is rebuilt each time it opens.
-                        isDark: NSApp.effectiveAppearance.isDark,
-                        isDestructive: action.isDestructive),
-                    shortcut: action.shortcutCaps?.joined(),
-                    isDestructive: action.isDestructive
-                ) {
-                    guard let handler = action.handler else { return }
-                    core.extensions.dispatch(handler: handler)
-                }
-            })
+    /// Called from the render path alone — resolving an icon per ↑/↓ would probe SF Symbols on main.
+    static func rows(_ actions: [ExtensionAction], assetsPath: String?) -> [ExtensionActionItem] {
+        actions.map { action in
+            ExtensionActionItem(
+                title: action.title,
+                icon: ExtensionImage.actionIcon(
+                    action.iconValue, assetsPath: assetsPath,
+                    // Read rather than injected: a panel is rebuilt each time it opens.
+                    isDark: NSApp.effectiveAppearance.isDark,
+                    isDestructive: action.isDestructive),
+                shortcut: action.shortcutCaps?.joined(),
+                isDestructive: action.isDestructive)
+        }
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -67,7 +67,8 @@ enum ExtensionImage {
         var icon =
             resolve(value, assetsPath: assetsPath, isDark: isDark)
             ?? Resolved(source: .symbol(isDestructive ? "trash" : "bolt"))
-        if isDestructive, icon.tint == nil { icon.tint = .red }
+        // Symbols only: a tint masks artwork, so reddening a delete row's own PNG would erase it.
+        if isDestructive, icon.tint == nil, case .symbol = icon.source { icon.tint = .red }
         return icon
     }
 

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -58,6 +58,19 @@ enum ExtensionImage {
         }
     }
 
+    /// An action row's glyph. Unlike a list row's, it always resolves to something: an action with no
+    /// usable icon draws a generic one rather than an empty slot, and a destructive action that named
+    /// no tint of its own takes red — the convention a native menu's delete row is drawn with.
+    static func actionIcon(
+        _ value: RenderValue?, assetsPath: String?, isDark: Bool, isDestructive: Bool
+    ) -> Resolved {
+        var icon =
+            resolve(value, assetsPath: assetsPath, isDark: isDark)
+            ?? Resolved(source: .symbol(isDestructive ? "trash" : "bolt"))
+        if isDestructive, icon.tint == nil { icon.tint = .red }
+        return icon
+    }
+
     /// A `{light, dark}` themed source picks the side the host is rendering, falling back to the
     /// other when an extension supplies only one.
     private static func string(from value: RenderValue?, isDark: Bool) -> String? {

--- a/Tinycast/Palette/PaletteScreen.swift
+++ b/Tinycast/Palette/PaletteScreen.swift
@@ -9,10 +9,13 @@ enum PaletteAxis {
 /// A menu supplied by a palette screen, including its rendering and row activation.
 @MainActor struct PaletteMenuContent {
     let rowCount: Int
-    let view: AnyView
+    /// Built on demand: `moveMenu` resolves the open menu on every arrow key, and only the render
+    /// path needs a view out of it.
+    let view: () -> AnyView
+    /// Bounds-checked by the caller against `rowCount`, so a row index is always one this menu has.
     let activate: (Int) -> Void
 
-    init(rowCount: Int, view: AnyView, activate: @escaping (Int) -> Void) {
+    init(rowCount: Int, view: @escaping () -> AnyView, activate: @escaping (Int) -> Void) {
         self.rowCount = rowCount
         self.view = view
         self.activate = activate
@@ -24,14 +27,13 @@ enum PaletteAxis {
     ) {
         self.init(
             rowCount: popover.items.count,
-            view: AnyView(
-                PopoverMenu(
-                    header: popover.header, items: popover.items, selection: selection,
-                    width: width, onActivate: onActivate)),
-            activate: { index in
-                guard popover.items.indices.contains(index) else { return }
-                popover.items[index].action()
-            })
+            view: {
+                AnyView(
+                    PopoverMenu(
+                        header: popover.header, items: popover.items, selection: selection,
+                        width: width, onActivate: onActivate))
+            },
+            activate: { popover.items[$0].action() })
     }
 }
 
@@ -44,9 +46,12 @@ enum PaletteAxis {
 
     /// False when the selection can't be acted on, which hides the footer pill and swallows ⌘K.
     func hasPrimaryAction(at selection: Int) -> Bool
+    /// The ⌘K rows as the palette's own menu, which is every screen but one; nil when there are none.
     func actions(at selection: Int) -> PopoverMenuContent?
+    /// The ⌘K menu whole, for a screen whose rows the palette's menu can't express. Defaults to
+    /// wrapping `actions(at:)`, so a screen implements one or the other, never both.
     func menuContent(
-        at selection: Int, selection: Binding<Int>, onActivate: @escaping (Int) -> Void
+        at selection: Int, menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
     ) -> PaletteMenuContent?
     func activate(at selection: Int)
     /// ⌘↵. False when the selection has no secondary action, leaving the key unhandled.
@@ -65,8 +70,9 @@ enum PaletteAxis {
 
 extension PaletteScreen {
     func hasPrimaryAction(at selection: Int) -> Bool { true }
+    func actions(at selection: Int) -> PopoverMenuContent? { nil }
     func menuContent(
-        at selection: Int, selection menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
+        at selection: Int, menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
     ) -> PaletteMenuContent? {
         guard let content = actions(at: selection) else { return nil }
         return PaletteMenuContent(

--- a/Tinycast/Palette/PaletteScreen.swift
+++ b/Tinycast/Palette/PaletteScreen.swift
@@ -6,6 +6,35 @@ enum PaletteAxis {
     case horizontal
 }
 
+/// A menu supplied by a palette screen, including its rendering and row activation.
+@MainActor struct PaletteMenuContent {
+    let rowCount: Int
+    let view: AnyView
+    let activate: (Int) -> Void
+
+    init(rowCount: Int, view: AnyView, activate: @escaping (Int) -> Void) {
+        self.rowCount = rowCount
+        self.view = view
+        self.activate = activate
+    }
+
+    init(
+        popover: PopoverMenuContent, selection: Binding<Int>, width: CGFloat = Theme.Size.menuWidth,
+        onActivate: @escaping (Int) -> Void
+    ) {
+        self.init(
+            rowCount: popover.items.count,
+            view: AnyView(
+                PopoverMenu(
+                    header: popover.header, items: popover.items, selection: selection,
+                    width: width, onActivate: onActivate)),
+            activate: { index in
+                guard popover.items.indices.contains(index) else { return }
+                popover.items[index].action()
+            })
+    }
+}
+
 /// One palette mode. `rows` is its single source of visible order, so selection indexes it.
 @MainActor protocol PaletteScreen {
     associatedtype Row: Identifiable
@@ -16,6 +45,9 @@ enum PaletteAxis {
     /// False when the selection can't be acted on, which hides the footer pill and swallows ⌘K.
     func hasPrimaryAction(at selection: Int) -> Bool
     func actions(at selection: Int) -> PopoverMenuContent?
+    func menuContent(
+        at selection: Int, selection: Binding<Int>, onActivate: @escaping (Int) -> Void
+    ) -> PaletteMenuContent?
     func activate(at selection: Int)
     /// ⌘↵. False when the selection has no secondary action, leaving the key unhandled.
     func secondary(at selection: Int) -> Bool
@@ -33,6 +65,13 @@ enum PaletteAxis {
 
 extension PaletteScreen {
     func hasPrimaryAction(at selection: Int) -> Bool { true }
+    func menuContent(
+        at selection: Int, selection menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
+    ) -> PaletteMenuContent? {
+        guard let content = actions(at: selection) else { return nil }
+        return PaletteMenuContent(
+            popover: content, selection: menuSelection, onActivate: onActivate)
+    }
     func pasteKeepingWindowOpen(at selection: Int) -> Bool { false }
     func move(_ delta: Int, axis: PaletteAxis, from selection: Int) -> Int? { nil }
     func headerAccessory(

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -118,6 +118,15 @@ struct RootPaletteView: View {
         return screen.actions(at: selection(in: screen))
     }
 
+    /// A running command's own ⌘K rows. Its own path rather than `actionsContent`: an extension's
+    /// action names any icon and tints it, which the palette's menu row deliberately cannot carry.
+    private var extensionActionsContent: ExtensionActionsContent? {
+        guard let command = screen as? ExtensionCommandScreen else { return nil }
+        return ExtensionActionsMenu.content(
+            screen: command.screen, selection: selection(in: command),
+            assetsPath: command.assetsPath, core: core)
+    }
+
     /// The clipboard type filter's rows; activating one is the only way the filter changes.
     private var clipboardFilterContent: PopoverMenuContent {
         PopoverMenuContent(
@@ -169,6 +178,15 @@ struct RootPaletteView: View {
         }
     }
 
+    /// Whichever menu is open, as bare row actions — all `moveMenu` and `activateMenuItem` need, and
+    /// the one place the extension panel and the palette's own menu have to agree on row order.
+    private var menuRowActions: [() -> Void] {
+        if openMenu == .actions, let content = extensionActionsContent {
+            return content.items.map(\.action)
+        }
+        return menuContent?.items.map(\.action) ?? []
+    }
+
     var body: some View {
         // Resolve the screen once per render, so the flat index can't drift from the rows.
         let screen = screen
@@ -216,14 +234,14 @@ struct RootPaletteView: View {
             }
         }
         .overlay(alignment: .bottomTrailing) {
-            if openMenu == .actions, let content = actionsContent {
+            if openMenu == .actions {
                 Group {
                     // An extension declares its own panel, which runs long enough to need scrolling.
-                    if vm.mode == .extensionCommand {
+                    if let content = extensionActionsContent {
                         ExtensionActionsPanel(
                             header: content.header, items: content.items, selection: $menuSelection,
                             onActivate: activateMenuItem)
-                    } else {
+                    } else if let content = actionsContent {
                         PopoverMenu(
                             header: content.header, items: content.items, selection: $menuSelection,
                             onActivate: activateMenuItem)
@@ -770,14 +788,16 @@ struct RootPaletteView: View {
 
     /// Move the open menu's highlight, clamped at the ends (no wrap — consistent with `move`).
     private func moveMenu(_ delta: Int) {
-        guard let count = menuContent?.items.count, count > 0 else { return }
+        let count = menuRowActions.count
+        guard count > 0 else { return }
         menuSelection = min(max(menuSelection + delta, 0), count - 1)
     }
 
     /// The one activation path for a menu row: run its action, then close.
     private func activateMenuItem(_ index: Int) {
-        guard let items = menuContent?.items, items.indices.contains(index) else { return }
-        items[index].action()
+        let actions = menuRowActions
+        guard actions.indices.contains(index) else { return }
+        actions[index]()
         closeMenus()
         // A mouse click on a row takes the caret with it; menus close back into the field.
         if argumentFocused == nil { searchFocused = true }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -85,8 +85,7 @@ struct RootPaletteView: View {
                 openActions: openActions)
         case .extensionCommand:
             return ExtensionCommandScreen(
-                screen: extensionScreen, extensions: extensions, core: core, vm: vm,
-                openActions: openActions)
+                screen: extensionScreen, extensions: extensions, vm: vm, openActions: openActions)
         }
     }
 
@@ -152,12 +151,15 @@ struct RootPaletteView: View {
         ])
     }
 
+    /// Whichever menu is open — the one source `moveMenu`, `activateMenuItem` and the overlays
+    /// address rows through, so no two of them can disagree about what a row index means.
     private var menuContent: PaletteMenuContent? {
         switch openMenu {
         case .actions:
             let screen = screen
             return screen.menuContent(
-                at: selection(in: screen), selection: $menuSelection, onActivate: activateMenuItem)
+                at: selection(in: screen), menuSelection: $menuSelection,
+                onActivate: activateMenuItem)
         case .app:
             return PaletteMenuContent(
                 popover: appMenuContent, selection: $menuSelection, onActivate: activateMenuItem)
@@ -210,14 +212,14 @@ struct RootPaletteView: View {
         }
         .overlay(alignment: .bottomLeading) {
             if openMenu == .app, let content = menuContent {
-                content.view
+                content.view()
                     .padding(Self.menuInset)
                     .transition(Self.menuTransition(.bottomLeading))
             }
         }
         .overlay(alignment: .bottomTrailing) {
             if openMenu == .actions, let content = menuContent {
-                content.view
+                content.view()
                     .padding(Self.menuInset)
                     .transition(Self.menuTransition(.bottomTrailing))
             }
@@ -225,7 +227,7 @@ struct RootPaletteView: View {
         // Header menus hang from their buttons rather than a panel corner.
         .overlay(alignment: .topTrailing) {
             if openMenu == .clipboardFilter || openMenu == .aiModel, let content = menuContent {
-                content.view
+                content.view()
                     .padding(.top, Theme.Size.headerPadding + Theme.Size.headerHeight)
                     // Right edges flush with the button's, which sits inside the same trailing gutter.
                     .padding(.trailing, Theme.Spacing.md * 2)
@@ -761,7 +763,7 @@ struct RootPaletteView: View {
 
     /// The one activation path for a menu row: run its action, then close.
     private func activateMenuItem(_ index: Int) {
-        guard let content = menuContent, index >= 0, index < content.rowCount else { return }
+        guard let content = menuContent, (0..<content.rowCount).contains(index) else { return }
         content.activate(index)
         closeMenus()
         // A mouse click on a row takes the caret with it; menus close back into the field.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -112,21 +112,6 @@ struct RootPaletteView: View {
 
     // MARK: - Popover menu content
 
-    /// The Actions menu for the current selection, or nil when it has no actions.
-    private var actionsContent: PopoverMenuContent? {
-        let screen = screen
-        return screen.actions(at: selection(in: screen))
-    }
-
-    /// A running command's own ⌘K rows. Its own path rather than `actionsContent`: an extension's
-    /// action names any icon and tints it, which the palette's menu row deliberately cannot carry.
-    private var extensionActionsContent: ExtensionActionsContent? {
-        guard let command = screen as? ExtensionCommandScreen else { return nil }
-        return ExtensionActionsMenu.content(
-            screen: command.screen, selection: selection(in: command),
-            assetsPath: command.assetsPath, core: core)
-    }
-
     /// The clipboard type filter's rows; activating one is the only way the filter changes.
     private var clipboardFilterContent: PopoverMenuContent {
         PopoverMenuContent(
@@ -167,24 +152,25 @@ struct RootPaletteView: View {
         ])
     }
 
-    /// Whichever menu is open — the one source `moveMenu` and `activateMenuItem` address rows through.
-    private var menuContent: PopoverMenuContent? {
+    private var menuContent: PaletteMenuContent? {
         switch openMenu {
-        case .actions: return actionsContent
-        case .app: return appMenuContent
-        case .clipboardFilter: return clipboardFilterContent
-        case .aiModel: return aiModelContent
+        case .actions:
+            let screen = screen
+            return screen.menuContent(
+                at: selection(in: screen), selection: $menuSelection, onActivate: activateMenuItem)
+        case .app:
+            return PaletteMenuContent(
+                popover: appMenuContent, selection: $menuSelection, onActivate: activateMenuItem)
+        case .clipboardFilter:
+            return PaletteMenuContent(
+                popover: clipboardFilterContent, selection: $menuSelection,
+                width: headerMenuWidth, onActivate: activateMenuItem)
+        case .aiModel:
+            return PaletteMenuContent(
+                popover: aiModelContent, selection: $menuSelection,
+                width: headerMenuWidth, onActivate: activateMenuItem)
         case nil: return nil
         }
-    }
-
-    /// Whichever menu is open, as bare row actions — all `moveMenu` and `activateMenuItem` need, and
-    /// the one place the extension panel and the palette's own menu have to agree on row order.
-    private var menuRowActions: [() -> Void] {
-        if openMenu == .actions, let content = extensionActionsContent {
-            return content.items.map(\.action)
-        }
-        return menuContent?.items.map(\.action) ?? []
     }
 
     var body: some View {
@@ -223,46 +209,27 @@ struct RootPaletteView: View {
                 .allowsHitTesting(menuOpen)
         }
         .overlay(alignment: .bottomLeading) {
-            if openMenu == .app {
-                let content = appMenuContent
-                PopoverMenu(
-                    header: content.header, items: content.items, selection: $menuSelection,
-                    onActivate: activateMenuItem
-                )
-                .padding(Self.menuInset)
-                .transition(Self.menuTransition(.bottomLeading))
+            if openMenu == .app, let content = menuContent {
+                content.view
+                    .padding(Self.menuInset)
+                    .transition(Self.menuTransition(.bottomLeading))
             }
         }
         .overlay(alignment: .bottomTrailing) {
-            if openMenu == .actions {
-                Group {
-                    // An extension declares its own panel, which runs long enough to need scrolling.
-                    if let content = extensionActionsContent {
-                        ExtensionActionsPanel(
-                            header: content.header, items: content.items, selection: $menuSelection,
-                            onActivate: activateMenuItem)
-                    } else if let content = actionsContent {
-                        PopoverMenu(
-                            header: content.header, items: content.items, selection: $menuSelection,
-                            onActivate: activateMenuItem)
-                    }
-                }
-                .padding(Self.menuInset)
-                .transition(Self.menuTransition(.bottomTrailing))
+            if openMenu == .actions, let content = menuContent {
+                content.view
+                    .padding(Self.menuInset)
+                    .transition(Self.menuTransition(.bottomTrailing))
             }
         }
         // Header menus hang from their buttons rather than a panel corner.
         .overlay(alignment: .topTrailing) {
-            if openMenu == .clipboardFilter || openMenu == .aiModel {
-                let content = openMenu == .aiModel ? aiModelContent : clipboardFilterContent
-                PopoverMenu(
-                    items: content.items, selection: $menuSelection,
-                    width: headerMenuWidth, onActivate: activateMenuItem
-                )
-                .padding(.top, Theme.Size.headerPadding + Theme.Size.headerHeight)
-                // Right edges flush with the button's, which sits inside the same trailing gutter.
-                .padding(.trailing, Theme.Spacing.md * 2)
-                .transition(Self.menuTransition(.topTrailing))
+            if openMenu == .clipboardFilter || openMenu == .aiModel, let content = menuContent {
+                content.view
+                    .padding(.top, Theme.Size.headerPadding + Theme.Size.headerHeight)
+                    // Right edges flush with the button's, which sits inside the same trailing gutter.
+                    .padding(.trailing, Theme.Spacing.md * 2)
+                    .transition(Self.menuTransition(.topTrailing))
             }
         }
         // The window's frame is the size source, so the glass and clip stay matched.
@@ -788,16 +755,14 @@ struct RootPaletteView: View {
 
     /// Move the open menu's highlight, clamped at the ends (no wrap — consistent with `move`).
     private func moveMenu(_ delta: Int) {
-        let count = menuRowActions.count
-        guard count > 0 else { return }
-        menuSelection = min(max(menuSelection + delta, 0), count - 1)
+        guard let content = menuContent, content.rowCount > 0 else { return }
+        menuSelection = min(max(menuSelection + delta, 0), content.rowCount - 1)
     }
 
     /// The one activation path for a menu row: run its action, then close.
     private func activateMenuItem(_ index: Int) {
-        let actions = menuRowActions
-        guard actions.indices.contains(index) else { return }
-        actions[index]()
+        guard let content = menuContent, index >= 0, index < content.rowCount else { return }
+        content.activate(index)
         closeMenus()
         // A mouse click on a row takes the caret with it; menus close back into the field.
         if argumentFocused == nil { searchFocused = true }

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -181,7 +181,8 @@ screens hold (see [palette.md](palette.md)).
   extension icon and keeps its `tintColor` — which is what makes a palette of `{Icon.Circle, tintColor}`
   rows read as colours rather than a column of grey circles. A destructive action with no tint of its
   own falls back to red. The first action is the primary ↵ action; an action's own `shortcut` is
-  matched against modified keystrokes.
+  matched against modified keystrokes. The panel is supplied through `PaletteMenuContent`, so the
+  palette does not know the extension's row type or ordering.
 - **Feedback** — `showToast` stacks above the footer, `showHUD` is a centred pill, and `confirmAlert`
   goes through `DialogController` like every other question the app asks. Its dialog sits at
   `.modalPanel`, above the palette's `.floating`, so a view command keeps its screen behind it — and

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -175,8 +175,13 @@ screens hold (see [palette.md](palette.md)).
 - **Form** — label-left/control-right rows. Field values live in the extension (React owns them); every
   edit dispatches `onTinycastChange` and the resulting re-render is what updates the control, so
   `defaultValue`, a controlled `value`, and `ref.reset()` all behave.
-- **ActionPanel** — flattened (sections and submenus included) into the palette's ⌘K menu. The first
-  action is the primary ↵ action; an action's own `shortcut` is matched against modified keystrokes.
+- **ActionPanel** — flattened (sections and submenus included) into `ExtensionActionsPanel`, the
+  feature's own scrolling ⌘K panel. Its rows are `ExtensionActionItem`, not `PopoverMenuItem`: an
+  action's `icon` is a full `ImageLike`, so it resolves through `ExtensionImage` like every other
+  extension icon and keeps its `tintColor` — which is what makes a palette of `{Icon.Circle, tintColor}`
+  rows read as colours rather than a column of grey circles. A destructive action with no tint of its
+  own falls back to red. The first action is the primary ↵ action; an action's own `shortcut` is
+  matched against modified keystrokes.
 - **Feedback** — `showToast` stacks above the footer, `showHUD` is a centred pill, and `confirmAlert`
   goes through `DialogController` like every other question the app asks. Its dialog sits at
   `.modalPanel`, above the palette's `.floating`, so a view command keeps its screen behind it — and

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -181,8 +181,10 @@ screens hold (see [palette.md](palette.md)).
   extension icon and keeps its `tintColor` — which is what makes a palette of `{Icon.Circle, tintColor}`
   rows read as colours rather than a column of grey circles. A destructive action with no tint of its
   own falls back to red. The first action is the primary ↵ action; an action's own `shortcut` is
-  matched against modified keystrokes. The panel is supplied through `PaletteMenuContent`, so the
-  palette does not know the extension's row type or ordering.
+  matched against modified keystrokes. `ExtensionCommandScreen.menuContent` hands the whole panel to
+  the palette as a `PaletteMenuContent`, so the palette never learns the row type — and a row's
+  handler is taken from the flattened `ExtensionAction` list rather than the drawn rows, so ↵ and the
+  panel fire the same one without resolving an icon per arrow key.
 - **Feedback** — `showToast` stacks above the footer, `showHUD` is a centred pill, and `confirmAlert`
   goes through `DialogController` like every other question the app asks. Its dialog sits at
   `.modalPanel`, above the palette's `.floating`, so a view command keeps its screen behind it — and

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -253,9 +253,10 @@ the arrow outside it, and AppKit's own alternation over the field came straight 
 structural instead of a pair of `onChange` handlers pushing each other closed. Three cases today —
 the ⌘K Actions menu (`.bottomTrailing`), the app menu (`.bottomLeading`) and the clipboard type
 filter (`.topTrailing`, hung under its header button). `menuContent` resolves the open case to one
-`PopoverMenuContent`, which is what lets ↑/↓, plain ↵, Esc and the click-away catcher serve every
-menu without knowing which is up. Every open path goes through `open(_:highlighting:)` and states
-where the highlight starts: the first row, except the type filter, which opens on the active filter.
+`PaletteMenuContent`, so each screen owns its menu rendering and row actions while ↑/↓, plain ↵, Esc
+and the click-away catcher stay in the palette. Every open path goes through `open(_:highlighting:)`
+and states where the highlight starts: the first row, except the type filter, which opens on the active
+filter.
 
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -253,10 +253,15 @@ the arrow outside it, and AppKit's own alternation over the field came straight 
 structural instead of a pair of `onChange` handlers pushing each other closed. Three cases today —
 the ⌘K Actions menu (`.bottomTrailing`), the app menu (`.bottomLeading`) and the clipboard type
 filter (`.topTrailing`, hung under its header button). `menuContent` resolves the open case to one
-`PaletteMenuContent`, so each screen owns its menu rendering and row actions while ↑/↓, plain ↵, Esc
-and the click-away catcher stay in the palette. Every open path goes through `open(_:highlighting:)`
-and states where the highlight starts: the first row, except the type filter, which opens on the active
-filter.
+`PaletteMenuContent` — a row count, a row action and a view built on demand — so ↑/↓, plain ↵, Esc and
+the click-away catcher serve every menu without knowing which is up. A screen supplies its rows as a
+`PopoverMenuContent` through `actions(at:)` and the default `menuContent` wraps them; a screen whose
+rows the palette's menu can't express overrides `menuContent` and hands over its own view instead —
+`ExtensionCommandScreen` is the only one, and the reason the seam exists (see
+[extensions.md](extensions.md)). The view is a closure because `moveMenu` resolves the open menu on
+every arrow key and needs the row count alone. Every open path goes through `open(_:highlighting:)`
+and states where the highlight starts: the first row, except the type filter, which opens on the
+active filter.
 
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.


### PR DESCRIPTION
## Related issue

None filed — hit it with the Hugeicons UI extension.

## What changed

An `Action`'s `icon` is a full `ImageLike`, so it can name a source and tint it — Hugeicons builds its colour picker from `{source: Icon.Circle, tintColor: Color.Red}` rows. The panel's rows were `PopoverMenuItem`, whose glyph is a bare `.symbol(name)` or `.file(path)` and carries no tint, so `ExtensionActionsMenu` pulled the SF Symbol name out of each resolved icon and dropped the rest. Every row painted `Color.secondary`: ten grey circles where Raycast shows ten colours.

Rows are `ExtensionActionItem` now, carrying a resolved `ExtensionImage`, so themed `{light, dark}` tints, raw hex and `mask` behave as they do in a list. It stays inside `Features/Extensions/` per `AGENTS.md` — duplicating `PopoverMenuItem`'s shape is what keeps it there.

`ExtensionImage.actionIcon` holds the two panel-only rules: an action with no usable icon draws a glyph rather than an empty slot, and a destructive one with no tint takes red. Red is symbols only — a tint masks artwork, so a destructive PNG would otherwise draw as a red silhouette.

Two smaller things: the resolve call passed `assetsPath: nil`, so an action naming a bundled asset got the generic bolt. And `ExtensionCommandScreen.actions(at:)` returns nil by design now, since a command's panel isn't expressible as `PopoverMenuContent` — `menuRowActions` is the one row order the panel, ↑/↓ and ↵ share.

## Demo
Before:
<img width="750" height="475" alt="file-a20e3022b8100e21a7c00bcbdee5537d" src="https://github.com/user-attachments/assets/67530bca-27a5-4da9-bf63-eea78fa9b3d4" />
After:
<img width="750" height="475" alt="file-50efead2624e5ef28effa33d8d5cb59a" src="https://github.com/user-attachments/assets/d1a4891f-f801-46fd-a72d-b54a2b7789b1" />
Raycast:
<img width="797" height="522" alt="image" src="https://github.com/user-attachments/assets/a1ab10ce-0e20-458d-bf7e-5b685c38c0fb" />


## Drawbacks

A tinted artwork icon is masked rather than recoloured. That matches Raycast and the existing list behaviour, but an extension tinting a multi-colour PNG loses its colours.

## Tests & validation

- `ext-test` gains `actionIconChecks` — tint kept, raw hex, a themed tint picking the right side, asset names, the destructive fallback, an explicit tint beating it, and destructive artwork staying untinted. Needs `ExtensionImage` in the harness's source list.
- All 39 harnesses pass, Debug builds with no new warnings, `lint.sh` clean.
- Ran the installed Hugeicons bundle through the harness: `Red #FF4245`, `Orange #FF9230`, `Green #30D158` — distinct where they were one grey.
