### PR TITLE
Ring Tab through launcher, chat and clipboard, back chat out on Escape, and let Pop to Root end a conversation

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -127,6 +127,9 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
 run palette-escape-test    Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteEscapeAction.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift
+run palette-tab-test       Tinycast/Palette/PaletteMode.swift \
+                           Tinycast/Palette/PaletteTabAction.swift \
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
                            Tinycast/Features/HotKeys/Model/HyperKey.swift \

--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -50,7 +50,19 @@ struct PaletteEscapeTests {
         expect(
             PaletteEscapeAction.resolve(menuOpen: false, query: "why is the sky", mode: .ai),
             .clearQuery,
-            "an unsent chat draft clears before the palette hides")
+            "an unsent chat draft clears before chat itself is left")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .ai),
+            .exitToLauncher,
+            "an empty composer backs chat out to the launcher rather than hiding the palette")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .clipboard),
+            .hidePalette,
+            "only chat backs out; an empty clipboard filter still hides the palette")
+        expect(
+            PaletteEscapeAction.resolve(menuOpen: true, query: "", mode: .ai),
+            .closeMenu,
+            "a menu outranks the chat screen it is drawn over")
         expect(
             PaletteEscapeAction.resolve(menuOpen: true, query: "", mode: .extensionCommand),
             .closeMenu,

--- a/Tests/palette-tab-test.swift
+++ b/Tests/palette-tab-test.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Drives Tab's ring, so the three surfaces stay reachable in one direction and a chat draft never
+/// arrives in a list that would search it. Chat is skipped whole when the feature is turned off.
+@main
+@MainActor
+struct PaletteTabTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ actual: PaletteTabAction, _ expected: PaletteTabAction, _ message: String) {
+        if actual == expected {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message) — got \(actual), want \(expected)")
+        }
+    }
+
+    static func main() {
+        expect(
+            PaletteTabAction.resolve(mode: .launcher, aiEnabled: true),
+            .freshScreen(.ai),
+            "the launcher opens chat, and a search query is not seeded as a draft")
+        expect(
+            PaletteTabAction.resolve(mode: .ai, aiEnabled: true),
+            .freshScreen(.clipboard),
+            "chat hands on to the clipboard without carrying the unsent draft into the filter")
+        expect(
+            PaletteTabAction.resolve(mode: .clipboard, aiEnabled: true),
+            .carryQuery(.launcher),
+            "the clipboard closes the ring, and one search narrows both lists")
+
+        // Off, chat has no launcher command and no hotkey; the ring must not strand a reader there.
+        expect(
+            PaletteTabAction.resolve(mode: .launcher, aiEnabled: false),
+            .carryQuery(.clipboard),
+            "turned off, chat is skipped and the launcher flips straight to the clipboard")
+        expect(
+            PaletteTabAction.resolve(mode: .clipboard, aiEnabled: false),
+            .carryQuery(.launcher),
+            "turned off, the clipboard still returns to the launcher")
+
+        // A sub-screen is reached by a command or a hotkey, so Tab leaves rather than ringing on.
+        for mode in [PaletteMode.aiHistory, .emoji, .fileSearch, .calculatorHistory, .quicklinks] {
+            expect(
+                PaletteTabAction.resolve(mode: mode, aiEnabled: true),
+                .carryQuery(.launcher),
+                "\(mode.rawValue) is a sub-screen, so Tab exits to the launcher")
+        }
+
+        expect(
+            PaletteTabAction.resolve(mode: .extensionCommand, aiEnabled: true),
+            .carryQuery(.launcher),
+            "an extension command exits to the launcher rather than joining the ring")
+
+        // Three presses from the launcher have to land back on it, or the ring is a dead end.
+        var mode = PaletteMode.launcher
+        var visited: [PaletteMode] = []
+        for _ in 0..<3 {
+            switch PaletteTabAction.resolve(mode: mode, aiEnabled: true) {
+            case .carryQuery(let next), .freshScreen(let next): mode = next
+            }
+            visited.append(mode)
+        }
+        if visited == [.ai, .clipboard, .launcher] {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: three presses ring back to the launcher — got \(visited)")
+        }
+
+        var offMode = PaletteMode.launcher
+        var offVisited: [PaletteMode] = []
+        for _ in 0..<2 {
+            switch PaletteTabAction.resolve(mode: offMode, aiEnabled: false) {
+            case .carryQuery(let next), .freshScreen(let next): offMode = next
+            }
+            offVisited.append(offMode)
+        }
+        if offVisited == [.clipboard, .launcher] {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: turned off, two presses ring back to the launcher — got \(offVisited)")
+        }
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		3B02D6CE68E0E488955A19B5 /* SnippetTemplateEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58E564E6181EB15497E51CD /* SnippetTemplateEngine.swift */; };
 		3B0A75B76B65E651BCB97D71 /* CameraPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEBAA9641BC6C279DB0123C /* CameraPreviewController.swift */; };
 		3BC6CC35889FFC77D640C7CA /* SnippetsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2EF66267B0141279A43613 /* SnippetsSettingsView.swift */; };
