### PR TITLE
Draw a raycast-* colour named inside an extension's own SVG, and keep accessories in a detail list

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -114,7 +114,20 @@ run entry-icon-test        Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift
 run ext-icon-test          Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift \
-                           Tinycast/Features/Extensions/Service/ExtensionIconCache.swift
+                           Tinycast/Platform/Compression/Zlib.swift \
+                           Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/Features/Extensions/Model/ExtensionBootConfig.swift \
+                           Tinycast/Features/Extensions/Model/ExtensionManifest.swift \
+                           Tinycast/Features/Extensions/Model/RenderNode.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionCatalog.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionFetcher.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionNodeShims.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionOAuthKeychain.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionOAuthSession.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionRuntime.swift \
+                           Tinycast/Features/Extensions/Service/ExtensionIconCache.swift \
+                           Tinycast/Features/Extensions/UI/ExtensionAnimatedImage.swift \
+                           Tinycast/Features/Extensions/UI/ExtensionImage.swift
 run system-action-test     Tinycast/Features/SystemActions/Model/SystemAction.swift
 run volume-test            Tinycast/Features/SystemActions/Model/VolumeLevel.swift
 run window-command-test    Tinycast/Features/WindowManagement/WindowCommand.swift \

--- a/Tests/ext-icon-test.swift
+++ b/Tests/ext-icon-test.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftUI
 
 @main
 @MainActor
