### PR TITLE
Open the join preview on a live camera, and drop finished events from the launcher

### DIFF
--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -145,8 +145,16 @@ struct CalendarTests {
             event(id: "allday", start: 30, isAllDay: true),
             event(id: "declined", start: 30, isDeclined: true)
         ]
-        let agenda = UpcomingWindow.agenda(from: events)
+        let agenda = UpcomingWindow.agenda(from: events, now: at(0))
         expect(agenda.map(\.id) == ["early", "late"], "the agenda is timed, accepted and in start order")
+
+        let over = event(id: "over", start: 0, minutes: 30)
+        expect(
+            UpcomingWindow.agenda(from: [over], now: at(30)).isEmpty,
+            "a meeting is off the agenda the moment it ends, the way it leaves the menu bar")
+        expect(
+            UpcomingWindow.agenda(from: [over], now: at(29)).map(\.id) == ["over"],
+            "one still running stays, however long ago it started")
     }
 
     static func cardWindow() {
@@ -179,7 +187,7 @@ struct CalendarTests {
             window.carded(from: [linkless], now: start) == nil,
             "a meeting with no link is never carded")
         expect(
-            UpcomingWindow.agenda(from: [linkless]).map(\.id) == ["linkless"],
+            UpcomingWindow.agenda(from: [linkless], now: start).map(\.id) == ["linkless"],
             "but it stays on the agenda, so it is still listed and searchable")
     }
 

--- a/Tinycast/DesignSystem/Interaction/PanelTransition.swift
+++ b/Tinycast/DesignSystem/Interaction/PanelTransition.swift
@@ -21,8 +21,9 @@ extension NSWindow {
         }
     }
 