+		3C2812B921530D45B802B44C /* PaletteTabAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B107F5E532C8DE74430723B /* PaletteTabAction.swift */; };
 		3C30FB1AD99237898B4401C7 /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7DC9AD5E54C26387F29F6 /* MarkdownView.swift */; };
 		3D56F518ABEF5851534A710C /* AISettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C975F928132D3DAB1BB569F0 /* AISettingsStore.swift */; };
 		3DAB1821040DCA295BEB4437 /* AICommandSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ABB8CDB1469F8755B12567 /* AICommandSection.swift */; };
@@ -620,6 +621,7 @@
 		9A7F606D7F71B6FC0CC6ABC8 /* UninstallScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallScanner.swift; sourceTree = "<group>"; };
 		9AAFBFA70EF62B67F7357E0E /* UninstallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallCoordinator.swift; sourceTree = "<group>"; };
 		9ADAA05D695590C4B654E5BF /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
+		9B107F5E532C8DE74430723B /* PaletteTabAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteTabAction.swift; sourceTree = "<group>"; };
 		9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommand.swift; sourceTree = "<group>"; };
 		9BD81541882CBCC5B06F718F /* UpdateDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDownloader.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1676,6 +1678,7 @@
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
 				445B0374FD5D74DBE23243CD /* PaletteScreen.swift */,
 				188A6D3C5B6BC67716F15F83 /* PaletteState.swift */,
+				9B107F5E532C8DE74430723B /* PaletteTabAction.swift */,
 				209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */,
 				D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */,
 			);
@@ -2265,6 +2268,7 @@
 				9F8806D46EBAF7058FC2EAEC /* PaletteRowIndex.swift in Sources */,
 				DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */,
 				1BC16048EE05A1FD25739CB4 /* PaletteState.swift in Sources */,
+				3C2812B921530D45B802B44C /* PaletteTabAction.swift in Sources */,
 				52C4F57BB26F420CCD22C1D7 /* PaletteWindowController.swift in Sources */,
 				E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */,
 				FD4DDDCDC32AF921CDBCFB18 /* Paster.swift in Sources */,

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -66,6 +66,14 @@ final class AIChatCoordinator {
         palette.prepare(mode: .ai)
     }
 
