### PR TITLE
Add a Support window, reachable four ways, with a monthly reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A tiny, fully native macOS launcher — the essentials, without the bloat.
          src="https://img.shields.io/badge/%E2%99%A5%20%20Support%20Tinycast-863BFF?style=for-the-badge"></a>
 </p>
 
-Around **3 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background
+Around **5 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background
 CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there's nothing to it.
 
 It also **runs Raycast extensions** — the real ones, rendered as native SwiftUI. No Node.js, no

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ A tiny, fully native macOS launcher — the essentials, without the bloat.
 
 <p align="center">
   <a href="https://buy.polar.sh/polar_cl_NDVFC20DKQpLcNawsh97QzbARBXD3WNn8v35R0mbJmT">
-    <img alt="Support Tinycast" height="60"
-         src="https://img.shields.io/badge/%E2%99%A5%20%20Support%20Tinycast-863BFF?style=for-the-badge"></a>
+    <img alt="Support Tinycast" width="360" height="64" src="docs/support-button.svg"></a>
 </p>
 
 Around **5 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A tiny, fully native macOS launcher — the essentials, without the bloat.
 
 <p align="center">
   <a href="https://buy.polar.sh/polar_cl_NDVFC20DKQpLcNawsh97QzbARBXD3WNn8v35R0mbJmT">
-    <img alt="Support Tinycast" height="48"
+    <img alt="Support Tinycast" height="60"
          src="https://img.shields.io/badge/%E2%99%A5%20%20Support%20Tinycast-863BFF?style=for-the-badge"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A tiny, fully native macOS launcher — the essentials, without the bloat.
   <img src="docs/screenshot.png" alt="Tinycast command palette" width="720">
 </p>
 
+<p align="center">
+  <a href="https://buy.polar.sh/polar_cl_NDVFC20DKQpLcNawsh97QzbARBXD3WNn8v35R0mbJmT">
+    <img alt="Support Tinycast" height="48"
+         src="https://img.shields.io/badge/%E2%99%A5%20%20Support%20Tinycast-863BFF?style=for-the-badge"></a>
+</p>
+
 Around **3 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background
 CPU churn. Just SwiftUI + AppKit with zero dependencies. It's fast because there's nothing to it.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A tiny, fully native macOS launcher — the essentials, without the bloat.
 
 <p align="center">
   <a href="https://buy.polar.sh/polar_cl_NDVFC20DKQpLcNawsh97QzbARBXD3WNn8v35R0mbJmT">
-    <img alt="Support Tinycast" width="360" height="64" src="docs/support-button.svg"></a>
+    <img alt="Support Tinycast" width="320" height="64" src="docs/support-button.svg"></a>
 </p>
 
 Around **5 MB on disk** and **under 100 MB of RAM** — no Electron, no telemetry, no background

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -221,6 +221,7 @@ run slow ext-test          -parse-as-library \
 run settings-history-test  Tinycast/Features/Settings/SettingsTab.swift \
                            Tinycast/Features/Settings/SettingsHistory.swift
 run updates-test           Tinycast/Features/Updates/Model/*.swift
+run support-test           Tinycast/Features/Support/Model/*.swift
 run ai-provider-test       Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/AI/Model/*.swift \
                            Tinycast/Features/AI/Settings/AISettingsStore.swift

--- a/Tests/support-test.swift
+++ b/Tests/support-test.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+@main
+@MainActor
+struct SupportTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func main() {
+        waitsOutTheWholeInterval()
+        comesDueOnlyOnceTheIntervalHasPassed()
+        survivesAClockThatMovedBackwards()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    private static let interval = SupportReminderSchedule.interval
+    private static let anchor = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+    static func waitsOutTheWholeInterval() {
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor) == interval,
+            "a fresh anchor waits a full interval")
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor + interval / 2)
+                == interval / 2,
+            "half an interval in, half an interval is left")
+    }
+
+    static func comesDueOnlyOnceTheIntervalHasPassed() {
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor + interval - 1) == 1,
+            "one second short is not yet due")
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor + interval) == 0,
+            "due exactly at the interval")
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor + interval * 10) == 0,
+            "long overdue is due now, never a negative wait")
+    }
+
+    /// A clock moved backwards must not park the ask past one interval, however far back it went.
+    static func survivesAClockThatMovedBackwards() {
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor - 1) == interval,
+            "a second before the anchor still waits exactly one interval")
+        expect(
+            SupportReminderSchedule.wait(since: anchor, now: anchor - interval * 10) == interval,
+            "a decade before the anchor waits one interval, not eleven")
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		47A443F25878A27DE6DF24AA /* NoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAFF79E9897975CAC5EAC0E /* NoteEditorView.swift */; };
 		47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */; };
 		48AE2C9989F8FA2AA99D2D61 /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B4495E56754B05B5F3551D /* CalcPercent.swift */; };
+		4C960C8F11556B3FC4EFF98F /* SupportWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44875ABECB1F1B648EC90F4 /* SupportWindowView.swift */; };
 		4D3E47D6F382933EB3B1AB2F /* ExtensionCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F282D4BBC2F147D3A98FFB /* ExtensionCleanup.swift */; };
 		4D8C05DD67FAB9F2DA1F31FB /* AIStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */; };
 		4DA03A170E95F0D08E3569F9 /* ExtensionColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0266BAF4643A4B5C41B600DE /* ExtensionColors.swift */; };
@@ -287,6 +288,7 @@
 		B277075C16A5641C8F3E58C6 /* CameraAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD86B3ABBB71BC6EA116D85 /* CameraAccess.swift */; };
 		B566FC125D9D193F234EC1AB /* ExtensionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988EA3698EA86BA53590C24E /* ExtensionFetcher.swift */; };
 		B56F252262AA1BD3E2631F0C /* FileSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391B8024E8719506361B45F7 /* FileSearchQuery.swift */; };
+		B589C3ECFF03C790102361D4 /* SupportReminderSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E393E2CA842C5B344C6B499 /* SupportReminderSchedule.swift */; };
 		B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0F5891A80B604FBE21897B /* CalcCurrency.swift */; };
 		B72F17539405522E63D266F3 /* AIPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5861814F16B18935FBF034C /* AIPreamble.swift */; };
 		B8CECD85524BCCCBC0CDC2B5 /* ExtensionCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */; };
@@ -348,6 +350,8 @@
 		DFB25A4CDD35071B745F2EF9 /* DoubleTapModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */; };
 		E1A4472391E5AD3EE828202E /* RedactedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEA1E122A8139A21E646FE2 /* RedactedText.swift */; };
 		E268D74F0DEFFA598E2D02AA /* OnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6972F177922B1EB8831735 /* OnboardingCard.swift */; };
+		E29056264B57A3F0EC5F5698 /* SupportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97986EE62AE844FFCCD27449 /* SupportCoordinator.swift */; };
+		E29CF7293742DDCAE030682C /* SupportReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE1ED405A53ECA5DED66AA1 /* SupportReminderStore.swift */; };
 		E457BC709D195B8F5D0C2A79 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6DAC3B9FF387367C3FAB4 /* UninstallSession.swift */; };
 		E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E25B87C692D5FEE1FBF994 /* PanelTransition.swift */; };
 		E4E1403AA9A8ACE4A3D3581C /* MeetingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B330ABFC83721904159DDF2 /* MeetingEvent.swift */; };
