### PR TITLE
feat: Business days calculation and native AI tool calling subsystem

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -19,7 +19,7 @@ if [ "${1:-}" = "--exec" ]; then
     shift
     name=$1 opt=$2
     shift 2
-    if ! swiftc -swift-version 6 "$opt" "$@" "Tests/$name.swift" -o "$BIN/$name" > "$BIN/$name.log" 2>&1; then
+    if ! swiftc -swift-version 6 "$opt" $* "Tests/$name.swift" -o "$BIN/$name" > "$BIN/$name.log" 2>&1; then
         printf '\033[31mFAIL\033[0m  %-22s did not compile\n' "$name"
         : > "$BIN/$name.failed"
         exit 0
@@ -65,7 +65,7 @@ run() {
     local name=$1
     shift
     if [ -n "$only" ] && [ "$name" != "$only" ]; then return 0; fi
-    ran=$((ran + 1))
+    ran=$((ran + 1))\
 
     # Absolute paths throughout: sourcekit-lsp resolves the command itself and does not apply
     # `directory` to relative arguments, so a relative path there silently yields no index.
@@ -225,13 +225,23 @@ run support-test           Tinycast/Features/Support/Model/*.swift
 run ai-provider-test       Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/AI/Model/*.swift \
                            Tinycast/Features/AI/Settings/AISettingsStore.swift
-run ai-chat-test           Tinycast/Features/AI/Model/AIRequest.swift \
-                           Tinycast/Features/AI/Model/ChatMessage.swift \
-                           Tinycast/Features/AI/Model/ChatSession.swift \
-                           Tinycast/Features/AI/Model/MarkdownBlock.swift \
+run ai-chat-test           Tinycast/Platform/AppPaths.swift \
+                           Tinycast/Features/Calculator/Model/*.swift \
+                           Tinycast/Features/AI/Model/*.swift \
+                           Tinycast/Features/AI/Tools/WebSearch/Model/*.swift \
+                           Tinycast/Features/AI/Tools/WebSearch/Service/*.swift \
+                           Tinycast/Features/AI/Tools/WebSearch/Service/Engines/*.swift \
+                           Tinycast/Features/AI/Tools/WebFetch/Model/*.swift \
+                           Tinycast/Features/AI/Tools/WebFetch/Service/*.swift \
+                           Tinycast/Features/AI/Service/LocationProvider.swift \
+                           Tinycast/Features/AI/Service/WeatherService.swift \
+                           Tinycast/Features/AI/Service/CalculatorToolRunner.swift \
                            Tinycast/Features/AI/Service/AIProvider.swift \
+                           Tinycast/Features/AI/Service/AIToolRegistry.swift \
                            Tinycast/Features/AI/Service/ChatHistoryStore.swift \
                            Tinycast/Features/AI/UI/AIChatState.swift
+run web-search-test        Tinycast/Features/AI/Tools/WebSearch/Model/*.swift \
+                           Tinycast/Features/AI/Tools/WebFetch/Model/*.swift
 run slow codex-turn-test   Tinycast/Platform/AppPaths.swift \
                            Tinycast/Features/AI/Model/*.swift \
                            Tinycast/Features/AI/Service/AIProvider.swift \
@@ -258,25 +268,24 @@ fi
 
 if [ "$ran" -eq 0 ]; then
     echo "No harness named '$only'." >&2
-    exit 2
-fi
-
-# `sort -s` is stable, so the slow harnesses lead and everything else keeps its declaration order.
-JOBS="${TINYCAST_TEST_JOBS:-$(sysctl -n hw.ncpu)}"
-sort -s -k1,1n "$QUEUE" | cut -d' ' -f2- | xargs -P "$JOBS" -L1 "$SELF" --exec
-
-# A compiler diagnostic is far longer than PIPE_BUF, so the workers log it and it is replayed here.
-while read -r _ name _; do
-    if [ -f "$BIN/$name.failed" ]; then failed+=("$name"); fi
-done < "$QUEUE"
-
-if [ ${#failed[@]} -gt 0 ]; then
-    for name in "${failed[@]}"; do
-        printf '\n\033[31m--- %s ---\033[0m\n' "$name"
-        cat "$BIN/$name.log"
-    done
-    printf '\n%d harness(es) failed: %s\n' "${#failed[@]}" "${failed[*]}" >&2
     exit 1
 fi
-echo
-if [ -n "$only" ]; then echo "$only passed."; else echo "All $ran harnesses passed."; fi
+
+sort -n "$QUEUE" | while read -r _pri name opt sources; do
+    printf '%s\0%s\0%s\0' "$name" "$opt" "$sources"
+done | xargs -0 -n 3 -P "$(sysctl -n hw.ncpu 2>/dev/null || nproc || echo 4)" "$SELF" --exec
+
+for f in "$BIN"/*.failed; do
+    [ -f "$f" ] && failed+=("$(basename "$f" .failed)")
+done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    printf '\n\033[31m%d of %d harness(es) failed:\033[0m\n' "${#failed[@]}" "$ran"
+    for name in "${failed[@]}"; do
+        printf '  \033[31m•\033[0m %s\n' "$name"
+        sed 's/^/    /' "$BIN/$name.log"
+    done
+    exit 1
+fi
+
+printf '\n\033[32mAll %d harnesses passed.\033[0m\n' "$ran"

--- a/Tests/web-search-test.swift
+++ b/Tests/web-search-test.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+@main
+@MainActor
+struct WebSearchTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func main() {
+        testQueryParsing()
+        testURLRedirectDecoding()
+        testURLNormalizer()
+        testConsensusScoring()
+        testHTMLToMarkdownConverter()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    static func testQueryParsing() {
+        let q1 = WebSearchQuery(query: "swift 6 concurrency")
+        expect(q1.category == .general, "default category is general")
+        expect(q1.searchTerm == "swift 6 concurrency", "search term matches")
+
+        let q2 = WebSearchQuery(query: "steve jobs !w")
+        expect(q2.category == .wikipedia, "bang !w selects wikipedia")
+        expect(q2.searchTerm == "steve jobs", "bang is removed from search term")
+
+        let q3 = WebSearchQuery(query: "!news apple event")
+        expect(q3.category == .news, "bang !news selects news")
+        expect(q3.searchTerm == "apple event", "news bang stripped")
+
+        let q4 = WebSearchQuery(query: "site:github.com tinycast")
+        expect(q4.siteConstraint == "github.com", "site: extracted")
+        expect(q4.searchTerm == "site:github.com tinycast", "site: preserved in query")
+    }
+
+    static func testURLRedirectDecoding() {
+        let ddgRedirect = "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Ftarget%3Fparam%3D1&rut=..."
+        let decodedDDG = URLRedirectDecoder.decode(ddgRedirect)
+        expect(decodedDDG?.absoluteString == "https://example.com/target?param=1", "DDG uddg decoded")
+
+        let aolRedirect = "https://search.aol.com/aol/click/_ylt=.../RU=https%3A%2F%2Fswift.org%2Fabout/RK=2/..."
+        let decodedAOL = URLRedirectDecoder.decode(aolRedirect)
+        expect(decodedAOL?.absoluteString == "https://swift.org/about", "AOL RU decoded")
+
+        let protoRelative = "//developer.apple.com/documentation"
+        let decodedProto = URLRedirectDecoder.decode(protoRelative)
+        expect(decodedProto?.absoluteString == "https://developer.apple.com/documentation", "protocol-relative decoded")
+    }
+
+    static func testURLNormalizer() {
+        let dirtyURL = URL(string: "https://www.example.com/article?utm_source=twitter&utm_medium=social&fbclid=12345&id=42#heading")!
+        let cleanURL = URLNormalizer.normalize(dirtyURL)
+        expect(cleanURL.absoluteString == "https://example.com/article?id=42", "trackers, www, and fragment stripped")
+
+        let key1 = URLNormalizer.deduplicationKey(for: URL(string: "https://www.example.com/page/")!)
+        let key2 = URLNormalizer.deduplicationKey(for: URL(string: "https://example.com/page?utm_source=news")!)
+        expect(key1 == key2, "deduplication keys match for canonical URLs")
+    }
+
+    static func testConsensusScoring() {
+        let urlA = URL(string: "https://example.com/a")!
+        let urlB = URL(string: "https://example.com/b")!
+
+        let r1 = WebSearchResult(title: "Page A - DDG", url: urlA, snippet: "Short", engine: .duckDuckGo, rank: 1)
+        let r2 = WebSearchResult(title: "Page B - DDG", url: urlB, snippet: "Snippet B", engine: .duckDuckGo, rank: 2)
+
+        let r3 = WebSearchResult(title: "Page A - Brave", url: urlA, snippet: "Longer snippet for page A", engine: .brave, rank: 1)
+
+        let results = ConsensusScorer.score(engineResults: [[r1, r2], [r3]])
+
+        expect(results.count == 2, "deduplicated to 2 results")
+        expect(results[0].url.absoluteString == "https://example.com/a", "Page A ranked top due to consensus")
+        expect(results[0].score > results[1].score, "consensus score is higher")
+        expect(results[0].snippet == "Longer snippet for page A", "picked best snippet")
+    }
+
+    static func testHTMLToMarkdownConverter() {
+        let html = """
+        <html>
+        <head><title>Test Page</title><style>.hidden { display: none; }</style></head>
+        <body>
+        <nav><a href="/home">Home</a></nav>
+        <article>
+            <h1>Main Title</h1>
+            <p>This is a <b>bold</b> paragraph with a <a href="https://example.com">link</a>.</p>
+            <p>Here is <code>let x = 10</code> and an entity &amp; &lt; &gt; &#39;.</p>
+            <pre><code>func hello() {\n    print("hi")\n}</code></pre>
+            <ul>
+                <li>Item 1</li>
+                <li>Item 2</li>
+            </ul>
+        </article>
+        <footer><p>Copyright 2026</p></footer>
+        </body>
+        </html>
+        """
+
+        let md = HTMLToMarkdownConverter.convert(html: html, maxCharacters: 1000)
+        expect(md.contains("# Main Title"), "converted h1")
+        expect(md.contains("**bold**"), "converted bold")
+        expect(md.contains("[link](https://example.com)"), "converted link")
+        expect(md.contains("& < > '"), "decoded entities")
+        expect(md.contains("`let x = 10`"), "converted inline code")
+        expect(md.contains("```"), "converted code block")
+        expect(!md.contains("Copyright 2026"), "stripped footer")
+        expect(!md.contains("<style>"), "stripped style")
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0360C7038877B9CB656DB697 /* WindowManagementSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21678BAD7BA4A4E300FDA2C /* WindowManagementSettingsView.swift */; };
 		03C41F6394089BAEC7E630D6 /* ClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF6EF3A2C35F45B82D40968 /* ClipboardView.swift */; };
 		05683E4BDBD1FD73FCECACB9 /* RaycastV2Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686FF2D1ACA22007B8C9D534 /* RaycastV2Decoder.swift */; };
+		0650146C4DD0EEADBAFC6988 /* ConsensusScorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E2B964382B92F3E3D6060B /* ConsensusScorer.swift */; };
 		07726F26DC68689F8984F467 /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D0784E49BC5899A585F285 /* Scrypt.swift */; };
 		0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395BACF833C810961A248F0 /* BarButton.swift */; };
 		089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ABE4AF80DD5F5F8E91F63E /* SpotlightNames.swift */; };
@@ -30,6 +31,7 @@
 		0FC4608F65D69D465EFBBCE0 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E582B93EFB1A2AA85B048A87 /* CalcFormatter.swift */; };
 		106AF34CEAEB08CBCC924118 /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273827EB5CC04F1951C40387 /* VolumeLevel.swift */; };
 		109E27ACDAADDA42FE33E119 /* SettingsNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364BEC0805A8F5C39444EAF5 /* SettingsNavigationState.swift */; };
+		10A877768F2C16746FFE6B73 /* WebSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F201BE9293FB355E9178B017 /* WebSearchResult.swift */; };
 		11C3F9D5C786EF1D11787E0C /* CustomCommandCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41DC04958D7C2FF8C47F62 /* CustomCommandCoordinator.swift */; };
 		11EF7061ED64616FFB13423F /* SettingsHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C504229760FFFFA9D8A7799 /* SettingsHistory.swift */; };
 		122CA8786B58966376B27DC1 /* HyperKeyTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1868F87E31E20A4775C84E6A /* HyperKeyTap.swift */; };
@@ -38,11 +40,13 @@
 		14D056C9DA105D9D89A9691E /* HealthTicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB023D167225228757CC4B2 /* HealthTicker.swift */; };
 		15292937738B7CD3AE23EF73 /* VolumeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27FB790A72ACD75DFCDFDDF /* VolumeSlider.swift */; };
 		16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2575583134BE03EA9FA719CD /* ActivationPolicy.swift */; };
+		174A5ED6BE79E95E353D6817 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5683268B7227F8E592AE85 /* WeatherService.swift */; };
 		175DAAED3859A54861D8CEBC /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFFB1471D30C915BBC5DCBA /* SnippetRepository.swift */; };
 		17F61DEF6389FBCFCCFB467C /* CurrencyRateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEAC591704D983A2C31188F /* CurrencyRateStore.swift */; };
 		18B3F78B6363E80149D4A646 /* ReleaseNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */; };
 		19317D6C8A55E3F85BB7AE1F /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BCAB1F3B6930FE0B819F6D /* OnboardingState.swift */; };
 		19B0314193376FD1E4AC11A5 /* WindowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E779B6EF738591CB935F3F95 /* WindowLayout.swift */; };
+		19F36636F27933FA8278642A /* AITool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBE70702D22F894C6B1A790 /* AITool.swift */; };
 		1A831E78CC5D84D543763B9C /* ExtensionStoreSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AE5D924466E1E80818A98 /* ExtensionStoreSheet.swift */; };
 		1B9BC6B00770D1F002E62E0D /* ExtensionBootConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5AAA98FFF7A4D34D7B490D /* ExtensionBootConfig.swift */; };
 		1BC16048EE05A1FD25739CB4 /* PaletteState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188A6D3C5B6BC67716F15F83 /* PaletteState.swift */; };
@@ -54,22 +58,28 @@
 		1F8F2135470F74627A644ACC /* ClipboardFilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */; };
 		208FFC22E116E53E7BF3D147 /* CalcQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF9F16C3F5567240FF03122 /* CalcQuantity.swift */; };
 		21812A1B54A4DFDC88604C16 /* ReleaseChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198E4EC8AECAAD0D90C4BA50 /* ReleaseChannel.swift */; };
+		218977B28CEE5D5F41440267 /* AIToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050D1C23F4B3E5391A4DB8BE /* AIToolRegistry.swift */; };
 		22420E8A41685143315904F5 /* RaycastImportSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B711492A6DA473E6DC9646C /* RaycastImportSelection.swift */; };
 		22EE4D5AFAAA12E649666019 /* PermissionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C7D17F97002FD58E8A5F53 /* PermissionsSettingsView.swift */; };
 		22FD39D92B6AC3E3E2D9D6FB /* NoteSwitcherWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5311551EDC3AE497384CDE89 /* NoteSwitcherWindowController.swift */; };
+		23CA30B8687B5998B953CD5B /* WebSearchEngineType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785CF2506D1B2A45C3F228F2 /* WebSearchEngineType.swift */; };
 		23E8792D69F3F1C539BC3BC6 /* ExtensionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8CDDBAC59480E1A7559278 /* ExtensionManager.swift */; };
 		244668334681070EB823FF13 /* QuicklinkArgumentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F524FA7B33C0F861995EB1E6 /* QuicklinkArgumentsScreen.swift */; };
 		24EFA87B2617537B6CAAD52B /* FileSearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC2CD86BAA6567B66B2B4DB /* FileSearchSettingsView.swift */; };
 		24F4BF3EA74E8E65B2B92D6D /* VolumeHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09633E6F9C37F89267341D1D /* VolumeHUDController.swift */; };
+		25583F5306EB0B8F73D83E8F /* URLNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F93E4674020D9D746DF804 /* URLNormalizer.swift */; };
 		25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */; };
 		26DB736F18280E1BE6C6B8BE /* SettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA61A2FAF4E49E466DA8F37 /* SettingsTab.swift */; };
 		279F586CC34205EBA8ACA892 /* CalloutPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DFA4E0FDAC12379F2D38B5 /* CalloutPlacement.swift */; };
+		284EF595FD044A2D9DBF204F /* WebSearchAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D06F041C51BB38F00F22E6 /* WebSearchAggregator.swift */; };
+		28C4913DEAEDDDC6CB27F782 /* DuckDuckGoScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90A897018900F7472A650A1 /* DuckDuckGoScraper.swift */; };
 		29AE7D39F2969F706A8038A6 /* FileSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847C792F7F5F31259EB56ACC /* FileSearchScreen.swift */; };
 		2A7F775568D6F50A7AF4C587 /* CalcParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77FF4F18AAA5D514A674878 /* CalcParser.swift */; };
 		2C788DCDF146ED245150EF82 /* WindowCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */; };
 		2C8F7F5073D77EDC1070E639 /* ToolRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFEBE220187043060F7F286 /* ToolRunner.swift */; };
 		2D51D92BE8EAB5440F4C8517 /* ExtensionPaletteModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0FB3A9CA762A7A8DB99BA6 /* ExtensionPaletteModifiers.swift */; };
 		2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C7F0C39D24F068A8F84864 /* CurrencyData.generated.swift */; };
+		2EEF98FB38EAADBA3CDEFEA4 /* WikipediaEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECB7EA4C19AC4B137A2928C /* WikipediaEngine.swift */; };
 		2F1161E2706CD883E9599000 /* SpaceGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCE65EC20B4FB06BE31FE4 /* SpaceGesture.swift */; };
 		2F2360730BE4992D5745FAD3 /* ExtensionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471E1C3C250FD0A89E2C6430 /* ExtensionListView.swift */; };
 		2F38A89B3481A4C9A13F13A8 /* SnippetKeywordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B00EC4FD8D4D0CD2FE596A /* SnippetKeywordPolicy.swift */; };
@@ -144,12 +154,14 @@
 		5B5BCDD482A9058D38C49314 /* CalcUnits.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC67BADEB6FEC76C88585361 /* CalcUnits.swift */; };
 		5B90A314CF4801995EA0EE01 /* ExtensionHostBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38765BC6C35D03659655BD2B /* ExtensionHostBridge.swift */; };
 		5BF11E6F921BF8ED5CA10878 /* AutoJoinPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65353481F5F8684CB8A6BC8 /* AutoJoinPolicy.swift */; };
+		5C251207F5BCE65D078673C3 /* BraveSearchScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A93BD8AAB1E3E9A580DAA0B /* BraveSearchScraper.swift */; };
 		5C801A9043908577FB99A555 /* DialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32733B27AE0BD75742D1394F /* DialogView.swift */; };
 		5D3E51C5FDA9EE53AFD12181 /* ExtensionFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045EC0C36F08176EE0304F49 /* ExtensionFormView.swift */; };
 		5D3F00F708106ADE1CE263B1 /* EmojiGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1A2CE5E4D5F10346B5F6F3 /* EmojiGridView.swift */; };
 		5DBD1E52658FB1C3EC37AA4F /* AppLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33994DC2FB0A6B23A403CA29 /* AppLauncher.swift */; };
 		5E155BEE2FC62267F516A343 /* CalculatorHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CCB1A47E0022BAEDD1EE96 /* CalculatorHistoryView.swift */; };
 		5E7ABF41CE97983E05653D69 /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A8F78D3F1BFA8E86F9CB47 /* AppAppearance.swift */; };
+		5EBDA7D746E1CAC385143876 /* WebSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = F378046D627FCCD53E9CE231 /* WebSearchQuery.swift */; };
 		5FB708EC91426C41762AB96B /* CalculatorHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D032AC22E53BB9997E492F /* CalculatorHistoryStore.swift */; };
 		5FC53F9968A5DFF24CD109DD /* VisibilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EA0B9FFCBAB10941EC7702 /* VisibilityStore.swift */; };
 		5FED92BC16B1463EBDE38D77 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D41B9E6F2C617D28C83AFF /* ShortcutRecorder.swift */; };
@@ -180,6 +192,7 @@
 		6CDA82FD63F87D07E30E3F82 /* Zlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F097C9983DF27A99694C8BC5 /* Zlib.swift */; };
 		6DF29BAB73F545DA2DE63F9B /* APIKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48D823882DF192FBA253985 /* APIKeyStore.swift */; };
 		6FC9F74D9119AC25D178D748 /* ExtensionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */; };
+		70CA312305A77FDE4D8F03CC /* HTMLToMarkdownConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A89EECB32EFF3DA61341D33 /* HTMLToMarkdownConverter.swift */; };
 		71AA40FC4B8C57FFDE5F8DFC /* SystemAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE72CE02F853ACE956627347 /* SystemAction.swift */; };
 		7320E4B2ABFAE8C1D76A3526 /* ExtensionArgumentsAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154222C91EFDB4D4490B6CE2 /* ExtensionArgumentsAccessory.swift */; };
 		743C70ACA40F61F635DB0B55 /* CalendarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0A2005448E6F88C3F78489 /* CalendarStore.swift */; };
@@ -201,11 +214,13 @@
 		7FDE88F4E065FF80DCB92445 /* NotesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B77DA46386E7E459406E4 /* NotesStore.swift */; };
 		7FF6A0A4702E1C1365F2D76A /* LauncherScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97A8C3E88FEBCBBEADF415B /* LauncherScreen.swift */; };
 		8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */; };
+		80DF4804EBA1150190705E9E /* LocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C1AC3049BEF9241423EB62 /* LocationProvider.swift */; };
 		80E77985425032856DEECDFD /* CalloutShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */; };
 		82D95EF7539498A9A484B3D1 /* SystemActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEB022D080E6DAF703D8132 /* SystemActionsSettingsView.swift */; };
 		8453CF4C0D8D015A66C9B400 /* HoverArming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */; };
 		84A1F72DA5038C3725DCA201 /* FileSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B96B69CB4E52319BB3EC7D /* FileSearchService.swift */; };
 		84DC02099149C542C886B019 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B710F99B5B4E42FFB3EAA8FB /* EmojiCatalog.swift */; };
+		84F6EC70C839BCD0D04809B9 /* NewsRSSEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D760E1899C56808EE6618B5E /* NewsRSSEngine.swift */; };
 		85B372E9A8F8D00D3A5FA260 /* HyperKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BFA41B0D7F369A8CF1E013 /* HyperKey.swift */; };
 		867B82EDC8A12BBC51592786 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD4CE330F75BC5FE5EAD99E /* Tooltip.swift */; };
 		8696DC1B16B6618D22F804D5 /* AIChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC662BDA6856590DCF96B94 /* AIChatState.swift */; };
@@ -241,6 +256,7 @@
 		9B05C47A7414D04E20237B09 /* RenderNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A1D354C1785923E612848C /* RenderNode.swift */; };
 		9B3BC1DCC478DA7517F04182 /* CalculatorHistoryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86545F54669A075FBDA5D1F1 /* CalculatorHistoryScreen.swift */; };
 		9BB417EBD7843DDE09AA0200 /* ChatCopyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E67F6AC9A292F385FB5A5 /* ChatCopyButton.swift */; };
+		9C73CE4491198501BEB39E33 /* YahooSearchScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4540089E8CAB1F69F0C99D1 /* YahooSearchScraper.swift */; };
 		9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387BE675F580496656E72559 /* SymbolCatalog.swift */; };
 		9E257392434C62CCC26C9B04 /* MenuBarLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5844785DFED1196342431F18 /* MenuBarLabel.swift */; };
 		9E4497ECAD183E5C2B49475B /* MeetingDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0599199132DAFBE12C59FBD /* MeetingDay.swift */; };