+    /// Pop to Root reaches the conversation too, so a palette that forgets its screen does not
+    /// reopen still holding a thread from before; the transcript is already saved by then.
+    func popToRoot() {
+        // A reply still arriving was asked for, and cancelling it here would throw away the answer.
+        guard settings.aiEnabled, !chat.isStreaming else { return }
+        chat.startNewChat()
+    }
+
     func showHistory() {
         palette.prepare(mode: .aiHistory)
     }

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -5,6 +5,7 @@ enum PaletteEscapeAction: Equatable {
     case closeMenu
     case clearQuery
     case exitExtensionScreen
+    case exitToLauncher
     case hidePalette
 
     static func resolve(menuOpen: Bool, query: String, mode: PaletteMode) -> Self {
@@ -12,6 +13,8 @@ enum PaletteEscapeAction: Equatable {
         if !query.isEmpty { return .clearQuery }
         // An extension pops its own navigation stack before the command is left.
         if mode == .extensionCommand { return .exitExtensionScreen }
+        // Chat is a surface of its own, so leaving it lands on the launcher, not on nothing.
+        if mode == .ai { return .exitToLauncher }
         return .hidePalette
     }
 }

--- a/Tinycast/Palette/PaletteTabAction.swift
+++ b/Tinycast/Palette/PaletteTabAction.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Where Tab goes next. Launcher, chat and clipboard are the three surfaces a reader opens directly,
+/// so Tab rings those; every other mode is a sub-screen, which Tab leaves for the launcher.
+enum PaletteTabAction: Equatable {
+    /// The typed text rides along, because both ends narrow their own list by the same query.
+    case carryQuery(PaletteMode)
+    /// A fresh screen: chat's field holds a half-written message, which is nobody else's search.
+    case freshScreen(PaletteMode)
+
+    static func resolve(mode: PaletteMode, aiEnabled: Bool) -> Self {
+        switch mode {
+        // Turned off, chat is not a stop on the ring, which leaves the launcher ↔ clipboard flip.
+        case .launcher: return aiEnabled ? .freshScreen(.ai) : .carryQuery(.clipboard)
+        case .ai: return .freshScreen(.clipboard)
+        case .clipboard: return .carryQuery(.launcher)
+        default: return .carryQuery(.launcher)
+        }
+    }
+}

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -99,7 +99,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         popToRootTimer?.invalidate()
         let timeout = core.settings.popToRootTimeout
         guard timeout != .immediately else {
-            core.palette.prepare(mode: .launcher)
+            popToRoot()
             return
         }
         popToRootTimer = Timer.scheduledTimer(withTimeInterval: timeout.interval, repeats: false) {
@@ -107,9 +107,16 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             MainActor.assumeIsolated {
                 guard let self, !self.core.extensions.isAuthorizing else { return }
                 self.popToRootTimer = nil
-                self.core.palette.prepare(mode: .launcher)
+                self.popToRoot()
             }
         }
+    }
+
+    /// Both reset paths come through here, so the screen and the conversation cannot disagree about
+    /// whether the palette was left behind — a chat is a thing being done, like a typed query.
+    private func popToRoot() {
+        core.palette.prepare(mode: .launcher)
+        core.aiChatCoordinator.popToRoot()
     }
 
     /// True while a hidden palette still holds pre-close state; consuming cancels the reset.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -487,6 +487,10 @@ struct RootPaletteView: View {
                 accessory.view
                 Spacer(minLength: 0)
             }
+            if tabOpensChat {
+                headerGutter(width: Theme.Spacing.md)
+                aiChatTabHint
+            }
             // Keyed off the mode, which is what says which screen is up; the field just flexes narrower.
             if !isCollapsed, vm.mode == .clipboard {
                 headerGutter(width: Theme.Spacing.md)
@@ -531,6 +535,26 @@ struct RootPaletteView: View {
         guard vm.mode == .launcher || vm.mode == .ai, !isCollapsed else { return nil }
         let screen = screen
         return screen.headerAccessory(at: selection(in: screen), focus: $argumentFocused)
+    }
+
+    /// Nothing else advertises Tab, so the launcher says where it goes — the footer's own pairing
+    /// of a label with its cap, never a click target: the header belongs to the field.
+    private var aiChatTabHint: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Text("AI Chat")
+                .font(Theme.Typography.bar)
+                .foregroundStyle(Theme.Colors.textSecondary)
+            KeyCapChip(text: "⇥", style: .outline)
+        }
+        .allowsHitTesting(false)
+    }
+
+    /// Resolved through `PaletteTabAction` rather than restated, so the hint cannot promise a
+    /// destination the key does not go to — an argument field to walk takes Tab first.
+    private var tabOpensChat: Bool {
+        guard !isCollapsed, headerAccessory?.fieldNames.isEmpty ?? true else { return false }
+        return PaletteTabAction.resolve(mode: vm.mode, aiEnabled: settings.aiEnabled)
+            == .freshScreen(.ai)
     }
 
     /// Width the search field shrinks to when an accessory sits beside it: the typed text's own