@@ -37,6 +38,52 @@ struct ExtensionIconTests {
     static func missingFileFallsBack() {
         let icon = ExtensionIconCache.icon(atPath: "/nonexistent/\(UUID().uuidString).png")
         expect(icon.size.width > 0, "a missing icon falls back to the puzzle-piece tile")
+    }
+
+    /// An extension drawing its own SVG writes a Raycast colour name straight into `stroke`, which
+    /// no SVG renderer understands — left alone the shape draws nothing at all.
+    static func paletteColorsInSVGResolve() async {
+        // The usage-ring shape every quota extension draws: a track and an arc, each named.
+        let ring = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="100px" height="100px"><circle cx="50" \
+            cy="50" r="40" stroke-width="10" stroke="raycast-secondary-text" fill="none" />\
+            <path d="M 50 10 A 40 40 0 0 0 20 25" stroke="raycast-green" stroke-width="10" \
+            fill="none" /></svg>
+            """
+        guard let url = inlineSource(ring, isDark: true) else {
+            return expect(false, "a data: URL resolves to an inline source")
+        }
+        expect(!url.absoluteString.contains("raycast-"), "every colour name is rewritten")
+
+        let image = await ExtensionIconCache.loadInlineAsync(url)
+        expect(image.flatMap(inkExtent) != nil, "the rewritten ring draws ink")
+
+        // A known name occurring inside a longer unknown one may not be substituted there: the
+        // rewrite has to walk whole names rather than search for the ones it knows.
+        let shadowed =
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle stroke=\"raycast-green\" "
+            + "fill=\"raycast-green-invented\" /></svg>"
+        let left = inlineSource(shadowed, isDark: true)?.absoluteString.removingPercentEncoding
+        expect(left?.contains("raycast-green-invented") == true, "an unknown name is left whole")
+        expect(left?.contains("\"raycast-green\"") == false, "the known name beside it resolves")
+
+        // Light and dark disagree on every ramp, so the pick has to follow the surface drawn on.
+        let ramp =
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle "
+            + "stroke=\"raycast-primary-text\" /></svg>"
+        let dark = inlineSource(ramp, isDark: true)?.absoluteString.removingPercentEncoding
+        let light = inlineSource(ramp, isDark: false)?.absoluteString.removingPercentEncoding
+        expect(dark != nil && dark != light, "a ramp resolves per appearance")
+    }
+
+    /// The `data:` URL an SVG resolves to, as a row would ask for it.
+    static func inlineSource(_ svg: String, isDark: Bool) -> URL? {
+        let allowed = CharacterSet(charactersIn: "<>\"# %{}|\\^~[]`").inverted
+        guard let encoded = svg.addingPercentEncoding(withAllowedCharacters: allowed),
+            case .inline(let url)? = ExtensionImage.resolve(
+                .string("data:image/svg+xml,\(encoded)"), assetsPath: nil, isDark: isDark)?.source
+        else { return nil }
+        return url
     }
 
     /// Extensions that render their own artwork hand it over as a `data:` URL rather than a file,
@@ -125,6 +172,7 @@ struct ExtensionIconTests {
         artworkIsNormalized()
         missingFileFallsBack()
         await inlineDataURLsDecode()
+        await paletteColorsInSVGResolve()
 
         print(failures == 0 ? "Extension icon tests passed" : "\(failures) tests failed")
         exit(failures == 0 ? 0 : 1)

--- a/Tests/ext-icon-test.swift
+++ b/Tests/ext-icon-test.swift
@@ -50,40 +50,68 @@ struct ExtensionIconTests {
             <path d="M 50 10 A 40 40 0 0 0 20 25" stroke="raycast-green" stroke-width="10" \
             fill="none" /></svg>
             """
-        guard let url = inlineSource(ring, isDark: true) else {
-            return expect(false, "a data: URL resolves to an inline source")
-        }
-        expect(!url.absoluteString.contains("raycast-"), "every colour name is rewritten")
-
-        let image = await ExtensionIconCache.loadInlineAsync(url)
-        expect(image.flatMap(inkExtent) != nil, "the rewritten ring draws ink")
+        let drawn = await drawnInk(ring, isDark: true)
+        expect(drawn != nil, "the rewritten ring draws ink")
+        // Both encodings: base64 hides the name from a scan, so the payload has to be decoded.
+        let asBase64 = await drawnInk(ring, isDark: true, base64: true)
+        expect(asBase64 != nil, "a base64 ring draws ink too")
+        // Detail markdown's sizing query trails the payload and is not part of it.
+        let sized = await drawnInk(ring, isDark: true, query: "?raycast-width=32")
+        expect(sized != nil, "a sized payload still draws")
 
         // A known name occurring inside a longer unknown one may not be substituted there: the
         // rewrite has to walk whole names rather than search for the ones it knows.
-        let shadowed =
-            "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle stroke=\"raycast-green\" "
-            + "fill=\"raycast-green-invented\" /></svg>"
-        let left = inlineSource(shadowed, isDark: true)?.absoluteString.removingPercentEncoding
-        expect(left?.contains("raycast-green-invented") == true, "an unknown name is left whole")
-        expect(left?.contains("\"raycast-green\"") == false, "the known name beside it resolves")
+        let unknown = await drawnInk(circle(stroke: "raycast-green-invented"), isDark: true)
+        expect(unknown == nil, "an unknown name is left whole, and draws nothing")
+        let known = await drawnInk(circle(stroke: "raycast-green"), isDark: true)
+        expect(known != nil, "the known name it shadows still resolves")
 
         // Light and dark disagree on every ramp, so the pick has to follow the surface drawn on.
-        let ramp =
-            "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle "
-            + "stroke=\"raycast-primary-text\" /></svg>"
-        let dark = inlineSource(ramp, isDark: true)?.absoluteString.removingPercentEncoding
-        let light = inlineSource(ramp, isDark: false)?.absoluteString.removingPercentEncoding
-        expect(dark != nil && dark != light, "a ramp resolves per appearance")
+        let ramp = circle(stroke: "raycast-primary-text")
+        let dark = await drawnColor(ramp, isDark: true)
+        let light = await drawnColor(ramp, isDark: false)
+        expect(dark?.brightnessComponent ?? 0 > 0.9, "the dark ramp strokes white ink")
+        expect(light?.brightnessComponent ?? 1 < 0.1, "the light ramp strokes black ink")
+
+        // A photo names no colour, and is never decoded as text: its bytes must reach the decoder.
+        let png = writePNG("photo", inset: 0).flatMap { try? Data(contentsOf: $0) }
+        let photo = URL(string: "data:image/png;base64,\(png?.base64EncodedString() ?? "")")!
+        let passed = await ExtensionIconCache.loadInlineAsync(
+            photo, palette: ExtensionImage.svgPalette(isDark: true))
+        expect(passed != nil, "an inline photo is passed through untouched")
     }
 
-    /// The `data:` URL an SVG resolves to, as a row would ask for it.
-    static func inlineSource(_ svg: String, isDark: Bool) -> URL? {
+    /// A stroked ring, thick enough that a 96pt raster samples the colour cleanly.
+    static func circle(stroke: String) -> String {
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100px\" height=\"100px\"><circle "
+            + "cx=\"50\" cy=\"50\" r=\"36\" stroke-width=\"24\" stroke=\"\(stroke)\" "
+            + "fill=\"none\" /></svg>"
+    }
+
+    /// An SVG drawn the way a row draws it: encoded as a `data:` URL, then decoded with the palette.
+    static func drawnImage(
+        _ svg: String, isDark: Bool, base64: Bool = false, query: String = ""
+    ) async -> NSImage? {
         let allowed = CharacterSet(charactersIn: "<>\"# %{}|\\^~[]`").inverted
-        guard let encoded = svg.addingPercentEncoding(withAllowedCharacters: allowed),
-            case .inline(let url)? = ExtensionImage.resolve(
-                .string("data:image/svg+xml,\(encoded)"), assetsPath: nil, isDark: isDark)?.source
-        else { return nil }
-        return url
+        let payload =
+            base64
+            ? Data(svg.utf8).base64EncodedString()
+            : svg.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
+        let header = base64 ? "data:image/svg+xml;base64," : "data:image/svg+xml,"
+        guard let url = URL(string: header + payload + query) else { return nil }
+        return await ExtensionIconCache.loadInlineAsync(
+            url, palette: ExtensionImage.svgPalette(isDark: isDark))
+    }
+
+    static func drawnInk(
+        _ svg: String, isDark: Bool, base64: Bool = false, query: String = ""
+    ) async -> CGFloat? {
+        await drawnImage(svg, isDark: isDark, base64: base64, query: query).flatMap(inkExtent)
+    }
+
+    /// The colour an unresolved name never produces, since the shape it strokes draws nothing.
+    static func drawnColor(_ svg: String, isDark: Bool) async -> NSColor? {
+        await drawnImage(svg, isDark: isDark).flatMap(inkColor)
     }
 
     /// Extensions that render their own artwork hand it over as a `data:` URL rather than a file,
@@ -100,18 +128,18 @@ struct ExtensionIconTests {
 
         for suffix in ["", "?raycast-width=200&raycast-height=200"] {
             let url = URL(string: "data:image/svg+xml,\(encoded)\(suffix)")!
-            let image = await ExtensionIconCache.loadInlineAsync(url)
+            let image = await ExtensionIconCache.loadInlineAsync(url, palette: [:])
             expect(image?.size == NSSize(width: 24, height: 24), "percent-encoded SVG\(suffix)")
         }
 
         let png = writePNG("inline", inset: 0).flatMap { try? Data(contentsOf: $0) }
         guard let png else { return expect(false, "the PNG fixture writes") }
         let base64 = URL(string: "data:image/png;base64,\(png.base64EncodedString())")!
-        let decoded = await ExtensionIconCache.loadInlineAsync(base64)
+        let decoded = await ExtensionIconCache.loadInlineAsync(base64, palette: [:])
         expect(decoded != nil, "base64 payload decodes")
 
         let broken = URL(string: "data:image/png;base64,not-base-64")!
-        let rejected = await ExtensionIconCache.loadInlineAsync(broken)
+        let rejected = await ExtensionIconCache.loadInlineAsync(broken, palette: [:])
         expect(rejected == nil, "a broken payload is nil")
     }
 
@@ -142,6 +170,41 @@ struct ExtensionIconTests {
 
     /// The larger side of the alpha bounding box, as a share of the canvas.
     static func inkExtent(_ image: NSImage) -> CGFloat? {
+        rasterize(image).flatMap { rep in
+            var minX = 96, maxX = -1, minY = 96, maxY = -1
+            for y in 0..<96 {
+                for x in 0..<96 where (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.06 {
+                    minX = min(minX, x)
+                    maxX = max(maxX, x)
+                    minY = min(minY, y)
+                    maxY = max(maxY, y)
+                }
+            }
+            guard maxX >= 0 else { return nil }
+            return CGFloat(max(maxX - minX + 1, maxY - minY + 1)) / 96
+        }
+    }
+
+    /// The most opaque pixel drawn, which for a stroked ring is the stroke's own colour.
+    /// A palette ramp strokes at its own alpha, so the bar sits below opaque.
+    static func inkColor(_ image: NSImage) -> NSColor? {
+        guard let rep = rasterize(image) else { return nil }
+        var best: NSColor?
+        var strongest: CGFloat = 0.5
+        for y in 0..<96 {
+            for x in 0..<96 {
+                guard let color = rep.colorAt(x: x, y: y), color.alphaComponent > strongest else {
+                    continue
+                }
+                strongest = color.alphaComponent
+                best = color.usingColorSpace(.sRGB)
+            }
+        }
+        return best
+    }
+
+    /// The image drawn into a fixed 96pt canvas, which every pixel assertion reads from.
+    static func rasterize(_ image: NSImage) -> NSBitmapImageRep? {
         let side = 96
         guard
             let rep = NSBitmapImageRep(
@@ -154,18 +217,7 @@ struct ExtensionIconTests {
         NSGraphicsContext.current = ctx
         image.draw(in: NSRect(x: 0, y: 0, width: side, height: side))
         NSGraphicsContext.restoreGraphicsState()
-
-        var minX = side, maxX = -1, minY = side, maxY = -1
-        for y in 0..<side {
-            for x in 0..<side where (rep.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.06 {
-                minX = min(minX, x)
-                maxX = max(maxX, x)
-                minY = min(minY, y)
-                maxY = max(maxY, y)
-            }
-        }
-        guard maxX >= 0 else { return nil }
-        return CGFloat(max(maxX - minX + 1, maxY - minY + 1)) / CGFloat(side)
+        return rep
     }
 
     static func main() async {

--- a/Tinycast/Features/Extensions/Service/ExtensionIconCache.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionIconCache.swift
@@ -56,13 +56,50 @@ enum ExtensionIconCache {
 
     // MARK: - Carried inline by the extension
 
-    /// The bytes a `data:` URL holds. Uncached and unfitted: the payload is already resident, and an
-    /// extension that draws its own SVG has already sized it.
-    static func loadInlineAsync(_ url: URL) async -> NSImage? {
+    /// The bytes a `data:` URL holds, with `palette` resolved into them so no render pass pays for
+    /// it. Uncached and unfitted: the payload is resident, and the extension has already sized it.
+    static func loadInlineAsync(_ url: URL, palette: [String: String]) async -> NSImage? {
         guard let data = inlineData(url) else { return nil }
+        let names = isSVG(url) ? palette : [:]
         return await Task.detached(priority: .userInitiated) {
-            Decoded(image: NSImage(data: data))
+            Decoded(image: NSImage(data: resolvingPaletteNames(in: data, palette: names)))
         }.value.image
+    }
+
+    /// A `raycast-*` colour name is legal wherever a tint is, so an extension drawing its own SVG
+    /// writes one straight into `stroke` — no renderer knows the keyword and the shape draws nothing.
+    private static func resolvingPaletteNames(in data: Data, palette: [String: String]) -> Data {
+        guard !palette.isEmpty, let source = String(data: data, encoding: .utf8),
+            let rewritten = rewritingNames(in: source, palette: palette)
+        else { return data }
+        return Data(rewritten.utf8)
+    }
+
+    /// Walked as whole names rather than searched for known ones: `raycast-red` sits inside
+    /// `raycast-red-invented`, and substituting it there would corrupt a name this cannot resolve.
+    private static func rewritingNames(in text: String, palette: [String: String]) -> String? {
+        // `.literal`: the default search is Unicode-canonical and costs 3x on a long payload.
+        guard text.range(of: paletteNamePrefix, options: .literal) != nil else { return nil }
+        var resolved = ""
+        var rest = Substring(text)
+        while let match = rest.range(of: paletteNamePrefix, options: .literal) {
+            let name = rest[match.lowerBound...].prefix { paletteNameCharacters.contains($0) }
+            resolved += rest[..<match.lowerBound]
+            resolved += palette[String(name)] ?? String(name)
+            rest = rest[name.endIndex...]
+        }
+        return resolved + rest
+    }
+
+    private static let paletteNamePrefix = "raycast-"
+    private static let paletteNameCharacters = Set("abcdefghijklmnopqrstuvwxyz-")
+
+    /// Only a payload that says it is an SVG is decoded as text; a photo is left byte-identical.
+    /// Case-insensitive because a media type is, and `image/SVG+XML` is a legal spelling.
+    private static func isSVG(_ url: URL) -> Bool {
+        let text = url.absoluteString
+        guard let comma = text.firstIndex(of: ",") else { return false }
+        return text[..<comma].range(of: "svg", options: .caseInsensitive) != nil
     }
 
     /// `data:[<mediatype>][;base64],<payload>`, minus any query — Detail markdown appends Raycast's

--- a/Tinycast/Features/Extensions/UI/ExtensionDetailView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionDetailView.swift
@@ -377,6 +377,7 @@ extension String {
 
 /// An image inside a Detail's markdown, capped so a large asset can't push the layout around.
 private struct ExtensionMarkdownImage: View {
+    @Environment(\.isDarkAppearance) private var isDark
     let url: URL
     @State private var image: NSImage?
 
@@ -398,11 +399,17 @@ private struct ExtensionMarkdownImage: View {
                     .frame(height: 120)
             }
         }
-        .task(id: url) {
+        // Keyed on the appearance too: an inline SVG's palette resolves at decode, not in the URL.
+        .task(id: ExtensionImage.LoadKey(source: source, isDark: isDark)) {
             image =
                 url.scheme == "data"
-                ? await ExtensionIconCache.loadInlineAsync(url)
+                ? await ExtensionIconCache.loadInlineAsync(
+                    url, palette: ExtensionImage.svgPalette(isDark: isDark))
                 : await ExtensionIconCache.loadRemoteAsync(url, asIcon: false)
         }
+    }
+
+    private var source: ExtensionImage.Source {
+        url.scheme == "data" ? .inline(url) : .remote(url)
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -33,7 +33,9 @@ enum ExtensionImage {
         guard let value else { return nil }
         switch value {
         case .string(let text):
-            guard let source = source(from: text, assetsPath: assetsPath) else { return nil }
+            guard let source = source(from: text, assetsPath: assetsPath, isDark: isDark) else {
+                return nil
+            }
             return Resolved(source: source)
         case .object(let fields):
             // Raycast's icon-with-tooltip form; unwrap only when it looks like one, not when themed.
@@ -76,7 +78,7 @@ enum ExtensionImage {
     ) -> Source? {
         switch value {
         case .string(let text):
-            return source(from: text, assetsPath: assetsPath)
+            return source(from: text, assetsPath: assetsPath, isDark: isDark)
         case .object(let fields):
             if let path = fields["fileIcon"]?.stringValue, !path.isEmpty {
                 return .fileIcon((path as NSString).expandingTildeInPath)
@@ -88,7 +90,7 @@ enum ExtensionImage {
         }
     }
 
-    private static func source(from text: String, assetsPath: String?) -> Source? {
+    private static func source(from text: String, assetsPath: String?, isDark: Bool) -> Source? {
         guard !text.isEmpty else { return nil }
         // Icon enum values all carry the `-16` suffix Raycast's generated enum uses.
         if text.hasSuffix("-16") {
@@ -97,7 +99,9 @@ enum ExtensionImage {
         }
         if let url = URL(string: text), let scheme = url.scheme {
             if scheme.hasPrefix("http") { return .remote(url) }
-            if scheme == "data" { return .inline(url) }
+            if scheme == "data" {
+                return URL(string: resolvingPaletteColors(in: text, isDark: isDark)).map { .inline($0) }
+            }
         }
         if text.hasPrefix("/") || text.hasPrefix("~") {
             return .file((text as NSString).expandingTildeInPath)
@@ -108,6 +112,38 @@ enum ExtensionImage {
         }
         // Anything else short enough to be an emoji or a couple of initials is drawn as a glyph.
         return text.count <= 4 ? .glyph(text) : nil
+    }
+
+    /// A Raycast colour name is legal wherever a tint is, so an extension drawing its own SVG writes
+    /// one straight into `stroke`; SVG has no such keyword and the shape silently vanishes.
+    /// Walked as whole names rather than searched for known ones: `raycast-red` sits inside
+    /// `raycast-red-invented`, and substituting it there would corrupt a name this cannot resolve.
+    private static func resolvingPaletteColors(in text: String, isDark: Bool) -> String {
+        guard text.contains("raycast-") else { return text }
+        var resolved = ""
+        var rest = Substring(text)
+        while let match = rest.range(of: "raycast-") {
+            let name = rest[match.lowerBound...].prefix { paletteNameCharacters.contains($0) }
+            resolved += rest[..<match.lowerBound]
+            resolved += cssColor(named: String(name), isDark: isDark) ?? String(name)
+            rest = rest[name.endIndex...]
+        }
+        return resolved + rest
+    }
+
+    private static let paletteNameCharacters = Set("abcdefghijklmnopqrstuvwxyz-")
+
+    /// Resolved against the appearance being drawn, since `.primary` and the ramps are both dynamic.
+    private static func cssColor(named name: String, isDark: Bool) -> String? {
+        guard let color = color(named: name) else { return nil }
+        var css: String?
+        NSAppearance(named: isDark ? .darkAqua : .aqua)?.performAsCurrentDrawingAppearance {
+            guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return }
+            css =
+                "rgba(\(Int(srgb.redComponent * 255)),\(Int(srgb.greenComponent * 255)),"
+                + "\(Int(srgb.blueComponent * 255)),\(srgb.alphaComponent))"
+        }
+        return css
     }
 
     static func color(_ value: RenderValue?, isDark: Bool) -> Color? {

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -28,6 +28,13 @@ enum ExtensionImage {
         var isCircular = false
     }
 
+    /// What a drawn image actually depends on: its source, and — for an SVG naming a palette
+    /// colour — the appearance that palette resolves against.
+    struct LoadKey: Equatable {
+        var source: Source?
+        var isDark: Bool
+    }
+
     /// An `ImageLike`: a string, or `{source, tintColor, mask, fallback}` with a themed `source`.
     static func resolve(_ value: RenderValue?, assetsPath: String?, isDark: Bool) -> Resolved? {
         guard let value else { return nil }
@@ -99,9 +106,7 @@ enum ExtensionImage {
         }
         if let url = URL(string: text), let scheme = url.scheme {
             if scheme.hasPrefix("http") { return .remote(url) }
-            if scheme == "data" {
-                return URL(string: resolvingPaletteColors(in: text, isDark: isDark)).map { .inline($0) }
-            }
+            if scheme == "data" { return .inline(url) }
         }
         if text.hasPrefix("/") || text.hasPrefix("~") {
             return .file((text as NSString).expandingTildeInPath)
@@ -114,37 +119,33 @@ enum ExtensionImage {
         return text.count <= 4 ? .glyph(text) : nil
     }
 
-    /// A Raycast colour name is legal wherever a tint is, so an extension drawing its own SVG writes
-    /// one straight into `stroke`; SVG has no such keyword and the shape silently vanishes.
-    /// Walked as whole names rather than searched for known ones: `raycast-red` sits inside
-    /// `raycast-red-invented`, and substituting it there would corrupt a name this cannot resolve.
-    private static func resolvingPaletteColors(in text: String, isDark: Bool) -> String {
-        guard text.contains("raycast-") else { return text }
-        var resolved = ""
-        var rest = Substring(text)
-        while let match = rest.range(of: "raycast-") {
-            let name = rest[match.lowerBound...].prefix { paletteNameCharacters.contains($0) }
-            resolved += rest[..<match.lowerBound]
-            resolved += cssColor(named: String(name), isDark: isDark) ?? String(name)
-            rest = rest[name.endIndex...]
-        }
-        return resolved + rest
+    /// The palette as CSS, for an extension that writes a colour name straight into its own SVG.
+    /// Resolved once per appearance: the conversion is main-actor work the decode must not do.
+    static func svgPalette(isDark: Bool) -> [String: String] {
+        isDark ? darkSVGPalette : lightSVGPalette
     }
 
-    private static let paletteNameCharacters = Set("abcdefghijklmnopqrstuvwxyz-")
+    private static let darkSVGPalette = svgPalette(from: palette, isDark: true)
+    private static let lightSVGPalette = svgPalette(from: palette, isDark: false)
 
-    /// Resolved against the appearance being drawn, since `.primary` and the ramps are both dynamic.
-    private static func cssColor(named name: String, isDark: Bool) -> String? {
-        guard let color = color(named: name) else { return nil }
+    private static func svgPalette(from palette: [String: Color], isDark: Bool) -> [String: String] {
+        palette.compactMapValues { cssColor($0, isDark: isDark) }
+    }
+
+    /// Resolved against the appearance drawn, since `.primary` and the ramps are both dynamic.
+    private static func cssColor(_ color: Color, isDark: Bool) -> String? {
         var css: String?
         NSAppearance(named: isDark ? .darkAqua : .aqua)?.performAsCurrentDrawingAppearance {
             guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return }
             css =
-                "rgba(\(Int(srgb.redComponent * 255)),\(Int(srgb.greenComponent * 255)),"
-                + "\(Int(srgb.blueComponent * 255)),\(srgb.alphaComponent))"
+                "rgba(\(channel(srgb.redComponent)),\(channel(srgb.greenComponent)),"
+                + "\(channel(srgb.blueComponent)),\((srgb.alphaComponent * 1000).rounded() / 1000))"
         }
         return css
     }
+
+    /// Rounded, not truncated: `* 255` on a stored float lands a channel one low often enough.
+    private static func channel(_ value: CGFloat) -> Int { Int((value * 255).rounded()) }
 
     static func color(_ value: RenderValue?, isDark: Bool) -> Color? {
         guard let value else { return nil }
@@ -155,21 +156,22 @@ enum ExtensionImage {
         return nil
     }
 
+    /// The one source for both a SwiftUI tint and the CSS an SVG's own `stroke` is rewritten to.
+    private static let palette: [String: Color] = [
+        "raycast-blue": .blue,
+        "raycast-green": .green,
+        "raycast-magenta": Color(red: 0.85, green: 0.24, blue: 0.62),
+        "raycast-orange": .orange,
+        "raycast-purple": .purple,
+        "raycast-red": .red,
+        "raycast-yellow": .yellow,
+        "raycast-primary-text": .primary,
+        "raycast-secondary-text": Theme.Colors.textSecondary
+    ]
+
     private static func color(named raw: String) -> Color? {
-        switch raw {
-        case "raycast-blue": return .blue
-        case "raycast-green": return .green
-        case "raycast-magenta": return Color(red: 0.85, green: 0.24, blue: 0.62)
-        case "raycast-orange": return .orange
-        case "raycast-purple": return .purple
-        case "raycast-red": return .red
-        case "raycast-yellow": return .yellow
-        case "raycast-primary-text": return .primary
-        case "raycast-secondary-text": return Theme.Colors.textSecondary
-        default:
-            // Extensions also pass raw hex.
-            return hexColor(raw)
-        }
+        // Extensions also pass raw hex.
+        palette[raw] ?? hexColor(raw)
     }
 
     private static func hexColor(_ raw: String) -> Color? {
@@ -352,6 +354,7 @@ enum ExtensionImage {
 
 /// A resolved icon at row size; an unresolvable one draws the faint tile, so rows never jump.
 struct ExtensionIconView: View {
+    @Environment(\.isDarkAppearance) private var isDark
     let resolved: ExtensionImage.Resolved?
     var size: CGFloat = Theme.Size.rowIcon
     /// Opt-in, and off for row icons: a playing GIF at 24pt is noise, and a list is hundreds of rows.
@@ -362,7 +365,10 @@ struct ExtensionIconView: View {
         content
             .frame(width: size, height: size)
             .clipShape(shape)
-            .task(id: resolved?.source) { await load() }
+            // Keyed on the appearance too: an inline SVG's palette resolves at decode, not in the URL.
+            .task(id: ExtensionImage.LoadKey(source: resolved?.source, isDark: isDark)) {
+                await load()
+            }
     }
 
     @ViewBuilder
@@ -425,7 +431,8 @@ struct ExtensionIconView: View {
         case .remote(let url):
             loaded = await ExtensionIconCache.loadRemoteAsync(url, asIcon: !animates)
         case .inline(let url):
-            loaded = await ExtensionIconCache.loadInlineAsync(url)
+            loaded = await ExtensionIconCache.loadInlineAsync(
+                url, palette: ExtensionImage.svgPalette(isDark: isDark))
         default:
             loaded = nil
         }

--- a/Tinycast/Features/Extensions/UI/ExtensionListView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListView.swift
@@ -180,10 +180,10 @@ private struct ExtensionItemRow: View {
                     .lineLimit(1)
             }
             Spacer(minLength: Theme.Spacing.sm)
-            if !compact {
-                ExtensionAccessoriesView(
-                    accessories: node.array("accessories"), assetsPath: assetsPath)
-            }
+            // The API only advises an extension against accessories here; Raycast still draws the
+            // ones it is given, and a quota row's entire signal is in them.
+            ExtensionAccessoriesView(
+                accessories: node.array("accessories"), assetsPath: assetsPath)
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)

--- a/Tinycast/Features/Extensions/UI/ExtensionListView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListView.swift
@@ -173,6 +173,8 @@ private struct ExtensionItemRow: View {
             Text(node.string("title") ?? "")
                 .font(Theme.Typography.rowTitle)
                 .lineLimit(1)
+                // A detail list is 290pt wide, and an accessory would otherwise win the squeeze.
+                .layoutPriority(1)
             if !compact, let subtitle = node.string("subtitle"), !subtitle.isEmpty {
                 Text(subtitle)
                     .font(Theme.Typography.rowTrailing)

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -174,10 +174,16 @@ screens hold (see [palette.md](palette.md)).
   image file — an `.app` has no bitmap to read. A `data:` URL is a source of its own too: an extension
   that renders its own SVG hands over the bytes, so they are decoded inline rather than fetched. A
   `tintColor` on any of them draws the image as a template, which is what colours an SVG written
-  against `currentColor`. A `raycast-*` colour name inside that SVG is rewritten to `rgba(…)` first,
-  resolved against the appearance being drawn: the name is legal wherever a Raycast tint is, so
-  extensions write it straight into `stroke`, and no SVG renderer knows it — left alone the shape
-  draws nothing at all. The feature's own fills live in `ExtensionColors` — never in `Theme`.
+  against `currentColor`. A `raycast-*` colour name **inside** that SVG is rewritten to `rgba(…)`
+  during the decode, in `ExtensionIconCache.loadInlineAsync`: the name is legal wherever a Raycast
+  tint is, so extensions write it straight into `stroke`, and no SVG renderer knows it — left alone
+  the shape draws nothing at all. It happens there rather than in `resolve` because `resolve` runs
+  in a `body` and the decode already runs detached, and because the markdown images a Detail draws
+  never pass through `resolve` at all. The palette is handed in as `[name: css]`, resolved once per
+  appearance by `ExtensionImage.svgPalette(isDark:)` — a `Color` can only be flattened to sRGB on the
+  main actor, which is exactly what the decode must not touch. Anything reading a decoded image keys
+  its `.task` on `ExtensionImage.LoadKey`, since the URL alone no longer says what will be drawn.
+  The feature's own fills live in `ExtensionColors` — never in `Theme`.
 - **Form** — label-left/control-right rows. Field values live in the extension (React owns them); every
   edit dispatches `onTinycastChange` and the resulting re-render is what updates the control, so
   `defaultValue`, a controlled `value`, and `ref.reset()` all behave.
@@ -478,7 +484,8 @@ fitted: the extension that drew it has already sized it, and rasterizing would c
 
 Change the number only against a rendered strip of real icons; it means nothing on its own.
 `ext-icon-test` guards the invariant: padding in the source cannot change the drawn size, and a
-`data:` payload decodes in either encoding — and one naming a `raycast-*` colour still draws ink.
+`data:` payload decodes in either encoding — and one naming a `raycast-*` colour draws ink, in the
+stroke that appearance calls for.
 
 - `ExtensionAppearance` (symbol + `ExtensionTint`) is stored per extension by manifest name in
   `ExtensionAppearanceStore`, and applies to **every command** of that extension — the same inheritance

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -155,7 +155,10 @@ screens hold (see [palette.md](palette.md)).
 - **List / Grid** — sections and items flattened in render order. When `filtering` is on (Raycast's
   default unless the command supplies `onSearchTextChange`) rows are filtered with the launcher's own
   `FuzzyMatch` over title, subtitle and keywords, and a section whose items all drop loses its header
-  too. `isShowingDetail` splits the screen into rows plus a detail pane. `ExtensionScreen.Item`
+  too. `isShowingDetail` splits the screen into rows plus a detail pane and drops each row's
+  subtitle, but **not its accessories**: the API only advises an extension against sending them in
+  this mode, and Raycast draws the ones it is sent, so suppressing them here would lose a row its
+  whole signal. `ExtensionScreen.Item`
   carries both the flat `selection` index and the scroll id, and is the `ForEach` identity of the row
   and the grid cell alike — see the scroll-id rule in [ui.md](../ui.md#rows-selection-hover).
 - **Detail** — markdown rendered block-by-block (headings, lists, code fences, quotes, rules, fetched
@@ -171,7 +174,10 @@ screens hold (see [palette.md](palette.md)).
   image file — an `.app` has no bitmap to read. A `data:` URL is a source of its own too: an extension
   that renders its own SVG hands over the bytes, so they are decoded inline rather than fetched. A
   `tintColor` on any of them draws the image as a template, which is what colours an SVG written
-  against `currentColor`. The feature's own fills live in `ExtensionColors` — never in `Theme`.
+  against `currentColor`. A `raycast-*` colour name inside that SVG is rewritten to `rgba(…)` first,
+  resolved against the appearance being drawn: the name is legal wherever a Raycast tint is, so
+  extensions write it straight into `stroke`, and no SVG renderer knows it — left alone the shape
+  draws nothing at all. The feature's own fills live in `ExtensionColors` — never in `Theme`.
 - **Form** — label-left/control-right rows. Field values live in the extension (React owns them); every
   edit dispatches `onTinycastChange` and the resulting re-render is what updates the control, so
   `defaultValue`, a controlled `value`, and `ref.reset()` all behave.
@@ -472,7 +478,7 @@ fitted: the extension that drew it has already sized it, and rasterizing would c
 
 Change the number only against a rendered strip of real icons; it means nothing on its own.
 `ext-icon-test` guards the invariant: padding in the source cannot change the drawn size, and a
-`data:` payload decodes in either encoding.
+`data:` payload decodes in either encoding — and one naming a `raycast-*` colour still draws ink.
 
 - `ExtensionAppearance` (symbol + `ExtensionTint`) is stored per extension by manifest name in
   `ExtensionAppearanceStore`, and applies to **every command** of that extension — the same inheritance


### PR DESCRIPTION
## Related issue

None filed — hit it with a quota extension's usage ring.

## What changed

A `raycast-*` colour name is legal wherever a Raycast tint is, so an extension drawing its own SVG writes one straight into `stroke`. No renderer knows the keyword, so the shape draws nothing at all: a usage ring came out as an empty slot rather than an arc.

The name resolves to `rgba(…)` during the decode, in `ExtensionIconCache.loadInlineAsync` — already detached, already holding the bytes. Doing it in `resolve` instead would put it in a `body`, re-decoding and re-encoding every inline SVG on the main actor on each hover and selection move: 50 rows of a 6 KB chart cost 0.45 ms a pass at decode versus 12.9 ms there.

Decoding is also the only place that reaches the markdown images a Detail draws, which never pass through `resolve` and so kept drawing nothing.

The palette arrives as `[name: css]` from `ExtensionImage.svgPalette(isDark:)`, flattened once per appearance into two `static let`s — a `Color` only resolves to sRGB on the main actor, which is exactly what the decode must not touch. `ExtensionImage.palette` is now the one source both the SwiftUI tint and the CSS rewrite read from, replacing the switch that listed the same nine names.

The rewrite walks whole names rather than searching for known ones: `raycast-red` sits inside `raycast-red-invented`, and substituting it there would corrupt a name we can't resolve. It early-outs on a `.literal` scan, since the default search is Unicode-canonical and costs ~3x on a long payload. The media-type guard covers a percent-encoded payload too, so a photo is never walked as text.

Both call sites key their `.task` on `ExtensionImage.LoadKey` rather than the source alone — the URL no longer says what will be drawn, and without it a dark/light flip leaves the old ink on screen.

Separately, a List with `isShowingDetail` dropped each row's accessories. The API only *advises* an extension against sending them there; Raycast draws the ones it's given, and a quota row's entire signal is in them. They're drawn now, with `layoutPriority(1)` on the title so a 290pt detail row doesn't truncate it.

## Demo
Before:
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/2024691d-44ad-472b-847a-a0926eb6ce23" />
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/78325c19-e7ee-4be4-9113-fd8beedae974" />

After:
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/f9be224b-f8c8-4702-b933-dfd91d001e77" />
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/972c46aa-fd85-4ccb-999e-28f471012354" />


Raycast:
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/e8073a26-6417-450f-9ba5-eae075b98bc0" />
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/43e688f9-6092-4b15-99a3-638d5d17e666" />

## Drawbacks

The rewrite is textual, not attribute-scoped, so a name is substituted wherever it appears in an SVG that names one. `<text>raycast-green</text>` becomes the rgba string, and a `raycast-blue` gradient `id` is rewritten along with its `url(#…)` ref — the pair still matches, but reads oddly. `class="raycast-red-box"` and an uppercase `raycast-Green` are both correctly left alone. Scoping it properly means parsing XML in the decode path, which costs more than the bug is worth.

A long title in a detail list squeezes its accessories out: unchanged to ~20 chars, 47pt → 15pt at 24, effectively gone past 26. Giving the accessory the priority instead truncates titles on every row rather than a few, which reads worse.

## Tests & validation

- `ext-icon-test` gains `paletteColorsInSVGResolve`, asserting on drawn pixels rather than the rewritten string — the string proves nothing about whether the shape draws. Covers both encodings, a trailing `?raycast-width=` query, an unknown name shadowing a known one, the light and dark ramps landing on white and black ink, and a PNG passing through untouched. Needs `ExtensionImage` and its dependencies in the harness's source list.
- All 39 harnesses pass, Debug builds with no new warnings, `lint.sh` clean.
- Merges into current `main` without conflict, and `ext-icon-test` passes on the merged tree — `main` has since touched both `ExtensionImage.swift` and this harness.