@@ -276,6 +292,7 @@
 		ACB45791BFE60896455293B4 /* FileSearchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC86115B040B8C574EAD0B5 /* FileSearchPolicy.swift */; };
 		ACD8CAE659B1C49EC8652576 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AD346C8FD5F2D4F00FF2B6 /* HotKeyCenter.swift */; };
 		ACE645630E536C93CA102050 /* VolumeHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90559D7DB9F6F3874CAFCDE /* VolumeHUDView.swift */; };
+		AD8A6A0FD4852DB4D911D6ED /* ChatAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46D988168734C5233DF9FE1 /* ChatAttachment.swift */; };
 		AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */; };
 		AD98F015439106F0E9D32015 /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */; };
 		ADC43E68C1B617D098C71D6E /* AIInstructions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6420FE45699DC3E53907CAE3 /* AIInstructions.swift */; };
@@ -309,7 +326,9 @@
 		C385AEF3C8C5A6B2BACC1D9A /* OverflowFade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88499DF2F503F2A3A19DEF07 /* OverflowFade.swift */; };
 		C396379DCAD85611D4C6F587 /* UpdateDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD81541882CBCC5B06F718F /* UpdateDownloader.swift */; };
 		C4479572F65559306118A9F0 /* CodexTurnRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82DD04042376EBDEF3E84C /* CodexTurnRunner.swift */; };
+		C47B5C70923FF3B3E65EE6F0 /* CalculatorToolRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77E4C211477E42B1E865473 /* CalculatorToolRunner.swift */; };
 		C4B9E9B3E965BFDFD31EDC3D /* LauncherCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858E08BB313EC330C2D5E50C /* LauncherCoordinator.swift */; };
+		C547B48E21926BF664DF1AEB /* PDFDocumentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44284459BF2D9E71E19AE8 /* PDFDocumentReader.swift */; };
 		C5F60D8681235B95DAA3314F /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */; };
 		C7468FBE50BAEC5084D4DB17 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848E14DE51403235A82BC287 /* AIProvider.swift */; };
 		C9A7290682E9D0881713C009 /* ExtensionGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85C82C66132C7723272E873 /* ExtensionGridGeometry.swift */; };
@@ -329,6 +348,7 @@
 		D02DD53E9BE6C679EA0C0375 /* NoteSwitcherInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AD14D51F74D1891D5532B0 /* NoteSwitcherInteraction.swift */; };
 		D07983DDEA61E5F2B8681F01 /* QuicklinkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CD7B0E866AEF486F9EC5E9 /* QuicklinkCoordinator.swift */; };
 		D07F272D0E095B6000D53716 /* NotesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5AFB680B55BBAFF2207F99 /* NotesCoordinator.swift */; };
+		D1BF5F85DDD6E22F5805B412 /* URLRedirectDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4777ECE381597380E6A3DDCA /* URLRedirectDecoder.swift */; };
 		D1F9C28CA4048480DB818EE9 /* LauncherList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132C5A534C02305C1A29CC74 /* LauncherList.swift */; };
 		D3F07F4AEBEAA489EDCD0763 /* FileSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FE27F894A8777C8ACCF1D /* FileSearchList.swift */; };
 		D44E20726F1EB11C8C297C4D /* WindowActionMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */; };
@@ -357,6 +377,7 @@
 		E4E1403AA9A8ACE4A3D3581C /* MeetingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B330ABFC83721904159DDF2 /* MeetingEvent.swift */; };
 		E58AB83C608F8BBF99EAEB7E /* QuicklinkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856F65245B10433A230194E6 /* QuicklinkListView.swift */; };
 		E63AA3E7A400CB81FBFC3214 /* RaycastFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09A0608AC763EBC26216118 /* RaycastFormat.swift */; };
+		E6BCD8E2D2746D93824C57DE /* WebSearchCacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C285819B27AA3C2D3704A29 /* WebSearchCacheStore.swift */; };
 		E6E8E3E2ECD0CD9A982115F3 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAA05D695590C4B654E5BF /* OnboardingCoordinator.swift */; };
 		E6E929E9284E8AC361D64D6A /* MenuBarSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6FD4FBAC3F5E6255D62773 /* MenuBarSummary.swift */; };
 		E77BF5D26A6D9E9FC7E82259 /* ChatTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798C6CF803D5E1BB2FFE4 /* ChatTranscriptView.swift */; };
@@ -365,17 +386,20 @@
 		EA077323DE71DAF8FE17693C /* CalendarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC504A12A2D9CC00B502D9E /* CalendarCoordinator.swift */; };
 		EA2587800F2CA347788C6F8C /* UninstallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0508EBDFD6E59370AB2E5B7 /* UninstallScreen.swift */; };
 		EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C045C66BB654E4CB407A673 /* AppActionsMenu.swift */; };
+		EB862E1E6104609429412155 /* WebPageReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB8F1BE3257D46C414C4117 /* WebPageReader.swift */; };
 		EBCDF88CD59A4B6F21F945C6 /* Quicklink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3385A84985A52E2DA3596 /* Quicklink.swift */; };
 		EDD7861202ECC1B0FA3B278E /* FileSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7420F642776452B469182D0 /* FileSearchResult.swift */; };
 		F3E0C5D483CC854D63448A4B /* UpdateReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76460C2D60828CC79F0CE972 /* UpdateReadiness.swift */; };
 		F44DA0C81285A90138E13A7B /* ChatGPTSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */; };
 		F51785CF5A6EC0B87D6802C9 /* ExtensionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCBDD92DEAD780A1DC423CA /* ExtensionScreen.swift */; };
 		F71FC7195AC8D6626BEE8931 /* NotesPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91151402A1A4586B2496BF35 /* NotesPanel.swift */; };
+		F7E452309C7C0C10E1C0FFD0 /* WebSearchCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828709FB1AA8E57E993EF8E3 /* WebSearchCategory.swift */; };
 		F801D00F877421DC7045C5F3 /* RedactedPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131B15F5EF86A067FA6C36D7 /* RedactedPlaceholder.swift */; };
 		F85CE4CDCF7589ACAEF2CA20 /* AppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E23F92F4B4DEEE55077C7C /* AppIconView.swift */; };
 		F8D69CE2A8C04DEEC1810A1F /* UninstallRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D134673CB1B563A3758FC37 /* UninstallRunner.swift */; };
 		F8E1B044D84E96FB455155CD /* AIModelDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B27ECEB1C09B14C403FC8 /* AIModelDiscoveryService.swift */; };
 		F8EC987B884BD2ED6A6690A9 /* SnippetKeywordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301BA9123035D6BFB808F763 /* SnippetKeywordListener.swift */; };
+		F9D0BA815A91F3B63D621F69 /* AolSearchScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826BC9BB49A1E81B69469C66 /* AolSearchScraper.swift */; };
 		FA05D882203673A9FEE5F421 /* UninstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFBFA70EF62B67F7357E0E /* UninstallCoordinator.swift */; };
 		FA386C9B6DA24481565D506D /* ExtensionPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */; };
 		FAF6C108845548DDC7F978CB /* SnippetExpansionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102C22092D130BD8E1A07CD6 /* SnippetExpansionCoordinator.swift */; };
@@ -396,8 +420,10 @@
 		030E67F6AC9A292F385FB5A5 /* ChatCopyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCopyButton.swift; sourceTree = "<group>"; };
 		0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIStreamDecoder.swift; sourceTree = "<group>"; };
 		03757CDEFC14359CAEF4CE93 /* FileSearchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchSession.swift; sourceTree = "<group>"; };
+		03D06F041C51BB38F00F22E6 /* WebSearchAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchAggregator.swift; sourceTree = "<group>"; };
 		03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarView.swift; sourceTree = "<group>"; };
 		045EC0C36F08176EE0304F49 /* ExtensionFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFormView.swift; sourceTree = "<group>"; };
+		050D1C23F4B3E5391A4DB8BE /* AIToolRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToolRegistry.swift; sourceTree = "<group>"; };
 		0548C62E98174F92E13437FB /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
 		06125F7DDE68BB4D52065C06 /* WindowCommandCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommandCoordinator.swift; sourceTree = "<group>"; };
 		08279257B0F5995E86FF2C03 /* EntryIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryIconView.swift; sourceTree = "<group>"; };
@@ -433,6 +459,7 @@
 		188A6D3C5B6BC67716F15F83 /* PaletteState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteState.swift; sourceTree = "<group>"; };
 		197035E213BEBA67DDA3377B /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
 		198E4EC8AECAAD0D90C4BA50 /* ReleaseChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChannel.swift; sourceTree = "<group>"; };
+		1A89EECB32EFF3DA61341D33 /* HTMLToMarkdownConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLToMarkdownConverter.swift; sourceTree = "<group>"; };
 		1AA26F487C06DC6F03F78B13 /* ExtensionAppearanceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearanceStore.swift; sourceTree = "<group>"; };
 		1B865FF16D3C395A8D509B94 /* QuicklinkLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkLauncher.swift; sourceTree = "<group>"; };
 		1DE1B6753513C787B3FFE423 /* AIConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConnection.swift; sourceTree = "<group>"; };
@@ -468,6 +495,7 @@
 		2E393E2CA842C5B344C6B499 /* SupportReminderSchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportReminderSchedule.swift; sourceTree = "<group>"; };
 		2EC7DC9AD5E54C26387F29F6 /* MarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownView.swift; sourceTree = "<group>"; };
 		2EE496AA4863086BB49CBF2E /* EventDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDraft.swift; sourceTree = "<group>"; };
+		2F44284459BF2D9E71E19AE8 /* PDFDocumentReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentReader.swift; sourceTree = "<group>"; };
 		2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSourceSwitcher.swift; sourceTree = "<group>"; };
 		301BA9123035D6BFB808F763 /* SnippetKeywordListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetKeywordListener.swift; sourceTree = "<group>"; };
 		30BBF211CE6A076EAF8D6C33 /* ExtensionManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManifest.swift; sourceTree = "<group>"; };
@@ -489,6 +517,7 @@
 		387BE675F580496656E72559 /* SymbolCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolCatalog.swift; sourceTree = "<group>"; };
 		38A97022BE0F95B5D19F0C26 /* CalcDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateTime.swift; sourceTree = "<group>"; };
 		391B8024E8719506361B45F7 /* FileSearchQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchQuery.swift; sourceTree = "<group>"; };
+		3A93BD8AAB1E3E9A580DAA0B /* BraveSearchScraper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveSearchScraper.swift; sourceTree = "<group>"; };
 		3AA3385A84985A52E2DA3596 /* Quicklink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quicklink.swift; sourceTree = "<group>"; };
 		3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
 		3C504229760FFFFA9D8A7799 /* SettingsHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHistory.swift; sourceTree = "<group>"; };
@@ -510,6 +539,7 @@
 		46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCoordinator.swift; sourceTree = "<group>"; };
 		471E1C3C250FD0A89E2C6430 /* ExtensionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionListView.swift; sourceTree = "<group>"; };
 		474E6D9830E336752C79F461 /* MeetingClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingClock.swift; sourceTree = "<group>"; };
+		4777ECE381597380E6A3DDCA /* URLRedirectDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRedirectDecoder.swift; sourceTree = "<group>"; };
 		4AA61A2FAF4E49E466DA8F37 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		4AEBAA9641BC6C279DB0123C /* CameraPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewController.swift; sourceTree = "<group>"; };
 		4BEA1E122A8139A21E646FE2 /* RedactedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactedText.swift; sourceTree = "<group>"; };
@@ -519,6 +549,7 @@
 		4EF9F16C3F5567240FF03122 /* CalcQuantity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcQuantity.swift; sourceTree = "<group>"; };
 		4FA081CD5CEA054447D0691F /* ExtensionRegistriesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRegistriesSheet.swift; sourceTree = "<group>"; };
 		4FAE24CC14F7DFECD1BD7FB1 /* PopoverMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverMenu.swift; sourceTree = "<group>"; };
+		4FBE70702D22F894C6B1A790 /* AITool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITool.swift; sourceTree = "<group>"; };
 		50E2E570E54DEEF29FF2B65E /* NotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesView.swift; sourceTree = "<group>"; };
 		518429EDBFBEA0B866CCAA81 /* CalculatorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCoordinator.swift; sourceTree = "<group>"; };
 		52146CB01C791AB02518273D /* ExtensionCommandScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCommandScreen.swift; sourceTree = "<group>"; };
@@ -530,6 +561,7 @@
 		53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteEscapeAction.swift; sourceTree = "<group>"; };
 		548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardScreen.swift; sourceTree = "<group>"; };
 		54E48A8D5E2BC00E9E1CD5BF /* QuicklinkArgumentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentSession.swift; sourceTree = "<group>"; };
+		55F93E4674020D9D746DF804 /* URLNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLNormalizer.swift; sourceTree = "<group>"; };
 		570CE37C7133E28F7495ED91 /* MarkdownCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeView.swift; sourceTree = "<group>"; };
 		5844785DFED1196342431F18 /* MenuBarLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabel.swift; sourceTree = "<group>"; };
 		590A432CC25ED6372B453BFA /* ScheduleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleScreen.swift; sourceTree = "<group>"; };
@@ -558,7 +590,9 @@
 		686FF2D1ACA22007B8C9D534 /* RaycastV2Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastV2Decoder.swift; sourceTree = "<group>"; };
 		6AF26598BE61F114D5999541 /* NotesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesSettingsView.swift; sourceTree = "<group>"; };
 		6C045C66BB654E4CB407A673 /* AppActionsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActionsMenu.swift; sourceTree = "<group>"; };
+		6C285819B27AA3C2D3704A29 /* WebSearchCacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchCacheStore.swift; sourceTree = "<group>"; };
 		6D594CB90475093D58A2AB1E /* NoteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSearch.swift; sourceTree = "<group>"; };
+		6ECB7EA4C19AC4B137A2928C /* WikipediaEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikipediaEngine.swift; sourceTree = "<group>"; };
 		71B96B69CB4E52319BB3EC7D /* FileSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchService.swift; sourceTree = "<group>"; };
 		725A38B32FDAA64D4A4A88DF /* SnippetTextInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTextInjector.swift; sourceTree = "<group>"; };
 		72DF1178CD8AD726AC6F9874 /* CalculatorCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCardView.swift; sourceTree = "<group>"; };
@@ -568,7 +602,9 @@
 		74284B4E771DA0B2869C914E /* RaycastRuntime.generated.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = RaycastRuntime.generated.js; sourceTree = "<group>"; };
 		76460C2D60828CC79F0CE972 /* UpdateReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateReadiness.swift; sourceTree = "<group>"; };
 		7732FB0ED92C8FBFE22599CE /* ExtensionStoreResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStoreResponse.swift; sourceTree = "<group>"; };
+		77C1AC3049BEF9241423EB62 /* LocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProvider.swift; sourceTree = "<group>"; };
 		7817B7A8760B36FDA43F48FC /* CalcEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcEngine.swift; sourceTree = "<group>"; };
+		785CF2506D1B2A45C3F228F2 /* WebSearchEngineType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchEngineType.swift; sourceTree = "<group>"; };
 		787059DAE8AB67FFE684C0D9 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		79BC68E042182F7068220BB3 /* QuicklinksSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinksSettingsView.swift; sourceTree = "<group>"; };
 		79E1BEE80A3B75140D10D740 /* AppPickerPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPickerPopover.swift; sourceTree = "<group>"; };
@@ -584,6 +620,8 @@
 		7F84B7743B803F55C41D5C4A /* NotesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesRepository.swift; sourceTree = "<group>"; };
 		802BD2F4CC057228F2528217 /* PalettePlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalettePlacement.swift; sourceTree = "<group>"; };
 		810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRegistry.swift; sourceTree = "<group>"; };
+		826BC9BB49A1E81B69469C66 /* AolSearchScraper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AolSearchScraper.swift; sourceTree = "<group>"; };
+		828709FB1AA8E57E993EF8E3 /* WebSearchCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchCategory.swift; sourceTree = "<group>"; };
 		83C54F3A609CD1C2CDF304FB /* DoubleTapDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapDetector.swift; sourceTree = "<group>"; };
 		83CD7B0E866AEF486F9EC5E9 /* QuicklinkCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkCoordinator.swift; sourceTree = "<group>"; };
 		847C792F7F5F31259EB56ACC /* FileSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchScreen.swift; sourceTree = "<group>"; };
@@ -626,8 +664,10 @@
 		9979DED5579535D1F0A32DBF /* AppWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppWindowController.swift; sourceTree = "<group>"; };
 		9A7F606D7F71B6FC0CC6ABC8 /* UninstallScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallScanner.swift; sourceTree = "<group>"; };
 		9AAFBFA70EF62B67F7357E0E /* UninstallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallCoordinator.swift; sourceTree = "<group>"; };
+		9AB8F1BE3257D46C414C4117 /* WebPageReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageReader.swift; sourceTree = "<group>"; };
 		9ADAA05D695590C4B654E5BF /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		9B107F5E532C8DE74430723B /* PaletteTabAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteTabAction.swift; sourceTree = "<group>"; };
+		9B5683268B7227F8E592AE85 /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		9B9ADC5C0B42F7EF38F77DE6 /* WindowCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommand.swift; sourceTree = "<group>"; };
 		9BD81541882CBCC5B06F718F /* UpdateDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDownloader.swift; sourceTree = "<group>"; };
 		9C37CCD024267EB21876C7E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -700,6 +740,7 @@
 		C54C4540AD6F188A2455473F /* ExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRuntime.swift; sourceTree = "<group>"; };
 		C5BA06E4CC7E8D40E3285F16 /* KeyCapChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCapChip.swift; sourceTree = "<group>"; };
 		C72AE5D924466E1E80818A98 /* ExtensionStoreSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStoreSheet.swift; sourceTree = "<group>"; };
+		C77E4C211477E42B1E865473 /* CalculatorToolRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorToolRunner.swift; sourceTree = "<group>"; };
 		C7B3FC48B58E1005453E7E18 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		C80806A442BADAC390ECD993 /* RaycastSnippetImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastSnippetImport.swift; sourceTree = "<group>"; };
 		C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDetailView.swift; sourceTree = "<group>"; };
@@ -719,8 +760,10 @@
 		D3F82845FDA307DF71676352 /* CalendarAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccess.swift; sourceTree = "<group>"; };
 		D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTSubscription.swift; sourceTree = "<group>"; };
 		D43F1080FB443A1D0616790E /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
+		D4540089E8CAB1F69F0C99D1 /* YahooSearchScraper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YahooSearchScraper.swift; sourceTree = "<group>"; };
 		D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotesView.swift; sourceTree = "<group>"; };
 		D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearance.swift; sourceTree = "<group>"; };
+		D760E1899C56808EE6618B5E /* NewsRSSEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsRSSEngine.swift; sourceTree = "<group>"; };
 		D8B10DA3A9B1CBD9A03F3DE5 /* NoteDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDocument.swift; sourceTree = "<group>"; };
 		DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasStore.swift; sourceTree = "<group>"; };
 		DA8CBA97041AAA96C0B7FF2E /* BackupActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupActions.swift; sourceTree = "<group>"; };
@@ -757,7 +800,11 @@
 		F023729C84682E9231F3D73B /* ExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstaller.swift; sourceTree = "<group>"; };
 		F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		F097C9983DF27A99694C8BC5 /* Zlib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zlib.swift; sourceTree = "<group>"; };
+		F201BE9293FB355E9178B017 /* WebSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchResult.swift; sourceTree = "<group>"; };
+		F378046D627FCCD53E9CE231 /* WebSearchQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchQuery.swift; sourceTree = "<group>"; };
 		F3F97240A718D95DFD9343DB /* UpcomingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingWindow.swift; sourceTree = "<group>"; };
+		F46D988168734C5233DF9FE1 /* ChatAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachment.swift; sourceTree = "<group>"; };
+		F4E2B964382B92F3E3D6060B /* ConsensusScorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsensusScorer.swift; sourceTree = "<group>"; };
 		F524FA7B33C0F861995EB1E6 /* QuicklinkArgumentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsScreen.swift; sourceTree = "<group>"; };
 		F58E564E6181EB15497E51CD /* SnippetTemplateEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplateEngine.swift; sourceTree = "<group>"; };
 		F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArchive.swift; sourceTree = "<group>"; };
@@ -767,6 +814,7 @@
 		F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClick.swift; sourceTree = "<group>"; };
 		F85C82C66132C7723272E873 /* ExtensionGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionGridGeometry.swift; sourceTree = "<group>"; };
 		F9044F107ADD5896746DBC35 /* Signposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signposts.swift; sourceTree = "<group>"; };
+		F90A897018900F7472A650A1 /* DuckDuckGoScraper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckDuckGoScraper.swift; sourceTree = "<group>"; };
 		FA90C004E55AB1BBC12D9F96 /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		FBF6EF3A2C35F45B82D40968 /* ClipboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardView.swift; sourceTree = "<group>"; };
 		FBFE3C41897391C14DB5A55C /* ShellCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellCommandRunner.swift; sourceTree = "<group>"; };
@@ -819,6 +867,14 @@
 				F9044F107ADD5896746DBC35 /* Signposts.swift */,
 			);
 			path = Platform;
+			sourceTree = "<group>";
+		};
+		05BB3DC1F111E729A9E65200 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				1A89EECB32EFF3DA61341D33 /* HTMLToMarkdownConverter.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		08C16F52EE13C1A75EAAB00F /* Settings */ = {
@@ -1214,6 +1270,8 @@
 				E5861814F16B18935FBF034C /* AIPreamble.swift */,
 				106F9FEF3F0C36E0C5686DA7 /* AIRequest.swift */,
 				0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */,
+				4FBE70702D22F894C6B1A790 /* AITool.swift */,
+				F46D988168734C5233DF9FE1 /* ChatAttachment.swift */,
 				D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */,
 				8F29EE2711B96305EE10B8D8 /* ChatMessage.swift */,
 				1E95EA1EBD6E4B5ECE149FA0 /* ChatSession.swift */,
@@ -1240,6 +1298,15 @@
 				787059DAE8AB67FFE684C0D9 /* AboutView.swift */,
 			);
 			path = About;
+			sourceTree = "<group>";
+		};
+		6EC75F8B6E4F7BF1F4AE145F /* WebFetch */ = {
+			isa = PBXGroup;
+			children = (
+				05BB3DC1F111E729A9E65200 /* Model */,
+				E21D076684272E8E60B221A8 /* Service */,
+			);
+			path = WebFetch;
 			sourceTree = "<group>";
 		};
 		6F218021C90FC685A2DF21CE /* Interaction */ = {
@@ -1386,6 +1453,7 @@
 				62F0568B29175D36EF95BB84 /* Model */,
 				E98B3DB43012A362EF8DAE1D /* Service */,
 				F582FC7869A272CD878A62D4 /* Settings */,
+				8A3BFBF209166CF27DA22A59 /* Tools */,
 				23D42A75084582E88213F309 /* UI */,
 			);
 			path = AI;
@@ -1418,6 +1486,15 @@
 				A4BE2A27D71EDA81D3336B09 /* UI */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		8A3BFBF209166CF27DA22A59 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				6EC75F8B6E4F7BF1F4AE145F /* WebFetch */,
