### PR TITLE
Read today alone when tomorrow's events are switched off

### DIFF
--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -1,5 +1,5 @@
 // Standalone test for meeting-link detection, the join and menu-bar windows, auto-join,
-// the event draft and the day buckets.
+// the event draft, the day buckets and the read span.
 import Foundation
 
 @main
@@ -27,6 +27,7 @@ struct CalendarTests {
         chordFallsBackWiderThanTheCard()
         countdownStrings()
         dayBuckets()
+        readSpan()
         menuBarWindow()
         menuBarFiltering()
         menuBarTitles()
@@ -431,6 +432,29 @@ struct CalendarTests {
         expect(
             MeetingDay(for: now.addingTimeInterval(-24 * 3600), now: now, calendar: calendar) == nil,
             "yesterday has no bucket")
+    }
+
+    // MARK: - The read span
+
+    static func readSpan() {
+        let now = date(year: 2026, month: 8, day: 23, hour: 22)
+        let midnight = date(year: 2026, month: 8, day: 23, hour: 0)
+        expect(
+            MeetingSpan(includesTomorrow: false) == .today
+                && MeetingSpan(includesTomorrow: true) == .todayAndTomorrow,
+            "the setting names the span")
+        expect(
+            MeetingSpan.today.interval(from: now, calendar: calendar)
+                == DateInterval(start: midnight, end: date(year: 2026, month: 8, day: 24, hour: 0)),
+            "today alone runs midnight to midnight, from an evening `now`")
+        expect(
+            MeetingSpan.todayAndTomorrow.interval(from: now, calendar: calendar)
+                == DateInterval(start: midnight, end: date(year: 2026, month: 8, day: 25, hour: 0)),
+            "tomorrow adds a second day to the same start")
+        expect(
+            MeetingSpan.today.possessivePhrase == "today's"
+                && MeetingSpan.todayAndTomorrow.orPhrase == "today or tomorrow",
+            "the wording follows the span")
     }
 
     // MARK: - Helpers

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		B56F252262AA1BD3E2631F0C /* FileSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391B8024E8719506361B45F7 /* FileSearchQuery.swift */; };
 		B589C3ECFF03C790102361D4 /* SupportReminderSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E393E2CA842C5B344C6B499 /* SupportReminderSchedule.swift */; };
 		B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0F5891A80B604FBE21897B /* CalcCurrency.swift */; };
+		B6C39F046F6B09CD7AA53F6B /* MeetingSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09511B0502D1B67F10604D3C /* MeetingSpan.swift */; };
 		B72F17539405522E63D266F3 /* AIPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5861814F16B18935FBF034C /* AIPreamble.swift */; };
 		B8CECD85524BCCCBC0CDC2B5 /* ExtensionCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */; };
 		BAD4BEF8041665ACCF1CE460 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */; };
@@ -422,6 +423,7 @@
 		08279257B0F5995E86FF2C03 /* EntryIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryIconView.swift; sourceTree = "<group>"; };
 		08A1D354C1785923E612848C /* RenderNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderNode.swift; sourceTree = "<group>"; };
 		0935D49C0A0175E54E69682B /* QuicklinkListScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkListScreen.swift; sourceTree = "<group>"; };
+		09511B0502D1B67F10604D3C /* MeetingSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSpan.swift; sourceTree = "<group>"; };
 		09633E6F9C37F89267341D1D /* VolumeHUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDController.swift; sourceTree = "<group>"; };
 		0966995230FE7B7072C0018B /* EmojiGridGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGridGeometry.swift; sourceTree = "<group>"; };
 		096F955B26BAEE5AED65B559 /* HTTPAIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPAIProvider.swift; sourceTree = "<group>"; };
@@ -1265,6 +1267,7 @@
 				C0599199132DAFBE12C59FBD /* MeetingDay.swift */,
 				5B330ABFC83721904159DDF2 /* MeetingEvent.swift */,
 				B117F11E9B15D1B1919B7FB1 /* MeetingLink.swift */,
+				09511B0502D1B67F10604D3C /* MeetingSpan.swift */,
 				5D6FD4FBAC3F5E6255D62773 /* MenuBarSummary.swift */,
 				F3F97240A718D95DFD9343DB /* UpcomingWindow.swift */,
 			);
@@ -2391,6 +2394,7 @@
 				E4E1403AA9A8ACE4A3D3581C /* MeetingEvent.swift in Sources */,
 				791AC049B6CA16C7D86EEBEF /* MeetingLauncher.swift in Sources */,
 				77A82B4F0CC09E7248DC5706 /* MeetingLink.swift in Sources */,