@@ -461,6 +465,7 @@
 		2BECF24B674F9458E4A876DA /* AppCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCore.swift; sourceTree = "<group>"; };
 		2C5FFE395B9164BDC77B3470 /* SettingsBackupCoverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBackupCoverage.swift; sourceTree = "<group>"; };
 		2D303E193CFEFE455778C150 /* CommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandsSettingsView.swift; sourceTree = "<group>"; };
+		2E393E2CA842C5B344C6B499 /* SupportReminderSchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportReminderSchedule.swift; sourceTree = "<group>"; };
 		2EC7DC9AD5E54C26387F29F6 /* MarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownView.swift; sourceTree = "<group>"; };
 		2EE496AA4863086BB49CBF2E /* EventDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDraft.swift; sourceTree = "<group>"; };
 		2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSourceSwitcher.swift; sourceTree = "<group>"; };
@@ -616,6 +621,7 @@
 		95BFA41B0D7F369A8CF1E013 /* HyperKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKey.swift; sourceTree = "<group>"; };
 		95E3AA9E226F39DBB232501F /* RaycastImportV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV2.swift; sourceTree = "<group>"; };
 		976A1F05AD82DB8A04B3C3F9 /* MessageHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageHUDView.swift; sourceTree = "<group>"; };
+		97986EE62AE844FFCCD27449 /* SupportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportCoordinator.swift; sourceTree = "<group>"; };
 		988EA3698EA86BA53590C24E /* ExtensionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFetcher.swift; sourceTree = "<group>"; };
 		9979DED5579535D1F0A32DBF /* AppWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppWindowController.swift; sourceTree = "<group>"; };
 		9A7F606D7F71B6FC0CC6ABC8 /* UninstallScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallScanner.swift; sourceTree = "<group>"; };
@@ -628,6 +634,7 @@
 		9D0A2005448E6F88C3F78489 /* CalendarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarStore.swift; sourceTree = "<group>"; };
 		9D134673CB1B563A3758FC37 /* UninstallRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRunner.swift; sourceTree = "<group>"; };
 		9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverArming.swift; sourceTree = "<group>"; };
+		9DE1ED405A53ECA5DED66AA1 /* SupportReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportReminderStore.swift; sourceTree = "<group>"; };
 		9F1798C6CF803D5E1BB2FFE4 /* ChatTranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptView.swift; sourceTree = "<group>"; };
 		9F9A0A3867D1B8E1D3284471 /* ExtensionNodeShims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionNodeShims.swift; sourceTree = "<group>"; };
 		A061D1B64684905BA0E998C5 /* ChatHistoryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryScreen.swift; sourceTree = "<group>"; };
@@ -730,6 +737,7 @@
 		E01488803F8025B0523D44BA /* RelaunchRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaunchRunner.swift; sourceTree = "<group>"; };
 		E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		E27FB790A72ACD75DFCDFDDF /* VolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSlider.swift; sourceTree = "<group>"; };
+		E44875ABECB1F1B648EC90F4 /* SupportWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportWindowView.swift; sourceTree = "<group>"; };
 		E475F373557FD3524086CE19 /* MeetingCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCalendar.swift; sourceTree = "<group>"; };
 		E54932083F6BC197453EA0C8 /* UninstallSearchRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSearchRoot.swift; sourceTree = "<group>"; };
 		E582B93EFB1A2AA85B048A87 /* CalcFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcFormatter.swift; sourceTree = "<group>"; };
@@ -1364,6 +1372,14 @@
 			path = Dialog;
 			sourceTree = "<group>";
 		};
+		861C60E74357CCA209E5E117 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2E393E2CA842C5B344C6B499 /* SupportReminderSchedule.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		87070A80E9E3AB3E4B0A9E54 /* AI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1452,6 +1468,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		952EBD1EB0253BE3132DA99E /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				9DE1ED405A53ECA5DED66AA1 /* SupportReminderStore.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		95CA98985928A88B33F82556 /* Features */ = {
 			isa = PBXGroup;
 			children = (
@@ -1471,6 +1495,7 @@
 				60DCE6A46E636364E5C3B5B4 /* Quicklinks */,
 				E3202F504002B7792FC50B2F /* Settings */,
 				7CD438390F8FA4B3C2AE5F28 /* Snippets */,
+				D301BB64789647AB76909F82 /* Support */,
 				1DBBAD792549702C243871CD /* SystemActions */,
 				5EC7DD3F09EBCC7AC71C230B /* Uninstall */,
 				8CA62C0A3BE575C89C39F198 /* Updates */,
@@ -1748,6 +1773,16 @@
 			path = Service;
 			sourceTree = "<group>";
 		};
+		D301BB64789647AB76909F82 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				861C60E74357CCA209E5E117 /* Model */,
+				952EBD1EB0253BE3132DA99E /* Service */,
+				FCF0B265883B60146C913937 /* UI */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
 		D62A9A3E2CCA4CC188B8E3FB /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -1942,6 +1977,15 @@
 				B36FACE26406FD2205FEF03E /* NOTICE.md */,
 				114270CAA80F01D311693B63 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		FCF0B265883B60146C913937 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				97986EE62AE844FFCCD27449 /* SupportCoordinator.swift */,
+				E44875ABECB1F1B648EC90F4 /* SupportWindowView.swift */,
+			);
+			path = UI;
 			sourceTree = "<group>";
 		};
 		FE2191441B39CE41CC3052ED /* Model */ = {
@@ -2351,6 +2395,10 @@
 				2F1161E2706CD883E9599000 /* SpaceGesture.swift in Sources */,
 				68DE5268907FD4F96C1A346E /* SpaceSwitcher.swift in Sources */,
 				089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */,
+				E29056264B57A3F0EC5F5698 /* SupportCoordinator.swift in Sources */,
+				B589C3ECFF03C790102361D4 /* SupportReminderSchedule.swift in Sources */,
+				E29CF7293742DDCAE030682C /* SupportReminderStore.swift in Sources */,
+				4C960C8F11556B3FC4EFF98F /* SupportWindowView.swift in Sources */,
 				9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */,
 				FF934DD9FBD8F26BAB72ACD1 /* SymbolImage.swift in Sources */,
 				71AA40FC4B8C57FFDE5F8DFC /* SystemAction.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -32,6 +32,7 @@ final class AppCore {
     let calendarStore = CalendarStore()
     let meetingClock = MeetingClock()
     let updateChecker = UpdateCheckStore()
+    let supportReminders: SupportReminderStore
     let emojiIndex = EmojiIndex()
     let frequentEmoji = FrequentEmojiStore()
     let runningApps = RunningAppsMonitor()
@@ -122,6 +123,8 @@ final class AppCore {
         paletteCoordinator: paletteCoordinator, core: self)
     @ObservationIgnored private(set) lazy var updateCoordinator = UpdateCoordinator(
         store: updateChecker, core: self)
+    @ObservationIgnored private(set) lazy var supportCoordinator = SupportCoordinator(
+        store: supportReminders, core: self)
     @ObservationIgnored private(set) lazy var aiChatCoordinator = AIChatCoordinator(
         chat: aiChat, settings: settings, appIndex: appIndex, palette: palette,
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,
@@ -140,6 +143,7 @@ final class AppCore {
         self.launcherRanking = launcherRanking
         self.settings = settings
         self.chatHistory = chatHistory
+        supportReminders = SupportReminderStore(settings: settings)
         aiChat = AIChatState(history: chatHistory)
         appIndex = AppIndex(ranking: launcherRanking, aliases: aliases)
         let clipboardManager = ClipboardManager(store: clipboardStore, settings: settings)
@@ -199,6 +203,8 @@ final class AppCore {
                 self?.updateCoordinator.presentIfAvailable(release) ?? true
             }
             updateChecker.start()
+            supportReminders.onDue = { [weak self] in self?.supportCoordinator.presentIfDue() }
+            supportReminders.start()
 
             hyperKeyTap.healthTicker = healthTicker
             hotKeys.doubleTapMonitor.healthTicker = healthTicker
@@ -275,6 +281,7 @@ final class AppCore {
         if settingsCoordinator.focusExisting() { return }
         if onboardingCoordinator.focusExisting() { return }
         if updateCoordinator.focusExisting() { return }
+        if supportCoordinator.focusExisting() { return }
         paletteCoordinator.showPalette(mode: .launcher, restoreAnyMode: true)
     }
 
@@ -415,6 +422,23 @@ final class AppCore {
         let visible = settings.windowManagementEnabled && settings.windowManagementShowInLauncher
         appIndex.setWindowCommandsVisible(visible)
     }
+
+    // MARK: - Interruption
+
+    /// What the app is in the middle of; the update prompt and the support reminder both ask first.
+    var currentActivity: UpdateActivity {
+        UpdateActivity(
+            isExpandingSnippet: snippetTextInjector.isDelivering,
+            isRunningExtension: extensions.running != nil,
+            isUninstalling: uninstall.isTrashing,
+            isRecordingHotKey: hotKeys.recordingAction != nil,
+            isPromptingForArguments: quicklinkArguments.isActive,
+            isShowingDialog: isShowingDialog,
+            isPaletteVisible: paletteCoordinator.isVisible)
+    }
+
+    /// Whether a window may take focus without interrupting something the user started.
+    var canInterruptUser: Bool { UpdateReadiness.evaluate(currentActivity) == nil }
 
     // MARK: - Dialogs, routed here so `dialogs` stays the single owner
 

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -25,6 +25,7 @@ struct TinycastApp: App {
             }
             Divider()
             Button("Check for Updates...") { AppCore.shared.updateCoordinator.checkForUpdates() }
+            Button("Support \(appName)...") { AppCore.shared.supportCoordinator.showSupport() }
             Button("Settings...") { AppCore.shared.settingsCoordinator.showSettings() }
                 .keyboardShortcut(",")
             Divider()

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -59,6 +59,8 @@ struct SettingsBackup: Codable {
         var menuBarEvents: Int?
         var menuBarLinkedEventsOnly: Bool?
         var hideCurrentEvent: Int?
+        // Safe to carry: it silences a prompt rather than granting anything.
+        var supportReminders: Bool?
     }
 
     /// Combos keep the legacy shape, so older files import. docs/features/hotkeys.md#persistence
@@ -139,7 +141,8 @@ extension SettingsBackup {
             autoJoinConfirms: s.autoJoinConfirms,
             menuBarEvents: s.menuBarEvents.rawValue,
             menuBarLinkedEventsOnly: s.menuBarLinkedEventsOnly,
-            hideCurrentEvent: s.hideCurrentEvent.rawValue)
+            hideCurrentEvent: s.hideCurrentEvent.rawValue,
+            supportReminders: s.supportRemindersEnabled)
 
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
@@ -375,6 +378,10 @@ extension SettingsBackup {
         }
         if let raw = s.hideCurrentEvent, let hide = HideCurrentEvent(rawValue: raw) {
             settings.hideCurrentEvent = hide
+            count += 1
+        }
+        if let flag = s.supportReminders {
+            settings.supportRemindersEnabled = flag
             count += 1
         }
         return count

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -39,7 +39,8 @@ enum SettingsBackupCoverage {
         "autoJoinConfirms": .autoJoinConfirms,
         "menuBarEvents": .menuBarEvents,
         "menuBarLinkedEventsOnly": .menuBarLinkedEventsOnly,
-        "hideCurrentEvent": .hideCurrentEvent
+        "hideCurrentEvent": .hideCurrentEvent,
+        "supportReminders": .supportReminders
     ]
 
     /// The `SettingsData` fields no `AppSettings` key stands behind, and what they read instead.

--- a/Tinycast/Features/Launcher/Model/CommandID.swift
+++ b/Tinycast/Features/Launcher/Model/CommandID.swift
@@ -25,6 +25,7 @@ enum CommandID: String, CaseIterable, Sendable {
     case checkForUpdates = "command:check-for-updates"
     case settings = "command:settings"
     case about = "command:about"
+    case support = "command:support"
     case quit = "command:quit"
 
     var name: String {
@@ -52,6 +53,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .checkForUpdates: return "Check for Updates"
         case .settings: return "Settings"
         case .about: return "About Tinycast"
+        case .support: return "Support Tinycast"
         case .quit: return "Quit Tinycast"
         }
     }
@@ -81,6 +83,7 @@ enum CommandID: String, CaseIterable, Sendable {
         case .checkForUpdates: return "arrow.down.circle"
         case .settings: return "gearshape"
         case .about: return "info.circle"
+        case .support: return "heart"
         case .quit: return "power"
         }
     }

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -173,6 +173,9 @@ final class LauncherCoordinator {
         case .about:
             paletteCoordinator.hidePalette(restoreFocus: false)
             settingsCoordinator.showAbout()
+        case .support:
+            paletteCoordinator.hidePalette(restoreFocus: false)
+            core.supportCoordinator.showSupport()
         case .quit:
             NSApp.terminate(nil)
         case nil:

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -357,6 +357,11 @@ final class AppSettings {
         }
     }
 
+    /// Whether the support window may reopen itself; off means never ask again.
+    var supportRemindersEnabled: Bool {
+        didSet { defaults.set(supportRemindersEnabled, forKey: Key.supportReminders.rawValue) }
+    }
+
     init() {
         // `integer(forKey:)` returns 0 when unset, which no case matches.
         clipboardRetention =
@@ -472,5 +477,8 @@ final class AppSettings {
         quicklinkConfirmsBeforeDelete =
             defaults.object(forKey: Key.quicklinkConfirmsBeforeDelete.rawValue) == nil
             || defaults.bool(forKey: Key.quicklinkConfirmsBeforeDelete.rawValue)
+        supportRemindersEnabled =
+            defaults.object(forKey: Key.supportReminders.rawValue) == nil
+            || defaults.bool(forKey: Key.supportReminders.rawValue)
     }
 }

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -55,4 +55,5 @@ enum AppSettingsKey: String, CaseIterable {
     case aiWebSearch = "aiWebSearch"
     case aiSystemPrompt = "aiSystemPrompt"
     case aiSystemPromptEnabled = "aiSystemPromptEnabled"
+    case supportReminders = "supportReminders"
 }

--- a/Tinycast/Features/Support/Model/SupportReminderSchedule.swift
+++ b/Tinycast/Features/Support/Model/SupportReminderSchedule.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// When the support window may next ask. Pure: every date is handed in.
+enum SupportReminderSchedule {
+    static let interval: TimeInterval = 30 * 24 * 3600
+
+    /// Seconds until the next ask; `0` is due now. Anchor on the last ask, or first run if none.
+    static func wait(since anchor: Date, now: Date) -> TimeInterval {
+        // Clamped both ways: a clock moved backwards must not park the ask past one interval.
+        let elapsed = min(max(0, now.timeIntervalSince(anchor)), interval)
+        return interval - elapsed
+    }
+}

--- a/Tinycast/Features/Support/Service/SupportReminderStore.swift
+++ b/Tinycast/Features/Support/Service/SupportReminderStore.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// The support reminder's clock: it decides when to ask, and never presents anything itself.
+@MainActor
+final class SupportReminderStore {
+    /// Keeps the first evaluation, and any window it raises, clear of the login rush.
+    private static let startupDelay = Duration.seconds(60)
+    /// A due-but-withheld ask comes back this often, rather than waiting out another interval.
+    private static let retryInterval: TimeInterval = 600
+    /// Switched off, the only thing left to wait for is the switch, so the pump idles instead.
+    private static let idleInterval: TimeInterval = 3600
+
+    var onDue: (@MainActor () -> Void)?
+
+    private let settings: AppSettings
+    private let fileURL: URL
+    private var state: State
+    private var pump: Task<Void, Never>?
+
+    init(settings: AppSettings) {
+        self.settings = settings
+        fileURL = AppPaths.applicationSupport().appendingPathComponent("support-reminder.json")
+        if let data = try? Data(contentsOf: fileURL),
+            let stored = try? JSONDecoder().decode(State.self, from: data)
+        {
+            state = stored
+        } else {
+            state = State(firstSeenAt: Date())
+            persist()
+        }
+    }
+
+    deinit { pump?.cancel() }
+
+    func start() {
+        // Replace rather than bail: an exited loop leaves a non-nil task that would block restart.
+        pump?.cancel()
+        pump = Task { [weak self] in
+            try? await Task.sleep(for: Self.startupDelay)
+            while !Task.isCancelled {
+                // Optional-chained: the sleep must not retain the store, or nothing can release it.
+                guard let wait = self?.advance() else { return }
+                try? await Task.sleep(for: .seconds(wait))
+            }
+        }
+    }
+
+    /// Called on every showing, by any route: whoever just read the pitch is not asked again soon.
+    func markAsked(at now: Date = Date()) {
+        state.lastAskedAt = now
+        persist()
+    }
+
+    // MARK: - Private
+
+    /// The last ask, or first run when there has been none.
+    private var anchor: Date { state.lastAskedAt ?? state.firstSeenAt }
+
+    /// One turn of the pump: offer the ask if it is due, and answer how long to wait.
+    private func advance() -> TimeInterval {
+        let wait = SupportReminderSchedule.wait(since: anchor, now: Date())
+        guard settings.supportRemindersEnabled else { return max(wait, Self.idleInterval) }
+        guard wait <= 0 else { return wait }
+        onDue?()
+        // Floored: a withheld ask leaves the anchor where it was, and this must not spin on it.
+        return max(SupportReminderSchedule.wait(since: anchor, now: Date()), Self.retryInterval)
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private struct State: Codable {
+        var firstSeenAt: Date
+        var lastAskedAt: Date?
+    }
+}

--- a/Tinycast/Features/Support/UI/SupportCoordinator.swift
+++ b/Tinycast/Features/Support/UI/SupportCoordinator.swift
@@ -1,0 +1,50 @@
+import AppKit
+import SwiftUI
+
+/// The support window's lifecycle. Every route lands here, so the anchor moves once per showing.
+@MainActor
+final class SupportCoordinator {
+    /// The one place the checkout URL is written down; every surface links to this.
+    static let checkout = URL(
+        string: "https://buy.polar.sh/polar_cl_NDVFC20DKQpLcNawsh97QzbARBXD3WNn8v35R0mbJmT")!
+
+    private let store: SupportReminderStore
+    /// Environment injection and activity reads only — never for state this type owns.
+    private unowned let core: AppCore
+    private lazy var window = AppWindowController(
+        title: "Support Tinycast", contentSize: SupportWindowView.initialSize,
+        activation: core.activationPolicy)
+
+    init(store: SupportReminderStore, core: AppCore) {
+        self.store = store
+        self.core = core
+    }
+
+    func showSupport() {
+        store.markAsked()
+        window.show {
+            SupportWindowView(support: self)
+                .environment(self.core.settings)
+        }
+    }
+
+    /// The reminder's path: it asks only when nothing else has the user's attention.
+    func presentIfDue() {
+        guard core.canInterruptUser else { return }
+        showSupport()
+    }
+
+    func openCheckout() {
+        NSWorkspace.shared.open(Self.checkout)
+        window.close()
+    }
+
+    /// The window takes the height its content measured, so nothing is padded out with space.
+    func fit(height: CGFloat) {
+        window.fitContent(width: SupportWindowView.width, height: height)
+    }
+
+    func focusExisting() -> Bool {
+        window.focus()
+    }
+}

--- a/Tinycast/Features/Support/UI/SupportWindowView.swift
+++ b/Tinycast/Features/Support/UI/SupportWindowView.swift
@@ -1,0 +1,124 @@
+import AppKit
+import SwiftUI
+
+/// The support surface: the ask, the one button, and the reminder switch.
+struct SupportWindowView: View {
+    /// Held directly, not injected: it publishes nothing, so `@Observable` would buy nothing.
+    let support: SupportCoordinator
+
+    @Environment(AppSettings.self) private var settings
+
+    static let width: CGFloat = 460
+    /// Only until the first layout measures the real one, which is what the window then takes.
+    static let initialSize = CGSize(width: width, height: 340)
+
+    private static let iconSize: CGFloat = 76
+
+    var body: some View {
+        @Bindable var settings = settings
+        return VStack(spacing: Theme.Spacing.xxl) {
+            hero
+            action
+            reminder(isOn: $settings.supportRemindersEnabled)
+        }
+        // Less on top: the title bar already contributes its own 32pt above this.
+        .padding(.top, Theme.Spacing.md)
+        .padding([.horizontal, .bottom], Theme.Spacing.xxl)
+        // The ideal height, not the window's: measuring its own output would feed back.
+        .fixedSize(horizontal: false, vertical: true)
+        .onGeometryChange(for: CGFloat.self) {
+            $0.size.height
+        } action: {
+            support.fit(height: $0)
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        // Only the gradient reaches under the titlebar; the content stays in the safe area.
+        .background(
+            LinearGradient(
+                colors: [Theme.Colors.sheen, Color.clear], startPoint: .top, endPoint: .center
+            )
+            .ignoresSafeArea()
+        )
+    }
+
+    // MARK: - Hero
+
+    private var hero: some View {
+        VStack(spacing: Theme.Spacing.xl) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: Self.iconSize, height: Self.iconSize)
+                .shadow(color: .black.opacity(0.35), radius: 12, y: 6)
+            VStack(spacing: Theme.Spacing.sm) {
+                Text("Support \(Bundle.main.appDisplayName)")
+                    .font(.title2.weight(.semibold))
+                Text("Built with love.")
+                    .font(.callout)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Action
+
+    private var action: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            SupportActionButton(title: "Support \(Bundle.main.appDisplayName)", icon: "heart") {
+                support.openCheckout()
+            }
+            Text("Secure checkout on Polar.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Reminder
+
+    private func reminder(isOn: Binding<Bool>) -> some View {
+        Toggle("Remind me occasionally", isOn: isOn)
+            .toggleStyle(.checkbox)
+            .font(.callout)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .help(
+                "About once a month. Turn this off and"
+                    + " \(Bundle.main.appDisplayName) won't ask again.")
+    }
+}
+
+/// The window's one call to action. Local to Support, like every other view this feature owns.
+private struct SupportActionButton: View {
+    let title: String
+    let icon: String
+    let action: () -> Void
+
+    @State private var hovered = false
+
+    private static let height: CGFloat = 46
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(.body.weight(.semibold))
+                Text(title)
+                    .font(.headline)
+            }
+            // White ink in both appearances: a saturated fill carries its own contrast.
+            .foregroundStyle(Color.white)
+            .padding(.horizontal, Theme.Spacing.xxxl)
+            .frame(height: Self.height)
+            .background(
+                Capsule()
+                    .fill(Theme.Colors.brand)
+                    .brightness(hovered ? 0.08 : 0)
+            )
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .animation(.easeOut(duration: Theme.Duration.tooltip), value: hovered)
+    }
+}

--- a/Tinycast/Features/Updates/UI/UpdateCoordinator.swift
+++ b/Tinycast/Features/Updates/UI/UpdateCoordinator.swift
@@ -88,7 +88,7 @@ final class UpdateCoordinator {
         case .installing, .readyToRelaunch:
             return true
         case .checking, .upToDate, .localBuild, .available, .blocked, .failed:
-            guard UpdateReadiness.evaluate(activity) == nil else { return false }
+            guard UpdateReadiness.evaluate(core.currentActivity) == nil else { return false }
             stage = .available(release)
             present()
             return true
@@ -100,7 +100,7 @@ final class UpdateCoordinator {
     func install() {
         guard let release = pendingRelease else { return }
         // Re-asked at the moment of the click, never read from a flag that could have gone stale.
-        if let blocker = UpdateReadiness.evaluate(activity) {
+        if let blocker = UpdateReadiness.evaluate(core.currentActivity) {
             stage = .blocked(blocker, release)
             return
         }
@@ -172,17 +172,6 @@ final class UpdateCoordinator {
         UpdateInstaller(
             bundleURL: Bundle.main.bundleURL,
             stagingDirectory: AppPaths.caches().appendingPathComponent("Updates", isDirectory: true))
-    }
-
-    private var activity: UpdateActivity {
-        UpdateActivity(
-            isExpandingSnippet: core.snippetTextInjector.isDelivering,
-            isRunningExtension: core.extensions.running != nil,
-            isUninstalling: core.uninstall.isTrashing,
-            isRecordingHotKey: core.hotKeys.recordingAction != nil,
-            isPromptingForArguments: core.quicklinkArguments.isActive,
-            isShowingDialog: core.isShowingDialog,
-            isPaletteVisible: core.paletteCoordinator.isVisible)
     }
 
     private func present() {

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -139,11 +139,14 @@ struct RootPaletteView: View {
             })
     }
 
-    /// The bottom-left app menu content (About / Settings).
+    /// The bottom-left app menu content (About / Support / Settings).
     private var appMenuContent: PopoverMenuContent {
         PopoverMenuContent(items: [
             PopoverMenuItem(title: "About Tinycast", systemImage: "info.circle") {
                 core.settingsCoordinator.showAbout()
+            },
+            PopoverMenuItem(title: "Support Tinycast", systemImage: "heart") {
+                core.supportCoordinator.showSupport()
             },
             PopoverMenuItem(title: "Settings", systemImage: "gearshape", shortcut: "⌘,") {
                 core.settingsCoordinator.showSettings()

--- a/Tinycast/Windows/About/AboutView.swift
+++ b/Tinycast/Windows/About/AboutView.swift
@@ -22,6 +22,7 @@ struct AboutView: View {
     }()
 
     private static let iconSize: CGFloat = 88
+    private static let supportTile: CGFloat = 30
 
     var body: some View {
         VStack(spacing: 0) {
@@ -87,20 +88,30 @@ struct AboutView: View {
 
     private var support: some View {
         Section {
-            HStack(alignment: .top, spacing: Theme.Spacing.lg) {
-                Image(systemName: "bolt.fill")
-                    .foregroundStyle(Theme.Colors.brand)
-                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-                    Text("Buy Me Brave Origin")
-                    Text(
-                        "If you enjoy my work and would like to support me or buy me Brave Origin,"
-                            + " feel free to reach out on Discord, X, or via email."
+            HStack(spacing: Theme.Spacing.xl) {
+                // Brand is a fixed hue, so an alpha on it holds up in both appearances.
+                RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                    .fill(Theme.Colors.brand.opacity(0.16))
+                    .frame(width: Self.supportTile, height: Self.supportTile)
+                    .overlay(
+                        Image(systemName: "heart.fill")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(Theme.Colors.brand)
                     )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                    Text("Support \(Bundle.main.appDisplayName)")
+                        .font(.body.weight(.medium))
+                    Text("Free and open source, funded out of pocket.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
+                Spacer(minLength: Theme.Spacing.lg)
+                Button("Support…") { core.supportCoordinator.showSupport() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Theme.Colors.brand)
             }
+            .padding(.vertical, Theme.Spacing.xs)
         }
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,8 @@ open with an `## Invariants` section; read it before changing anything in that a
 [backup](features/backup.md) ·
 [Raycast import](features/raycast-import.md) ·
 [Raycast extensions](features/extensions.md) ·
-[updates](features/updates.md)
+[updates](features/updates.md) ·
+[support](features/support.md)
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ Independently of the folder tree, every mature subsystem has converged on the sa
 │ ShellCommandRunner · DoubleTap{Modifier,Detector} · ClipboardStore ·       │
 │ RaycastFormat · RaycastV1Decoder · AppSettingsKey · SettingsBackupCoverage │
 │ MeetingLink · MeetingEvent · UpcomingWindow · MeetingDay · MenuBarSummary  │
-│ AutoJoinPolicy · EventDraft                                                │
+│ AutoJoinPolicy · EventDraft · SupportReminderSchedule                      │
 └──────────────────────────────────┬─────────────────────────────────────────┘
                                    │ consumed by
 ┌─ EFFECT ─────────────────────────▼─────────────────────────────────────────┐
@@ -33,7 +33,8 @@ Independently of the folder tree, every mature subsystem has converged on the sa
 │ SystemActionRunner · QuicklinkLauncher · SnippetTextInjector ·             │
 │ SnippetKeywordListener · NotesRepository · CurrencyRateStore · Paster ·    │
 │ HotKeyCenter · HyperKeyTap · DoubleTapMonitor · RunningAppsMonitor ·       │
-│ CalendarStore · MeetingLauncher · MeetingClock · CameraPreviewSession      │
+│ CalendarStore · MeetingLauncher · MeetingClock · CameraPreviewSession ·    │
+│ SupportReminderStore                                                       │
 └──────────────────────────────────┬─────────────────────────────────────────┘
                                    │ published through
 ┌─ OBSERVABLE STATE ───────────────▼─────────────────────────────────────────┐
@@ -125,6 +126,10 @@ imperatively from AppKit.
   confirmations, failure reports and value prompts. Presentation is `async`, so nothing blocks the main
   actor, and the presenter refuses a second dialog while one is up — that, not a flag, is what stops a
   held hotkey stacking dialogs.
+- **Support** — a titled `AppWindowController` window owned by `SupportCoordinator`, sized to the
+  height its content measured. Every route into it — the palette's menu circle, Settings → About, the
+  menu bar, the launcher, and the 30-day reminder — lands on `showSupport()`, which is what moves the
+  reminder's anchor. See [features/support.md](features/support.md).
 - **The camera preview** — a borderless, non-activating `CameraPreviewPanel` at `.floating`,
   managed by `CameraPreviewController` and owned by `CalendarCoordinator` the way `NotesCoordinator`
   owns its window. It gates a join and doubles as auto join's confirmation.
@@ -198,6 +203,7 @@ Tinycast/
     PaletteRowIndex.swift   the flat selection index — palette-owned, so it sits at the top
     Launcher/ Clipboard/ Calculator/ Calendar/ Emoji/ FileSearch/ Notes/ Quicklinks/ Snippets/
     Uninstall/ SystemActions/ CustomCommands/ HotKeys/ Backup/ WindowManagement/ Onboarding/
+    Updates/ Support/ AI/ Settings/
     Extensions/
         Model/      pure — the harness inputs
         Service/    effects — stores, monitors, runners, AppKit glue

--- a/docs/features/support.md
+++ b/docs/features/support.md
@@ -1,0 +1,75 @@
+# Support
+
+One window, one checkout link, and a checkbox deciding whether it may ever reopen itself. Every other
+surface — the website's hero and footer, the docs sidebar, the README badge — is a bare link to the
+same URL, so `SupportCoordinator.checkout` is the only place the destination is written down.
+
+## Invariants
+
+- **Showing the window is what moves the anchor.** `SupportCoordinator.showSupport()` calls
+  `markAsked()` on every route into the window — the palette's app menu, Settings → About, the menu
+  bar, the launcher command and the reminder itself. Someone who has just read the pitch is not asked
+  again next week, however they came to it, and one call site is what keeps that true.
+- **The reminder never takes focus from something the user started.** `presentIfDue()` returns without
+  presenting unless `AppCore.canInterruptUser`, which is `UpdateReadiness` over `AppCore.currentActivity`
+  — the same seven-case gate the update prompt uses, shared rather than copied. A withheld ask leaves
+  the anchor alone, so it is still owed and the pump comes back in ten minutes rather than a month.
+- **The checkbox defaults on, and off means off forever.** `AppSettings.supportRemindersEnabled` reads
+  `defaults.object(forKey:) == nil || defaults.bool(forKey:)`, so absence is on and a stored `false`
+  survives. It rides a settings backup: it grants no capability, it silences a prompt, and a user who
+  turned it off should stay off across a restore.
+- **The schedule state is a file, not a default.** `support-reminder.json` lives under
+  `AppPaths.applicationSupport()`, not `caches()` — a purged cache would reset the anchor and ask
+  early. It holds `firstSeenAt` and `lastAskedAt` and nothing else; the *preference* stays in
+  `AppSettings`, and the two never mix.
+- **The first ask lands one interval after first run, not after launch.** With no `lastAskedAt` the
+  anchor is `firstSeenAt`, stamped the first time the store finds no file, so a fresh install is
+  never asked on day one.
+- **One button, one link.** `SupportCoordinator.checkout` is the only destination, and no surface
+  restates what is behind it — the checkout page owns that, so nothing here can fall out of step
+  with it. Adding a second button means adding a second thing to keep in sync.
+- **The button is the composition, not its footer.** It sits under the hero at 46pt tall, because this
+  window asks where the update window reports — an actions row pinned to the bottom edge reads as a
+  utility dialog.
+- **Brand colour appears exactly twice**: the app icon, which is violet on its own, and the button.
+- **Support's views are Support's own.** `SupportActionButton` is private to `SupportWindowView`
+  rather than reaching for Onboarding's card rows, which are that window's.
+
+## How it is put together
+
+| Piece | Holds |
+| --- | --- |
+| `Model/SupportReminderSchedule.swift` | pure — seconds until the next ask, clamped at both ends |
+| `Service/SupportReminderStore.swift` | the JSON state, and the one `Task` pump that offers the ask |
+| `UI/SupportCoordinator.swift` | the window's lifecycle, the checkout link, the anchor write |
+| `UI/SupportWindowView.swift` | the window: hero, the button, and the reminder checkbox |
+
+`SupportReminderStore.advance()` is one turn of the pump: it answers how long to sleep, and calls
+`onDue` when the wait has reached zero. `AppCore.start()` wires that closure to
+`supportCoordinator.presentIfDue()`. The store itself never presents anything and never writes the
+anchor on its own — that write belongs to the coordinator, so there is exactly one of it.
+
+The wait after an offer is floored at the retry interval. Showing the window is what moves the anchor,
+and the floor is what stops the pump spinning if it did not.
+
+## The window
+
+`AppWindowController` at 460pt wide, taking the height its content measured through
+`.onGeometryChange` → `fit(height:)`. It is titled and transparent-titlebar'd, so `ActivationPolicy`
+brings the Dock icon in and out on its own, and `⌘W` or the close button dismisses it.
+
+The composition is centred: a shadowed 76pt app icon, the ask in `.title2`, one line of copy, then
+the button and the reminder switch. Nothing carries a keyboard shortcut —
+with a custom button style there is no focus ring to advertise one, and ↵ silently opening a payment
+page is a surprise rather than a convenience.
+
+Only the mechanism is shared with the Software Update window — `AppWindowController`, the
+content-measured height and the `sheen` gradient. The layout deliberately is not: that window reports
+and closes, so its actions belong in a trailing row; this one asks, so the ask is the centrepiece.
+
+## Where it is reachable from
+
+The palette's bottom-left menu circle (between About and Settings), Settings → About, the menu bar
+menu, and the launcher as `CommandID.support`. All four land on `showSupport()`. The launcher arm
+hides the palette first, the way `.about` does; the menu-circle row does not, because the panel
+dismisses itself on `windowDidResignKey`.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -167,7 +167,7 @@ Budgets, not aspirations:
 
 - **Resident memory under 100 MB, always.** No feature is worth going over. Memory returns to baseline
   after the palette closes.
-- Release binary under **4 MB**.
+- Release binary under **5 MB**.
 - Launch is the thing the app protects most. Work added to `AppCore.start()` or to an initialiser is the
   most expensive place to put it; defer it into a `Task` or do it on first use.
 - The palette must feel instant. Anything on the summon path is resolved once per show, never per render.

--- a/docs/support-button.svg
+++ b/docs/support-button.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="64" viewBox="0 0 360 64" role="img" aria-label="Support Tinycast">
+  <title>Support Tinycast</title>
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#9B5CFF"/>
+      <stop offset="1" stop-color="#7912FF"/>
+    </linearGradient>
+  </defs>
+  <rect width="360" height="64" rx="32" fill="url(#fill)"/>
+  <rect x="0.5" y="0.5" width="359" height="63" rx="31.5" fill="none" stroke="#ffffff" stroke-opacity="0.22"/>
+  <g transform="translate(75 20)" fill="#ffffff">
+    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+  </g>
+  <text x="111" y="40" fill="#ffffff" font-size="21" font-weight="600" textLength="174" lengthAdjust="spacingAndGlyphs"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif">Support Tinycast</text>
+</svg>

--- a/docs/support-button.svg
+++ b/docs/support-button.svg
@@ -1,16 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="360" height="64" viewBox="0 0 360 64" role="img" aria-label="Support Tinycast">
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="64" viewBox="0 0 320 64" role="img" aria-label="Support Tinycast">
   <title>Support Tinycast</title>
-  <defs>
-    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#9B5CFF"/>
-      <stop offset="1" stop-color="#7912FF"/>
-    </linearGradient>
-  </defs>
-  <rect width="360" height="64" rx="32" fill="url(#fill)"/>
-  <rect x="0.5" y="0.5" width="359" height="63" rx="31.5" fill="none" stroke="#ffffff" stroke-opacity="0.22"/>
-  <g transform="translate(75 20)" fill="#ffffff">
+  <rect width="320" height="64" fill="#863BFF"/>
+  <g transform="translate(55 20)" fill="#ffffff">
     <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
   </g>
-  <text x="111" y="40" fill="#ffffff" font-size="21" font-weight="600" textLength="174" lengthAdjust="spacingAndGlyphs"
+  <text x="91" y="40" fill="#ffffff" font-size="21" font-weight="600" textLength="174" lengthAdjust="spacingAndGlyphs"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif">Support Tinycast</text>
 </svg>

--- a/docs/support-button.svg
+++ b/docs/support-button.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="64" viewBox="0 0 320 64" role="img" aria-label="Support Tinycast">
   <title>Support Tinycast</title>
-  <rect width="320" height="64" fill="#863BFF"/>
+  <rect x="-2" y="-2" width="324" height="68" fill="#863BFF"/>
   <g transform="translate(55 20)" fill="#ffffff">
     <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
   </g>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -101,6 +101,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `entry-icon-test` | `EntryIcon` — that each case draws, caches and prints apart from the others |
 | `settings-backup-test` | `Settings/AppSettingsKey.swift`, `Backup/Model/SettingsBackupCoverage.swift` |
 | `updates-test` | `Updates/Model/` — version precedence, channel filtering, install route, readiness |
+| `support-test` | `Support/Model/` — when the support reminder comes due, and a clock moved backwards |
 
 A harness that passed before a change passes after it. There is no "I'll fix it next commit" and no
 commenting out a case. If a change genuinely invalidates an assertion, the assertion is rewritten in the
@@ -142,7 +143,7 @@ find ~/Library/Developer/Xcode/DerivedData -name "Tinycast*.app" -maxdepth 6 -pr
 - No `@unchecked Sendable`, `nonisolated(unsafe)` or `assumeIsolated` added without a stated reason.
 - The type-checker did not time out. `LauncherList.rows` already carries an explicit annotation for
   this reason; the fix for a timeout is an annotation, not a restructure.
-- Release binary under **4 MB**, and under 2% growth for an ordinary change.
+- Release binary under **5 MB**, and under 2% growth for an ordinary change.
 
 ### Lint
 

--- a/website/content/docs/index.md
+++ b/website/content/docs/index.md
@@ -6,7 +6,7 @@ description: What Tinycast is, and the few minutes that set it up.
 Tinycast is a native macOS launcher that lives in the menu bar. Press a shortcut, a palette floats
 in over whatever you were doing, you type, and it gets out of the way.
 
-It is around 3 MB on disk and stays under 100 MB of memory, because it is SwiftUI and AppKit with
+It is around 5 MB on disk and stays under 100 MB of memory, because it is SwiftUI and AppKit with
 zero third-party dependencies. There is no Electron, no account, no sign-in and no telemetry.
 
 ## Set it up

--- a/website/src/app/docs/layout.tsx
+++ b/website/src/app/docs/layout.tsx
@@ -1,4 +1,5 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { Heart } from "lucide-react";
 import type { ReactNode } from "react";
 import { DocsProvider } from "../../components/docs-provider";
 import { DiscordLogo, GitHubLogo, Logo } from "../../components/ui/icon";
@@ -18,6 +19,18 @@ export default function Layout({ children }: { children: ReactNode }) {
         // beside the theme switch. Passing `githubUrl` instead would put
         // GitHub there but leave Discord with nowhere to go.
         links={[
+          // A button, not an icon: a 16pt glyph would hide it beside GitHub and Discord.
+          {
+            type: "button",
+            text: (
+              <span className="flex items-center gap-1.5">
+                <Heart size={15} />
+                Support
+              </span>
+            ),
+            url: site.support,
+            external: true,
+          },
           {
             type: "icon",
             text: "GitHub",

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 const description =
-  "Tinycast is a tiny, fully native macOS launcher: fuzzy app search, an inline calculator, clipboard history, snippets, notes, window management and global hotkeys — around 3 MB, with no Electron, no account and no telemetry.";
+  "Tinycast is a tiny, fully native macOS launcher: fuzzy app search, an inline calculator, clipboard history, snippets, notes, window management and global hotkeys — around 5 MB, with no Electron, no account and no telemetry.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(site.url),

--- a/website/src/components/footer.tsx
+++ b/website/src/components/footer.tsx
@@ -1,14 +1,16 @@
+import { Heart } from "lucide-react";
 import { site } from "../data/site";
 import { DiscordLogo, GitHubLogo, Logo } from "./ui/icon";
 import { Link } from "./ui/link";
 import { MetaStrip } from "./ui/meta-strip";
+import { ThemeToggle } from "./ui/theme-toggle";
 
 export function Footer() {
   const repoPath = site.repo.replace("https://", "");
 
   return (
     <footer className="border-t border-border/50">
-      <div className="container-page flex flex-col items-center gap-6 py-14 text-center">
+      <div className="container-page relative flex flex-col items-center gap-6 py-14 text-center">
         <Link
           href="/"
           className="flex items-center gap-1 text-body font-medium text-fg"
@@ -49,6 +51,20 @@ export function Footer() {
             <DiscordLogo size={16} />
             Join the Discord
           </a>
+          <a
+            href={site.support}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 text-small text-fg-muted transition-colors hover:text-fg"
+          >
+            <Heart size={16} />
+            Support Tinycast
+          </a>
+        </div>
+
+        {/* In flow on mobile, where an absolute one would cover the links. */}
+        <div className="md:absolute md:bottom-14 md:right-6">
+          <ThemeToggle />
         </div>
       </div>
     </footer>