+				BFF990A619FF3DCAFE034C1D /* WebSearch */,
+			);
+			path = Tools;
 			sourceTree = "<group>";
 		};
 		8C33B7F733F716420E5387F2 /* Settings */ = {
@@ -1511,6 +1588,19 @@
 				8AC2CD86BAA6567B66B2B4DB /* FileSearchSettingsView.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		9CA0148CE4F4C35A842F0071 /* Engines */ = {
+			isa = PBXGroup;
+			children = (
+				826BC9BB49A1E81B69469C66 /* AolSearchScraper.swift */,
+				3A93BD8AAB1E3E9A580DAA0B /* BraveSearchScraper.swift */,
+				F90A897018900F7472A650A1 /* DuckDuckGoScraper.swift */,
+				D760E1899C56808EE6618B5E /* NewsRSSEngine.swift */,
+				6ECB7EA4C19AC4B137A2928C /* WikipediaEngine.swift */,
+				D4540089E8CAB1F69F0C99D1 /* YahooSearchScraper.swift */,
+			);
+			path = Engines;
 			sourceTree = "<group>";
 		};
 		A09C141A9646EEE1B40831B1 /* UI */ = {
@@ -1625,6 +1715,20 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		A7414E5CC2BC10AEF27B986D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				F4E2B964382B92F3E3D6060B /* ConsensusScorer.swift */,
+				55F93E4674020D9D746DF804 /* URLNormalizer.swift */,
+				4777ECE381597380E6A3DDCA /* URLRedirectDecoder.swift */,
+				828709FB1AA8E57E993EF8E3 /* WebSearchCategory.swift */,
+				785CF2506D1B2A45C3F228F2 /* WebSearchEngineType.swift */,
+				F378046D627FCCD53E9CE231 /* WebSearchQuery.swift */,
+				F201BE9293FB355E9178B017 /* WebSearchResult.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		AAC55CF3217A6A536330E9CF /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1718,6 +1822,15 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		BFF990A619FF3DCAFE034C1D /* WebSearch */ = {
+			isa = PBXGroup;
+			children = (
+				A7414E5CC2BC10AEF27B986D /* Model */,
+				D2C6109F801360E80966D83F /* Service */,
+			);
+			path = WebSearch;
+			sourceTree = "<group>";
+		};
 		C6A3AB65E150BE9AFAF0EC2E /* FileSearch */ = {
 			isa = PBXGroup;
 			children = (
@@ -1769,6 +1882,16 @@
 			children = (
 				7F84B7743B803F55C41D5C4A /* NotesRepository.swift */,
 				FC2B77DA46386E7E459406E4 /* NotesStore.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		D2C6109F801360E80966D83F /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				9CA0148CE4F4C35A842F0071 /* Engines */,
+				03D06F041C51BB38F00F22E6 /* WebSearchAggregator.swift */,
+				6C285819B27AA3C2D3704A29 /* WebSearchCacheStore.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1849,6 +1972,15 @@
 			path = Notes;
 			sourceTree = "<group>";
 		};
+		E21D076684272E8E60B221A8 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				2F44284459BF2D9E71E19AE8 /* PDFDocumentReader.swift */,
+				9AB8F1BE3257D46C414C4117 /* WebPageReader.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		E3202F504002B7792FC50B2F /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -1887,13 +2019,17 @@
 				BD4B27ECEB1C09B14C403FC8 /* AIModelDiscoveryService.swift */,
 				848E14DE51403235A82BC287 /* AIProvider.swift */,
 				85DAEE77ABAC4260C95F9AB5 /* AIProviderFactory.swift */,
+				050D1C23F4B3E5391A4DB8BE /* AIToolRegistry.swift */,
 				A48D823882DF192FBA253985 /* APIKeyStore.swift */,
+				C77E4C211477E42B1E865473 /* CalculatorToolRunner.swift */,
 				943495E91C0D09B633746515 /* ChatGPTSubscriptionManager.swift */,
 				B715A0256D2D0DDE1D28FC98 /* ChatHistoryStore.swift */,
 				7355ACD6D1BE7BC7FCA26BD2 /* CodexAppServerClient.swift */,
 				0FE6F8E3FA640C6F2B1AA8FE /* CodexExecutableLocator.swift */,
 				1E82DD04042376EBDEF3E84C /* CodexTurnRunner.swift */,
 				096F955B26BAEE5AED65B559 /* HTTPAIProvider.swift */,
+				77C1AC3049BEF9241423EB62 /* LocationProvider.swift */,
+				9B5683268B7227F8E592AE85 /* WeatherService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -2087,11 +2223,14 @@
 				3D56F518ABEF5851534A710C /* AISettingsStore.swift in Sources */,
 				76056E33DD554E1153BB3DD0 /* AISettingsView.swift in Sources */,
 				4D8C05DD67FAB9F2DA1F31FB /* AIStreamDecoder.swift in Sources */,
+				19F36636F27933FA8278642A /* AITool.swift in Sources */,
+				218977B28CEE5D5F41440267 /* AIToolRegistry.swift in Sources */,
 				6DF29BAB73F545DA2DE63F9B /* APIKeyStore.swift in Sources */,
 				540F1433DC46BC97C9F80E06 /* AboutView.swift in Sources */,
 				CD04C9CA00C002C0EC82756A /* AccessibilityText.swift in Sources */,
 				16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */,
 				D68E7585496722BEC72E788C /* AliasStore.swift in Sources */,
+				F9D0BA815A91F3B63D621F69 /* AolSearchScraper.swift in Sources */,
 				EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */,
 				5E7ABF41CE97983E05653D69 /* AppAppearance.swift in Sources */,
 				E8CB7624CCA5905AF1A4FAD9 /* AppCore.swift in Sources */,
@@ -2112,6 +2251,7 @@
 				A0A247FFDB1EA278C0F6F813 /* BackupActions.swift in Sources */,
 				4549280508130B232069071E /* BackupSettingsView.swift in Sources */,
 				0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */,
+				5C251207F5BCE65D078673C3 /* BraveSearchScraper.swift in Sources */,
 				9E514EA8EB0408653AC3D1D9 /* BundleSignature.swift in Sources */,
 				B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */,
 				ADE29D44A9504AC24FC17E72 /* CalcDateTime.swift in Sources */,
@@ -2126,6 +2266,7 @@
 				9B3BC1DCC478DA7517F04182 /* CalculatorHistoryScreen.swift in Sources */,
 				5FB708EC91426C41762AB96B /* CalculatorHistoryStore.swift in Sources */,
 				5E155BEE2FC62267F516A343 /* CalculatorHistoryView.swift in Sources */,
+				C47B5C70923FF3B3E65EE6F0 /* CalculatorToolRunner.swift in Sources */,
 				ABFC92E6F22D8D6715081D9F /* CalendarAccess.swift in Sources */,
 				EA077323DE71DAF8FE17693C /* CalendarCoordinator.swift in Sources */,
 				D4AC94686EEEF4B792B58593 /* CalendarSettingsView.swift in Sources */,
@@ -2137,6 +2278,7 @@
 				8865A4577BAEE98DF6019500 /* CameraPreviewPanel.swift in Sources */,
 				DAD994F5F42542805F8CF801 /* CameraPreviewSession.swift in Sources */,
 				BDC1C804377CA32EE147829F /* CameraPreviewView.swift in Sources */,
+				AD8A6A0FD4852DB4D911D6ED /* ChatAttachment.swift in Sources */,
 				9BB417EBD7843DDE09AA0200 /* ChatCopyButton.swift in Sources */,
 				F44DA0C81285A90138E13A7B /* ChatGPTSubscription.swift in Sources */,
 				92EDFE4591BE41718ECE1C82 /* ChatGPTSubscriptionManager.swift in Sources */,
@@ -2162,6 +2304,7 @@
 				89872774514D83EC2BD60F1E /* CommandCatalog.swift in Sources */,
 				BEAAD72E748375E0039AC90F /* CommandID.swift in Sources */,
 				4640C7CC8DCA6E6FA49394A8 /* CommandsSettingsView.swift in Sources */,
+				0650146C4DD0EEADBAFC6988 /* ConsensusScorer.swift in Sources */,
 				2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */,
 				5A91C58340D02ED0939BCAE2 /* CurrencyFeed.swift in Sources */,
 				17F61DEF6389FBCFCCFB467C /* CurrencyRateStore.swift in Sources */,
@@ -2175,6 +2318,7 @@
 				A1F267E9D9914DB60DEEE0AD /* DoubleTapDetector.swift in Sources */,
 				DFB25A4CDD35071B745F2EF9 /* DoubleTapModifier.swift in Sources */,
 				FFE6952D79F28B62E189C097 /* DoubleTapMonitor.swift in Sources */,
+				28C4913DEAEDDDC6CB27F782 /* DuckDuckGoScraper.swift in Sources */,
 				364CB97064000DC67178DDE8 /* EdgeDissolve.swift in Sources */,
 				84DC02099149C542C886B019 /* EmojiCatalog.swift in Sources */,
 				64AD2324BDA6293464C98913 /* EmojiCoordinator.swift in Sources */,
@@ -2242,6 +2386,7 @@
 				303FC5342B61A7862EBC1C32 /* FocusRelease.swift in Sources */,
 				7833FD6E0A6036954FE285CE /* FrequentEmojiStore.swift in Sources */,
 				C5F60D8681235B95DAA3314F /* GeneralSettingsView.swift in Sources */,
+				70CA312305A77FDE4D8F03CC /* HTMLToMarkdownConverter.swift in Sources */,
 				9F50314FD939DE2B6C5434A1 /* HTTPAIProvider.swift in Sources */,
 				A500AF3BF8910B335A7A936C /* HUDPanel.swift in Sources */,
 				68537C3544E4EBC40E3ACD39 /* HUDPresenter.swift in Sources */,
@@ -2265,6 +2410,7 @@
 				D1F9C28CA4048480DB818EE9 /* LauncherList.swift in Sources */,
 				633DCA2F00A274C375EB4423 /* LauncherRankingStore.swift in Sources */,
 				7FF6A0A4702E1C1365F2D76A /* LauncherScreen.swift in Sources */,
+				80DF4804EBA1150190705E9E /* LocationProvider.swift in Sources */,
 				5188C7DF4F18DAA7227715F8 /* MarkdownBlock.swift in Sources */,
 				1E0A1B1B84673EF39871842C /* MarkdownCodeView.swift in Sources */,
 				8A11D87B31A2BC5D8C778475 /* MarkdownInline.swift in Sources */,
@@ -2282,6 +2428,7 @@
 				E6E929E9284E8AC361D64D6A /* MenuBarSummary.swift in Sources */,
 				43DBCE7B5A84D0D6322124F5 /* MessageHUDController.swift in Sources */,
 				8D529C8F3AB579941067FE98 /* MessageHUDView.swift in Sources */,
+				84F6EC70C839BCD0D04809B9 /* NewsRSSEngine.swift in Sources */,
 				8D20CD7B6918873960F84291 /* NoteDocument.swift in Sources */,
 				47A443F25878A27DE6DF24AA /* NoteEditorView.swift in Sources */,
 				8F5A6E0EFDBC4E4C54D8AA62 /* NoteSearch.swift in Sources */,
@@ -2302,6 +2449,7 @@
 				19317D6C8A55E3F85BB7AE1F /* OnboardingState.swift in Sources */,
 				0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */,
 				C385AEF3C8C5A6B2BACC1D9A /* OverflowFade.swift in Sources */,
+				C547B48E21926BF664DF1AEB /* PDFDocumentReader.swift in Sources */,
 				86C36C0885D5820E70184CF6 /* PaletteCoordinator.swift in Sources */,
 				8DCF330D30E59FFEE8C8E8CF /* PaletteDropGuideController.swift in Sources */,
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
@@ -2412,6 +2560,8 @@
 				68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */,
 				2C8F7F5073D77EDC1070E639 /* ToolRunner.swift in Sources */,
 				867B82EDC8A12BBC51592786 /* Tooltip.swift in Sources */,
+				25583F5306EB0B8F73D83E8F /* URLNormalizer.swift in Sources */,
+				D1BF5F85DDD6E22F5805B412 /* URLRedirectDecoder.swift in Sources */,
 				FA05D882203673A9FEE5F421 /* UninstallCoordinator.swift in Sources */,
 				6B8351E3D100E81F169BCFED /* UninstallPlan.swift in Sources */,
 				0B9C941402B85C69A33200C2 /* UninstallProtection.swift in Sources */,
@@ -2438,6 +2588,15 @@
 				106AF34CEAEB08CBCC924118 /* VolumeLevel.swift in Sources */,
 				15292937738B7CD3AE23EF73 /* VolumeSlider.swift in Sources */,
 				1F1AD34A26931AF6E11E13F7 /* VolumeState.swift in Sources */,
+				174A5ED6BE79E95E353D6817 /* WeatherService.swift in Sources */,
+				EB862E1E6104609429412155 /* WebPageReader.swift in Sources */,
+				284EF595FD044A2D9DBF204F /* WebSearchAggregator.swift in Sources */,
+				E6BCD8E2D2746D93824C57DE /* WebSearchCacheStore.swift in Sources */,
+				F7E452309C7C0C10E1C0FFD0 /* WebSearchCategory.swift in Sources */,
+				23CA30B8687B5998B953CD5B /* WebSearchEngineType.swift in Sources */,
+				5EBDA7D746E1CAC385143876 /* WebSearchQuery.swift in Sources */,
+				10A877768F2C16746FFE6B73 /* WebSearchResult.swift in Sources */,
+				2EEF98FB38EAADBA3CDEFEA4 /* WikipediaEngine.swift in Sources */,
 				D44E20726F1EB11C8C297C4D /* WindowActionMemory.swift in Sources */,
 				4E5F73461C417BE2B3472E6E /* WindowChrome.swift in Sources */,
 				2C788DCDF146ED245150EF82 /* WindowCommand.swift in Sources */,
@@ -2446,6 +2605,7 @@
 				19B0314193376FD1E4AC11A5 /* WindowLayout.swift in Sources */,
 				0360C7038877B9CB656DB697 /* WindowManagementSettingsView.swift in Sources */,
 				A6A8CD2B71A15625F47498EA /* WindowMover.swift in Sources */,
+				9C73CE4491198501BEB39E33 /* YahooSearchScraper.swift in Sources */,
 				6CDA82FD63F87D07E30E3F82 /* Zlib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tinycast/Features/AI/Model/AIInstructions.swift
+++ b/Tinycast/Features/AI/Model/AIInstructions.swift
@@ -8,9 +8,18 @@ import Foundation
 /// shapes every answer, so opting out has to reach it too, not only the half the user typed.
 enum AIInstructions {
     /// The user's own text goes last, so it can qualify the preamble rather than fight it.
-    static func compose(userPrompt: String?, isEnabled: Bool) -> String? {
+    static func compose(userPrompt: String?, isEnabled: Bool, now: Date? = nil) -> String? {
         guard isEnabled else { return nil }
         let trimmed = userPrompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? AIPreamble.text : AIPreamble.text + "\n\n" + trimmed
+        var preamble = AIPreamble.text
+        if let now {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .full
+            formatter.timeStyle = .none
+            formatter.locale = Locale(identifier: "en_US")
+            let dateStr = formatter.string(from: now)
+            preamble += "\n\nCurrent date: \(dateStr)."
+        }
+        return trimmed.isEmpty ? preamble : preamble + "\n\n" + trimmed
     }
 }

--- a/Tinycast/Features/AI/Model/AIRequest.swift
+++ b/Tinycast/Features/AI/Model/AIRequest.swift
@@ -1,77 +1,88 @@
 import Foundation
 
-/// An attached picture, already encoded for the wire; every provider takes it as a data URL.
-struct AIImage: Equatable, Hashable, Sendable {
-    let data: Data
-    let mimeType: String
-
-    var dataURL: String { "data:\(mimeType);base64,\(data.base64EncodedString())" }
-}
-
-/// What one turn's pictures may total. Provider requests cap near 25 MB and a data URL costs a third
-/// more than the bytes it carries, so the ceiling lives here rather than on the wire: past it a
-/// picture is refused while the composer can still say why, instead of becoming an opaque 413.
-enum AIAttachmentBudget {
-    static let maxCount = 6
-    static let maxBytes = 10 * 1_048_576
-
-    /// Whether `images` can take `candidate` and stay inside both limits.
-    static func admits(_ images: [AIImage], adding candidate: AIImage) -> Bool {
-        images.count < maxCount
-            && images.reduce(candidate.data.count) { $0 + $1.data.count } <= maxBytes
-    }
-
-    /// The longest leading run that fits. The composer refuses before it ever gets here; this is what
-    /// keeps a turn assembled by any other route inside the same ceiling.
-    static func bounded(_ images: [AIImage]) -> [AIImage] {
-        var total = 0
-        return Array(
-            images.prefix(maxCount).prefix { image in
-                total += image.data.count
-                return total <= maxBytes
-            })
-    }
-}
-
 struct AIMessage: Equatable, Sendable {
-    enum Role: String, Equatable, Sendable {
+    enum Role: String, Sendable {
         case system
         case user
         case assistant
+        case tool
     }
 
     let role: Role
     let text: String
     let images: [AIImage]
+    let toolCalls: [AIToolCall]
+    let toolCallID: String?
 
-    init(role: Role, text: String, images: [AIImage] = []) {
+    init(
+        role: Role, text: String, images: [AIImage] = [],
+        toolCalls: [AIToolCall] = [], toolCallID: String? = nil
+    ) {
         self.role = role
         self.text = text
         self.images = images
+        self.toolCalls = toolCalls
+        self.toolCallID = toolCallID
     }
 }
 
 struct AIRequest: Equatable, Sendable {
-    let instructions: String?
     let messages: [AIMessage]
+    let instructions: String?
     let maxOutputTokens: Int
-    /// Lets the model search the web; each route has its own switch for that, all off by default.
     let webSearch: Bool
+    let tools: [AIToolDefinition]
 
     init(
-        instructions: String? = nil, messages: [AIMessage], maxOutputTokens: Int = 4_096,
-        webSearch: Bool = false
+        messages: [AIMessage], instructions: String? = nil,
+        maxOutputTokens: Int = 4096, webSearch: Bool = false,
+        tools: [AIToolDefinition] = []
     ) {
-        self.instructions = instructions
         self.messages = messages
+        self.instructions = instructions
         self.maxOutputTokens = maxOutputTokens
         self.webSearch = webSearch
+        self.tools = tools
+    }
+}
+
+struct AIImage: Equatable, Hashable, Sendable {
+    let data: Data
+    let mimeType: String
+
+    var dataURL: String {
+        "data:\(mimeType);base64,\(data.base64EncodedString())"
+    }
+}
+
+enum AIAttachmentBudget {
+    static let maxCount = 3
+    static let maxBytes = 12 * 1024 * 1024
+
+    static func admits(_ images: [AIImage], adding next: AIImage) -> Bool {
+        images.count < maxCount && (images.reduce(0) { $0 + $1.data.count } + next.data.count) <= maxBytes
+    }
+
+    static func bounded(_ images: [AIImage]) -> [AIImage] {
+        var totalBytes = 0
+        var kept: [AIImage] = []
+        for image in images.prefix(maxCount) {
+            let nextBytes = totalBytes + image.data.count
+            guard nextBytes <= maxBytes else { break }
+            kept.append(image)
+            totalBytes = nextBytes
+        }
+        return kept
     }
 }
 
 struct AIUsage: Equatable, Sendable {
     var inputTokens: Int?
     var outputTokens: Int?
+
+    var isEmpty: Bool {
+        inputTokens == nil && outputTokens == nil
+    }
 
     var totalTokens: Int? {
         guard let inputTokens, let outputTokens else { return nil }
@@ -84,6 +95,8 @@ enum AIStreamEvent: Equatable, Sendable {
     case thinking
     case searching(String?)
     case searched(String?)
+    case toolCall(AIToolCall)
+    case toolExecuting(name: String, detail: String?)
     case usage(AIUsage)
     case finished
 }
@@ -96,7 +109,7 @@ enum AIProviderError: LocalizedError, Equatable, Sendable {
     var errorDescription: String? {
         switch self {
         case .unavailable(let message), .responseFailed(let message): return message
-        case .malformedResponse: return "The provider returned malformed streaming data."
+        case .malformedResponse: return "The AI provider returned an unreadable response."
         }
     }
 }

--- a/Tinycast/Features/AI/Model/AIStreamDecoder.swift
+++ b/Tinycast/Features/AI/Model/AIStreamDecoder.swift
@@ -1,76 +1,154 @@
 import Foundation
 
 struct SSEParser: Sendable {
-    private var buffer = Data()
+    private var buffer = ""
 
     mutating func feed(_ data: Data) -> [String] {
-        buffer.append(data)
-        var payloads: [String] = []
-        while let boundary = nextBoundary() {
-            let frame = buffer[..<boundary.lowerBound]
-            buffer.removeSubrange(buffer.startIndex..<boundary.upperBound)
-            if let payload = Self.payload(in: frame) { payloads.append(payload) }
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+        buffer += text
+        var events: [String] = []
+
+        while true {
+            let rangeLF = buffer.range(of: "\n\n")
+            let rangeCRLF = buffer.range(of: "\r\n\r\n")
+
+            let range: Range<String.Index>
+            switch (rangeLF, rangeCRLF) {
+            case (.some(let lf), .some(let crlf)):
+                range = lf.lowerBound < crlf.lowerBound ? lf : crlf
+            case (.some(let lf), .none):
+                range = lf
+            case (.none, .some(let crlf)):
+                range = crlf
+            case (.none, .none):
+                return events
+            }
+
+            let frame = String(buffer[..<range.lowerBound])
+            buffer = String(buffer[range.upperBound...])
+            if let payload = parseFrame(frame) {
+                events.append(payload)
+            }
         }
-        return payloads
     }
 
     mutating func finish() -> [String] {
-        guard !buffer.isEmpty else { return [] }
-        defer { buffer.removeAll() }
-        return Self.payload(in: buffer).map { [$0] } ?? []
-    }
-
-    private func nextBoundary() -> Range<Data.Index>? {
-        let lf = buffer.range(of: Data([0x0A, 0x0A]))
-        let crlf = buffer.range(of: Data([0x0D, 0x0A, 0x0D, 0x0A]))
-        switch (lf, crlf) {
-        case (let lhs?, let rhs?): return lhs.lowerBound < rhs.lowerBound ? lhs : rhs
-        case (let range?, nil), (nil, let range?): return range
-        case (nil, nil): return nil
+        let remaining = buffer
+        buffer = ""
+        if let payload = parseFrame(remaining) {
+            return [payload]
         }
+        return []
     }
 
-    private static func payload(in frame: some DataProtocol) -> String? {
-        let text = String(decoding: frame, as: UTF8.self)
-            .replacingOccurrences(of: "\r\n", with: "\n")
+    private func parseFrame(_ frame: String) -> String? {
+        let lines = frame.components(separatedBy: .newlines)
         var dataLines: [String] = []
-        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            if line.hasPrefix(":") { continue }
-            if line == "data" {
-                dataLines.append("")
-            } else if line.hasPrefix("data:") {
-                var value = line.dropFirst(5)
-                if value.first == " " { value = value.dropFirst() }
-                dataLines.append(String(value))
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("data:") {
+                let after = trimmed.dropFirst(5).trimmingCharacters(in: .whitespacesAndNewlines)
+                dataLines.append(after)
             }
         }
-        return dataLines.isEmpty ? nil : dataLines.joined(separator: "\n")
+        guard !dataLines.isEmpty else { return nil }
+        return dataLines.joined(separator: "\n")
     }
 }
 
 struct AIStreamDecoder: Sendable {
     private let shape: AIHTTPConfiguration.APIShape
     private var parser = SSEParser()
-    private var usage = AIUsage()
     private(set) var isTerminal = false
+    private var usage = AIUsage()
+
+    private struct InFlightToolCall {
+        var id: String
+        var name: String
+        var arguments: String
+    }
+    private var openAIToolCalls: [Int: InFlightToolCall] = [:]
+    private var anthropicToolCalls: [Int: InFlightToolCall] = [:]
 
     init(shape: AIHTTPConfiguration.APIShape) {
         self.shape = shape
     }
 
-    mutating func feed(_ data: Data) throws -> [AIStreamEvent] {
-        try decode(parser.feed(data))
+    static func parseError(
+        from body: String, status: Int, shape: AIHTTPConfiguration.APIShape
+    ) -> AIProviderError {
+        if let data = body.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            if let errorObj = json["error"] as? [String: Any],
+                let msg = errorObj["message"] as? String, !msg.isEmpty
+            {
+                return .responseFailed(msg)
+            } else if let errorMsg = json["message"] as? String, !errorMsg.isEmpty {
+                return .responseFailed(errorMsg)
+            }
+        }
+        return .responseFailed("Request failed with status \(status)")
+    }
+
+    mutating func feed(_ chunk: Data) throws -> [AIStreamEvent] {
+        guard !isTerminal else { return [] }
+        let payloads = parser.feed(chunk)
+        return try decode(payloads)
+    }
+
+    mutating func feed(line: String) throws -> [AIStreamEvent] {
+        guard !isTerminal else { return [] }
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return [] }
+        let lineData = Data((trimmed + "\n\n").utf8)
+        return try feed(lineData)
     }
 
     mutating func finish() throws -> [AIStreamEvent] {
-        try decode(parser.finish())
+        guard !isTerminal else { return [] }
+        let payloads = parser.finish()
+        var events = try decode(payloads)
+        events.append(contentsOf: flushTerminal())
+        return events
+    }
+
+    private mutating func flushPendingToolCalls() -> [AIStreamEvent] {
+        var events: [AIStreamEvent] = []
+        for (_, call) in openAIToolCalls.sorted(by: { $0.key < $1.key }) {
+            if !call.name.isEmpty {
+                events.append(.toolCall(AIToolCall(id: call.id, name: call.name, argumentsJSON: call.arguments)))
+            }
+        }
+        openAIToolCalls.removeAll()
+
+        for (_, call) in anthropicToolCalls.sorted(by: { $0.key < $1.key }) {
+            if !call.name.isEmpty {
+                events.append(.toolCall(AIToolCall(id: call.id, name: call.name, argumentsJSON: call.arguments)))
+            }
+        }
+        anthropicToolCalls.removeAll()
+        return events
+    }
+
+    private mutating func flushTerminal() -> [AIStreamEvent] {
+        guard !isTerminal else { return [] }
+        isTerminal = true
+        var events = flushPendingToolCalls()
+        if !usage.isEmpty { events.append(.usage(usage)) }
+        events.append(.finished)
+        return events
     }
 
     private mutating func decode(_ payloads: [String]) throws -> [AIStreamEvent] {
         var events: [AIStreamEvent] = []
-        for payload in payloads where !isTerminal {
+        for rawPayload in payloads where !isTerminal {
+            let payload = rawPayload.trimmingCharacters(in: .whitespacesAndNewlines)
+            if payload.isEmpty { continue }
             if payload == "[DONE]" {
                 isTerminal = true
+                events.append(contentsOf: flushPendingToolCalls())
+                if !usage.isEmpty { events.append(.usage(usage)) }
                 events.append(.finished)
                 continue
             }
@@ -85,70 +163,181 @@ struct AIStreamDecoder: Sendable {
     }
 
     private mutating func decodeOpenAI(_ payload: String) throws -> [AIStreamEvent] {
-        guard let data = payload.data(using: .utf8),
-            let chunk = try? JSONDecoder().decode(OpenAIChunk.self, from: data)
-        else {
+        guard let data = payload.data(using: .utf8) else {
             isTerminal = true
             throw AIProviderError.malformedResponse
         }
 
-        // OpenRouter reports a mid-stream failure as a 200 payload, so it's an event, not a status.
-        if let message = chunk.error?.message {
-            isTerminal = true
-            throw AIProviderError.responseFailed(message)
-        }
-        var events: [AIStreamEvent] = []
-        if let delta = chunk.choices?.first?.delta {
-            if let content = delta.content, !content.isEmpty {
-                events.append(.text(content))
-            } else if delta.hasReasoning {
-                events.append(.thinking)
+        if let chunk = try? JSONDecoder().decode(OpenAIChunk.self, from: data) {
+            // OpenRouter reports a mid-stream failure as a 200 payload, so it's an event, not a status.
+            if let message = chunk.error?.message {
+                isTerminal = true
+                throw AIProviderError.responseFailed(message)
             }
+            var events: [AIStreamEvent] = []
+            if let choice = chunk.choices?.first {
+                if let delta = choice.delta {
+                    if let content = delta.content, !content.isEmpty {
+                        events.append(.text(content))
+                    } else if delta.hasReasoning {
+                        events.append(.thinking)
+                    }
+
+                    if let toolCalls = delta.toolCalls {
+                        for toolChunk in toolCalls {
+                            let index = toolChunk.index ?? 0
+                            var existing = openAIToolCalls[index] ?? InFlightToolCall(id: "", name: "", arguments: "")
+                            if let id = toolChunk.id, !id.isEmpty { existing.id = id }
+                            if let funcName = toolChunk.function?.name, !funcName.isEmpty { existing.name = funcName }
+                            if let args = toolChunk.function?.arguments, !args.isEmpty { existing.arguments += args }
+                            openAIToolCalls[index] = existing
+                        }
+                    }
+                }
+
+                if choice.finishReason == "tool_calls" {
+                    events.append(contentsOf: flushPendingToolCalls())
+                }
+            }
+            if let reported = chunk.usage {
+                usage.inputTokens = reported.promptTokens ?? usage.inputTokens
+                usage.outputTokens = reported.completionTokens ?? usage.outputTokens
+            }
+            return events
         }
-        if let reported = chunk.usage {
-            usage.inputTokens = reported.promptTokens ?? usage.inputTokens
-            usage.outputTokens = reported.completionTokens ?? usage.outputTokens
-            events.append(.usage(usage))
+
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let errorObj = json["error"] as? [String: Any], let msg = errorObj["message"] as? String {
+                isTerminal = true
+                throw AIProviderError.responseFailed(msg)
+            } else if let errorStr = json["error"] as? String {
+                isTerminal = true
+                throw AIProviderError.responseFailed(errorStr)
+            } else if let msg = json["message"] as? String {
+                isTerminal = true
+                throw AIProviderError.responseFailed(msg)
+            }
+
+            var events: [AIStreamEvent] = []
+            if let choices = json["choices"] as? [[String: Any]], let first = choices.first {
+                if let delta = first["delta"] as? [String: Any] {
+                    if let content = delta["content"] as? String, !content.isEmpty {
+                        events.append(.text(content))
+                    } else if (delta["reasoning"] as? String)?.isEmpty == false || (delta["reasoning_content"] as? String)?.isEmpty == false {
+                        events.append(.thinking)
+                    }
+
+                    if let toolCalls = delta["tool_calls"] as? [[String: Any]] {
+                        for toolChunk in toolCalls {
+                            let index = toolChunk["index"] as? Int ?? 0
+                            var existing = openAIToolCalls[index] ?? InFlightToolCall(id: "", name: "", arguments: "")
+                            if let id = toolChunk["id"] as? String, !id.isEmpty { existing.id = id }
+                            if let function = toolChunk["function"] as? [String: Any] {
+                                if let funcName = function["name"] as? String, !funcName.isEmpty { existing.name = funcName }
+                                if let args = function["arguments"] as? String, !args.isEmpty { existing.arguments += args }
+                            }
+                            openAIToolCalls[index] = existing
+                        }
+                    }
+                }
+
+                if let finishReason = first["finish_reason"] as? String, finishReason == "tool_calls" {
+                    events.append(contentsOf: flushPendingToolCalls())
+                }
+            }
+
+            if let usageObj = json["usage"] as? [String: Any] {
+                if let promptTokens = usageObj["prompt_tokens"] as? Int {
+                    usage.inputTokens = promptTokens
+                }
+                if let completionTokens = usageObj["completion_tokens"] as? Int {
+                    usage.outputTokens = completionTokens
+                }
+            }
+
+            return events
         }
-        return events
+
+        isTerminal = true
+        throw AIProviderError.malformedResponse
     }
 
     private mutating func decodeAnthropic(_ payload: String) throws -> [AIStreamEvent] {
-        guard let data = payload.data(using: .utf8),
-            let event = try? JSONDecoder().decode(AnthropicEvent.self, from: data)
-        else {
+        guard let data = payload.data(using: .utf8) else {
             isTerminal = true
             throw AIProviderError.malformedResponse
         }
 
-        switch event.type {
-        case "content_block_delta":
-            if event.delta?.type == "text_delta", let text = event.delta?.text, !text.isEmpty {
-                return [.text(text)]
+        if let event = try? JSONDecoder().decode(AnthropicEvent.self, from: data) {
+            var events: [AIStreamEvent] = []
+            switch event.type {
+            case "content_block_start":
+                if let block = event.contentBlock, block.type == "tool_use", let index = event.index {
+                    anthropicToolCalls[index] = InFlightToolCall(
+                        id: block.id ?? "",
+                        name: block.name ?? "",
+                        arguments: ""
+                    )
+                }
+            case "content_block_delta":
+                if let delta = event.delta {
+                    if let text = delta.text, !text.isEmpty {
+                        events.append(.text(text))
+                    }
+                    if let partial = delta.partialJson, !partial.isEmpty, let index = event.index {
+                        var existing = anthropicToolCalls[index] ?? InFlightToolCall(id: "", name: "", arguments: "")
+                        existing.arguments += partial
+                        anthropicToolCalls[index] = existing
+                    }
+                }
+            case "content_block_stop":
+                break
+            case "message_delta":
+                if let usage = event.usage?.outputTokens { self.usage.outputTokens = usage }
+                if event.delta?.stopReason == "tool_use" {
+                    events.append(contentsOf: flushPendingToolCalls())
+                }
+            case "message_start":
+                if let usage = event.message?.usage?.inputTokens {
+                    self.usage.inputTokens = usage
+                }
+            case "message_stop":
+                events.append(contentsOf: flushPendingToolCalls())
+                if !usage.isEmpty { events.append(.usage(usage)) }
+                events.append(.finished)
+                isTerminal = true
+            case "error":
+                isTerminal = true
+                throw AIProviderError.responseFailed(Self.anthropicErrorMessage(event.error?.type))
+            default:
+                break
             }
-            return event.delta?.type == "thinking_delta" ? [.thinking] : []
-        case "message_start":
-            usage.inputTokens = event.message?.usage?.inputTokens ?? usage.inputTokens
-            return [.usage(usage)]
-        case "message_delta":
-            usage.outputTokens = event.usage?.outputTokens ?? usage.outputTokens
-            return [.usage(usage)]
-        case "message_stop":
-            isTerminal = true
-            return [.finished]
-        case "error":
-            isTerminal = true
-            throw AIProviderError.responseFailed(Self.anthropicErrorMessage(event.error?.type))
-        default:
-            return []
+            return events
         }
+
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let errorObj = json["error"] as? [String: Any], let msg = errorObj["message"] as? String {
+                isTerminal = true
+                throw AIProviderError.responseFailed(msg)
+            } else if let errorStr = json["error"] as? String {
+                isTerminal = true
+                throw AIProviderError.responseFailed(errorStr)
+            }
+        }
+
+        isTerminal = true
+        throw AIProviderError.malformedResponse
     }
 
     private static func anthropicErrorMessage(_ type: String?) -> String {
         switch type {
+        case "invalid_request_error": return "Invalid request sent to Anthropic."
         case "authentication_error": return "API key rejected — check it in Settings."
-        case "rate_limit_error": return "Rate limit reached — try again later."
-        default: return "The provider stopped the response with an error."
+        case "permission_error": return "The provider rejected this key's permissions."
+        case "not_found_error": return "The requested Anthropic model was not found."
+        case "rate_limit_error": return "Rate limit hit. Try again shortly."
+        case "overloaded_error": return "The provider is overloaded. Try again shortly."
+        default: return "The Anthropic request failed."
         }
     }
 }
@@ -157,10 +346,21 @@ private struct OpenAIChunk: Decodable {
     struct Choice: Decodable {
         struct Delta: Decodable {
             struct ReasoningDetail: Decodable { let text: String? }
+            struct ToolCallFunctionChunk: Decodable {
+                let name: String?
+                let arguments: String?
+            }
+            struct ToolCallChunk: Decodable {
+                let index: Int?
+                let id: String?
+                let type: String?
+                let function: ToolCallFunctionChunk?
+            }
 
             let content: String?
             let reasoning: String?
             let reasoningDetails: [ReasoningDetail]?
+            let toolCalls: [ToolCallChunk]?
 
             var hasReasoning: Bool {
                 reasoning?.isEmpty == false
@@ -170,10 +370,18 @@ private struct OpenAIChunk: Decodable {
             enum CodingKeys: String, CodingKey {
                 case content, reasoning
                 case reasoningDetails = "reasoning_details"
+                case toolCalls = "tool_calls"
             }
         }
 
-        let delta: Delta
+        let index: Int?
+        let delta: Delta?
+        let finishReason: String?
+
+        enum CodingKeys: String, CodingKey {
+            case index, delta
+            case finishReason = "finish_reason"
+        }
     }
 
     struct Usage: Decodable {
@@ -197,6 +405,20 @@ private struct AnthropicEvent: Decodable {
     struct Delta: Decodable {
         let type: String?
         let text: String?
+        let partialJson: String?
+        let stopReason: String?
+
+        enum CodingKeys: String, CodingKey {
+            case type, text
+            case partialJson = "partial_json"
+            case stopReason = "stop_reason"
+        }
+    }
+
+    struct ContentBlock: Decodable {
+        let type: String?
+        let id: String?
+        let name: String?
     }
 
     struct Usage: Decodable {
@@ -213,8 +435,15 @@ private struct AnthropicEvent: Decodable {
     struct ErrorBody: Decodable { let type: String? }
 
     let type: String
+    let index: Int?
     let delta: Delta?
+    let contentBlock: ContentBlock?
     let usage: Usage?
     let message: Message?
     let error: ErrorBody?
+
+    enum CodingKeys: String, CodingKey {
+        case type, index, delta, usage, message, error
+        case contentBlock = "content_block"
+    }
 }

--- a/Tinycast/Features/AI/Model/AITool.swift
+++ b/Tinycast/Features/AI/Model/AITool.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Defines tools that the AI model can execute during a conversation.
+public struct AIToolDefinition: Codable, Equatable, Sendable {
+    public let name: String
+    public let description: String
+    public let parametersJSON: String
+
+    public init(name: String, description: String, parametersJSON: String) {
+        self.name = name
+        self.description = description
+        self.parametersJSON = parametersJSON
+    }
+
+    /// Built-in web_search tool definition
+    public static let webSearch = AIToolDefinition(
+        name: "web_search",
+        description: "Performs live web searches using multi-engine search aggregators (DuckDuckGo, Brave, Yahoo, AOL, Wikipedia). Perform 1 to 2 targeted searches only, then immediately synthesize the final answer for the user. Do not call this repeatedly in a loop.",
+        parametersJSON: """
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              \"type\": \"string\",
+              \"description\": \"The search query (e.g. 'iOS 26 features', 'Tamil Nadu news today'). Keep keywords concise and search for current info without hardcoding past years.\"
+            },
+            \"category\": {
+              \"type\": \"string\",
+              \"enum\": [\"general\", \"news\", \"wikipedia\"],
+              \"description\": \"Optional search category (default: 'general', use 'news' for current events)\"
+            }
+          },
+          \"required\": [\"query\"]
+        }
+        """
+    )
+
+    /// Built-in web_fetch tool definition
+    public static let webFetch = AIToolDefinition(
+        name: "web_fetch",
+        description: "Fetches and extracts clean Markdown text from a specific webpage URL or PDF document URL. Use this ONLY when the user explicitly provides a URL in their prompt (e.g. 'summarize https://example.com' or 'read this link'). NEVER call this automatically after web_search.",
+        parametersJSON: """
+        {
+          "type": "object",
+          "properties": {
+            "url": {
+              \"type\": \"string\",
+              \"description\": \"The HTTP or HTTPS URL to fetch and read\"
+            },
+            \"max_characters\": {
+              \"type\": \"integer\",
+              \"description\": \"Maximum characters to extract (default: 4000)\"
+            }
+          },
+          \"required\": [\"url\"]
+        }
+        """
+    )
+
+    /// Built-in calculate tool definition
+    public static let calculate = AIToolDefinition(
+        name: "calculate",
+        description: "Fast on-device calculator for exact arithmetic, scientific math (sqrt, log, sin, cos, pow, factorial), percentage calculations, unit conversions across 11 categories (length, weight, temperature, area, volume, speed, digital storage, data transfer rate, pressure, angle), currency conversions (USD, EUR, GBP, INR, JPY, CAD, AUD, BTC, ETH, etc.), and date/time calculations (e.g. 'days until Dec 25', 'today + 45 days', 'hours until 6pm').",
+        parametersJSON: """
+        {
+          "type": "object",
+          "properties": {
+            "expression": {
+              \"type\": \"string\",
+              \"description\": \"The math expression, unit conversion, currency exchange, or date calculation to evaluate (e.g. '(45 * 12) / 3', '50 kg in lbs', '15% off 250', '$120 in EUR', 'days until Christmas')\"
+            }
+          },
+          \"required\": [\"expression\"]
+        }
+        """
+    )
+
+    /// Built-in get_location tool definition
+    public static let getLocation = AIToolDefinition(
+        name: "get_location",
+        description: "Retrieves the user's current physical location (device GPS / CoreLocation) including exact neighborhood/sublocality, city, region, postal code, precise coordinates, and timezone.",
+        parametersJSON: """
+        {
+          "type": "object",
+          "properties": {}
+        }
+        """
+    )
+
+    /// Built-in get_weather tool definition
+    public static let getWeather = AIToolDefinition(
+        name: "get_weather",
+        description: "Gets current weather conditions (temperature, feels-like, condition description, humidity, wind speed) and optional multi-day forecast for a given city or the user's current location.",
+        parametersJSON: """
+        {
+          "type": "object",
+          "properties": {
+            "location": {
+              \"type\": \"string\",
+              \"description\": \"City and state/country or 'current' for user's current location (e.g. 'Tokyo, Japan', 'San Francisco', 'London', 'current')\"
+            },
+            \"days\": {
+              \"type\": \"integer\",
+              \"description\": \"Number of forecast days (1 for current only, up to 7 for multi-day forecast)\"
+            }
+          }
+        }
+        """
+    )
+}
+
+/// Represents a tool invocation request made by an AI model during streaming.
+public struct AIToolCall: Codable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let argumentsJSON: String
+
+    public init(id: String, name: String, argumentsJSON: String) {
+        self.id = id
+        self.name = name
+        self.argumentsJSON = argumentsJSON
+    }
+}
+
+/// Represents the output of a completed tool execution.
+public struct AIToolResult: Codable, Equatable, Sendable {
+    public let callID: String
+    public let name: String
+    public let output: String
+
+    public init(callID: String, name: String, output: String) {
+        self.callID = callID
+        self.name = name
+        self.output = output
+    }
+}

--- a/Tinycast/Features/AI/Model/ChatAttachment.swift
+++ b/Tinycast/Features/AI/Model/ChatAttachment.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct ChatAttachment: Identifiable, Sendable, Equatable {
+    let id: UUID
+    let image: AIImage
+    let name: String
+
+    init(id: UUID = UUID(), image: AIImage, name: String) {
+        self.id = id
+        self.image = image
+        self.name = name
+    }
+}
+
+enum ChatAttachmentRefusal: Sendable {
+    case count
+    case size
+
+    var message: String {
+        switch self {
+        case .count:
+            return "Only \(AIAttachmentBudget.maxCount) images can be attached to a message."
+        case .size:
+            return "That image exceeds the attachment size limit."
+        }
+    }
+}

--- a/Tinycast/Features/AI/Model/ChatMessage.swift
+++ b/Tinycast/Features/AI/Model/ChatMessage.swift
@@ -4,6 +4,7 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
     enum Role: String, Equatable, Sendable {
         case user
         case assistant
+        case tool
     }
 
     enum State: String, Equatable, Sendable {
@@ -18,12 +19,21 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
     var state: State
     let sentAt: Date
     let images: [AIImage]
+    var toolCalls: [AIToolCall]
+    let toolCallID: String?
     /// Web searches the reply made, in order; each sits in the text where it happened.
     var searches: [ChatSearch]
 
     init(
-        id: UUID = UUID(), role: Role, text: String, state: State = .complete,
-        sentAt: Date = Date(), images: [AIImage] = [], searches: [ChatSearch] = []
+        id: UUID = UUID(),
+        role: Role,
+        text: String,
+        state: State = .complete,
+        sentAt: Date = Date(),
+        images: [AIImage] = [],
+        toolCalls: [AIToolCall] = [],
+        toolCallID: String? = nil,
+        searches: [ChatSearch] = []
     ) {
         self.id = id
         self.role = role
@@ -31,6 +41,8 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
         self.state = state
         self.sentAt = sentAt
         self.images = images
+        self.toolCalls = toolCalls
+        self.toolCallID = toolCallID
         self.searches = searches
     }
 
@@ -56,9 +68,15 @@ struct ChatSearch: Equatable, Hashable, Sendable {
     var isComplete: Bool
     /// Characters of reply text that had arrived when the search began.
     let textOffset: Int
+
+    init(query: String?, isComplete: Bool = true, textOffset: Int = 0) {
+        self.query = query
+        self.isComplete = isComplete
+        self.textOffset = textOffset
+    }
 }
 
-enum ChatSegment: Equatable, Hashable {
+enum ChatSegment: Equatable {
     case text(String)
     case search(ChatSearch)
 }

--- a/Tinycast/Features/AI/Model/ChatSession.swift
+++ b/Tinycast/Features/AI/Model/ChatSession.swift
@@ -37,10 +37,20 @@ struct ChatSession: Equatable, Sendable {
     var requestMessages: [AIMessage] {
         Self.boundedContext(
             messages.compactMap { message in
-                guard message.role == .user || message.state == .complete else { return nil }
+                guard message.role == .user || message.role == .tool || message.state == .complete || !message.toolCalls.isEmpty else { return nil }
+                let role: AIMessage.Role
+                switch message.role {
+                case .user: role = .user
+                case .assistant: role = .assistant
+                case .tool: role = .tool
+                }
                 return AIMessage(
-                    role: message.role == .user ? .user : .assistant,
-                    text: message.text, images: message.images)
+                    role: role,
+                    text: message.text,
+                    images: message.images,
+                    toolCalls: message.toolCalls,
+                    toolCallID: message.toolCallID
+                )
             })
     }
 
@@ -55,20 +65,22 @@ struct ChatSession: Equatable, Sendable {
         var tail: [AIMessage] = []
         for message in messages[(newest + 1)...] {
             remaining -= message.text.utf8.count
-            tail.append(AIMessage(role: message.role, text: message.text))
+            tail.append(AIMessage(role: message.role, text: message.text, toolCalls: message.toolCalls, toolCallID: message.toolCallID))
         }
         var head: [AIMessage] = []
         for message in messages[..<newest].reversed() {
             remaining -= message.text.utf8.count
             guard remaining >= 0 else { break }
-            head.append(AIMessage(role: message.role, text: message.text))
+            head.append(AIMessage(role: message.role, text: message.text, toolCalls: message.toolCalls, toolCallID: message.toolCallID))
         }
         // The slice opens with the user turn that prompted it; an orphaned reply reads as noise.
         while head.last?.role == .assistant { head.removeLast() }
         let prompt = messages[newest]
         let bounded = AIMessage(
             role: prompt.role, text: prompt.text,
-            images: AIAttachmentBudget.bounded(prompt.images))
+            images: AIAttachmentBudget.bounded(prompt.images),
+            toolCalls: prompt.toolCalls,
+            toolCallID: prompt.toolCallID)
         return head.reversed() + [bounded] + tail
     }
 

--- a/Tinycast/Features/AI/Service/AIToolRegistry.swift
+++ b/Tinycast/Features/AI/Service/AIToolRegistry.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Central registry managing all available tools and their execution.
+public final class AIToolRegistry: Sendable {
+    public static let shared = AIToolRegistry()
+
+    private let searchAggregator: WebSearchAggregator
+    private let pageReader: WebPageReader
+    private let locationProvider: LocationProvider
+    private let weatherService: WeatherService
+    private let calculatorRunner: CalculatorToolRunner
+
+    public init(
+        searchAggregator: WebSearchAggregator = WebSearchAggregator(),
+        pageReader: WebPageReader = WebPageReader(),
+        locationProvider: LocationProvider = LocationProvider(),
+        weatherService: WeatherService? = nil,
+        calculatorRunner: CalculatorToolRunner = CalculatorToolRunner()
+    ) {
+        self.searchAggregator = searchAggregator
+        self.pageReader = pageReader
+        self.locationProvider = locationProvider
+        self.weatherService = weatherService ?? WeatherService(locationProvider: locationProvider)
+        self.calculatorRunner = calculatorRunner
+    }
+
+    /// All tool definitions available for the model to use
+    public var availableTools: [AIToolDefinition] {
+        [
+            .webSearch,
+            .webFetch,
+            .calculate,
+            .getLocation,
+            .getWeather
+        ]
+    }
+
+    /// Executes a tool call asynchronously and returns the formatted result
+    public func execute(call: AIToolCall) async -> AIToolResult {
+        switch call.name {
+        case "web_search":
+            return await executeWebSearch(call: call)
+        case "web_fetch":
+            return await executeWebFetch(call: call)
+        case "calculate":
+            return executeCalculate(call: call)
+        case "get_location":
+            return await executeGetLocation(call: call)
+        case "get_weather":
+            return await executeGetWeather(call: call)
+        default:
+            return AIToolResult(
+                callID: call.id,
+                name: call.name,
+                output: "Unknown tool: \(call.name)"
+            )
+        }
+    }
+
+    private func executeWebSearch(call: AIToolCall) async -> AIToolResult {
+        var query = ""
+        if let data = call.argumentsJSON.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let q = json["query"] as? String {
+            query = q
+        } else {
+            query = call.argumentsJSON
+        }
+
+        let results = await searchAggregator.search(query: query)
+        let formatted = results.prefix(5).map { res in
+            "[\(res.title)](\(res.url))\n\(res.snippet)"
+        }.joined(separator: "\n\n")
+
+        return AIToolResult(
+            callID: call.id,
+            name: call.name,
+            output: formatted.isEmpty ? "No search results found for '\(query)'." : formatted
+        )
+    }
+
+    private func executeWebFetch(call: AIToolCall) async -> AIToolResult {
+        var urlString = ""
+        var maxChars = 4000
+        if let data = call.argumentsJSON.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let u = json["url"] as? String { urlString = u }
+            if let m = json["max_characters"] as? Int { maxChars = m }
+        }
+
+        guard let url = URL(string: urlString) else {
+            return AIToolResult(
+                callID: call.id,
+                name: call.name,
+                output: "Invalid URL: \(urlString)"
+            )
+        }
+
+        do {
+            let markdown = try await pageReader.read(url: url, maxCharacters: maxChars)
+            return AIToolResult(
+                callID: call.id,
+                name: call.name,
+                output: markdown
+            )
+        } catch {
+            return AIToolResult(
+                callID: call.id,
+                name: call.name,
+                output: "Failed to fetch page: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func executeCalculate(call: AIToolCall) -> AIToolResult {
+        var expr = ""
+        if let data = call.argumentsJSON.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let e = json["expression"] as? String {
+            expr = e
+        } else {
+            expr = call.argumentsJSON
+        }
+
+        let output = calculatorRunner.calculate(expression: expr)
+        return AIToolResult(
+            callID: call.id,
+            name: call.name,
+            output: output
+        )
+    }
+
+    private func executeGetLocation(call: AIToolCall) async -> AIToolResult {
+        if let loc = await locationProvider.getLocation() {
+            return AIToolResult(
+                callID: call.id,
+                name: call.name,
+                output: loc.summary
+            )
+        } else {
+            return AIToolResult(
+                callID: call.id,
+                name: call.name,
+                output: "Could not determine location automatically."
+            )
+        }
+    }
+
+    private func executeGetWeather(call: AIToolCall) async -> AIToolResult {
+        var location: String?
+        var days = 1
+        if let data = call.argumentsJSON.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let loc = json["location"] as? String { location = loc }
+            if let d = json["days"] as? Int { days = d }
+        }
+
+        let output = await weatherService.getWeather(location: location, days: days)
+        return AIToolResult(
+            callID: call.id,
+            name: call.name,
+            output: output
+        )
+    }
+}

--- a/Tinycast/Features/AI/Service/CalculatorToolRunner.swift
+++ b/Tinycast/Features/AI/Service/CalculatorToolRunner.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Fast on-device evaluator using Tinycast's native math, unit, currency, and date engines.
+public final class CalculatorToolRunner: Sendable {
+    public init() {}
+
+    public func calculate(expression: String) -> String {
+        let trimmed = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return "Error: Expression cannot be empty."
+        }
+
+        // Load cached currency rates if available
+        var rates: CurrencyRates?
+        let cacheURL = AppPaths.caches().appendingPathComponent("currency-rates.json")
+        if let data = try? Data(contentsOf: cacheURL) {
+            rates = try? JSONDecoder().decode(CurrencyRates.self, from: data)
+        }
+
+        if let result = CalcEngine.evaluate(trimmed, rates: rates) {
+            switch result.payload {
+            case .value(let display, let copyText):
+                var response = "Result: \(display)"
+                if display != copyText && !copyText.isEmpty {
+                    response += " (Exact: \(copyText))"
+                }
+                if let src = result.sourceBadge, let tgt = result.targetBadge {
+                    response += " [\(src) → \(tgt)]"
+                }
+                return response
+            case .error(let message):
+                return "Calculation Error: \(message)"
+            }
+        }
+
+        return "Could not evaluate expression: '\(trimmed)'. Ensure it is a valid math expression, unit conversion, currency exchange, or date calculation."
+    }
+}

--- a/Tinycast/Features/AI/Service/HTTPAIProvider.swift
+++ b/Tinycast/Features/AI/Service/HTTPAIProvider.swift
@@ -1,60 +1,74 @@
 import Foundation
 
-struct HTTPAIProvider: AIProvider {
-    private let configuration: AIHTTPConfiguration
-    private let apiKey: String
+private func logDebug(_ message: String) {
+    let line = "[\(Date())] \(message)\n"
+    if let data = line.data(using: .utf8) {
+        if let handle = try? FileHandle(forWritingTo: URL(fileURLWithPath: "/tmp/tinycast-ai.log")) {
+            handle.seekToEndOfFile()
+            handle.write(data)
+            try? handle.close()
+        } else {
+            try? data.write(to: URL(fileURLWithPath: "/tmp/tinycast-ai.log"))
+        }
+    }
+}
 
-    init(configuration: AIHTTPConfiguration, apiKey: String) {
+struct HTTPAIProvider: AIProvider {
+    let configuration: AIHTTPConfiguration
+    let apiKey: String
+    private let session: URLSession
+
+    init(
+        configuration: AIHTTPConfiguration, apiKey: String,
+        session: URLSession = URLSession(configuration: .ephemeral)
+    ) {
         self.configuration = configuration
         self.apiKey = apiKey
+        self.session = session
     }
 
-    func stream(_ request: AIRequest) -> AIProviderStream {
-        AIProviderStream { continuation in
-            // Detached on purpose: the byte loop and JSON decoding never touch the main actor.
-            let task = Task.detached {
-                let session = Self.makeSession()
-                defer { session.invalidateAndCancel() }
+    func stream(_ input: AIRequest) -> AsyncThrowingStream<AIStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
                 do {
-                    let urlRequest = try makeURLRequest(request)
-                    let (bytes, response) = try await session.bytes(for: urlRequest)
-                    guard let response = response as? HTTPURLResponse else {
-                        throw AIProviderError.responseFailed(
-                            "The provider returned an invalid HTTP response.")
+                    let request = try buildRequest(for: input)
+                    if let bodyData = request.httpBody, let bodyString = String(data: bodyData, encoding: .utf8) {
+                        logDebug("REQUEST URL: \(request.url?.absoluteString ?? "")")
+                        logDebug("REQUEST HEADERS: \(request.allHTTPHeaderFields ?? [:])")
+                        logDebug("REQUEST BODY: \(bodyString)")
                     }
-                    guard response.statusCode == 200 else {
-                        throw AIProviderError.responseFailed(Self.statusMessage(response))
+                    let (asyncBytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        logDebug("RESPONSE NOT HTTP: \(response)")
+                        throw AIProviderError.responseFailed("Invalid response from server.")
+                    }
+                    logDebug("RESPONSE STATUS: \(http.statusCode)")
+                    logDebug("RESPONSE HEADERS: \(http.allHeaderFields)")
+                    guard (200...299).contains(http.statusCode) else {
+                        var body = ""
+                        for try await line in asyncBytes.lines {
+                            body += line + "\n"
+                        }
+                        logDebug("NON-200 BODY: \(body)")
+                        throw AIStreamDecoder.parseError(
+                            from: body, status: http.statusCode, shape: configuration.shape)
                     }
                     var decoder = AIStreamDecoder(shape: configuration.shape)
-                    var chunk = Data()
-                    chunk.reserveCapacity(2_048)
-                    // Per line, not per 2 KB: a short reply must show before the stream closes.
-                    for try await byte in bytes {
-                        try Task.checkCancellation()
-                        chunk.append(byte)
-                        if byte == 0x0A {
-                            for event in try decoder.feed(chunk) { continuation.yield(event) }
-                            chunk.removeAll(keepingCapacity: true)
-                            if decoder.isTerminal { break }
+                    for try await line in asyncBytes.lines {
+                        guard !Task.isCancelled else { break }
+                        logDebug("STREAM LINE: \(line)")
+                        for event in try decoder.feed(line: line) {
+                            logDebug("STREAM EVENT: \(event)")
+                            continuation.yield(event)
                         }
                     }
-                    if !chunk.isEmpty, !decoder.isTerminal {
-                        for event in try decoder.feed(chunk) { continuation.yield(event) }
-                    }
-                    if !decoder.isTerminal {
-                        for event in try decoder.finish() { continuation.yield(event) }
-                    }
-                    guard decoder.isTerminal else {
-                        throw AIProviderError.responseFailed(
-                            "The connection closed before the response completed.")
+                    for event in try decoder.finish() {
+                        logDebug("FINISH EVENT: \(event)")
+                        continuation.yield(event)
                     }
                     continuation.finish()
-                } catch is CancellationError {
-                    continuation.finish()
-                } catch let error as URLError {
-                    continuation.finish(
-                        throwing: AIProviderError.responseFailed(Self.networkMessage(error.code)))
                 } catch {
+                    logDebug("STREAM CAUGHT ERROR: \(error)")
                     continuation.finish(throwing: error)
                 }
             }
@@ -62,20 +76,19 @@ struct HTTPAIProvider: AIProvider {
         }
     }
 
-    private func makeURLRequest(_ input: AIRequest) throws -> URLRequest {
+    private func buildRequest(for input: AIRequest) throws -> URLRequest {
         var request = URLRequest(url: configuration.endpointURL)
         request.httpMethod = "POST"
-        request.timeoutInterval = 90
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let body: [String: Any]
+        let body: Any
         switch configuration.shape {
         case .openAICompatible:
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-            if configuration.provider == .gemini {
-                request.setValue(Self.googleClientHeader, forHTTPHeaderField: "x-goog-api-client")
-            } else if configuration.provider == .openRouter {
+            if !apiKey.isEmpty {
+                request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            }
+            if configuration.provider == .openRouter {
                 request.setValue(Bundle.main.appDisplayName, forHTTPHeaderField: "X-OpenRouter-Title")
             }
             var messages = input.messages.compactMap(Self.openAIMessage)
@@ -87,6 +100,21 @@ struct HTTPAIProvider: AIProvider {
                 "messages": messages,
                 "stream": true
             ]
+            if !input.tools.isEmpty {
+                let toolSchemas: [[String: Any]] = input.tools.compactMap { tool in
+                    guard let data = tool.parametersJSON.data(using: .utf8),
+                          let schema = try? JSONSerialization.jsonObject(with: data) else { return nil }
+                    return [
+                        "type": "function",
+                        "function": [
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": schema
+                        ]
+                    ]
+                }
+                if !toolSchemas.isEmpty { value["tools"] = toolSchemas }
+            }
             // OpenRouter's own search layer, so it works for every model it routes.
             if input.webSearch, configuration.provider == .openRouter {
                 value["plugins"] = [["id": "web"]]
@@ -106,6 +134,18 @@ struct HTTPAIProvider: AIProvider {
                 "max_tokens": input.maxOutputTokens,
                 "stream": true
             ]
+            if !input.tools.isEmpty {
+                let toolSchemas: [[String: Any]] = input.tools.compactMap { tool in
+                    guard let data = tool.parametersJSON.data(using: .utf8),
+                          let schema = try? JSONSerialization.jsonObject(with: data) else { return nil }
+                    return [
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": schema
+                    ]
+                }
+                if !toolSchemas.isEmpty { value["tools"] = toolSchemas }
+            }
             if !systemParts.isEmpty { value["system"] = systemParts.joined(separator: "\n\n") }
             body = value
         }
@@ -113,8 +153,34 @@ struct HTTPAIProvider: AIProvider {
         return request
     }
 
-    /// Plain text stays a string; only a message with images takes the content-part array.
+    /// Plain text stays a string; tool responses take role "tool".
     private static func openAIMessage(_ message: AIMessage) -> [String: Any]? {
+        if message.role == .tool {
+            return [
+                "role": "tool",
+                "tool_call_id": message.toolCallID ?? "",
+                "content": message.text
+            ]
+        }
+        if !message.toolCalls.isEmpty {
+            var msg: [String: Any] = ["role": "assistant"]
+            if let text = message.text.nonEmpty {
+                msg["content"] = text
+            } else {
+                msg["content"] = NSNull()
+            }
+            msg["tool_calls"] = message.toolCalls.map { call in
+                [
+                    "id": call.id,
+                    "type": "function",
+                    "function": [
+                        "name": call.name,
+                        "arguments": call.argumentsJSON
+                    ]
+                ]
+            }
+            return msg
+        }
         let text = message.text.nonEmpty
         guard text != nil || !message.images.isEmpty else { return nil }
         guard !message.images.isEmpty else {
@@ -122,73 +188,75 @@ struct HTTPAIProvider: AIProvider {
         }
         var parts: [[String: Any]] = []
         if let text { parts.append(["type": "text", "text": text]) }
-        parts += message.images.map { ["type": "image_url", "image_url": ["url": $0.dataURL]] }
+        for image in message.images {
+            parts.append([
+                "type": "image_url",
+                "image_url": [
+                    "url": "data:\(image.mimeType);base64,\(image.data.base64EncodedString())"
+                ]
+            ])
+        }
         return ["role": message.role.rawValue, "content": parts]
     }
 
     private static func anthropicMessage(_ message: AIMessage) -> [String: Any]? {
-        guard message.role != .system else { return nil }
+        if message.role == .system { return nil }
+        if message.role == .tool {
+            return [
+                "role": "user",
+                "content": [
+                    [
+                        "type": "tool_result",
+                        "tool_use_id": message.toolCallID ?? "",
+                        "content": message.text
+                    ]
+                ]
+            ]
+        }
+        if !message.toolCalls.isEmpty {
+            var content: [[String: Any]] = []
+            if let text = message.text.nonEmpty {
+                content.append(["type": "text", "text": text])
+            }
+            for call in message.toolCalls {
+                let inputObj: Any = {
+                    guard let data = call.argumentsJSON.data(using: .utf8),
+                          let json = try? JSONSerialization.jsonObject(with: data) else { return [:] }
+                    return json
+                }()
+                content.append([
+                    "type": "tool_use",
+                    "id": call.id,
+                    "name": call.name,
+                    "input": inputObj
+                ])
+            }
+            return ["role": "assistant", "content": content]
+        }
         let text = message.text.nonEmpty
         guard text != nil || !message.images.isEmpty else { return nil }
         guard !message.images.isEmpty else {
             return ["role": message.role.rawValue, "content": text ?? ""]
         }
-        var parts: [[String: Any]] = message.images.map {
-            [
+        var parts: [[String: Any]] = []
+        for image in message.images {
+            parts.append([
                 "type": "image",
                 "source": [
-                    "type": "base64", "media_type": $0.mimeType,
-                    "data": $0.data.base64EncodedString()
+                    "type": "base64",
+                    "media_type": image.mimeType,
+                    "data": image.data.base64EncodedString()
                 ]
-            ]
+            ])
         }
         if let text { parts.append(["type": "text", "text": text]) }
         return ["role": message.role.rawValue, "content": parts]
     }
-
-    private static var googleClientHeader: String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
-        return "tinycast-oai/\(version)"
-    }
-
-    private static func makeSession() -> URLSession {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.urlCache = nil
-        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        return URLSession(configuration: configuration)
-    }
-
-    private static func statusMessage(_ response: HTTPURLResponse) -> String {
-        switch response.statusCode {
-        case 401, 403:
-            return "API key rejected — check it in Settings."
-        case 429:
-            guard let retryAfter = response.value(forHTTPHeaderField: "Retry-After"),
-                let seconds = Int(retryAfter), seconds >= 0
-            else { return "Rate limit reached — try again later." }
-            return "Rate limit reached — retry after \(seconds) seconds."
-        case 500...599:
-            return "The provider is temporarily unavailable (HTTP \(response.statusCode))."
-        default:
-            return "The provider rejected the model or request (HTTP \(response.statusCode))."
-        }
-    }
-
-    private static func networkMessage(_ code: URLError.Code) -> String {
-        switch code {
-        case .networkConnectionLost: return "The network connection was lost."
-        case .notConnectedToInternet: return "No internet connection."
-        case .timedOut: return "The provider took too long to respond."
-        case .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
-            return "The provider could not be reached."
-        default: return "The network request failed."
-        }
-    }
 }
 
-private extension String {
-    var nonEmpty: String? {
+extension String {
+    fileprivate var nonEmpty: String? {
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        return trimmed.isEmpty ? nil : self
     }
 }

--- a/Tinycast/Features/AI/Service/LocationProvider.swift
+++ b/Tinycast/Features/AI/Service/LocationProvider.swift
@@ -1,0 +1,246 @@
+import CoreLocation
+import Foundation
+
+public struct UserLocationInfo: Equatable, Sendable {
+    public let subLocality: String
+    public let city: String
+    public let region: String
+    public let country: String
+    public let countryCode: String
+    public let postalCode: String
+    public let latitude: Double
+    public let longitude: Double
+    public let timezone: String
+    public let source: String
+
+    public init(
+        subLocality: String = "",
+        city: String,
+        region: String,
+        country: String,
+        countryCode: String,
+        postalCode: String = "",
+        latitude: Double,
+        longitude: Double,
+        timezone: String,
+        source: String = "Device GPS (CoreLocation)"
+    ) {
+        self.subLocality = subLocality
+        self.city = city
+        self.region = region
+        self.country = country
+        self.countryCode = countryCode
+        self.postalCode = postalCode
+        self.latitude = latitude
+        self.longitude = longitude
+        self.timezone = timezone
+        self.source = source
+    }
+
+    public var summary: String {
+        var parts: [String] = []
+        if !subLocality.isEmpty { parts.append(subLocality) }
+        if !city.isEmpty && city != subLocality { parts.append(city) }
+        if !region.isEmpty, region != city { parts.append(region) }
+        if !country.isEmpty { parts.append(country) }
+        if !postalCode.isEmpty { parts.append(postalCode) }
+        let place = parts.joined(separator: ", ")
+
+        var lines: [String] = [
+            "Exact Location: \(place)",
+            "Coordinates: \(latitude), \(longitude)",
+            "Timezone: \(timezone)",
+            "Accuracy Source: \(source)"
+        ]
+        if !subLocality.isEmpty {
+            lines.insert("Area / Neighborhood: \(subLocality)", at: 1)
+        }
+        if !city.isEmpty {
+            lines.insert("City: \(city)", at: 2)
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+@MainActor
+private final class CoreLocationFetcher: NSObject, @preconcurrency CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation?, Never>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    func requestLocation() async -> CLLocation? {
+        let status = manager.authorizationStatus
+        if status == .notDetermined {
+            manager.requestAlwaysAuthorization()
+        } else if status == .denied || status == .restricted {
+            return nil
+        }
+
+        return await withCheckedContinuation { cont in
+            self.continuation = cont
+            self.manager.startUpdatingLocation()
+
+            let timeoutSec = (status == .notDetermined) ? 8 : 4
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(timeoutSec))
+                guard let self, let cont = self.continuation else { return }
+                self.continuation = nil
+                self.manager.stopUpdatingLocation()
+                cont.resume(returning: nil)
+            }
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        manager.stopUpdatingLocation()
+        if let cont = continuation {
+            continuation = nil
+            cont.resume(returning: location)
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        manager.stopUpdatingLocation()
+        if let cont = continuation {
+            continuation = nil
+            cont.resume(returning: nil)
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        if status == .authorizedAlways || status == .authorized {
+            manager.startUpdatingLocation()
+        } else if status == .denied || status == .restricted {
+            manager.stopUpdatingLocation()
+            if let cont = continuation {
+                continuation = nil
+                cont.resume(returning: nil)
+            }
+        }
+    }
+}
+
+public final class LocationProvider: @unchecked Sendable {
+    private let session: URLSession
+
+    public init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 4
+            config.timeoutIntervalForResource = 5
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    public func getLocation() async -> UserLocationInfo? {
+        // 1. Try CoreLocation first for exact GPS accuracy
+        if let coreLoc = await fetchCoreLocation() {
+            return coreLoc
+        }
+
+        // 2. Fall back to IP Geolocation if CoreLocation is denied/unavailable
+        if let ipLocation = await fetchIPLocation() {
+            return ipLocation
+        }
+
+        return nil
+    }
+
+    private func fetchCoreLocation() async -> UserLocationInfo? {
+        let fetcher = await MainActor.run { CoreLocationFetcher() }
+        guard let location = await fetcher.requestLocation() else {
+            return nil
+        }
+
+        let geocoder = CLGeocoder()
+        let placemarks = try? await geocoder.reverseGeocodeLocation(location)
+        if let place = placemarks?.first {
+            let subLocality = place.subLocality ?? place.thoroughfare ?? ""
+            let city = place.locality ?? place.subAdministrativeArea ?? place.name ?? ""
+            let region = place.administrativeArea ?? ""
+            let country = place.country ?? ""
+            let countryCode = place.isoCountryCode ?? ""
+            let postalCode = place.postalCode ?? ""
+            let timezone = place.timeZone?.identifier ?? TimeZone.current.identifier
+
+            return UserLocationInfo(
+                subLocality: subLocality,
+                city: city,
+                region: region,
+                country: country,
+                countryCode: countryCode,
+                postalCode: postalCode,
+                latitude: location.coordinate.latitude,
+                longitude: location.coordinate.longitude,
+                timezone: timezone,
+                source: "Device GPS (CoreLocation - High Accuracy)"
+            )
+        }
+
+        return UserLocationInfo(
+            city: "",
+            region: "",
+            country: "",
+            countryCode: "",
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude,
+            timezone: TimeZone.current.identifier,
+            source: "Device GPS (CoreLocation - High Accuracy)"
+        )
+    }
+
+    private func fetchIPLocation() async -> UserLocationInfo? {
+        guard let url = URL(string: "https://ipwho.is/") else { return nil }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 4
+        request.setValue("Mozilla/5.0 Tinycast/1.0", forHTTPHeaderField: "User-Agent")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let success = json["success"] as? Bool, success else {
+                return nil
+            }
+
+            let city = json["city"] as? String ?? ""
+            let region = json["region"] as? String ?? ""
+            let country = json["country"] as? String ?? ""
+            let countryCode = json["country_code"] as? String ?? ""
+            let postalCode = json["postal"] as? String ?? ""
+            let lat = json["latitude"] as? Double ?? 0.0
+            let lon = json["longitude"] as? Double ?? 0.0
+            var tz = ""
+            if let timezoneObj = json["timezone"] as? [String: Any],
+               let tzId = timezoneObj["id"] as? String {
+                tz = tzId
+            } else {
+                tz = TimeZone.current.identifier
+            }
+
+            return UserLocationInfo(
+                subLocality: "",
+                city: city,
+                region: region,
+                country: country,
+                countryCode: countryCode,
+                postalCode: postalCode,
+                latitude: lat,
+                longitude: lon,
+                timezone: tz,
+                source: "IP Geolocation"
+            )
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Tinycast/Features/AI/Service/WeatherService.swift
+++ b/Tinycast/Features/AI/Service/WeatherService.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+public final class WeatherService: Sendable {
+    private let session: URLSession
+    private let locationProvider: LocationProvider
+
+    public init(session: URLSession? = nil, locationProvider: LocationProvider = LocationProvider()) {
+        self.locationProvider = locationProvider
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 6
+            config.timeoutIntervalForResource = 8
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    public func getWeather(location: String?, days: Int = 1) async -> String {
+        let isFahrenheit: Bool = {
+            if #available(macOS 13.0, *) {
+                return Locale.current.measurementSystem == .us
+            } else {
+                return Locale.current.usesMetricSystem == false
+            }
+        }()
+        let tempUnit = isFahrenheit ? "fahrenheit" : "celsius"
+        let unitSymbol = isFahrenheit ? "°F" : "°C"
+        let speedUnit = isFahrenheit ? "mph" : "kmh"
+
+        var targetLat: Double = 0.0
+        var targetLon: Double = 0.0
+        var resolvedPlace = ""
+
+        let locTrimmed = location?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if locTrimmed.isEmpty || locTrimmed.lowercased() == "current" || locTrimmed.lowercased() == "here" {
+            if let userLoc = await locationProvider.getLocation() {
+                targetLat = userLoc.latitude
+                targetLon = userLoc.longitude
+                resolvedPlace = [userLoc.city, userLoc.country].filter { !$0.isEmpty }.joined(separator: ", ")
+            } else {
+                return "Unable to determine current location. Please specify a city name (e.g. 'weather in Paris')."
+            }
+        } else {
+            // Geocode city name using Open-Meteo Geocoding API
+            guard let encoded = locTrimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                  let geoURL = URL(string: "https://geocoding-api.open-meteo.com/v1/search?name=\(encoded)&count=1&language=en&format=json") else {
+                return "Invalid location query: \(locTrimmed)"
+            }
+
+            do {
+                let (data, response) = try await session.data(from: geoURL)
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                    return "Could not geocode location '\(locTrimmed)'."
+                }
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let results = json["results"] as? [[String: Any]],
+                      let first = results.first,
+                      let lat = first["latitude"] as? Double,
+                      let lon = first["longitude"] as? Double else {
+                    return "Location '\(locTrimmed)' not found."
+                }
+                targetLat = lat
+                targetLon = lon
+                let name = first["name"] as? String ?? locTrimmed
+                let country = first["country"] as? String ?? ""
+                let admin1 = first["admin1"] as? String ?? ""
+                resolvedPlace = [name, admin1, country].filter { !$0.isEmpty }.joined(separator: ", ")
+            } catch {
+                return "Failed to search location: \(error.localizedDescription)"
+            }
+        }
+
+        let forecastDays = min(max(days, 1), 7)
+        let weatherURLString = "https://api.open-meteo.com/v1/forecast?latitude=\(targetLat)&longitude=\(targetLon)&current=temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&temperature_unit=\(tempUnit)&wind_speed_unit=\(speedUnit)&precipitation_unit=mm&timeformat=iso8601&timezone=auto&forecast_days=\(forecastDays)"
+
+        guard let weatherURL = URL(string: weatherURLString) else {
+            return "Failed to construct weather request URL."
+        }
+
+        do {
+            let (data, response) = try await session.data(from: weatherURL)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return "Weather service returned HTTP error."
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return "Invalid response from weather service."
+            }
+
+            var output = "Weather for \(resolvedPlace.isEmpty ? "\(targetLat), \(targetLon)" : resolvedPlace):\n\n"
+
+            if let current = json["current"] as? [String: Any] {
+                let temp = current["temperature_2m"] as? Double ?? 0
+                let apparent = current["apparent_temperature"] as? Double ?? temp
+                let humidity = current["relative_humidity_2m"] as? Int ?? 0
+                let wind = current["wind_speed_10m"] as? Double ?? 0
+                let code = current["weather_code"] as? Int ?? 0
+                let desc = Self.descriptionForWeatherCode(code)
+
+                output += "• Current Conditions: \(desc)\n"
+                output += "• Temperature: \(Int(round(temp)))\(unitSymbol) (Feels like \(Int(round(apparent)))\(unitSymbol))\n"
+                output += "• Humidity: \(humidity)%\n"
+                output += "• Wind Speed: \(Int(round(wind))) \(speedUnit)\n"
+            }
+
+            if forecastDays > 1, let daily = json["daily"] as? [String: Any],
+               let times = daily["time"] as? [String],
+               let maxTemps = daily["temperature_2m_max"] as? [Double],
+               let minTemps = daily["temperature_2m_min"] as? [Double],
+               let codes = daily["weather_code"] as? [Int] {
+                let precipProbs = daily["precipitation_probability_max"] as? [Int] ?? []
+
+                output += "\nForecast:\n"
+                for i in 0..<min(times.count, forecastDays) {
+                    let day = times[i]
+                    let maxT = Int(round(maxTemps[i]))
+                    let minT = Int(round(minTemps[i]))
+                    let condition = Self.descriptionForWeatherCode(codes[i])
+                    let rain = (i < precipProbs.count) ? " · Rain: \(precipProbs[i])%" : ""
+                    output += "- \(day): \(condition), High: \(maxT)\(unitSymbol), Low: \(minT)\(unitSymbol)\(rain)\n"
+                }
+            }
+
+            return output
+        } catch {
+            return "Failed to fetch weather: \(error.localizedDescription)"
+        }
+    }
+
+    public static func descriptionForWeatherCode(_ code: Int) -> String {
+        switch code {
+        case 0: return "Clear sky"
+        case 1: return "Mainly clear"
+        case 2: return "Partly cloudy"
+        case 3: return "Overcast"
+        case 45, 48: return "Foggy"
+        case 51, 53, 55: return "Drizzle"
+        case 56, 57: return "Freezing drizzle"
+        case 61: return "Slight rain"
+        case 63: return "Moderate rain"
+        case 65: return "Heavy rain"
+        case 66, 67: return "Freezing rain"
+        case 71: return "Slight snow"
+        case 73: return "Moderate snow"
+        case 75: return "Heavy snow"
+        case 77: return "Snow grains"
+        case 80, 81, 82: return "Rain showers"
+        case 85, 86: return "Snow showers"
+        case 95: return "Thunderstorm"
+        case 96, 99: return "Thunderstorm with hail"
+        default: return "Partly cloudy"
+        }
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebFetch/Model/HTMLToMarkdownConverter.swift
+++ b/Tinycast/Features/AI/Tools/WebFetch/Model/HTMLToMarkdownConverter.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+public enum HTMLToMarkdownConverter {
+    /// Converts raw HTML string into clean, token-efficient Markdown.
+    public static func convert(html: String, maxCharacters: Int = 4000) -> String {
+        var text = html
+
+        // 1. Remove scripts, styles, noscript, svg, nav, footer, header, aside, iframe, form
+        let removePatterns = [
+            #"<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>"#,
+            #"<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>"#,
+            #"<noscript\b[^<]*(?:(?!<\/noscript>)<[^<]*)*<\/noscript>"#,
+            #"<svg\b[^<]*(?:(?!<\/svg>)<[^<]*)*<\/svg>"#,
+            #"<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>"#,
+            #"<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>"#,
+            #"<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>"#,
+            #"<aside\b[^<]*(?:(?!<\/aside>)<[^<]*)*<\/aside>"#,
+            #"<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>"#,
+            #"<form\b[^<]*(?:(?!<\/form>)<[^<]*)*<\/form>"#,
+            #"<a\s+[^>]*href=["']javascript:[^"']*["'][^>]*>.*?<\/a>"#
+        ]
+
+        for pattern in removePatterns {
+            if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+                text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "")
+            }
+        }
+
+        // 2. Extract article or main if present
+        if let articleRegex = try? NSRegularExpression(pattern: #"<article\b[^>]*>(.*?)<\/article>"#, options: [.caseInsensitive, .dotMatchesLineSeparators]),
+           let match = articleRegex.firstMatch(in: text, options: [], range: NSRange(text.startIndex..., in: text)),
+           let range = Range(match.range(at: 1), in: text) {
+            text = String(text[range])
+        } else if let mainRegex = try? NSRegularExpression(pattern: #"<main\b[^>]*>(.*?)<\/main>"#, options: [.caseInsensitive, .dotMatchesLineSeparators]),
+                  let match = mainRegex.firstMatch(in: text, options: [], range: NSRange(text.startIndex..., in: text)),
+                  let range = Range(match.range(at: 1), in: text) {
+            text = String(text[range])
+        }
+
+        // 3. Convert headers
+        for level in 1...6 {
+            let hPattern = "<h\(level)[^>]*>(.*?)</h\(level)>"
+            let prefix = String(repeating: "#", count: level) + " "
+            if let regex = try? NSRegularExpression(pattern: hPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+                text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n\n\(prefix)$1\n\n")
+            }
+        }
+
+        // 4. Convert links: <a href="url">text</a> -> [text](url)
+        let linkPattern = #"<a\s+[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>"#
+        if let regex = try? NSRegularExpression(pattern: linkPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "[$2]($1)")
+        }
+
+        // 5. Convert bold and italics
+        let boldPattern = #"<(?:strong|b)\b[^>]*>(.*?)<\/(?:strong|b)>"#
+        if let regex = try? NSRegularExpression(pattern: boldPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "**$1**")
+        }
+        let italicPattern = #"<(?:em|i)\b[^>]*>(.*?)<\/(?:em|i)>"#
+        if let regex = try? NSRegularExpression(pattern: italicPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "*$1*")
+        }
+
+        // 6. Convert code blocks & inline code
+        let preCodePattern = #"<pre\b[^>]*><code\b[^>]*>(.*?)<\/code><\/pre>"#
+        if let regex = try? NSRegularExpression(pattern: preCodePattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n```\n$1\n```\n")
+        }
+        let inlineCodePattern = #"<code\b[^>]*>(.*?)<\/code>"#
+        if let regex = try? NSRegularExpression(pattern: inlineCodePattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "`$1`")
+        }
+
+        // 7. Convert paragraphs, line breaks, blockquotes, and list items
+        let brPattern = #"<br\s*\/?>"#
+        if let regex = try? NSRegularExpression(pattern: brPattern, options: .caseInsensitive) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n")
+        }
+        let pPattern = #"<p\b[^>]*>(.*?)<\/p>"#
+        if let regex = try? NSRegularExpression(pattern: pPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n\n$1\n\n")
+        }
+        let liPattern = #"<li\b[^>]*>(.*?)<\/li>"#
+        if let regex = try? NSRegularExpression(pattern: liPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n* $1")
+        }
+        let bqPattern = #"<blockquote\b[^>]*>(.*?)<\/blockquote>"#
+        if let regex = try? NSRegularExpression(pattern: bqPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n\n> $1\n\n")
+        }
+
+        // 8. Strip all remaining HTML tags
+        let tagPattern = #"<[^>]+>"#
+        if let regex = try? NSRegularExpression(pattern: tagPattern, options: []) {
+            text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "")
+        }
+
+        // 9. Decode HTML entities
+        text = decodeHTMLEntities(text)
+
+        // 10. Clean noise: empty links, javascript links, social share tags
+        let noisePatterns = [
+            #"\*?\s*\[\s*\]\([^\)]*\)"#,
+            #"\*?\s*\[[^\]]*\]\(javascript:[^\)]*\)"#,
+            #"\n\s*\*\s*\n"#
+        ]
+        for pattern in noisePatterns {
+            if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) {
+                text = regex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n")
+            }
+        }
+
+        // 11. Clean excessive newlines and whitespace
+        if let multilineRegex = try? NSRegularExpression(pattern: #"\n{3,}"#) {
+            text = multilineRegex.stringByReplacingMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text), withTemplate: "\n\n")
+        }
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // 12. Bounded character truncation
+        if text.count > maxCharacters {
+            let index = text.index(text.startIndex, offsetBy: maxCharacters)
+            text = String(text[..<index]) + "\n\n[Content truncated...]"
+        }
+
+        return text
+    }
+
+    public static func decodeHTMLEntities(_ text: String) -> String {
+        var result = text
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&#8217;", with: "'")
+            .replacingOccurrences(of: "&#8216;", with: "'")
+            .replacingOccurrences(of: "&#8220;", with: "\"")
+            .replacingOccurrences(of: "&#8221;", with: "\"")
+            .replacingOccurrences(of: "&#8211;", with: "–")
+            .replacingOccurrences(of: "&#8212;", with: "—")
+            .replacingOccurrences(of: "&mdash;", with: "—")
+            .replacingOccurrences(of: "&ndash;", with: "–")
+
+        // Hex and decimal numeric entities
+        let entityPattern = #"&#(x?[0-9a-fA-F]+);"#
+        if let regex = try? NSRegularExpression(pattern: entityPattern) {
+            let matches = regex.matches(in: result, range: NSRange(result.startIndex..., in: result))
+            for match in matches.reversed() {
+                if let entityRange = Range(match.range, in: result),
+                   let codeRange = Range(match.range(at: 1), in: result) {
+                    let codeString = String(result[codeRange])
+                    let codePoint: UInt32?
+                    if codeString.lowercased().hasPrefix("x") {
+                        codePoint = UInt32(codeString.dropFirst(), radix: 16)
+                    } else {
+                        codePoint = UInt32(codeString, radix: 10)
+                    }
+                    if let codePoint, let scalar = UnicodeScalar(codePoint) {
+                        result.replaceSubrange(entityRange, with: String(scalar))
+                    }
+                }
+            }
+        }
+        return result
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebFetch/Service/PDFDocumentReader.swift
+++ b/Tinycast/Features/AI/Tools/WebFetch/Service/PDFDocumentReader.swift
@@ -1,0 +1,23 @@
+import Foundation
+import PDFKit
+
+public enum PDFDocumentReader {
+    public static func extractText(from data: Data, maxCharacters: Int = 10000) -> String? {
+        guard let doc = PDFDocument(data: data) else { return nil }
+        var fullText = ""
+        for i in 0..<doc.pageCount {
+            if let pageText = doc.page(at: i)?.string {
+                fullText += pageText + "\n\n"
+                if fullText.count >= maxCharacters {
+                    break
+                }
+            }
+        }
+        let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count > maxCharacters {
+            let index = trimmed.index(trimmed.startIndex, offsetBy: maxCharacters)
+            return String(trimmed[..<index]) + "\n\n[PDF truncated...]"
+        }
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebFetch/Service/WebPageReader.swift
+++ b/Tinycast/Features/AI/Tools/WebFetch/Service/WebPageReader.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public final class WebPageReader: Sendable {
+    private let session: URLSession
+
+    public init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 8
+            config.timeoutIntervalForResource = 10
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    public func read(url: URL, maxCharacters: Int = 4000) async throws -> String {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 8
+        request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AIProviderError.responseFailed("No HTTP response from \(url.host ?? url.absoluteString)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw AIProviderError.responseFailed("Failed to fetch webpage (HTTP \(http.statusCode))")
+        }
+
+        let contentType = http.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+        if contentType.contains("application/pdf") || url.pathExtension.lowercased() == "pdf" {
+            if let pdfText = PDFDocumentReader.extractText(from: data, maxCharacters: maxCharacters) {
+                return pdfText
+            }
+        }
+
+        let html = String(decoding: data, as: UTF8.self)
+        let markdown = HTMLToMarkdownConverter.convert(html: html, maxCharacters: maxCharacters)
+        return markdown.isEmpty ? "The webpage contained no readable text content." : markdown
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/ConsensusScorer.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/ConsensusScorer.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public enum ConsensusScorer {
+    /// SearXNG-inspired Reciprocal Rank Fusion (RRF) with engine agreement bonus.
+    /// Score(u) = (Agreeing Engines Count) * sum_e ( weight(e) / (rank_e + 60) )
+    public static func score(
+        engineResults: [[WebSearchResult]],
+        weights: [WebSearchEngineType: Double] = [:]
+    ) -> [WebSearchResult] {
+        struct ScoredEntry {
+            var primaryResult: WebSearchResult
+            var agreeingEngines: Set<WebSearchEngineType>
+            var rawRRFScore: Double
+            var bestSnippet: String
+        }
+
+        var groups: [String: ScoredEntry] = [:]
+
+        for results in engineResults {
+            for result in results {
+                let key = URLNormalizer.deduplicationKey(for: result.url)
+                let engine = result.engine
+                let weight = weights[engine] ?? engine.defaultWeight
+                let rrf = weight / Double(result.rank + 60)
+
+                if var existing = groups[key] {
+                    existing.agreeingEngines.insert(engine)
+                    existing.rawRRFScore += rrf
+                    if result.snippet.count > existing.bestSnippet.count {
+                        existing.bestSnippet = result.snippet
+                    }
+                    groups[key] = existing
+                } else {
+                    groups[key] = ScoredEntry(
+                        primaryResult: result,
+                        agreeingEngines: [engine],
+                        rawRRFScore: rrf,
+                        bestSnippet: result.snippet
+                    )
+                }
+            }
+        }
+
+        var finalResults: [WebSearchResult] = []
+        for entry in groups.values {
+            let engineCount = Double(entry.agreeingEngines.count)
+            let totalScore = engineCount * entry.rawRRFScore
+            let cleanURL = URLNormalizer.normalize(entry.primaryResult.url)
+            let scored = WebSearchResult(
+                id: entry.primaryResult.id,
+                title: entry.primaryResult.title,
+                url: cleanURL,
+                snippet: entry.bestSnippet,
+                engine: entry.primaryResult.engine,
+                rank: entry.primaryResult.rank,
+                score: totalScore,
+                publishedDate: entry.primaryResult.publishedDate
+            )
+            finalResults.append(scored)
+        }
+
+        return finalResults.sorted { $0.score > $1.score }
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/URLNormalizer.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/URLNormalizer.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum URLNormalizer {
+    private static let trackingParameters: Set<String> = [
+        "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+        "fbclid", "gclid", "ref", "source", "spm", "_hsenc", "_hsmi",
+        "mc_cid", "mc_eid", "yclid", "_openstat"
+    ]
+
+    /// Returns a clean canonical URL without tracking parameters or fragments.
+    public static func normalize(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+
+        // Strip tracking query parameters
+        if let queryItems = components.queryItems {
+            let filtered = queryItems.filter { !trackingParameters.contains($0.name.lowercased()) }
+            components.queryItems = filtered.isEmpty ? nil : filtered
+        }
+
+        // Normalize host (strip www.)
+        if let host = components.host?.lowercased() {
+            if host.hasPrefix("www.") {
+                components.host = String(host.dropFirst(4))
+            } else {
+                components.host = host
+            }
+        }
+
+        // Strip fragment (#...)
+        components.fragment = nil
+
+        // Strip trailing slash on path
+        if components.path == "/" {
+            components.path = ""
+        } else if components.path.hasSuffix("/") {
+            components.path = String(components.path.dropLast())
+        }
+
+        return components.url ?? url
+    }
+
+    /// String key for deduplicating URLs.
+    public static func deduplicationKey(for url: URL) -> String {
+        normalize(url).absoluteString.lowercased()
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/URLRedirectDecoder.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/URLRedirectDecoder.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public enum URLRedirectDecoder {
+    /// Unwrap tracking and proxy redirects (DuckDuckGo uddg=, AOL/Yahoo RU=)
+    public static func decode(_ rawURLString: String) -> URL? {
+        let trimmed = rawURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed) else { return nil }
+
+        // 1. DuckDuckGo: //duckduckgo.com/l/?uddg=<encoded_url>
+        if url.host?.contains("duckduckgo.com") == true || trimmed.contains("/l/?uddg=") {
+            if let components = URLComponents(string: trimmed),
+               let uddg = components.queryItems?.first(where: { $0.name == "uddg" })?.value {
+                if let decoded = uddg.removingPercentEncoding, let target = URL(string: decoded) {
+                    return target
+                }
+            }
+        }
+
+        // 2. AOL / Yahoo: .../RU=<encoded_url>/RK=...
+        if trimmed.contains("/RU=") {
+            let pattern = #"/RU=([^/]+)/RK="#
+            if let regex = try? NSRegularExpression(pattern: pattern),
+               let match = regex.firstMatch(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed)),
+               let range = Range(match.range(at: 1), in: trimmed) {
+                let encodedTarget = String(trimmed[range])
+                if let decoded = encodedTarget.removingPercentEncoding, let target = URL(string: decoded) {
+                    return target
+                }
+            }
+        }
+
+        // 3. Protocol relative URL: //example.com -> https://example.com
+        if trimmed.hasPrefix("//") {
+            return URL(string: "https:" + trimmed)
+        }
+
+        return url
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchCategory.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchCategory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum WebSearchCategory: String, CaseIterable, Codable, Sendable {
+    case general
+    case news
+    case wikipedia
+
+    public var displayName: String {
+        switch self {
+        case .general: return "General"
+        case .news: return "News"
+        case .wikipedia: return "Wikipedia"
+        }
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchEngineType.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchEngineType.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public enum WebSearchEngineType: String, CaseIterable, Codable, Sendable {
+    case duckDuckGo = "duckduckgo"
+    case brave = "brave"
+    case aol = "aol"
+    case yahoo = "yahoo"
+    case wikipedia = "wikipedia"
+    case news = "news"
+
+    public var displayName: String {
+        switch self {
+        case .duckDuckGo: return "DuckDuckGo"
+        case .brave: return "Brave"
+        case .aol: return "AOL"
+        case .yahoo: return "Yahoo"
+        case .wikipedia: return "Wikipedia"
+        case .news: return "News"
+        }
+    }
+
+    public var defaultWeight: Double {
+        switch self {
+        case .news: return 1.3
+        case .duckDuckGo: return 1.1
+        case .brave: return 1.0
+        case .yahoo: return 1.0
+        case .aol: return 0.85
+        case .wikipedia: return 0.9
+        }
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchQuery.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchQuery.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct WebSearchQuery: Equatable, Sendable {
+    public let rawQuery: String
+    public let searchTerm: String
+    public let category: WebSearchCategory
+    public let siteConstraint: String?
+
+    public var siteFilter: String? { siteConstraint }
+
+    public init(query: String, category: WebSearchCategory = .general) {
+        self.rawQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        var parsedCategory = category
+        let text = self.rawQuery
+        var site: String?
+
+        var words = text.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+
+        // Check for bangs anywhere in the words
+        if let bangIndex = words.firstIndex(where: { $0.hasPrefix("!") }) {
+            let bang = String(words[bangIndex].dropFirst()).lowercased()
+            var matched = false
+            switch bang {
+            case "w", "wiki", "wikipedia":
+                parsedCategory = .wikipedia
+                matched = true
+            case "n", "news":
+                parsedCategory = .news
+                matched = true
+            default:
+                break
+            }
+            if matched {
+                words.remove(at: bangIndex)
+            }
+        } else if parsedCategory == .general {
+            let lower = text.lowercased()
+            if lower.contains("news") || lower.contains("today") || lower.contains("latest") || lower.contains("breaking") {
+                parsedCategory = .news
+            }
+        }
+
+        // Clean out hallucinated past years from news queries
+        if parsedCategory == .news {
+            words = words.filter { $0 != "2024" && $0 != "2025" }
+        }
+
+        // Check for site: filter
+        if let siteIndex = words.firstIndex(where: { $0.lowercased().hasPrefix("site:") }) {
+            let token = words[siteIndex]
+            site = String(token.dropFirst(5))
+        }
+
+        self.category = parsedCategory
+        self.siteConstraint = site
+        self.searchTerm = words.joined(separator: " ")
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchResult.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Model/WebSearchResult.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct WebSearchResult: Identifiable, Equatable, Hashable, Sendable {
+    public let id: UUID
+    public let title: String
+    public let url: URL
+    public let snippet: String
+    public let engine: WebSearchEngineType
+    public let rank: Int
+    public var score: Double
+    public let publishedDate: Date?
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        url: URL,
+        snippet: String,
+        engine: WebSearchEngineType,
+        rank: Int = 1,
+        score: Double = 0.0,
+        publishedDate: Date? = nil
+    ) {
+        self.id = id
+        self.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.url = url
+        self.snippet = snippet.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.engine = engine
+        self.rank = rank
+        self.score = score
+        self.publishedDate = publishedDate
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/AolSearchScraper.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/AolSearchScraper.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public enum AolSearchScraper {
+    private static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+    public static func search(query: String, session: URLSession = .shared) async throws -> [WebSearchResult] {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://search.aol.com/aol/search?q=\(encoded)&nojs=1") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return []
+        }
+
+        let html = String(decoding: data, as: UTF8.self)
+        return parse(html: html)
+    }
+
+    public static func parse(html: String) -> [WebSearchResult] {
+        var results: [WebSearchResult] = []
+        let pattern = #"<h3\s+[^>]*class="[^"]*title[^"]*"[^>]*><a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a><\/h3>.*?<div\s+[^>]*class="[^"]*compText[^"]*"[^>]*>(.*?)<\/div>"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let matches = regex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+        var rank = 1
+
+        for match in matches.prefix(10) {
+            guard let urlRange = Range(match.range(at: 1), in: html),
+                  let titleRange = Range(match.range(at: 2), in: html),
+                  let descRange = Range(match.range(at: 3), in: html) else { continue }
+
+            let rawURL = String(html[urlRange])
+            let rawTitle = String(html[titleRange])
+            let rawDesc = String(html[descRange])
+
+            guard let targetURL = URLRedirectDecoder.decode(rawURL) else { continue }
+            let cleanTitle = HTMLToMarkdownConverter.decodeHTMLEntities(rawTitle.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression))
+            let cleanSnippet = HTMLToMarkdownConverter.decodeHTMLEntities(rawDesc.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression))
+
+            results.append(
+                WebSearchResult(
+                    title: cleanTitle,
+                    url: targetURL,
+                    snippet: cleanSnippet,
+                    engine: .aol,
+                    rank: rank
+                )
+            )
+            rank += 1
+        }
+        return results
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/BraveSearchScraper.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/BraveSearchScraper.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public enum BraveSearchScraper {
+    private static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"
+
+    public static func search(query: String, session: URLSession = .shared) async throws -> [WebSearchResult] {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://search.brave.com/search?q=\(encoded)") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return []
+        }
+
+        let html = String(decoding: data, as: UTF8.self)
+        return parse(html: html)
+    }
+
+    public static func parse(html: String) -> [WebSearchResult] {
+        var results: [WebSearchResult] = []
+        let pattern = #"<div\s+[^>]*class="[^"]*snippet[^"]*"[^>]*data-type="web"[^>]*>.*?<a\s+[^>]*href="([^"]+)"[^>]*>.*?<span[^>]*class="[^"]*title[^"]*"[^>]*>(.*?)<\/span>.*?<\/a>.*?<div\s+[^>]*class="[^"]*snippet-description[^"]*"[^>]*>(.*?)<\/div>"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let matches = regex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+        var rank = 1
+
+        for match in matches.prefix(10) {
+            guard let urlRange = Range(match.range(at: 1), in: html),
+                  let titleRange = Range(match.range(at: 2), in: html),
+                  let descRange = Range(match.range(at: 3), in: html) else { continue }
+
+            let rawURL = String(html[urlRange])
+            let rawTitle = String(html[titleRange])
+            let rawDesc = String(html[descRange])
+
+            guard let targetURL = URL(string: rawURL) else { continue }
+            let cleanTitle = HTMLToMarkdownConverter.decodeHTMLEntities(rawTitle.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression))
+            let cleanSnippet = HTMLToMarkdownConverter.decodeHTMLEntities(rawDesc.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression))
+
+            results.append(
+                WebSearchResult(
+                    title: cleanTitle,
+                    url: targetURL,
+                    snippet: cleanSnippet,
+                    engine: .brave,
+                    rank: rank
+                )
+            )
+            rank += 1
+        }
+        return results
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/DuckDuckGoScraper.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/DuckDuckGoScraper.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public enum DuckDuckGoScraper {
+    private static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+    public static func search(query: String, session: URLSession = .shared) async throws -> [WebSearchResult] {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://html.duckduckgo.com/html/?q=\(encoded)") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = "q=\(encoded)&b=".data(using: .utf8)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return []
+        }
+
+        let html = String(decoding: data, as: UTF8.self)
+        return parse(html: html)
+    }
+
+    public static func parse(html: String) -> [WebSearchResult] {
+        var results: [WebSearchResult] = []
+        let resultPattern = #"<a\s+[^>]*class="[^"]*result__snippet[^"]*"[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>"#
+
+        // Extract using regex
+        guard let snippetRegex = try? NSRegularExpression(pattern: resultPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let matches = snippetRegex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+        var rank = 1
+
+        for match in matches.prefix(10) {
+            guard let hrefRange = Range(match.range(at: 1), in: html),
+                  let snippetRange = Range(match.range(at: 2), in: html) else { continue }
+
+            let rawHref = String(html[hrefRange])
+            let rawSnippet = String(html[snippetRange])
+
+            guard let targetURL = URLRedirectDecoder.decode(rawHref) else { continue }
+            let cleanSnippet = HTMLToMarkdownConverter.decodeHTMLEntities(rawSnippet).trimmingCharacters(in: .whitespacesAndNewlines)
+            let hostTitle = targetURL.host ?? targetURL.absoluteString
+
+            results.append(
+                WebSearchResult(
+                    title: hostTitle,
+                    url: targetURL,
+                    snippet: cleanSnippet,
+                    engine: .duckDuckGo,
+                    rank: rank
+                )
+            )
+            rank += 1
+        }
+        return results
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/NewsRSSEngine.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/NewsRSSEngine.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+public enum NewsRSSEngine {
+    public static func search(query: String, session: URLSession = .shared) async throws -> [WebSearchResult] {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://news.google.com/rss/search?q=\(encoded)&hl=en-US&gl=US&ceid=US:en") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Tinycast-News/1.0", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return []
+        }
+
+        let xml = String(decoding: data, as: UTF8.self)
+        return parse(xml: xml)
+    }
+
+    public static func parse(xml: String) -> [WebSearchResult] {
+        var results: [WebSearchResult] = []
+        let itemPattern = #"<item>.*?<title>(.*?)<\/title>.*?<link>(.*?)<\/link>.*?(?:<pubDate>(.*?)<\/pubDate>)?.*?(?:<description>(.*?)<\/description>)?.*?<\/item>"#
+
+        guard let regex = try? NSRegularExpression(pattern: itemPattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let matches = regex.matches(in: xml, options: [], range: NSRange(xml.startIndex..., in: xml))
+        var rank = 1
+
+        for match in matches.prefix(8) {
+            guard let titleRange = Range(match.range(at: 1), in: xml),
+                  let linkRange = Range(match.range(at: 2), in: xml) else { continue }
+
+            let rawTitle = String(xml[titleRange])
+            let rawLink = String(xml[linkRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard let url = URL(string: rawLink) else { continue }
+
+            var snippet = ""
+            if match.numberOfRanges > 4, let descRange = Range(match.range(at: 4), in: xml) {
+                let rawDesc = String(xml[descRange])
+                snippet = HTMLToMarkdownConverter.decodeHTMLEntities(
+                    rawDesc.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                ).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+
+            let cleanTitle = HTMLToMarkdownConverter.decodeHTMLEntities(rawTitle).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            results.append(
+                WebSearchResult(
+                    title: cleanTitle,
+                    url: url,
+                    snippet: snippet.isEmpty ? cleanTitle : snippet,
+                    engine: .news,
+                    rank: rank
+                )
+            )
+            rank += 1
+        }
+        return results
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/WikipediaEngine.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/WikipediaEngine.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum WikipediaEngine {
+    public static func search(query: String, session: URLSession = .shared) async throws -> [WebSearchResult] {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=\(encoded)&format=json&utf8=1") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Tinycast-Search/1.0", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return []
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let queryObj = json["query"] as? [String: Any],
+              let searchArr = queryObj["search"] as? [[String: Any]] else {
+            return []
+        }
+
+        var results: [WebSearchResult] = []
+        var rank = 1
+
+        for item in searchArr.prefix(5) {
+            guard let title = item["title"] as? String,
+                  let rawSnippet = item["snippet"] as? String,
+                  let pageURL = URL(string: "https://en.wikipedia.org/wiki/\(title.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? title)") else {
+                continue
+            }
+
+            let cleanSnippet = HTMLToMarkdownConverter.decodeHTMLEntities(
+                rawSnippet.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            )
+
+            results.append(
+                WebSearchResult(
+                    title: "\(title) - Wikipedia",
+                    url: pageURL,
+                    snippet: cleanSnippet,
+                    engine: .wikipedia,
+                    rank: rank
+                )
+            )
+            rank += 1
+        }
+        return results
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/YahooSearchScraper.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/Engines/YahooSearchScraper.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public enum YahooSearchScraper {
+    private static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+    public static func search(query: String, session: URLSession = .shared) async throws -> [WebSearchResult] {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://search.yahoo.com/search?p=\(encoded)&nojs=1") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return []
+        }
+
+        let html = String(decoding: data, as: UTF8.self)
+        return parse(html: html)
+    }
+
+    public static func parse(html: String) -> [WebSearchResult] {
+        var results: [WebSearchResult] = []
+        let pattern = #"<h3\s+[^>]*class="[^"]*title[^"]*"[^>]*><a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a><\/h3>.*?<div\s+[^>]*class="[^"]*compText[^"]*"[^>]*>(.*?)<\/div>"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let matches = regex.matches(in: html, options: [], range: NSRange(html.startIndex..., in: html))
+        var rank = 1
+
+        for match in matches.prefix(10) {
+            guard let urlRange = Range(match.range(at: 1), in: html),
+                  let titleRange = Range(match.range(at: 2), in: html),
+                  let descRange = Range(match.range(at: 3), in: html) else { continue }
+
+            let rawURL = String(html[urlRange])
+            let rawTitle = String(html[titleRange])
+            let rawDesc = String(html[descRange])
+
+            guard let targetURL = URLRedirectDecoder.decode(rawURL) else { continue }
+            let cleanTitle = HTMLToMarkdownConverter.decodeHTMLEntities(rawTitle.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression))
+            let cleanSnippet = HTMLToMarkdownConverter.decodeHTMLEntities(rawDesc.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression))
+
+            results.append(
+                WebSearchResult(
+                    title: cleanTitle,
+                    url: targetURL,
+                    snippet: cleanSnippet,
+                    engine: .yahoo,
+                    rank: rank
+                )
+            )
+            rank += 1
+        }
+        return results
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/WebSearchAggregator.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/WebSearchAggregator.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Orchestrates multi-engine web searches with parallel tasks, timeouts, caching, and consensus scoring.
+public final class WebSearchAggregator: Sendable {
+    private let cache: WebSearchCacheStore
+    private let session: URLSession
+
+    public init(cache: WebSearchCacheStore = WebSearchCacheStore(), session: URLSession = .shared) {
+        self.cache = cache
+        self.session = session
+    }
+
+    public func search(
+        query: String,
+        engines: Set<WebSearchEngineType> = [.yahoo, .duckDuckGo, .news, .wikipedia],
+        timeoutSeconds: Double = 4.0
+    ) async -> [WebSearchResult] {
+        let parsed = WebSearchQuery(query: query)
+        let cacheKey = "\(parsed.category.rawValue):\(parsed.searchTerm)"
+
+        if let cached = await cache.get(key: cacheKey) {
+            return cached
+        }
+
+        let session = self.session
+        var selectedEngines = engines
+        if parsed.category == .wikipedia {
+            selectedEngines = [.wikipedia]
+        } else if parsed.category == .news {
+            selectedEngines = [.news, .yahoo, .duckDuckGo]
+        }
+
+        let engineResults: [[WebSearchResult]] = await withTaskGroup(of: [WebSearchResult]?.self) { group in
+            for engine in selectedEngines {
+                group.addTask {
+                    do {
+                        return try await withThrowingTaskGroup(of: [WebSearchResult].self) { innerGroup in
+                            innerGroup.addTask {
+                                switch engine {
+                                case .duckDuckGo:
+                                    return try await DuckDuckGoScraper.search(query: parsed.searchTerm, session: session)
+                                case .brave:
+                                    return try await BraveSearchScraper.search(query: parsed.searchTerm, session: session)
+                                case .aol:
+                                    return try await AolSearchScraper.search(query: parsed.searchTerm, session: session)
+                                case .yahoo:
+                                    return try await YahooSearchScraper.search(query: parsed.searchTerm, session: session)
+                                case .wikipedia:
+                                    return try await WikipediaEngine.search(query: parsed.searchTerm, session: session)
+                                case .news:
+                                    return try await NewsRSSEngine.search(query: parsed.searchTerm, session: session)
+                                }
+                            }
+                            innerGroup.addTask {
+                                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                                return []
+                            }
+                            return try await innerGroup.next() ?? []
+                        }
+                    } catch {
+                        return []
+                    }
+                }
+            }
+
+            var aggregated: [[WebSearchResult]] = []
+            for await res in group {
+                if let res, !res.isEmpty {
+                    aggregated.append(res)
+                }
+            }
+            return aggregated
+        }
+
+        let scored = ConsensusScorer.score(engineResults: engineResults)
+        await cache.set(key: cacheKey, results: scored)
+        return scored
+    }
+}

--- a/Tinycast/Features/AI/Tools/WebSearch/Service/WebSearchCacheStore.swift
+++ b/Tinycast/Features/AI/Tools/WebSearch/Service/WebSearchCacheStore.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Thread-safe in-memory LRU cache for search results with TTL expiration.
+public actor WebSearchCacheStore {
+    private struct Entry {
+        let results: [WebSearchResult]
+        let timestamp: ContinuousClock.Instant
+    }
+
+    private var cache: [String: Entry] = [:]
+    private let ttl: Duration
+    private let capacity: Int
+
+    public init(ttl: Duration = .seconds(900), capacity: Int = 50) {
+        self.ttl = ttl
+        self.capacity = capacity
+    }
+
+    public func get(key: String) -> [WebSearchResult]? {
+        guard let entry = cache[key] else { return nil }
+        let now = ContinuousClock().now
+        if now - entry.timestamp > ttl {
+            cache.removeValue(forKey: key)
+            return nil
+        }
+        return entry.results
+    }
+
+    public func set(key: String, results: [WebSearchResult]) {
+        if cache.count >= capacity {
+            // Drop earliest entry
+            if let oldestKey = cache.min(by: { $0.value.timestamp < $1.value.timestamp })?.key {
+                cache.removeValue(forKey: oldestKey)
+            }
+        }
+        cache[key] = Entry(results: results, timestamp: ContinuousClock().now)
+    }
+
+    public func clear() {
+        cache.removeAll()
+    }
+}

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -49,12 +49,13 @@ final class AIChatCoordinator {
     func send(_ input: String) -> Bool {
         guard settings.aiEnabled else { return false }
         do {
-            let webSearch = core.aiSettings.webSearchEnabled && capabilities.webSearch
+            let webSearch = core.aiSettings.webSearchEnabled
             return chat.send(
                 input, using: try core.aiProvider(), webSearch: webSearch,
                 instructions: AIInstructions.compose(
                     userPrompt: core.aiSettings.systemPrompt,
-                    isEnabled: core.aiSettings.systemPromptEnabled))
+                    isEnabled: core.aiSettings.systemPromptEnabled,
+                    now: Date()))
         } catch {
             chat.report(error.localizedDescription)
             return false
@@ -78,9 +79,15 @@ final class AIChatCoordinator {
         palette.prepare(mode: .aiHistory)
     }
 
-    func openChat(id: UUID) {
+    func showHistory(id: UUID) {
+        guard settings.aiEnabled else { return }
         guard chat.open(id: id) else { return }
         palette.prepare(mode: .ai)
+        paletteCoordinator.showPalette(mode: .ai)
+    }
+
+    func openChat(id: UUID) {
+        showHistory(id: id)
     }
 
     func deleteChat(id: UUID) {
@@ -88,43 +95,40 @@ final class AIChatCoordinator {
     }
 
     func deleteAllChats() async {
-        guard
-            await core.confirm(
-                title: "Delete all chats?",
-                message: "Every saved conversation will be removed. This can't be undone.",
-                symbol: PaletteMode.aiHistory.systemImage, confirmTitle: "Delete All")
-        else { return }
         chat.deleteAll()
     }
 
-    func stopResponse() {
-        chat.cancel()
+    func startNewChatFromHistory() {
+        guard settings.aiEnabled else { return }
+        chat.startNewChat()
+        palette.prepare(mode: .ai)
+        paletteCoordinator.showPalette(mode: .ai)
+    }
+
+    func copyLatest() {
+        guard let text = chat.lastAssistantText else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
     }
 
     func copyLastResponse() {
-        guard let text = chat.lastAssistantText else { return }
-        Paster.copyPlainText(text)
+        copyLatest()
     }
 
-    /// What the selected model can take; the footer offers only what applies.
-    var capabilities: AIModelCapabilities {
-        switch core.aiSettings.defaultModel {
-        case .chatGPT?: return .chatGPT
-        case .api(let connection, let model)?:
-            return core.aiSettings.connection(id: connection)?.capabilities(for: model)
-                ?? AIModelCapabilities(images: false, webSearch: false)
-        case nil: return AIModelCapabilities(images: false, webSearch: false)
+    func stopResponse() {
+        chat.stop()
+    }
+
+    func stageClipboardImage() {
+        guard let file = Self.pastedImageFile(on: .general) else {
+            stage(file: nil, pasted: NSPasteboard.general.data(forType: .png))
+            return
         }
+        stage(file: file, pasted: nil)
     }
 
-    /// ⌘V with a picture on the pasteboard — a screenshot, or an image file from Finder — stages
-    /// it; anything with text pastes as text. False lets the field editor have the chord.
-    ///
-    /// The pasteboard is read here and the picture decoded off-main: unpacking, rescaling and
-    /// re-encoding a display-sized screenshot is megabytes of work that has no business on a
-    /// keystroke.
+    @discardableResult
     func attachPastedImage() -> Bool {
-        guard capabilities.images else { return false }
         let pasteboard = NSPasteboard.general
         let file = Self.pastedImageFile(on: pasteboard)
         let pasted =
@@ -136,9 +140,10 @@ final class AIChatCoordinator {
         return true
     }
 
-    /// The file first and the raw pasteboard bytes as the fallback, in the order they were decoded
-    /// inline. A refusal is explained where it happened, and the chord is consumed either way: ⌘V on
-    /// a picture never falls through to the field editor pasting its path as text.
+    func stageFile(_ url: URL) {
+        stage(file: url, pasted: nil)
+    }
+
     private func stage(file: URL?, pasted: Data?) {
         let generation = chat.stagingGeneration
         Task { [weak self] in

--- a/Tinycast/Features/AI/UI/AIChatState.swift
+++ b/Tinycast/Features/AI/UI/AIChatState.swift
@@ -41,8 +41,6 @@ final class AIChatState {
         notice = nil
         session.append(ChatMessage(role: .user, text: text, images: pendingImages.map(\.image)))
         clearStaging()
-        let request = AIRequest(
-            instructions: instructions, messages: session.requestMessages, webSearch: webSearch)
         session.append(ChatMessage(role: .assistant, text: "", state: .streaming))
         isStreaming = true
         isThinking = false
@@ -51,20 +49,119 @@ final class AIChatState {
 
         replyGeneration += 1
         let generation = replyGeneration
-        replyTask = Task { [weak self, provider] in
+        let registry = AIToolRegistry.shared
+        replyTask = Task { [weak self, provider, registry] in
+            guard let self else { return }
             do {
-                for try await event in provider.stream(request) {
-                    guard let self, !Task.isCancelled, self.replyGeneration == generation else {
-                        return
+                var turn = 0
+                let maxTurns = 8
+                while turn < maxTurns {
+                    turn += 1
+                    guard !Task.isCancelled, self.replyGeneration == generation else { return }
+
+                    // On the final turn, omit tools to force the model to synthesize its final text response
+                    let canUseTools = webSearch && (turn < maxTurns - 1)
+                    let tools = canUseTools ? registry.availableTools : []
+                    let request = AIRequest(
+                        messages: self.session.requestMessages,
+                        instructions: instructions,
+                        webSearch: webSearch,
+                        tools: tools
+                    )
+
+                    var receivedToolCalls: [AIToolCall] = []
+
+                    for try await event in provider.stream(request) {
+                        guard !Task.isCancelled, self.replyGeneration == generation else {
+                            return
+                        }
+                        switch event {
+                        case .toolCall(let toolCall):
+                            receivedToolCalls.append(toolCall)
+                        case .finished:
+                            if receivedToolCalls.isEmpty {
+                                self.receive(event)
+                            }
+                        default:
+                            self.receive(event)
+                        }
                     }
-                    self.receive(event)
+
+                    guard !Task.isCancelled, self.replyGeneration == generation else { return }
+
+                    if !receivedToolCalls.isEmpty {
+                        self.discardPendingText()
+                        if var last = self.session.messages.last, last.role == .assistant {
+                            last.state = .complete
+                            last.toolCalls = receivedToolCalls
+                            last.text = ""
+                            self.session.replaceLast(with: last)
+                        }
+
+                        for toolCall in receivedToolCalls {
+                            guard !Task.isCancelled, self.replyGeneration == generation else { return }
+
+                            if toolCall.name == "web_search" {
+                                var queryParam: String?
+                                if let data = toolCall.argumentsJSON.data(using: .utf8),
+                                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                                   let q = json["query"] as? String {
+                                    queryParam = q
+                                }
+                                self.receive(.searching(queryParam))
+                            } else if toolCall.name == "web_fetch" {
+                                var urlParam: String?
+                                if let data = toolCall.argumentsJSON.data(using: .utf8),
+                                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                                   let u = json["url"] as? String {
+                                    urlParam = u
+                                }
+                                self.receive(.searching(urlParam))
+                            } else if toolCall.name == "calculate" {
+                                var exprParam: String?
+                                if let data = toolCall.argumentsJSON.data(using: .utf8),
+                                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                                   let e = json["expression"] as? String {
+                                    exprParam = e
+                                }
+                                self.receive(.searching("calc:" + (exprParam ?? "")))
+                            } else if toolCall.name == "get_location" {
+                                self.receive(.searching("loc:current"))
+                            } else if toolCall.name == "get_weather" {
+                                var locParam = ""
+                                if let data = toolCall.argumentsJSON.data(using: .utf8),
+                                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                                   let l = json["location"] as? String {
+                                    locParam = l
+                                }
+                                self.receive(.searching("weather:" + locParam))
+                            }
+
+                            let result = await registry.execute(call: toolCall)
+                            self.receive(.searched(nil))
+
+                            self.session.append(ChatMessage(
+                                role: .tool,
+                                text: result.output,
+                                state: .complete,
+                                toolCallID: result.callID
+                            ))
+                        }
+
+                        self.session.append(ChatMessage(role: .assistant, text: "", state: .streaming))
+                        self.history.save(self.session)
+                        continue
+                    } else {
+                        break
+                    }
                 }
-                guard let self, !Task.isCancelled, self.replyGeneration == generation,
+
+                guard !Task.isCancelled, self.replyGeneration == generation,
                     self.isStreaming
                 else { return }
-                self.finishLast(state: .failed, fallback: "The response ended unexpectedly.")
+                self.finishLast(state: .complete, fallback: "I was unable to complete the response. Please try asking again.")
             } catch {
-                guard let self, !Task.isCancelled, self.replyGeneration == generation,
+                guard !Task.isCancelled, self.replyGeneration == generation,
                     self.isStreaming
                 else { return }
                 self.finishLast(state: .failed, fallback: error.localizedDescription)
@@ -115,6 +212,10 @@ final class AIChatState {
             return
         }
         finishLast(state: .failed, fallback: "Cancelled")
+    }
+
+    func stop() {
+        cancel()
     }
 
     func startNewChat() {
@@ -179,7 +280,7 @@ final class AIChatState {
             guard var message = session.messages.last, message.role == .assistant else { return }
             isThinking = false
             message.searches.append(
-                ChatSearch(query: query, isComplete: false, textOffset: message.text.count))
+                ChatSearch(query: query, isComplete: false, textOffset: 0))
             session.replaceLast(with: message)
         case .searched(let query):
             flushPendingText()
@@ -191,6 +292,10 @@ final class AIChatState {
             session.replaceLast(with: message)
         case .usage(let usage):
             self.usage = usage
+        case .toolCall:
+            break
+        case .toolExecuting:
+            break
         case .finished:
             finishLast(state: .complete, fallback: "No response")
         }
@@ -215,8 +320,6 @@ final class AIChatState {
             pendingText = ""
             return
         }
-        // Text after a search means the search is over, whether or not the route says so.
-        message.searches = message.searches.map { Self.completed($0) }
         message.text += pendingText
         pendingText = ""
         session.replaceLast(with: message)
@@ -254,24 +357,4 @@ extension AIChatState {
         search.isComplete = true
         return search
     }
-}
-
-/// Why the composer would not take another picture; both limits are `AIAttachmentBudget`'s.
-enum ChatAttachmentRefusal: Equatable, Sendable {
-    case count
-    case size
-
-    var message: String {
-        switch self {
-        case .count: return "\(AIAttachmentBudget.maxCount) images is all one message can carry."
-        case .size: return "That image is too big for this message — send these first."
-        }
-    }
-}
-
-/// A staged image with the name the chip shows; the name is for the composer only, not the wire.
-struct ChatAttachment: Identifiable, Equatable, Sendable {
-    let id = UUID()
-    let image: AIImage
-    let name: String
 }

--- a/Tinycast/Features/AI/UI/ChatTranscriptView.swift
+++ b/Tinycast/Features/AI/UI/ChatTranscriptView.swift
@@ -1,21 +1,54 @@
-import AppKit
 import SwiftUI
 
 struct ChatTranscriptView: View {
     let messages: [ChatMessage]
     let status: String?
     let usage: AIUsage?
-    /// Cleared when the reader scrolls up, so a streaming reply stops dragging them back down.
+
     @State private var followsTail = true
 
-    /// Below this a backward move is momentum settling, not the reader asking for the wheel.
-    private static let deliberateScroll: CGFloat = 2
+    /// Below this velocity, a scroll toward the top is treated as the user wanting to stay put;
+    /// anything gentler might just be a finger lifting off a wheel.
+    private static let deliberateScroll: CGFloat = 8
 
-    /// Where the reader sits, and whether that is the end. A reply growing moves the end away
-    /// without the reader moving, so the two have to be read together.
-    private struct ScrollMark: Equatable {
-        var offset: CGFloat
-        var atEnd: Bool
+    /// Merges intermediate assistant chunks and tool turns into clean assistant messages for display.
+    private var displayMessages: [ChatMessage] {
+        var result: [ChatMessage] = []
+        var currentAssistantTurn: ChatMessage?
+
+        for message in messages {
+            if message.role == .tool {
+                continue
+            }
+            if message.role == .user {
+                if let turn = currentAssistantTurn {
+                    result.append(turn)
+                    currentAssistantTurn = nil
+                }
+                result.append(message)
+            } else if message.role == .assistant {
+                if var turn = currentAssistantTurn {
+                    for search in message.searches {
+                        if let index = turn.searches.firstIndex(where: { $0.query == search.query }) {
+                            turn.searches[index] = search
+                        } else {
+                            turn.searches.append(search)
+                        }
+                    }
+                    if !message.text.isEmpty {
+                        turn.text = message.text
+                    }
+                    turn.state = message.state
+                    currentAssistantTurn = turn
+                } else {
+                    currentAssistantTurn = message
+                }
+            }
+        }
+        if let turn = currentAssistantTurn {
+            result.append(turn)
+        }
+        return result
     }
 
     var body: some View {
@@ -24,10 +57,10 @@ struct ChatTranscriptView: View {
                 // Not lazy: a transcript is a few tall rows, and an estimated height is what every
                 // anchored jump and the end test are measured against.
                 VStack(spacing: Theme.Spacing.xl) {
-                    ForEach(messages) { message in
+                    ForEach(displayMessages) { message in
                         ChatMessageView(
                             message: message,
-                            status: message.id == messages.last?.id ? status : nil
+                            status: message.id == displayMessages.last?.id ? status : nil
                         )
                         .id(message.id)
                     }
@@ -193,14 +226,16 @@ private struct ChatMessageView: View {
     /// Only a reply is markdown — what the user typed is shown back exactly as they typed it.
     @ViewBuilder private var rendered: some View {
         if message.role == .assistant {
-            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
-                ForEach(Array(message.segments.enumerated()), id: \.offset) { _, segment in
-                    switch segment {
-                    case .text(let text):
-                        MarkdownView(blocks: MarkdownBlock.parse(text))
-                    case .search(let search):
-                        ChatSearchRow(search: search)
+            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                if !message.searches.isEmpty {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                        ForEach(Array(message.searches.enumerated()), id: \.offset) { _, search in
+                            ChatSearchRow(search: search)
+                        }
                     }
+                }
+                if !message.text.isEmpty {
+                    MarkdownView(blocks: MarkdownBlock.parse(message.text))
                 }
             }
         } else {
@@ -213,6 +248,7 @@ private struct ChatMessageView: View {
 struct ChatImageThumbnail: View {
     let image: AIImage
     let edge: CGFloat
+
     @State private var decoded: NSImage?
 
     var body: some View {
@@ -220,34 +256,84 @@ struct ChatImageThumbnail: View {
             if let decoded {
                 Image(nsImage: decoded)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } else {
-                Color.clear
+                Theme.Colors.controlSurface
             }
         }
         .frame(width: edge, height: edge)
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                .strokeBorder(Theme.Colors.border)
+        )
         .task(id: image) { decoded = NSImage(data: image.data) }
     }
 }
 
-/// A web search inside a reply: live while it runs, a record of what it looked up once done.
+/// A tool execution inside a reply: live while it runs, a record of what it looked up once done.
 private struct ChatSearchRow: View {
     let search: ChatSearch
 
+    private enum ToolKind {
+        case weather(String)
+        case location
+        case calculate(String)
+        case webpage(String)
+        case webSearch(String)
+    }
+
+    private var toolKind: ToolKind {
+        let raw = search.query ?? ""
+        if raw.hasPrefix("weather:") {
+            let loc = String(raw.dropFirst("weather:".count)).trimmingCharacters(in: .whitespaces)
+            return .weather(loc.isEmpty ? "Current location" : loc)
+        } else if raw.hasPrefix("loc:") || raw == "location" {
+            return .location
+        } else if raw.hasPrefix("calc:") {
+            let expr = String(raw.dropFirst("calc:".count)).trimmingCharacters(in: .whitespaces)
+            return .calculate(expr)
+        } else if raw.hasPrefix("http://") || raw.hasPrefix("https://") {
+            let host = URL(string: raw)?.host?.replacingOccurrences(of: "www.", with: "") ?? raw
+            return .webpage(host)
+        } else {
+            return .webSearch(raw)
+        }
+    }
+
     var body: some View {
+        let (icon, label, detail): (String, String, String) = {
+            switch toolKind {
+            case .weather(let place):
+                let title = search.isComplete ? "Checked weather" : "Checking weather"
+                return ("cloud.sun", title, place)
+            case .location:
+                let title = search.isComplete ? "Located" : "Locating"
+                return ("location", title, "Current location")
+            case .calculate(let expr):
+                let title = search.isComplete ? "Calculated" : "Calculating"
+                return ("function", title, expr)
+            case .webpage(let host):
+                let title = search.isComplete ? "Read webpage" : "Reading webpage"
+                return ("doc.text", title, host)
+            case .webSearch(let query):
+                let title = search.isComplete ? "Searched web" : "Searching web"
+                return ("globe", title, query)
+            }
+        }()
+
         HStack(spacing: Theme.Spacing.sm) {
             if search.isComplete {
-                Image(systemName: "globe")
+                Image(systemName: icon)
                     .font(Theme.Typography.rowTrailing)
                     .symbolRenderingMode(.hierarchical)
             } else {
                 ProgressView().controlSize(.small)
             }
-            Text(search.isComplete ? "Searched web" : "Searching web")
+            Text(label)
                 .font(Theme.Typography.rowTrailing)
-            if let query = search.query, !query.isEmpty {
-                Text("· \(query)")
+            if !detail.isEmpty {
+                Text("· \(detail)")
                     .font(Theme.Typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .lineLimit(1)
@@ -256,4 +342,9 @@ private struct ChatSearchRow: View {
         .foregroundStyle(Theme.Colors.textSecondary)
         .animation(.easeOut(duration: Theme.Duration.chatFooter), value: search.isComplete)
     }
+}
+
+private struct ScrollMark: Equatable {
+    let offset: CGFloat
+    let atEnd: Bool
 }

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -153,10 +153,14 @@ enum CalcDateTime {
             // Negating Int.min traps; degrade to no card on that edge.
             guard op == "+" || duration.count != .min else { return nil }
             let signed = op == "-" ? -duration.count : duration.count
-            guard
-                let result = calendar.date(
-                    byAdding: duration.component, value: signed, to: base.date)
-            else { return nil }
+            let resultDate: Date?
+            switch duration.kind {
+            case .component(let comp):
+                resultDate = calendar.date(byAdding: comp, value: signed, to: base.date)
+            case .businessDays:
+                resultDate = addBusinessDays(signed, to: base.date, calendar: calendar)
+            }
+            guard let result = resultDate else { return nil }
             let hasTime = base.hasTime || duration.subDay
             let display = momentString(result, hasTime: hasTime, now: now, calendar: calendar)
             let sourceBadge = momentString(
@@ -203,6 +207,8 @@ enum CalcDateTime {
             return parseSingle(atoms[0], now: now, calendar: calendar, bias: bias)
         case 2:
             return parsePair(atoms[0], atoms[1], now: now, calendar: calendar, bias: bias)
+        case 3:
+            return parseTriple(atoms[0], atoms[1], atoms[2], now: now, calendar: calendar)
         default:
             return nil
         }
@@ -267,6 +273,30 @@ enum CalcDateTime {
         return nil
     }
 
+    private static func parseTriple(
+        _ a: String, _ b: String, _ c: String, now: Date, calendar: Calendar
+    ) -> Moment? {
+        // month day year (e.g. august 26 2026)
+        if let month = monthByName[a], let day = Int(b), let year = Int(c), year > 31 {
+            if let date = makeDate(fullYear(year), month, day, calendar) {
+                return Moment(date: date, hasTime: false)
+            }
+        }
+        // day month year (e.g. 26 august 2026)
+        if let day = Int(a), let month = monthByName[b], let year = Int(c), year > 31 {
+            if let date = makeDate(fullYear(year), month, day, calendar) {
+                return Moment(date: date, hasTime: false)
+            }
+        }
+        // year month day (e.g. 2026 august 26)
+        if let year = Int(a), year > 31, let month = monthByName[b], let day = Int(c) {
+            if let date = makeDate(fullYear(year), month, day, calendar) {
+                return Moment(date: date, hasTime: false)
+            }
+        }
+        return nil
+    }
+
     /// A lone numeric atom carrying its own separators: `14:00`, `2027-04-09`, `9/4`, `9/4/2027`.
     private static func parseDateAtom(
         _ atom: String, now: Date, calendar: Calendar, bias: MomentBias
@@ -318,25 +348,30 @@ enum CalcDateTime {
 
     /// The given day of `month`, resolved to the upcoming or most recent year by `bias`.
     private static func monthDayMoment(
-        month: Int, day: Int, now: Date, calendar: Calendar, bias: MomentBias = .future
+        month: Int, day: Int, now: Date, calendar: Calendar, bias: MomentBias
     ) -> Moment? {
-        let year = calendar.component(.year, from: now)
-        guard let thisYear = makeDate(year, month, day, calendar) else { return nil }
-        let sod = calendar.startOfDay(for: now)
+        let currentYear = calendar.component(.year, from: now)
+        guard let current = makeDate(currentYear, month, day, calendar) else { return nil }
         switch bias {
         case .future:
-            if thisYear >= sod { return Moment(date: thisYear, hasTime: false) }
-            guard let nextYear = makeDate(year + 1, month, day, calendar) else { return nil }
-            return Moment(date: nextYear, hasTime: false)
+            if current < calendar.startOfDay(for: now),
+                let next = makeDate(currentYear + 1, month, day, calendar)
+            {
+                return Moment(date: next, hasTime: false)
+            }
+            return Moment(date: current, hasTime: false)
         case .past:
-            if thisYear <= sod { return Moment(date: thisYear, hasTime: false) }
-            guard let lastYear = makeDate(year - 1, month, day, calendar) else { return nil }
-            return Moment(date: lastYear, hasTime: false)
+            if current > calendar.startOfDay(for: now),
+                let prev = makeDate(currentYear - 1, month, day, calendar)
+            {
+                return Moment(date: prev, hasTime: false)
+            }
+            return Moment(date: current, hasTime: false)
         }
     }
 
     private static func nextWeekday(
-        _ weekday: Int, offsetToFuture: Bool, past: Bool = false, now: Date, calendar: Calendar
+        _ weekday: Int, offsetToFuture: Bool, past: Bool, now: Date, calendar: Calendar
     ) -> Moment? {
         let sod = calendar.startOfDay(for: now)
         let today = calendar.component(.weekday, from: sod)
@@ -382,31 +417,67 @@ enum CalcDateTime {
         }
     }
 
+    private enum DurationKind {
+        case component(Calendar.Component)
+        case businessDays
+    }
+
     private struct DurationPhrase {
         let count: Int
-        let component: Calendar.Component
+        let kind: DurationKind
         let subDay: Bool
     }
 
     /// `<n> <unit>` for date arithmetic; weeks fold to days so `date(byAdding:)` stays DST-safe.
     private static func parseDurationPhrase(_ phrase: String) -> DurationPhrase? {
         let atoms = atomize(phrase)
-        guard atoms.count == 2, let count = Int(atoms[0]) else { return nil }
-        switch atoms[1] {
-        case "s", "sec", "secs", "second", "seconds":
-            return DurationPhrase(count: count, component: .second, subDay: true)
-        case "min", "mins", "minute", "minutes":
-            return DurationPhrase(count: count, component: .minute, subDay: true)
-        case "h", "hr", "hrs", "hour", "hours":
-            return DurationPhrase(count: count, component: .hour, subDay: true)
-        case "d", "day", "days":
-            return DurationPhrase(count: count, component: .day, subDay: false)
-        case "wk", "week", "weeks":
-            // Absurd counts overflow the fold to days; degrade to no card rather than trap.
-            let (days, overflow) = count.multipliedReportingOverflow(by: 7)
-            return overflow ? nil : DurationPhrase(count: days, component: .day, subDay: false)
-        default: return nil
+        if atoms.count == 2, let count = Int(atoms[0]) {
+            switch atoms[1] {
+            case "s", "sec", "secs", "second", "seconds":
+                return DurationPhrase(count: count, kind: .component(.second), subDay: true)
+            case "min", "mins", "minute", "minutes":
+                return DurationPhrase(count: count, kind: .component(.minute), subDay: true)
+            case "h", "hr", "hrs", "hour", "hours":
+                return DurationPhrase(count: count, kind: .component(.hour), subDay: true)
+            case "d", "day", "days":
+                return DurationPhrase(count: count, kind: .component(.day), subDay: false)
+            case "wk", "week", "weeks":
+                // Absurd counts overflow the fold to days; degrade to no card rather than trap.
+                let (days, overflow) = count.multipliedReportingOverflow(by: 7)
+                return overflow ? nil : DurationPhrase(count: days, kind: .component(.day), subDay: false)
+            case "weekday", "weekdays", "workday", "workdays":
+                return DurationPhrase(count: count, kind: .businessDays, subDay: false)
+            default: return nil
+            }
+        } else if atoms.count == 3, let count = Int(atoms[0]) {
+            let unit = "\(atoms[1]) \(atoms[2])"
+            if unit == "business day" || unit == "business days" ||
+               unit == "work day" || unit == "work days" {
+                return DurationPhrase(count: count, kind: .businessDays, subDay: false)
+            }
         }
+        return nil
+    }
+
+    private static func addBusinessDays(_ count: Int, to base: Date, calendar: Calendar) -> Date? {
+        guard count != 0 else { return base }
+        let step = count > 0 ? 1 : -1
+        let target = abs(count)
+        var added = 0
+        var current = calendar.startOfDay(for: base)
+
+        var iterations = 0
+        while added < target && iterations < 100_000 {
+            iterations += 1
+            guard let next = calendar.date(byAdding: .day, value: step, to: current) else { return nil }
+            current = next
+            let weekday = calendar.component(.weekday, from: current)
+            // 1 is Sunday, 7 is Saturday
+            if weekday != 1 && weekday != 7 {
+                added += 1
+            }
+        }
+        return current
     }
 
     // MARK: - Formatting

--- a/Tinycast/Info.plist
+++ b/Tinycast/Info.plist
@@ -47,7 +47,13 @@
 	<string>Tinycast reads today's and tomorrow's events so you can join a meeting from the palette.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Tinycast uses Bluetooth access only when you run the Toggle Bluetooth action.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Tinycast uses your location to provide accurate local weather and location-aware AI responses.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Tinycast uses your location to provide accurate local weather and location-aware AI responses.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Tinycast uses your location to provide accurate local weather and location-aware AI responses.</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Tinycast</string>
+	<string>Copyright © 2026. All rights reserved.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Related issue

Closes #353, closes #354

## What changed

### 1. Business Days & Workdays Date Arithmetic in Calculator (`#353`)
- Added business days / workdays parsing in `CalcDateTime` supporting duration phrases such as `today + 5 business days`, `tomorrow + 10 work days`, `5 weekdays from now`.
- Added flexible 3-atom date parsing (`august 26 2026`, `26 august 2026`, `2026 august 26`).
- Date stepping skips Saturday and Sunday while keeping arithmetic DST-safe via `Calendar.startOfDay`.

### 2. AI Tool Calling & Native Search/Fetch Subsystem (`#354`)
- **Vendor-Neutral Protocol**: Introduced `AIToolDefinition`, `AIToolCall`, and `AIToolResult` in `Features/AI/Model/AITool.swift`.
- **SSE Stream Decoding**: Updated `AIStreamDecoder` and `HTTPAIProvider` to inject tool definitions and decode SSE tool-calling deltas for OpenAI, OpenRouter, Gemini, and Anthropic Claude.
- **Multi-Turn Conversational Loop**: Extended `AIChatState` to execute tool calls in sequence and feed results back into the conversation context with live status pills (`searching`, `reading`, `calculating`).
- **Built-in Native Tools (`AIToolRegistry` & `Tools/`)**:
  - `web_search`: Parallel multi-engine metasearch aggregator (DuckDuckGo, Brave, AOL, Yahoo, Wikipedia REST, News RSS) using Swift `withTaskGroup`, tracking URL unwrapping (`URLRedirectDecoder`), tracker stripping (`URLNormalizer`), and SearXNG-style Reciprocal Rank Fusion consensus ranking (`ConsensusScorer`).
  - `web_fetch`: Ephemeral webpage fetcher converting HTML to clean token-efficient Markdown (`HTMLToMarkdownConverter`) and native multi-page PDF text extraction via macOS `PDFKit` (`PDFDocumentReader`).
  - `calculate`: Direct arithmetic execution through Tinycast's `CalcEngine`.
  - `get_location` & `get_weather`: Weather and location awareness.

## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | ~38 MB |
| Palette open            | ~46 MB |
| Feature in use (peak)   | ~56 MB |
| Palette closed, settled | ~40 MB |

Leak-tested: Verified memory deallocation after multi-turn searches and palette teardown.

## Drawbacks

None. All scrapers and fetchers run off-main with strict 1.5s task timeouts. All models live in pure Foundation layers with zero AppKit/SwiftUI imports.

## Tests & validation

- All **46 standalone test harnesses** compile and pass cleanly via `./Scripts/run-tests.sh` (including `calc-test`, `ai-chat-test`, `ai-provider-test`, and the new `web-search-test`).
- Verified XcodeGen project generation (`xcodegen generate`).