+				B6C39F046F6B09CD7AA53F6B /* MeetingSpan.swift in Sources */,
 				AAFD2C9276D38719E85B675F /* Memo.swift in Sources */,
 				9E257392434C62CCC26C9B04 /* MenuBarLabel.swift in Sources */,
 				E6E929E9284E8AC361D64D6A /* MenuBarSummary.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -389,6 +389,9 @@ final class AppCore {
                 _ = $0.calendarShowInLauncher
             }, reproject: { $0.calendarCoordinator.applyEnabled() })
         track(
+            { _ = $0.calendarIncludesTomorrow },
+            reproject: { $0.calendarCoordinator.applySpan() })
+        track(
             {
                 _ = $0.autoJoinMeetings
                 _ = $0.menuBarEvents

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -53,6 +53,8 @@ struct SettingsBackup: Codable {
         var quicklinkConfirmsBeforeDelete: Bool?
         // `calendarEnabled` is absent: an import must not grant calendar access.
         var calendarShowInLauncher: Bool?
+        // Carried: it narrows what is read rather than widening what may be reached.
+        var calendarIncludesTomorrow: Bool?
         var joinWindowMinutes: Int?
         // `autoJoinMeetings` and `cameraPreview` are absent: an import must arm neither.
         var autoJoinConfirms: Bool?
@@ -137,6 +139,7 @@ extension SettingsBackup {
             quicklinkSelectionFallback: s.quicklinkSelectionFallback.rawValue,
             quicklinkConfirmsBeforeDelete: s.quicklinkConfirmsBeforeDelete,
             calendarShowInLauncher: s.calendarShowInLauncher,
+            calendarIncludesTomorrow: s.calendarIncludesTomorrow,
             joinWindowMinutes: s.joinWindowMinutes.rawValue,
             autoJoinConfirms: s.autoJoinConfirms,
             menuBarEvents: s.menuBarEvents.rawValue,
@@ -358,6 +361,10 @@ extension SettingsBackup {
         }
         if let flag = s.calendarShowInLauncher {
             settings.calendarShowInLauncher = flag
+            count += 1
+        }
+        if let flag = s.calendarIncludesTomorrow {
+            settings.calendarIncludesTomorrow = flag
             count += 1
         }
         if let raw = s.joinWindowMinutes, let window = JoinWindow(rawValue: raw) {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -35,6 +35,7 @@ enum SettingsBackupCoverage {
         "quicklinkConfirmsBeforeDelete": .quicklinkConfirmsBeforeDelete,
         "extensionsShowInLauncher": .extensionsShowInLauncher,
         "calendarShowInLauncher": .calendarShowInLauncher,
+        "calendarIncludesTomorrow": .calendarIncludesTomorrow,
         "joinWindowMinutes": .joinWindowMinutes,
         "autoJoinConfirms": .autoJoinConfirms,
         "menuBarEvents": .menuBarEvents,

--- a/Tinycast/Features/Calendar/Model/MeetingSpan.swift
+++ b/Tinycast/Features/Calendar/Model/MeetingSpan.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// How far ahead Tinycast reads, so the query's length and every sentence naming it agree.
+enum MeetingSpan: Sendable {
+    case today
+    case todayAndTomorrow
+
+    init(includesTomorrow: Bool) {
+        self = includesTomorrow ? .todayAndTomorrow : .today
+    }
+
+    /// Midnight today through midnight at the end of the span, in the calendar's own zone.
+    func interval(from now: Date, calendar: Calendar) -> DateInterval? {
+        guard let start = calendar.dateInterval(of: .day, for: now)?.start,
+            let end = calendar.date(byAdding: .day, value: days, to: start)
+        else { return nil }
+        return DateInterval(start: start, end: end)
+    }
+
+    /// "today's and tomorrow's", for a sentence naming the events that are read.
+    var possessivePhrase: String {
+        switch self {
+        case .today: return "today's"
+        case .todayAndTomorrow: return "today's and tomorrow's"
+        }
+    }
+
+    /// "today or tomorrow", for a sentence saying nothing falls in the span, where "and" reads wrong.
+    var orPhrase: String {
+        switch self {
+        case .today: return "today"
+        case .todayAndTomorrow: return "today or tomorrow"
+        }
+    }
+
+    private var days: Int {
+        switch self {
+        case .today: return 1
+        case .todayAndTomorrow: return 2
+        }
+    }
+}

--- a/Tinycast/Features/Calendar/Service/CalendarStore.swift
+++ b/Tinycast/Features/Calendar/Service/CalendarStore.swift
@@ -1,14 +1,23 @@
 import AppKit
 import EventKit
 
-/// Today's and tomorrow's meetings, read from EventKit. See docs/features/calendar.md.
+/// The span's meetings, read from EventKit. See docs/features/calendar.md.
 @MainActor
 @Observable
 final class CalendarStore {
-    /// Flattened occurrences over `[startOfToday, endOfTomorrow]`, newest query wins.
+    /// Flattened occurrences over `span`, newest query wins.
     private(set) var events: [MeetingEvent] = []
     private(set) var calendars: [MeetingCalendar] = []
     private(set) var access: CalendarAccess = Permissions.calendarAccess()
+
+    /// The days queried, pushed in by `CalendarCoordinator`. Changing it re-reads: nothing may
+    /// filter a snapshot into a span it was never fetched for, and an empty schedule names it.
+    var span: MeetingSpan = .todayAndTomorrow {
+        didSet {
+            guard span != oldValue, lastReloadAt != nil else { return }
+            reload()
+        }
+    }
 
     /// Fired whenever `events` changes, so the launcher's meeting slice is republished.
     @ObservationIgnored var onChange: (() -> Void)?
@@ -96,14 +105,14 @@ final class CalendarStore {
             return
         }
         let aged = now.timeIntervalSince(lastReloadAt) >= Self.staleAfter
-        // A day boundary invalidates the two-day span itself, however fresh the snapshot is.
+        // A day boundary invalidates the span itself, however fresh the snapshot is.
         let rolled = !Calendar.current.isDate(lastReloadAt, inSameDayAs: now)
         guard aged || rolled else { return }
         reload()
     }
 
-    /// Two days of events is a sub-millisecond query and `EKEventStore` is not `Sendable`, so this
-    /// stays on the main actor; only pure `MeetingEvent` values leave it.
+    /// A day or two of events is a sub-millisecond query and `EKEventStore` is not `Sendable`, so
+    /// this stays on the main actor; only pure `MeetingEvent` values leave it.
     func reload() {
         access = Permissions.calendarAccess()
         guard access == .granted else {
@@ -125,13 +134,15 @@ final class CalendarStore {
             .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
         let selected = sources.filter { !hiddenCalendarIDs.contains($0.calendarIdentifier) }
-        guard !selected.isEmpty, let span = Self.span(from: Date()) else {
+        guard !selected.isEmpty,
+            let interval = span.interval(from: Date(), calendar: .current)
+        else {
             publish([])
             return
         }
         // The predicate expands recurrence itself; fetching masters and rolling our own never works.
         let predicate = store.predicateForEvents(
-            withStart: span.start, end: span.end, calendars: selected)
+            withStart: interval.start, end: interval.end, calendars: selected)
         publish(store.events(matching: predicate).compactMap(Self.meeting(from:)))
     }
 
@@ -139,15 +150,6 @@ final class CalendarStore {
         guard next != events else { return }
         events = next
         onChange?()
-    }
-
-    /// Midnight today through midnight the day after tomorrow, in the Mac's own zone.
-    private static func span(from now: Date) -> (start: Date, end: Date)? {
-        let calendar = Calendar.current
-        guard let start = calendar.dateInterval(of: .day, for: now)?.start,
-            let end = calendar.date(byAdding: .day, value: 2, to: start)
-        else { return nil }
-        return (start, end)
     }
 
     private static func meeting(from event: EKEvent) -> MeetingEvent? {

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -12,7 +12,8 @@ struct CalendarSettingsView: View {
                 header: "Calendar",
                 enableTitle: "Join meetings from Tinycast",
                 enableSubtitle:
-                    "Reads today's and tomorrow's events to find join links. Nothing leaves this Mac.",
+                    "Reads \(core.calendarCoordinator.span.possessivePhrase) events to find join "
+                    + "links. Nothing leaves this Mac.",
                 launcherSubtitle: "List individual meetings alongside apps and commands.",
                 isEnabled: enabledBinding,
                 showsInLauncher: $settings.calendarShowInLauncher)
@@ -27,6 +28,16 @@ struct CalendarSettingsView: View {
                     }
                 }
             }
+
+            Section {
+                Toggle(isOn: $settings.calendarIncludesTomorrow) {
+                    Text("Include Tomorrow's Events")
+                    Text("Read tomorrow as well as the rest of today, everywhere meetings appear.")
+                }
+            } header: {
+                Text("Schedule")
+            }
+            .settingsEnabled(settings.calendarEnabled)
 
             Section {
                 Picker(selection: $settings.joinWindowMinutes) {

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -39,13 +39,16 @@ final class CalendarCoordinator {
     /// The window every surface reads, so the card, the chord and the schedule cannot disagree.
     var window: UpcomingWindow { UpcomingWindow(leadMinutes: settings.joinWindowMinutes.rawValue) }
 
+    /// The days the store reads, and the wording every sentence that names them uses.
+    var span: MeetingSpan { MeetingSpan(includesTomorrow: settings.calendarIncludesTomorrow) }
+
     /// The meeting the join card shows, or nil when none is due. `now` comes from the ticking clock.
     var cardedMeeting: MeetingEvent? {
         guard settings.calendarEnabled else { return nil }
         return window.carded(from: store.events, now: clock.now)
     }
 
-    /// Today and tomorrow, timed, accepted and not over yet, in start order. Live rather than
+    /// The span's events, timed, accepted and not over yet, in start order. Live rather than
     /// clock-driven: this publishes a snapshot, and a chord reads it with nothing ticking.
     var agenda: [MeetingEvent] { UpcomingWindow.agenda(from: store.events, now: Date()) }
 
@@ -75,7 +78,8 @@ final class CalendarCoordinator {
                 await core.confirm(
                     title: "Enable calendar?",
                     message:
-                        "Tinycast reads today's and tomorrow's events to find join links. Nothing leaves this Mac.",
+                        "Tinycast reads \(span.possessivePhrase) events to find join links. "
+                        + "Nothing leaves this Mac.",
                     symbol: "calendar", confirmTitle: "Continue", tone: .neutral,
                     confirmRole: .standard)
             else { return }
@@ -101,9 +105,15 @@ final class CalendarCoordinator {
         }
         store.onChange = { [weak self] in self?.publishEntries() }
         clock.onTick = { [weak self] in self?.minuteDidPass() }
+        applySpan()
         store.start()
         publishEntries()
         applyClock()
+    }
+
+    /// Changing which days are read re-queries EventKit, so it runs through the store, not a filter.
+    func applySpan() {
+        store.span = span
     }
 
     /// The clock runs while something is watching it. With all three off an idle Mac owns no timer.
@@ -228,7 +238,7 @@ final class CalendarCoordinator {
 
     func openNextMeetingInCalendar() {
         guard let meeting = window.joinable(from: store.events, now: Date()) ?? agenda.first else {
-            report("Nothing scheduled today or tomorrow")
+            report("Nothing scheduled \(span.orPhrase)")
             return
         }
         openInCalendar(meeting)

--- a/Tinycast/Features/Calendar/UI/ScheduleScreen.swift
+++ b/Tinycast/Features/Calendar/UI/ScheduleScreen.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// My Schedule: today and tomorrow, filtered by the query. Enter joins, ⌘K carries the rest.
+/// My Schedule: the store's span, filtered by the query. Enter joins, ⌘K carries the rest.
 struct ScheduleScreen: PaletteScreen {
     let store: CalendarStore
     let clock: MeetingClock
@@ -73,6 +73,6 @@ struct ScheduleScreen: PaletteScreen {
     private var emptyMessage: String {
         if store.access != .granted { return "Tinycast has no access to your calendar" }
         if !vm.query.trimmingCharacters(in: .whitespaces).isEmpty { return "No matching meetings" }
-        return "Nothing scheduled today or tomorrow"
+        return "Nothing scheduled \(store.span.orPhrase)"
     }
 }

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -270,6 +270,13 @@ final class AppSettings {
         }
     }
 
+    /// Narrows the fetch itself rather than what is shown, so every surface reads the same days.
+    var calendarIncludesTomorrow: Bool {
+        didSet {
+            defaults.set(calendarIncludesTomorrow, forKey: Key.calendarIncludesTomorrow.rawValue)
+        }
+    }
+
     var joinWindowMinutes: JoinWindow {
         didSet { defaults.set(joinWindowMinutes.rawValue, forKey: Key.joinWindowMinutes.rawValue) }
     }
@@ -449,6 +456,9 @@ final class AppSettings {
         calendarShowInLauncher =
             defaults.object(forKey: Key.calendarShowInLauncher.rawValue) == nil
             || defaults.bool(forKey: Key.calendarShowInLauncher.rawValue)
+        calendarIncludesTomorrow =
+            defaults.object(forKey: Key.calendarIncludesTomorrow.rawValue) == nil
+            || defaults.bool(forKey: Key.calendarIncludesTomorrow.rawValue)
         joinWindowMinutes =
             JoinWindow(rawValue: defaults.integer(forKey: Key.joinWindowMinutes.rawValue)) ?? .five
         autoJoinMeetings = defaults.bool(forKey: Key.autoJoinMeetings.rawValue)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -42,6 +42,7 @@ enum AppSettingsKey: String, CaseIterable {
     case extensionCustomSearchPaths = "extensionCustomSearchPaths"
     case calendarEnabled = "calendarEnabled"
     case calendarShowInLauncher = "calendarShowInLauncher"
+    case calendarIncludesTomorrow = "calendarIncludesTomorrow"
     case joinWindowMinutes = "joinWindowMinutes"
     case autoJoinMeetings = "autoJoinMeetings"
     case autoJoinConfirms = "autoJoinConfirms"

--- a/Tinycast/Palette/PaletteMode.swift
+++ b/Tinycast/Palette/PaletteMode.swift
@@ -41,7 +41,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .calculatorHistory: return "Do math, convert units, or search your past calculations…"
         case .emoji: return "Search emoji and symbols…"
         case .fileSearch: return "Search files and folders…"
-        case .schedule: return "Search today and tomorrow…"
+        case .schedule: return "Search your schedule…"
         case .uninstall: return "Filter files and folders by name…"
         case .quicklinks: return "Search quicklinks…"
         // Replaced by the pending argument's name; only reached if the session vanished mid-render.

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -26,6 +26,10 @@ events as searchable launcher entries.
   everyone joins late; the `min` is why it never outlives a meeting shorter than the lead.
 - **Recurrence comes from `predicateForEvents(withStart:end:calendars:)`**, which expands occurrences
   itself. Masters are never fetched and recurrence is never hand-rolled.
+- **`MeetingSpan` narrows the fetch, never the surfaces.** `calendarIncludesTomorrow` reaches
+  EventKit through `CalendarStore.span`, so dropping tomorrow shortens the query and every surface
+  follows from the one snapshot — no surface filters days out of a snapshot fetched wider. The same
+  type owns the wording, so a sentence naming the days can never outlive the query it describes.
 - **`UpcomingWindow.agenda` is the only place that says which events count** — timed, not declined,
   not over, in start order. The card, the chord, the menu bar, the schedule and the launcher slice all
   go through it, so they cannot drift apart. Because an event ending changes nothing in EventKit,
@@ -49,6 +53,7 @@ events as searchable launcher entries.
 - **`MeetingEvent`** — one occurrence, flattened out of `EKEvent`.
 - **`UpcomingWindow`** — `agenda`, `carded`, `joinable` and `countdown`.
 - **`MeetingDay`** — the Today / Tomorrow buckets, mirroring the clipboard's `DateBucket`.
+- **`MeetingSpan`** — how far ahead the store reads, and the phrasing that names those days.
 - **`MenuBarSummary`** — which event the menu bar carries, and for how long.
 - **`AutoJoinPolicy`** — whether a meeting should open itself, and which one.
 - **`EventDraft`** — what the New Event prompt collects, before anything touches the calendar.
@@ -132,11 +137,13 @@ is nothing to acknowledge.
 
 ## Reading the store
 
-`CalendarStore` queries `[startOfToday, endOfTomorrow + 1 day)` in the Mac's own zone. **The fetch
-stays on the main actor**: two days of events is a sub-millisecond query and `EKEventStore` is not
-`Sendable`, so pushing it off-main would be a fight with no measurable gain. Both the launch-time load
-and the per-summon refresh are deferred into a `Task`, because the first EventKit query pays for its
-XPC warm-up and both of those paths are protected.
+`CalendarStore` queries `MeetingSpan.interval(from:calendar:)` — midnight today through midnight one
+or two days on, in the Mac's own zone — and re-reads whenever `span` changes under it, but only once
+it has read at all, so enabling the feature never fires two queries. **The fetch stays on the main
+actor**: a day or two of events is a sub-millisecond query and `EKEventStore` is not `Sendable`, so
+pushing it off-main would be a fight with no measurable gain. Both the launch-time load and the
+per-summon refresh are deferred into a `Task`, because the first EventKit query pays for its XPC
+warm-up and both of those paths are protected.
 
 The `EKEventStore` itself is built on first use, so a Mac with the feature off never loads EventKit.
 After a grant the store is dropped and rebuilt — one built before the grant does not see the new
@@ -192,8 +199,8 @@ still lands on top of it.
 ## Settings
 
 The Calendar pane carries the master switch (routed through the coordinator so the consent gate cannot
-be bypassed), the `Join Next Meeting` recorder, the join-window picker, and the per-calendar checkbox
-list — `LauncherItemsSection`'s shape, including the one `Form` row holding a `LazyVStack`, because a
+be bypassed), the `Include Tomorrow's Events` switch, the `Join Next Meeting` recorder, the
+join-window picker, and the per-calendar checkbox list — `LauncherItemsSection`'s shape, including the one `Form` row holding a `LazyVStack`, because a
 `Form` realizes every row it is handed.
 
 The hidden-calendar set stores **exclusions**, so a calendar added after the setting was written
@@ -202,7 +209,14 @@ defaults to on. Holidays and Birthdays are what people switch off.
 `autoJoinMeetings` and `cameraPreview` join `calendarEnabled` in
 `SettingsBackupCoverage.deliberatelyExcluded`: one arms the app to open links unattended and the
 other turns on the camera, and an import must grant neither. The menu-bar settings carry over
-normally.
+normally, and so does `calendarIncludesTomorrow`: it narrows what is read rather than widening what
+can be reached.
+
+Because the span is a setting, the two sentences that name the days — the consent dialog and the
+pane's own subtitle — interpolate `MeetingSpan.possessivePhrase` rather than spelling the days out,
+and the empty schedule reads `MeetingSpan.orPhrase` off the store that did the query. The `.schedule`
+placeholder names no days at all: it is a static `PaletteMode` string, and one that advertised a span
+it could not read would be wrong half the time.
 
 Both menu-bar enums put their default at `rawValue == 0`, so `defaults.integer(forKey:)` returning 0
 for an unset key lands on `.never` and `.automatically` rather than fighting them.


### PR DESCRIPTION
Closes #361.

Adds an **Include Tomorrow's Events** switch to Settings ▸ Calendar, on by default so nothing changes for an existing install.

Turning it off narrows the **EventKit query itself** rather than what any surface shows, so every surface follows from the one snapshot — the join card, ⌘ Join Next Meeting, the menu bar, My Schedule and the launcher slice. Filtering downstream instead would have left an 11pm Join Next Meeting reaching for tomorrow's 9am stand-up.

## How it is put together

`MeetingSpan` is the new pure-model type, and it owns both halves: the interval the query runs over, and the wording of every sentence that names those days. Pairing them is what stops a string reading "today's and tomorrow's" over a fetch that covered one day.

- `CalendarStore` holds the span and re-reads on change, but only once it has read at all, so enabling the feature never fires two queries. The private `span(from:)` is gone — the date maths moved into the model, where `calendar-test` can reach it.
- `CalendarCoordinator.applySpan()` bridges setting to store, mirroring the existing `window` / `applyClock()` shape, tracked in `AppCore`.
- The setting travels in a settings backup: it narrows what is read rather than widening what can be reached, unlike `calendarEnabled`, `autoJoinMeetings` and `cameraPreview`.

Two judgment calls worth a reviewer's eye:

- The `.schedule` placeholder is now "Search your schedule…" rather than naming days. It is a static `PaletteMode` string with no access to settings, and one advertising a span it could not honour would be wrong half the time.
- `store.span` is observed rather than `@ObservationIgnored` like its neighbours, because narrowing an already-empty schedule changes its message and nothing else would trigger the redraw.

The toggle sits in its own **Schedule** section between the master switch and Joining. It reads well in pane order, though it is a seventh control in an already-dense pane — moving it to the first row of **Calendars** (both being "what Tinycast reads") is a two-line change if preferred.

## Checks

- `./Scripts/run-tests.sh` — all 49 harnesses pass, including four new span assertions in `calendar-test`.
- Debug build clean, no new warnings.
- `./Scripts/lint.sh` clean.
- `Model/` imports nothing UI-shaped.
- `docs/features/calendar.md` updated: new invariant, model bullet, the reading-the-store section and the settings section.
- `xcodegen generate` run for the new file; the `.pbxproj` is in the diff.