@@ -793,17 +817,21 @@ struct RootPaletteView: View {
         }
     }
 
-    /// Tab flips launcher↔clipboard; Calculator History exits rather than joining. Chat stays put:
-    /// its field is a draft, and a bare mode swap would carry the draft into the launcher.
-    private func toggleMode() {
-        guard vm.mode != .ai, vm.mode != .aiHistory else { return }
-        vm.mode = vm.mode == .launcher ? .clipboard : .launcher
+    /// Tab rings launcher → chat → clipboard; every other mode exits rather than joining. Crossing
+    /// chat's edge opens a fresh screen, so a draft is never handed to a list that would search it.
+    private func cycleMode() {
+        switch PaletteTabAction.resolve(mode: vm.mode, aiEnabled: settings.aiEnabled) {
+        case .carryQuery(let mode): vm.mode = mode
+        case .freshScreen(let mode): vm.prepare(mode: mode)
+        }
     }
 
-    /// Tab walks the inline argument fields first — search field → each argument → back — and only
-    /// toggles the mode when the selection declares none.
+    /// Tab walks the inline argument fields first — search field → each argument → back — and rings
+    /// on when there are none, chat's staged-image chips included: those declare no fields to walk.
     private func advanceTabFocus() {
-        guard let accessory = headerAccessory else { return toggleMode() }
+        guard let accessory = headerAccessory, !accessory.fieldNames.isEmpty else {
+            return cycleMode()
+        }
         argumentFocused = accessory.fieldAfter(argumentFocused)
         searchFocused = argumentFocused == nil
     }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -347,6 +347,8 @@ struct RootPaletteView: View {
                 vm.query = ""
             case .exitExtensionScreen:
                 core.extensionCoordinator.exitExtensionScreen()
+            case .exitToLauncher:
+                exitToLauncher()
             case .hidePalette:
                 core.paletteCoordinator.hidePalette()
             }

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -41,9 +41,15 @@ AI Chat is the first consumer, but the provider layer does not depend on it.
   not create a second credential or response cache on disk.
 - **`Model/` stays Foundation-only.** `ai-provider-test` compiles the shipped provider models and pins
   endpoints, stream parsing, persistence repair and Codex protocol framing.
-- **Chat is a palette screen, not another window.** The launcher command enters `.ai`; its search
-  field is the composer, and the shared footer's primary pill is Return's job: Send (`↵`), or Stop
-  (`↵`) while a response streams — followed by Actions (`⌘K`), which owns New Chat.
+- **Chat is a palette screen, not another window** — including its lifetime. The launcher command
+  enters `.ai`; its search field is the composer, and the shared footer's primary pill is Return's
+  job: Send (`↵`), or Stop (`↵`) while a response streams — followed by Actions (`⌘K`), which owns
+  New Chat. A conversation lasts exactly as long as the palette remembers anything else: Pop to Root
+  Search resets the screen and starts a new chat in the same breath, through
+  `AIChatCoordinator.popToRoot`, so closing the palette and summoning it again does not reopen on a
+  thread from before. A reply still streaming is never reset out from under the reader — it was
+  asked for — and the transcript is saved regardless, so the old conversation is one ⌘K → Chat
+  History away.
 - **History is local and lazy.** Conversation summaries stay in memory while transcripts load from the
   system SQLite database only for the selected preview or opened chat. Empty chats are never saved.
 - **Everything but the newest message is bounded.** `ChatSession.boundedContext` sends that message

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -8,10 +8,11 @@ AI Chat is the first consumer, but the provider layer does not depend on it.
 
 - **AI is off out of the box, and off means fully off.** `AppSettings.aiEnabled` is the flag and
   `AIChatCoordinator.applyEnabled()` is the only place that projects it: no `AI Chat` command in the
-  launcher, no history database opened or created, no Codex helper resident, and the palette leaves
-  `.ai`. Turning it off cancels a streaming reply and drops the transcript, but touches neither the
-  saved conversations in `ai-chats.sqlite3` nor a Keychain key. `aiEnabled` is excluded from settings
-  backups like every other AI key, so an import can never arm a feature it cannot configure.
+  launcher, no history database opened or created, no Codex helper resident, no stop for it on Tab's
+  ring, and the palette leaves `.ai`. Turning it off cancels a streaming reply and drops the
+  transcript, but touches neither the saved conversations in `ai-chats.sqlite3` nor a Keychain key.
+  `aiEnabled` is excluded from settings backups like every other AI key, so an import can never arm
+  a feature it cannot configure.
 - **Every request carries Tinycast's own preamble, and the user's text goes after it.**
   `AIInstructions.compose` builds `AIRequest.instructions`: a fixed preamble that tells the model
   where it is running and what the app can do, then whatever Settings → AI holds. The preamble
@@ -40,9 +41,9 @@ AI Chat is the first consumer, but the provider layer does not depend on it.
   not create a second credential or response cache on disk.
 - **`Model/` stays Foundation-only.** `ai-provider-test` compiles the shipped provider models and pins
   endpoints, stream parsing, persistence repair and Codex protocol framing.
-- **Chat is a palette screen, not another window.** The launcher command enters `.ai`; its search field
-  is the composer, and the shared footer's primary pill is Return's job: Send (`↵`), or Stop (`↵`)
-  while a response streams — followed by Actions (`⌘K`), which owns New Chat.
+- **Chat is a palette screen, not another window.** The launcher command enters `.ai`; its search
+  field is the composer, and the shared footer's primary pill is Return's job: Send (`↵`), or Stop
+  (`↵`) while a response streams — followed by Actions (`⌘K`), which owns New Chat.
 - **History is local and lazy.** Conversation summaries stay in memory while transcripts load from the
   system SQLite database only for the selected preview or opened chat. Empty chats are never saved.
 - **Everything but the newest message is bounded.** `ChatSession.boundedContext` sends that message
@@ -93,15 +94,15 @@ hold neither settings nor credentials itself.
 ## Chat surface
 
 The built-in `AI Chat` launcher command enters `AIScreen`, and carries a bindable global shortcut
-(`HotKeyAction.aiChat`) that does the same thing from any app. Settings → AI holds both the recorder and
-a checkbox for the command's place in launcher search; the shortcut keeps working while the command is
-hidden, and does nothing at all while the feature is off. The palette search field becomes the
-single-line composer. The footer pill and Return are one action, `activate`: Send, or Stop while a
-response streams — an empty composer sends nothing, so the pill never needs a disabled state. The
-header's trailing model switcher uses the same in-window menu control as Clipboard's type filter and
-changes the app-wide default route for the next message. It does not interrupt a response already
-streaming; stopping one is the pill's job, so the header never has to fit a third control beside the
-switcher.
+(`HotKeyAction.aiChat`) that does the same thing from any app; Tab from the launcher is the third
+way in. Settings → AI holds both the recorder and a checkbox for the command's place in launcher
+search; the shortcut keeps working while the command is hidden, and does nothing at all while the
+feature is off. The palette search field becomes the single-line composer. The footer pill and
+Return are one action, `activate`: Send, or Stop while a response streams — an empty composer sends
+nothing, so the pill never needs a disabled state. The header's trailing model switcher uses the
+same in-window menu control as Clipboard's type filter and changes the app-wide default route for
+the next message. It does not interrupt a response already streaming; stopping one is the pill's
+job, so the header never has to fit a third control beside the switcher.
 
 The second footer control is the palette's normal Actions (`⌘K`) menu. It owns New Chat, Chat History
 and AI Settings, plus Stop Response and Copy Last Response when those actions apply. Chat adds no
@@ -247,8 +248,11 @@ chip before it backs out of chat; ⌘K → Remove Attachments clears them all. S
 The switcher's glyph comes from the selection — ChatGPT is OpenAI's mark, an API model resolves
 through its connection — never from `modelOptions`, which for ChatGPT is empty until the app-server
 has answered `model/list`; opening the chat on a ChatGPT model warms that list so the title is the
-display name from the first frame. Tab is a no-op in chat and history: `toggleMode` swaps the mode
-without `prepare`, which would carry the draft into the launcher's field.
+display name from the first frame. Tab hands chat on to the clipboard, and goes through `prepare`,
+so the unsent draft is dropped rather than carried into a field that would search it. History leaves
+by the ordinary sub-screen route — Tab carries its query to the launcher — because there the field
+really is a search. Tab does not touch the conversation: it lives on `AIChatState`, so Tab away and
+back resumes the same transcript.
 
 The model switcher is `fixedSize` with its title shortened in `AIChatCoordinator` (26 characters,
 middle ellipsis) rather than truncated by layout: a flexible label claimed the row up to its max

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -248,11 +248,12 @@ chip before it backs out of chat; ⌘K → Remove Attachments clears them all. S
 The switcher's glyph comes from the selection — ChatGPT is OpenAI's mark, an API model resolves
 through its connection — never from `modelOptions`, which for ChatGPT is empty until the app-server
 has answered `model/list`; opening the chat on a ChatGPT model warms that list so the title is the
-display name from the first frame. Tab hands chat on to the clipboard, and goes through `prepare`,
-so the unsent draft is dropped rather than carried into a field that would search it. History leaves
-by the ordinary sub-screen route — Tab carries its query to the launcher — because there the field
-really is a search. Tab does not touch the conversation: it lives on `AIChatState`, so Tab away and
-back resumes the same transcript.
+display name from the first frame. Tab hands chat on to the clipboard, and Escape on an empty
+composer backs it out to the launcher; both go through `prepare`, so the unsent draft is dropped
+rather than carried into a field that would search it. History leaves by the ordinary sub-screen
+route — Tab carries its query to the launcher — because there the field really is a search. Neither
+exit touches the conversation: it lives on `AIChatState`, so Tab away and back resumes the same
+transcript.
 
 The model switcher is `fixedSize` with its title shortened in `AIChatCoordinator` (26 characters,
 middle ellipsis) rather than truncated by layout: a flexible label claimed the row up to its max

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -72,11 +72,23 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 | `.quicklinkArguments` | `QuicklinkArgumentsScreen` | `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt)) |
 | `.extensionCommand` | `ExtensionCommandScreen` | `ExtensionCommandView` (see [extensions.md](extensions.md)) |
 
-Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab cycles launcher ↔
-clipboard and nothing else** unless the selected row declares arguments, in which case it walks those
-fields first (see below); the rest are reached by a command or a global hotkey, and Uninstall only
-from a launcher app's Actions menu, scoped to that app. **Escape clears a non-empty query before it
-hides the palette or exits an extension screen**, so one press clears and the next leaves.
+Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab rings the three
+surfaces a reader opens directly — launcher → AI chat → clipboard → launcher** — unless the selected
+row declares arguments, in which case it walks those fields first (see below); every other mode exits
+to the launcher rather than joining the ring, and is reached by a command or a global hotkey, with
+Uninstall only from a launcher app's Actions menu, scoped to that app. Chat is skipped whole when
+`aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced. **Escape clears a non-empty query
+before it hides the palette or exits an extension screen**, so one press clears and the next leaves.
+
+The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
+pairing of a label with its key. It is drawn only when Tab really would open chat, a condition read
+back out of `PaletteTabAction` rather than restated, so a hint can never promise a destination the
+key does not go to: an argument field to walk takes Tab first, and the hint steps aside for it.
+
+`PaletteTabAction` decides where Tab goes *and* whether the typed text travels with it. Launcher and
+clipboard hand the query over, since one search narrows either list; crossing chat's edge opens a
+fresh screen in both directions, because that field holds a half-written message rather than a query
+— seeding a composer from a search reads as noise, and a draft dropped into a filter matches nothing.
 
 The argument screen is the one mode where the search field is not a search field: it _is_ the current
 argument's input, so its placeholder names that argument and ↵ submits rather than activating a row.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -77,8 +77,9 @@ surfaces a reader opens directly — launcher → AI chat → clipboard → laun
 row declares arguments, in which case it walks those fields first (see below); every other mode exits
 to the launcher rather than joining the ring, and is reached by a command or a global hotkey, with
 Uninstall only from a launcher app's Actions menu, scoped to that app. Chat is skipped whole when
-`aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced. **Escape clears a non-empty query
-before it hides the palette or exits an extension screen**, so one press clears and the next leaves.
+`aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced. **Escape clears a
+non-empty query before it leaves the screen**, so one press clears and the next leaves: chat backs
+out to the launcher, an extension screen exits itself, and anywhere else the palette hides.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
 pairing of a label with its key. It is drawn only when Tab really would open chat, a condition read

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -55,6 +55,14 @@ only the closure wiring; the behaviour is `PaletteCoordinator`'s.
 Showing the palette calls `prepare(mode:)`, which resets state and bumps `focusToken` (a UUID) so the
 SwiftUI search field re-focuses.
 
+Hiding schedules Pop to Root Search, and `PaletteWindowController.popToRoot` is its only path: the
+palette returns to the launcher *and* chat starts a new conversation, at once or after
+`popToRootTimeout`, unless a re-summon inside that window consumes the pending reset first. An
+unfinished chat is a thing being done, exactly like a typed query, so the screen and the conversation
+are reset together rather than the screen alone. A reply still streaming is the one exception — it was
+asked for, and resetting would throw the answer away. Nothing is lost either way: a conversation is
+written to Chat History as soon as it has a message.
+
 Each `PaletteMode` maps to one type conforming to `PaletteScreen`, and the protocol is what keeps the
 selection invariant honest: a screen exposes `rows` as its single source of visible order, and the
 palette indexes into it. Adding a mode means adding a conformer, not a branch in `RootPaletteView`.


### PR DESCRIPTION
## Related issue

Discussed directly — three follow-ups on #319's chat, each self-contained and reviewable on its own.

## What changed

1. **Ring Tab through the launcher, chat and the clipboard** — Tab flipped launcher↔clipboard and stopped there. Chat was left out for a stated reason: its search field *is* the composer, so a bare mode swap would have handed a half-written message to a list that searches by it. The ring therefore crosses that edge with `prepare` rather than a swap. Launcher and clipboard still trade the query, since one search narrows either list; entering or leaving chat opens a fresh screen instead. `PaletteTabAction` holds both halves of that decision — where Tab goes, and whether the typed text goes with it — as a pure `Foundation`-only resolver beside `PaletteEscapeAction`, so `palette-tab-test` compiles the shipped type rather than a copy. Chat drops out of the ring entirely when `aiEnabled` is off, leaving exactly the flip the ring replaced. The launcher advertises the first hop in the header, `AI Chat` beside a `⇥` cap, built from the `KeyCapChip` + `Theme.Typography.bar` pairing the footer already uses for `Actions ⌘K`.

2. **Back chat out to the launcher on Escape** — Escape on an empty composer hid the palette outright, which made chat the one surface you had to leave the app to get out of. It now lands on the launcher, where a bare backspace has always gone. The ladder reads left to right: the first press clears an unsent draft, the second leaves chat, and a third — now on an empty launcher — hides the palette. Only chat gains the step; an empty clipboard filter still hides, and an extension screen still exits itself. `PaletteEscapeAction` gains one case and one line of precedence, below `.exitExtensionScreen` so a menu and a typed query both still outrank it.

3. **Let Pop to Root reach the conversation, not just the screen** — a conversation outlived every reset around it. `prepare(mode:)` cleared the mode, the query and the selection, but the transcript sits on `AIChatState` for the life of the process, so a palette that had returned to the launcher hours ago still reopened chat on a thread from before; only ⌘K → New Chat ended one. Nothing decided that — the two lifetimes were never connected. Pop to Root now resets both, through a single `popToRoot` that the two existing paths (immediate and timed) share, so the screen and the conversation cannot disagree about whether the palette was left behind. An unfinished chat is a thing being done, exactly like a typed query, and the setting that already says how long the palette remembers one now covers the other — no new setting, and on the default (`Immediately`) it reads as "closing the palette starts a new chat".

Non-obvious in the diff:

- **Tab could stall in chat, and this is the fix as much as the ring is.** `advanceTabFocus` walked any `headerAccessory` it found, and chat's staged-image chips are an accessory with `fieldNames: []` — nothing to walk. Before this change chat swallowed Tab anyway so it never showed; the moment Tab has somewhere to go, pasting a picture into chat would have left the key doing nothing at all. It now rings on when there are no fields to walk.
- **The header hint reads its own visibility back out of `PaletteTabAction`** rather than restating the condition, so it cannot promise a destination the key does not go to. That is what makes it disappear in compact mode, with AI off, and when a selected row declares argument fields — Tab walks those first.
- **`.aiHistory` stops swallowing Tab.** It was grouped with `.ai` under the old guard, but the draft argument never applied to it: its field is a genuine search over saved chats. It now leaves for the launcher like every other sub-screen, carrying its query the way Emoji and File Search already do.
- **A reply still streaming is never reset.** It was asked for, and it keeps arriving on a background task while the palette is hidden, so resetting there would cancel the answer on its way in.
- **Escape out of chat does not end the conversation**, since it reaches the launcher without closing the palette, so Pop to Root never fires. Escape out and Tab back resumes the same transcript.

## Drawbacks

- **Tab out of chat drops the unsent draft.** That is the point — carrying it into the clipboard's filter is the bug the original guard existed to prevent — but it is a real loss, and Tab sits next to the keys you type with. It is consistent with Escape, which has cleared the draft on one press since #338, so the draft was already treated as cheap; a reader who wants it kept has no way to ask for that.
- **Pop to Root now ends a conversation even when the palette was used for something else.** Launch an app from the launcher, and the close that follows resets a chat you had five minutes earlier. That is what "closing the palette starts a new chat" means on the default setting, but it is worth stating plainly. Anyone who wants a grace window has one: any non-`Immediately` Pop to Root timeout preserves the chat for that long.
- **Closing the palette also drops staged images**, since `startNewChat` disowns them. Consistent with every other route that starts a new chat, but it means a picture pasted and then left sitting does not survive a close.
- **The streaming exception makes the rule less than absolute.** "Every close starts a new chat" is true except while a reply is in flight, and after that reply lands the conversation stays until the *next* close. The alternative — cancelling an answer the user asked for — seemed clearly worse.
- **`.aiHistory`'s Tab is a behaviour change nobody asked for.** It was a no-op and is now an exit. It is grouped here because leaving Tab dead on one chat screen while it rings on every other surface reads as a bug, but it can be reverted on its own if you would rather it stayed put.

## Tests & validation

- `./Scripts/run-tests.sh` — all **46 harnesses** pass (45 + one new). New: `palette-tab-test`, 13 assertions, pinning each leg of the ring, that chat is skipped whole when `aiEnabled` is off, that every sub-screen exits to the launcher, and that three presses from the launcher return to it — plus the off-case ring closing in two. `palette-escape-test` grows 9 → **12**, adding the empty-composer back-out, a pin that only chat backs out (an empty clipboard filter still hides), and that a menu outranks the chat screen it is drawn over.
- **Debug and Release builds both succeed with zero warnings.**
- `./Scripts/format.sh --check` — clean, 417 files. `xcodegen generate` leaves no diff beyond the one new source file.
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` returns nothing.
- **Each commit was gated on its own**, not just the tip: format, 46 harnesses and a Debug build at commit 1 and commit 2 as well as at commit 3, so the series bisects cleanly.
- By hand, in an installed build: the ring in both directions and with AI off; the Escape ladder (draft → launcher → hidden); a launcher query not becoming a chat draft and a draft not becoming a clipboard filter; Tab with an image staged in chat; the header hint appearing and standing aside for a quicklink's argument field; a conversation gone after a close and reopen, present in ⌘K → Chat History, and a reply mid-stream surviving a close.
- `Scripts/lint.sh` did not run — swiftlint is not installed on this machine.