--- a/website/src/components/hero.tsx
+++ b/website/src/components/hero.tsx
@@ -1,7 +1,8 @@
+import { Heart } from "lucide-react";
 import { hero, site } from "../data/site";
 import { AppShot } from "./app-shot";
 import { Button } from "./ui/button";
-import { AppleLogo, GitHubLogo } from "./ui/icon";
+import { AppleLogo } from "./ui/icon";
 import { MetaStrip } from "./ui/meta-strip";
 
 // The one place the system breaks its own austerity: a soft violet/cyan
@@ -25,47 +26,53 @@ export function Hero() {
     <section id="top" className="relative overflow-hidden pb-8 pt-36 md:pt-48">
       <Atmosphere />
       <div className="container-page flex flex-col items-center text-center">
+        {/* A pill, not naked mono text: the dot is the one spot of brand up here. */}
         <p
-          className="rise font-mono text-eyebrow uppercase text-fg-muted"
+          className="rise inline-flex items-center gap-2 rounded-full border border-border px-3 py-1.5 font-mono text-eyebrow uppercase text-fg-muted"
           style={{ animationDelay: "0ms" }}
         >
+          <span
+            aria-hidden="true"
+            className="size-1.5 rounded-full bg-violet-bright"
+          />
           {hero.eyebrow}
         </p>
 
         <h1
-          className="rise mt-6 max-w-3xl text-display"
+          className="rise mt-7 max-w-3xl text-display"
           style={{ animationDelay: "80ms" }}
         >
           {hero.headline}
         </h1>
 
         <p
-          className="rise mt-6 max-w-lg text-body-lg text-fg-muted"
+          className="rise mt-6 max-w-xl text-body-lg text-fg-muted"
           style={{ animationDelay: "160ms" }}
         >
           {hero.sub}
         </p>
 
+        {/* Two, not three: View source moved to the nav's icon row. */}
         <div
-          className="rise mt-9 flex flex-wrap items-center justify-center gap-3"
+          className="rise mt-10 flex flex-wrap items-center justify-center gap-3"
           style={{ animationDelay: "240ms" }}
         >
-          <Button href="/#install" className="gap-1">
+          <Button href="/#install" size="lg" className="gap-2">
             <AppleLogo size={20} />
             Download for Mac
           </Button>
           <Button
-            href={site.repo}
+            href={site.support}
             variant="ghost"
-            target="_blank"
-            rel="noreferrer"
+            size="lg"
+            className="gap-2"
           >
-            <GitHubLogo size={20} />
-            View source
+            <Heart size={18} />
+            Support
           </Button>
         </div>
 
-        <div className="rise mt-2" style={{ animationDelay: "300ms" }}>
+        <div className="rise mt-5" style={{ animationDelay: "300ms" }}>
           <MetaStrip />
         </div>
 

--- a/website/src/components/install.tsx
+++ b/website/src/components/install.tsx
@@ -17,7 +17,8 @@ export function Install() {
       title="Install with Homebrew."
       intro="One command and you're running. Each channel installs as its own app, so a pre-release can live beside stable."
     >
-      <div className="mx-auto max-w-2xl">
+      {/* Full width: a 2xl column scrolled the brew commands sideways. */}
+      <div>
         <div className="mb-4 flex items-center justify-between gap-3">
           <div
             className="inline-flex items-center gap-1 rounded-lg bg-tint/5 p-1"

--- a/website/src/components/nav.tsx
+++ b/website/src/components/nav.tsx
@@ -5,9 +5,8 @@ import { useState } from "react";
 import { nav, site } from "../data/site";
 import { cn } from "../lib/cn";
 import { Button } from "./ui/button";
-import { AppleLogo, DiscordLogo, Logo } from "./ui/icon";
+import { AppleLogo, DiscordLogo, GitHubLogo, Logo } from "./ui/icon";
 import { Link } from "./ui/link";
-import { ThemeToggle } from "./ui/theme-toggle";
 
 export function Nav() {
   const [open, setOpen] = useState(false);
@@ -41,7 +40,17 @@ export function Nav() {
             </div>
 
             <div className="hidden items-center gap-2 md:flex">
-              <ThemeToggle />
+              {/* Moved out of the hero, so its pair stays Download and Support. */}
+              <a
+                href={site.repo}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="View source on GitHub"
+                title="View source on GitHub"
+                className="flex size-8 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-tint/5 hover:text-fg"
+              >
+                <GitHubLogo size={18} />
+              </a>
               <a
                 href={discord}
                 target="_blank"
@@ -114,12 +123,6 @@ export function Nav() {
                   <DiscordLogo size={16} />
                   Join the Discord
                 </a>
-                <div className="flex items-center justify-between gap-2 px-3 py-2.5">
-                  <span className="text-body font-medium text-fg-muted">
-                    Appearance
-                  </span>
-                  <ThemeToggle />
-                </div>
                 <Button
                   href="/#install"
                   size="sm"

--- a/website/src/components/ui/button.tsx
+++ b/website/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { cn } from "../../lib/cn";
 import { Link } from "./link";
 
 type Variant = "solid" | "ghost";
-type Size = "sm" | "md";
+type Size = "sm" | "md" | "lg";
 
 type ButtonProps = {
   children: ReactNode;
@@ -24,6 +24,8 @@ const variants: Record<Variant, string> = {
 const sizes: Record<Size, string> = {
   sm: "px-3 py-1.5",
   md: "px-4 py-2.5",
+  // Hero only. A CTA carrying the page shouldn't wear the nav's 13px type.
+  lg: "px-5 py-3 text-body",
 };
 
 // A link styled as a button. Everything on this page is a link (download /

--- a/website/src/components/ui/theme-toggle.tsx
+++ b/website/src/components/ui/theme-toggle.tsx
@@ -5,11 +5,10 @@ import { useTheme } from "next-themes";
 import { useSyncExternalStore } from "react";
 import { cn } from "../../lib/cn";
 
-// The same three choices the app's Appearance setting offers, in the same
-// order, so the site and Settings › General read as one product.
+// Three explicit targets, never a cycling button: landing on Light at night blinds the reader.
 const options = [
-  { value: "system", label: "System", Icon: Monitor },
   { value: "light", label: "Light", Icon: Sun },
+  { value: "system", label: "System", Icon: Monitor },
   { value: "dark", label: "Dark", Icon: Moon },
 ] as const;
 
@@ -28,7 +27,7 @@ export function ThemeToggle({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "inline-flex items-center gap-0.5 rounded-lg border border-border p-0.5",
+        "inline-flex items-center gap-1 rounded-full border border-border p-1",
         className,
       )}
       role="radiogroup"
@@ -46,13 +45,13 @@ export function ThemeToggle({ className }: { className?: string }) {
             title={label}
             onClick={() => setTheme(value)}
             className={cn(
-              "flex size-7 items-center justify-center rounded-md transition-colors",
+              "flex size-8 items-center justify-center rounded-full transition-colors",
               active
-                ? "bg-tint/8 text-fg"
+                ? "bg-tint/10 text-fg"
                 : "text-fg-subtle hover:bg-tint/5 hover:text-fg",
             )}
           >
-            <Icon size={15} strokeWidth={1.9} />
+            <Icon size={16} strokeWidth={1.9} />
           </button>
         );
       })}

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -14,6 +14,8 @@ export const site = {
   community: {
     discord: "https://discord.gg/v2Eeb4QQy3",
   },
+  support:
+    "https://buy.polar.sh/polar_cl_NDVFC20DKQpLcNawsh97QzbARBXD3WNn8v35R0mbJmT",
 } as const;
 
 // The hero, in as few words as possible — headline plus one punchy line.

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -65,7 +65,7 @@ export const quarantineCommand =
 
 // Headline numbers for the "why it's tiny" band. Kept honest, from the README.
 export const stats = [
-  { value: "<3", unit: "MB", label: "On disk" },
+  { value: "<5", unit: "MB", label: "On disk" },
   { value: "<100", unit: "MB", label: "Memory" },
   { value: "0", unit: "", label: "Dependencies" },
   { value: "0", unit: "", label: "Telemetry" },


### PR DESCRIPTION
## Related issue

Closes #

<!-- No issue linked yet. -->

## What changed

A **Support window** in the app, and a link to the same checkout from the site and the README.

**Reachable four ways** — the palette's bottom-left menu circle (between About and Settings), Settings → About, the menu bar, and `CommandID.support` in the launcher. All four land on `SupportCoordinator.showSupport()`, which is also the only place that writes the reminder anchor, so any route counts as an ask. `AppEntry.Kind` is untouched; a built-in command is already `.command`.

**The reminder.** `SupportReminderSchedule` is pure — Foundation only, every date injected — and answers one question: how long until the next ask. `SupportReminderStore` holds the anchor in `support-reminder.json` under Application Support (not `caches()`, which a purge would reset) and drives a single `Task` pump modelled on `UpdateCheckStore`.

Three things worth reading the diff for:

- **Showing the window is what moves the anchor**, by any route, so there is exactly one writer.
- **It withholds rather than interrupts.** A withheld ask leaves the anchor alone, so it is still owed and returns in ten minutes instead of losing the month. The wait after an offer is floored at that retry interval, which is what stops the pump spinning if the anchor did not move.
- **The first ask lands one interval after first run**, not after launch: with no `lastAskedAt` the anchor is `firstSeenAt`.

**One shared-policy change outside the feature.** `UpdateCoordinator`'s `private var activity` moves onto `AppCore` as `currentActivity`, with `canInterruptUser` beside it, so both prompts read one readiness gate instead of the support reminder duplicating seven cases under a different name. `UpdateReadiness` keeps its name and its `Blocker` messages; nothing in `Tests/updates-test.swift` changed.

**The preference.** `supportRemindersEnabled` defaults on (`object(forKey:) == nil || bool(...)`, so absence is on and a stored `false` survives) and is mirrored into settings backups — it grants no capability, it only silences a prompt.

**Outside the app** the link is a bare button and nothing else: the website's hero and footer, the docs sidebar, and a badge in the README. `SupportCoordinator.checkout` is the only copy of the URL on the app side.

### Also here, from working on the same pages

- The hero drops to two actions, Download and Support, at a new `lg` button size. View source moved to the nav's icon row beside Discord.
- The theme switcher left the nav for the footer's bottom-right corner. It stays **three explicit targets** rather than one cycling button — cycling can drop a reader onto Light at night with no warning.
- The install section takes the full container width; the brew commands were scrolling sideways inside a `max-w-2xl` column.
- Second commit: every claim of **3 MB on disk** becomes 5 MB, and the release-binary budget in `standards.md` / `testing.md` goes 4 → 5 so the ceiling is not below the claim.

## Memory footprint

<!-- NOT MEASURED — needs filling in before merge. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

The standing cost is one `SupportReminderStore` (two `Date`s and a `Task`) plus a window built on first show and torn down on close, so its SwiftUI tree deallocates. The pump sleeps until the next ask, capped at an hour, and idles at an hour when reminders are off.

## Demo

<!-- NOT RECORDED — the side-by-side before/after clip is still owed. -->

## Drawbacks

- **The reminder can open a window unprompted.** It is gated on `canInterruptUser` and capped at one ask per 30 days per showing, and the checkbox is on by default — the part most likely to draw comment. Turning it off is permanent and the window says so.
- **`AppCore.currentActivity` keeps the `UpdateActivity` type name** while now serving two callers. Renaming it would have churned 19 references in `updates-test`; a shared `canInterruptUser` accessor buys the same clarity for nothing.
- `SupportActionButton` is a custom button style local to Support rather than anything shared, on the same principle the extensions surfaces follow.
- The second commit is unrelated to the feature and could be split out if preferred.

## Tests & validation

- `./Scripts/run-tests.sh` — all 47 harnesses pass, rebased on `main`.
- **New harness `Tests/support-test.swift`** over `SupportReminderSchedule`: due exactly at the interval and not a second before, never a negative wait when long overdue, and clamped when the clock moved backwards — a machine whose clock went back a decade waits one interval, not eleven.
- `Tests/settings-backup-test.swift` covers the new key by construction: an `AppSettingsKey` that is neither mirrored nor deliberately excluded fails the suite.
- Debug build compiles with no new warnings; `./Scripts/lint.sh` clean; `swift-format lint` clean on the new files; the `Features/*/Model/` purity grep returns nothing.
- Website: `npm run build` (type-check + static export) and `npm run lint` both clean.
- Launched `Tinycast Dev.app` and confirmed a first run stamps `firstSeenAt` into `support-reminder.json`.

**Not yet exercised by hand**, which is why Demo is empty: I could not drive the menu bar item to open the window (no assistive access for `osascript` on this machine), so the four entry points, Light/Dark over a bright wallpaper, and the reminder firing on a back-dated anchor still need a manual pass.