-    /// Safe to interrupt: the handler checks opacity, so `cancelFade` can rescue it.
-    func fadeOut(duration: TimeInterval) {
+    /// Safe to interrupt: the handler checks opacity, so `cancelFade` can rescue it. `done` runs
+    /// once the panel is actually off screen, which is where teardown the user can see belongs.
+    func fadeOut(duration: TimeInterval, done: (@MainActor () -> Void)? = nil) {
         NSAnimationContext.runAnimationGroup { context in
             context.duration = duration
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
@@ -31,6 +32,7 @@ extension NSWindow {
             MainActor.assumeIsolated {
                 guard let self, self.alphaValue == 0 else { return }
                 self.orderOut(nil)
+                done?()
             }
         }
     }

--- a/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
+++ b/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
@@ -13,7 +13,7 @@ struct MenuBarSummary: Sendable {
 
     /// The earliest event still inside its window, so one hiding hands the space to the next.
     func event(from events: [MeetingEvent], now: Date) -> MeetingEvent? {
-        UpcomingWindow.agenda(from: events).first {
+        UpcomingWindow.agenda(from: events, now: now).first {
             (!linkedOnly || $0.link != nil) && now >= $0.start - lead && now < hidesAt($0)
         }
     }

--- a/Tinycast/Features/Calendar/Model/UpcomingWindow.swift
+++ b/Tinycast/Features/Calendar/Model/UpcomingWindow.swift
@@ -6,18 +6,18 @@ struct UpcomingWindow: Sendable {
 
     private var lead: TimeInterval { TimeInterval(leadMinutes * 60) }
 
-    /// The events any surface may show: timed, not declined, in start order. The one place that
-    /// rule lives, so the card, the chord, the schedule and the launcher cannot drift apart.
-    static func agenda(from events: [MeetingEvent]) -> [MeetingEvent] {
+    /// The events any surface may show: timed, not declined, not over, in start order. The one
+    /// place that rule lives, so the card, the chord, the schedule and the launcher cannot drift.
+    static func agenda(from events: [MeetingEvent], now: Date) -> [MeetingEvent] {
         events
-            .filter { !$0.isAllDay && !$0.isDeclined }
+            .filter { !$0.isAllDay && !$0.isDeclined && $0.end > now }
             .sorted { $0.start < $1.start }
     }
 
     /// The card's meeting: `now` inside `[start - lead, min(start + lead, end)]`, and joinable.
     /// The grace period never outlives the meeting, so a three-minute stand-up clears at its end.
     func carded(from events: [MeetingEvent], now: Date) -> MeetingEvent? {
-        Self.agenda(from: events).first {
+        Self.agenda(from: events, now: now).first {
             $0.link != nil && now >= $0.start - lead && now < min($0.start + lead, $0.end)
         }
     }
@@ -26,7 +26,7 @@ struct UpcomingWindow: Sendable {
     /// screen, then anything running, then the next one with a link.
     func joinable(from events: [MeetingEvent], now: Date) -> MeetingEvent? {
         if let carded = carded(from: events, now: now) { return carded }
-        let linked = Self.agenda(from: events).filter { $0.link != nil }
+        let linked = Self.agenda(from: events, now: now).filter { $0.link != nil }
         return linked.first { $0.isInProgress(now: now) } ?? linked.first { $0.start > now }
     }
 

--- a/Tinycast/Features/Calendar/Service/CameraPreviewSession.swift
+++ b/Tinycast/Features/Calendar/Service/CameraPreviewSession.swift
@@ -1,53 +1,52 @@
 import AVFoundation
 
 /// The capture session behind the join preview. `AVCaptureSession` is not `Sendable`, so it stays
-/// main-actor isolated; only `startRunning` — which blocks — goes off.
+/// main-actor isolated; only `startRunning` and `stopRunning` — which block — go off.
 @MainActor
-@Observable
 final class CameraPreviewSession {
-    private(set) var access: CameraAccess = Permissions.cameraAccess()
-    /// False when the Mac has no camera at all, which reads differently from a refused one.
-    private(set) var hasCamera = true
+    /// What the preview has to show, settled before the panel opens so it never renders a stage it
+    /// would have to swap out from under the user.
+    enum Feed {
+        case live(AVCaptureSession)
+        case denied
+        case noCamera
+    }
 
-    @ObservationIgnored private(set) var session: AVCaptureSession?
+    private var capture: AVCaptureSession?
 
-    /// Asks the first time and configures once; the grant is process-wide after that.
-    func start() async {
-        access = Permissions.cameraAccess()
+    /// Asks the first time and configures once; the grant is process-wide after that. Blocking on
+    /// `startRunning` is the point: the caller's first frame is video rather than black.
+    func start() async -> Feed {
+        var access = Permissions.cameraAccess()
         if access == .notDetermined {
             _ = await Permissions.requestCameraAccess()
             access = Permissions.cameraAccess()
         }
-        guard access == .granted else { return }
-        guard let session = session ?? configure() else { return }
-        self.session = session
-        guard !session.isRunning else { return }
-        let box = CaptureBox(session: session)
+        guard access == .granted else { return .denied }
+        guard let capture = capture ?? configure() else { return .noCamera }
+        self.capture = capture
+        guard !capture.isRunning else { return .live(capture) }
+        let box = CaptureBox(session: capture)
         await Task.detached { box.session.startRunning() }.value
+        return .live(capture)
     }
 
     func stop() {
-        guard let session, session.isRunning else { return }
+        guard let capture, capture.isRunning else { return }
         // The camera light must go out with the panel, so this is never left to deallocation.
-        let box = CaptureBox(session: session)
+        let box = CaptureBox(session: capture)
         Task.detached { box.session.stopRunning() }
     }
 
     private func configure() -> AVCaptureSession? {
         guard let device = AVCaptureDevice.default(for: .video),
             let input = try? AVCaptureDeviceInput(device: device)
-        else {
-            hasCamera = false
-            return nil
-        }
-        let session = AVCaptureSession()
-        session.sessionPreset = .medium
-        guard session.canAddInput(input) else {
-            hasCamera = false
-            return nil
-        }
-        session.addInput(input)
-        return session
+        else { return nil }
+        let capture = AVCaptureSession()
+        capture.sessionPreset = .medium
+        guard capture.canAddInput(input) else { return nil }
+        capture.addInput(input)
+        return capture
     }
 }
 

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -45,8 +45,9 @@ final class CalendarCoordinator {
         return window.carded(from: store.events, now: clock.now)
     }
 
-    /// Today and tomorrow, timed and accepted, in start order.
-    var agenda: [MeetingEvent] { UpcomingWindow.agenda(from: store.events) }
+    /// Today and tomorrow, timed, accepted and not over yet, in start order. Live rather than
+    /// clock-driven: this publishes a snapshot, and a chord reads it with nothing ticking.
+    var agenda: [MeetingEvent] { UpcomingWindow.agenda(from: store.events, now: Date()) }
 
     /// The event the menu bar carries, or nil for the plain icon.
     var menuBarEvent: MeetingEvent? {
@@ -127,8 +128,10 @@ final class CalendarCoordinator {
     }
 
     /// One minute's worth of work: keep the snapshot honest, then see if anything should open.
+    /// An event ending changes nothing in EventKit, so the republish is what drops it.
     private func minuteDidPass() {
         store.reloadIfStale(now: clock.now)
+        publishEntries()
         autoJoinIfDue()
     }
 
@@ -174,6 +177,8 @@ final class CalendarCoordinator {
         paletteVisible = true
         applyClock()
         guard settings.calendarEnabled else { return }
+        // Meetings end while the palette is closed, and with no clock nothing republished them.
+        publishEntries()
         // Off the summon path: the card is observation-driven, so it can land a frame later.
         Task { store.reload() }
     }

--- a/Tinycast/Features/Calendar/UI/CameraPreviewController.swift
+++ b/Tinycast/Features/Calendar/UI/CameraPreviewController.swift
@@ -7,22 +7,25 @@ final class CameraPreviewController: NSObject, NSWindowDelegate {
     private let session = CameraPreviewSession()
     private var panel: CameraPreviewPanel?
     private var continuation: CheckedContinuation<Bool, Never>?
+    /// Held across the camera warm-up too, so a chord repeating into it cannot stack previews.
+    private var presenting = false
 
-    /// True when the user took the join. Guarded on the continuation, so a held chord cannot
-    /// stack previews — the second call answers false rather than opening a second camera.
+    /// True when the user took the join. The camera settles first: a panel opened over a session
+    /// still starting shows a black stage, and the TCC prompt would take key and cancel the join.
     func present(meeting: MeetingEvent, now: Date) async -> Bool {
-        guard continuation == nil else { return false }
-        let taken = await withCheckedContinuation { continuation in
+        guard !presenting else { return false }
+        presenting = true
+        defer { presenting = false }
+        let feed = await session.start()
+        return await withCheckedContinuation { continuation in
             self.continuation = continuation
-            show(meeting: meeting, now: now)
+            show(meeting: meeting, now: now, feed: feed)
         }
-        session.stop()
-        return taken
     }
 
-    private func show(meeting: MeetingEvent, now: Date) {
+    private func show(meeting: MeetingEvent, now: Date, feed: CameraPreviewSession.Feed) {
         let view = CameraPreviewView(
-            meeting: meeting, now: now, session: session,
+            meeting: meeting, now: now, feed: feed,
             onJoin: { [weak self] in self?.finish(true) },
             onCancel: { [weak self] in self?.finish(false) })
         let hosting = NSHostingView(rootView: view)
@@ -37,8 +40,6 @@ final class CameraPreviewController: NSObject, NSWindowDelegate {
             panel.makeKeyAndOrderFront(nil)
             panel.orderFrontRegardless()
         }
-        // The prompt, if there is one to raise, comes from this gesture and nowhere else.
-        Task { await session.start() }
     }
 
     private func finish(_ taken: Bool) {
@@ -49,7 +50,12 @@ final class CameraPreviewController: NSObject, NSWindowDelegate {
         closing?.delegate = nil
         closing?.onKey = nil
         continuation.resume(returning: taken)
-        closing?.fadeOut(duration: Theme.Duration.exit)
+        // The camera goes with the panel, not before it: tearing it down mid-fade blanks the feed.
+        closing?.fadeOut(duration: Theme.Duration.exit) { [weak self] in
+            // Unless a preview raised inside the fade already owns the camera.
+            guard let self, !presenting else { return }
+            session.stop()
+        }
     }
 
     private func place(_ panel: NSPanel) {

--- a/Tinycast/Features/Calendar/UI/CameraPreviewView.swift
+++ b/Tinycast/Features/Calendar/UI/CameraPreviewView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct CameraPreviewView: View {
     let meeting: MeetingEvent
     let now: Date
-    let session: CameraPreviewSession
+    let feed: CameraPreviewSession.Feed
     let onJoin: () -> Void
     let onCancel: () -> Void
 
@@ -26,19 +26,26 @@ struct CameraPreviewView: View {
 
     @ViewBuilder
     private var stage: some View {
-        if let capture = session.session {
+        switch feed {
+        case .live(let capture):
             CameraFeed(session: capture)
-        } else {
-            VStack(spacing: Theme.Spacing.md) {
-                SymbolImage(name: "video.slash", size: Theme.Size.dialogIcon)
-                Text(unavailableMessage)
-                    .font(Theme.Typography.rowTrailing)
-                    .multilineTextAlignment(.center)
-            }
-            .foregroundStyle(Theme.Colors.textSecondary)
-            .padding(Theme.Spacing.xxl)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .denied:
+            unavailable("Tinycast has no access to the camera.")
+        case .noCamera:
+            unavailable("No camera on this Mac.")
         }
+    }
+
+    private func unavailable(_ message: String) -> some View {
+        VStack(spacing: Theme.Spacing.md) {
+            SymbolImage(name: "video.slash", size: Theme.Size.dialogIcon)
+            Text(message)
+                .font(Theme.Typography.rowTrailing)
+                .multilineTextAlignment(.center)
+        }
+        .foregroundStyle(Theme.Colors.textSecondary)
+        .padding(Theme.Spacing.xxl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var footer: some View {
@@ -57,14 +64,6 @@ struct CameraPreviewView: View {
         }
         .padding(Theme.Spacing.xl)
     }
-
-    private var unavailableMessage: String {
-        switch session.access {
-        case .denied: return "Tinycast has no access to the camera."
-        case .notDetermined, .granted:
-            return session.hasCamera ? "Starting the camera…" : "No camera on this Mac."
-        }
-    }
 }
 
 /// The one place `AVCaptureVideoPreviewLayer` is hosted; everything around it is Tinycast's own.
@@ -72,16 +71,20 @@ private struct CameraFeed: NSViewRepresentable {
     let session: AVCaptureSession
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        view.wantsLayer = true
         let preview = AVCaptureVideoPreviewLayer(session: session)
         preview.videoGravity = .resizeAspectFill
+        let view = NSView()
+        // Layer-hosting, not layer-backed: set before `wantsLayer`, so AppKit never replaces it.
         view.layer = preview
+        view.wantsLayer = true
         return view
     }
 
+    /// Reassigning the session rebuilds the preview connection, which blanks the layer for a frame.
     func updateNSView(_ view: NSView, context: Context) {
-        (view.layer as? AVCaptureVideoPreviewLayer)?.session = session
+        guard let preview = view.layer as? AVCaptureVideoPreviewLayer, preview.session !== session
+        else { return }
+        preview.session = session
     }
 }
 

--- a/Tinycast/Features/Calendar/UI/ScheduleScreen.swift
+++ b/Tinycast/Features/Calendar/UI/ScheduleScreen.swift
@@ -10,7 +10,7 @@ struct ScheduleScreen: PaletteScreen {
 
     var rows: [MeetingEvent] {
         let query = vm.query.trimmingCharacters(in: .whitespaces)
-        let agenda = UpcomingWindow.agenda(from: store.events)
+        let agenda = UpcomingWindow.agenda(from: store.events, now: clock.now)
         guard !query.isEmpty else { return agenda }
         return agenda.filter {
             $0.title.localizedCaseInsensitiveContains(query)

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -16,15 +16,21 @@ events as searchable launcher entries.
 - **Auto join fires at most once per meeting per launch**, and only for a meeting starting at or
   after the moment the switch was armed. Both are why `AutoJoinPolicy` takes `armedAt` and the
   already-joined set rather than reading a clock of its own.
-- **The camera stops with the panel.** `CameraPreviewSession.stop()` runs on every exit path, so the
-  camera light never outlives the preview.
+- **The camera settles before the panel opens, and stops after it closes.**
+  `CameraPreviewSession.start()` resolves access and blocks on `startRunning` first, then hands
+  `CameraPreviewController` a settled `Feed` — so the panel's first frame is live video rather than a
+  stage it has to swap out, and the TCC prompt never takes key from a panel already up.
+  `stop()` runs from the fade-out's completion, so the camera light never outlives the preview but
+  is never torn down under a visible one either.
 - **The card's window is `[start - lead, min(start + lead, end)]`.** The grace period exists because
   everyone joins late; the `min` is why it never outlives a meeting shorter than the lead.
 - **Recurrence comes from `predicateForEvents(withStart:end:calendars:)`**, which expands occurrences
   itself. Masters are never fetched and recurrence is never hand-rolled.
 - **`UpcomingWindow.agenda` is the only place that says which events count** — timed, not declined,
-  in start order. The card, the chord, the schedule and the launcher slice all go through it, so they
-  cannot drift apart.
+  not over, in start order. The card, the chord, the menu bar, the schedule and the launcher slice all
+  go through it, so they cannot drift apart. Because an event ending changes nothing in EventKit,
+  the filter alone is not enough for the launcher slice: `CalendarCoordinator` republishes it on the
+  minute boundary and on every summon.
 - **`calendarEnabled` doubles as consent**, so it is in `SettingsBackupCoverage.deliberatelyExcluded`
   and only `CalendarCoordinator.setCalendarEnabled` may write it. Tinycast's own dialog comes first,
   the macOS prompt second, and only from the gesture that asked.
@@ -132,8 +138,8 @@ calendars.
 shares one identifier across every instance. `calendarItemID` is kept separately: it is the only
 handle `ical://ekevent/…` accepts, and a recurring occurrence opens its series.
 
-A cancelled event never reaches a surface. A declined one is dropped by `agenda`, and an all-day one
-with it.
+A cancelled event never reaches a surface. A declined one is dropped by `agenda`, and an all-day or
+already-finished one with it.
 
 ## The menu bar
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -375,8 +375,11 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Hide Current Event on Automatically clears the entry at the start and hands the space to the next
   event inside its lead time; on 5 minutes it lingers counting up, then clears
 - Clicking the menu bar item opens the menu with `Join <title>` on top — a bare click never joins
-- Camera Preview on: ↵ on the join card opens the panel, ↵ joins, Esc drops the join; the camera
-  light goes out with the panel, and the first run prompts once
+- Camera Preview on: ↵ on the join card opens the panel **already showing live video** — no black
+  frame, no blank mid-preview; ↵ joins, Esc drops the join; the camera light goes out with the
+  panel, and the first run prompts once, before any panel appears
+- A meeting that ends leaves the launcher results and `My Schedule` on the same minute boundary it
+  leaves the menu bar, with the palette open or closed over the end
 - Auto Join on: the meeting opens itself at its start, **once** — dismiss it and it does not return.
   With confirm on and camera preview off, the dialog asks first
 - Arming Auto Join during a meeting already under way joins nothing


### PR DESCRIPTION
## Related issue

Closes #348

> **Scope note:** this covers items 1 and 2 of #348. Item 3 — `Open in Calendar` on a meeting
> **launcher entry**, which falls through to `AppActionsMenu` instead of `MeetingActionsMenu` — is
> not in here. Worth splitting into its own issue before merging this one closed.

## What changed

### The join preview flickered (#348, item 2)

Four defects stacked on the same 300 ms:

- **The panel opened before the camera ran.** `show()` faded the panel in and *then* kicked off
  `Task { await session.start() }`. `startRunning` blocks for a few hundred milliseconds, so the
  panel was always fully visible over an empty stage first, with the feed popping in afterwards.
- **The stage branched on state nothing observed.** It read `session.session`, which was
  `@ObservationIgnored`. The placeholder→feed swap happened only because `start()` re-assigned
  `access` and `@Observable` fires on every set, unchanged value or not — an accident holding up
  the one transition the user actually sees.
- **`updateNSView` rebuilt the preview connection on every update.** `preview.session = session`
  ran unconditionally, and that setter tears down and re-establishes the connection, blanking the
  layer. It fired at least twice per present (the `access` mutation, then `PanelEntrance.appeared`)
  — this is the blank that lands *after* frames are already flowing.
- **The hosting view was layer-backed, not layer-hosting.** `wantsLayer` was set before
  `view.layer`, the opposite of the order [`NSView.layer`](https://developer.apple.com/documentation/appkit/nsview/layer)
  documents for a custom layer. AppKit owns the layer that way, may replace it, and applies
  implicit animations to its bounds.

`CameraPreviewSession` now resolves access, configures and blocks on `startRunning` **before**
anything is shown, then hands back a settled `Feed` — `.live` / `.denied` / `.noCamera`. The panel's
first frame is live video, the view is a pure function of one value, and `@Observable` goes with the
three fields it published. `Starting the camera…` is unreachable and deleted.

Two consequences fall out of the same shape:

- `requestCameraAccess()` ran from `start()` **after** the panel was up, so on a first join the TCC
  prompt took key, `windowDidResignKey` fired, and the join was **silently dropped**. The prompt now
  comes first.
- `session.stop()` ran the instant the user answered, tearing the camera down under a still-visible
  panel. It now runs from a new `fadeOut(duration:done:)` completion — the symmetric twin of the
  closure `fadeIn` already takes — skipped when a preview raised inside the fade already owns the
  camera. The two existing `fadeOut` callers take the default and are untouched, and `cancelFade()`
  is HUD-only, so the rescue path can never strand a running camera.

### A finished event stayed in the launcher (#348, item 1)

`UpcomingWindow.agenda` is documented as *the* place that says which events count, but it had no
notion of `now` — so an event that ended an hour ago was still "timed, not declined". It now takes
one and filters `end > now`. Every caller already had a `now` in hand, and **none of them change
behaviour**: `carded`, `joinable` and `MenuBarSummary` already excluded finished events with their
own predicates, which is exactly why the menu bar was right and nothing else was.

The filter alone isn't enough for the launcher slice, because those entries are a *published
snapshot*: `CalendarStore.publish` short-circuits on an unchanged array, and an event ending changes
nothing in EventKit. So `CalendarCoordinator` republishes on the minute boundary and on every summon
— the second matters because with the menu bar and auto join both off, no clock runs at all while
the palette is closed.

## Memory footprint

<!-- NOT MEASURED — author to fill in before merge. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

No new long-lived state: `CameraPreviewSession` loses three stored properties and its `@Observable`
conformance, and the `AVCaptureSession` it caches for reuse is unchanged from before. The one new
closure (`fadeOut`'s `done:`) captures `self` weakly.

## Demo

<!-- NOT RECORDED — author to attach a side-by-side before/after of the join preview. -->

## Drawbacks

**The panel now appears ~200–500 ms after ↵ rather than immediately**, because it waits on
`startRunning`. This was a deliberate choice over the alternative — opening instantly on a stable
stage and cross-fading the video in — because waiting *deletes* the swap rather than animating over
it: no Observation, no second animation on top of the window fade, and the view becomes a pure
function of one settled value. The palette dismissing is the immediate feedback that ↵ registered.
If the delay reads badly in practice, the cross-fade is the fallback.

`My Schedule` now also drops a meeting when it ends, which follows from `agenda` being one rule
rather than several. That is beyond what #348 asked for, but the alternative is a second rule.

## Tests & validation

- `./Scripts/run-tests.sh` — all 45 harnesses pass.
- `Tests/calendar-test.swift` (`agendaFiltering`) gains two cases: a meeting is off the agenda the
  moment it ends, and one still running stays however long ago it started. Existing `agenda(from:)`
  call sites in `agendaFiltering` / `cardWindow` take the new `now:`.
- Debug build: no new warnings. `./Scripts/lint.sh`: clean. The `Model/` AppKit/SwiftUI grep from
  `AGENTS.md` still returns nothing.

**Not yet exercised by hand** — the flicker is presentation code no harness reaches, so these were
read out of the code rather than watched on screen:

- [ ] `tccutil reset Camera com.tinycast.app.dev`, then join from the launcher: the prompt appears
      **before** any panel, and granting completes the join rather than dropping it.
- [ ] Second and third joins in the same launch: the panel fades in already showing video — no
      `Starting the camera…`, no black frame, no mid-life blank.
- [ ] ↵ to join: video stays up through the fade, and the camera light goes out as the panel leaves.
- [ ] A 3-minute event that ends leaves the launcher results and `My Schedule` on the same minute
      boundary it leaves the menu bar, with the palette open and closed over the end.
