### PR TITLE
Dedicated Snippets browser and global shortcut

### DIFF
--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -93,6 +93,7 @@ struct DoubleTapDetectorTests {
                 (.clipboardHistory, .toggleClipboard, "hotkey.toggleClipboard"),
                 (.searchEmoji, .toggleEmoji, "hotkey.toggleEmoji"),
                 (.searchFiles, .searchFiles, "hotkey.searchFiles"),
+                (.searchSnippets, .searchSnippets, "hotkey.searchSnippets"),
                 (.joinNextMeeting, .joinNextMeeting, "hotkey.joinNextMeeting"),
                 (.mySchedule, .mySchedule, "hotkey.mySchedule"),
                 (.createEvent, .createEvent, "hotkey.createEvent"),

--- a/Tests/palette-tab-test.swift
+++ b/Tests/palette-tab-test.swift
@@ -42,7 +42,9 @@ struct PaletteTabTests {
             "turned off, the clipboard still returns to the launcher")
 
         // A sub-screen is reached by a command or a hotkey, so Tab leaves rather than ringing on.
-        for mode in [PaletteMode.aiHistory, .emoji, .fileSearch, .calculatorHistory, .quicklinks] {
+        for mode in [
+            PaletteMode.aiHistory, .emoji, .fileSearch, .calculatorHistory, .quicklinks, .snippets
+        ] {
             expect(
                 PaletteTabAction.resolve(mode: mode, aiEnabled: true),
                 .carryQuery(.launcher),

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802BD2F4CC057228F2528217 /* PalettePlacement.swift */; };
 		1CA10DE219BAB97BFC29E54A /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */; };
 		1E0A1B1B84673EF39871842C /* MarkdownCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570CE37C7133E28F7495ED91 /* MarkdownCodeView.swift */; };
+		1E48F2BED1C62873F424F180 /* SnippetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1847C927A1DA4EE0009201DF /* SnippetCoordinator.swift */; };
 		1F0E7F2EF27CB82211EDCB4C /* ExtensionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BAA0471DD8CE4352F45FED /* ExtensionCoordinator.swift */; };
 		1F1AD34A26931AF6E11E13F7 /* VolumeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B962318915EF7AEAC4996D /* VolumeState.swift */; };
 		1F8F2135470F74627A644ACC /* ClipboardFilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */; };
@@ -141,6 +142,7 @@
 		555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F1080FB443A1D0616790E /* FavoritesStore.swift */; };
 		56E4958BCEF1FED10B4A796E /* UpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */; };
 		5770FB1A3FD29E27C25C944E /* SearchRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB9DB77DCE25C41D86BB955 /* SearchRelevance.swift */; };
+		57784875AA132F7756399363 /* SnippetsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E419A4DA5AB5B3A87B80F2 /* SnippetsListView.swift */; };
 		58D369977E702AD66F070913 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */; };
 		5970306ABC24B03028E66D45 /* FileSearchIgnoreList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFF39C46E98D0808B188E2E /* FileSearchIgnoreList.swift */; };
 		5A91C58340D02ED0939BCAE2 /* CurrencyFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE35B5E7B1CC94F759116097 /* CurrencyFeed.swift */; };
@@ -239,6 +241,7 @@
 		939F3944AE8D36A8C337D46F /* Signposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9044F107ADD5896746DBC35 /* Signposts.swift */; };
 		94887F8E18AB2C08A8273897 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7B3EB88881CEEFCE71448D /* Permissions.swift */; };
 		9608AFDEDC3B330E64F53437 /* ExtensionStoreClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410684C9DEB3754962C20C9C /* ExtensionStoreClient.swift */; };
+		96BC636877D935C5EB20BF7F /* SnippetsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E06AA30E7BA44BC211B667F /* SnippetsScreen.swift */; };
 		97D71FF4C0D582828C6EC7F5 /* UpdateFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B475B5929CC0478EFAC7D8 /* UpdateFailure.swift */; };
 		97F6E58046553BDCEF5AD447 /* ExtensionOAuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7DEB147E5D718E00D67755 /* ExtensionOAuthSession.swift */; };
 		9802E5495E65CCB318ACF5F2 /* RaycastImportV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658C57A4CE41C0FA80BBE41D /* RaycastImportV1.swift */; };
@@ -397,7 +400,6 @@
 		F9750CE5EC2E7E541F740A15 /* QuickActionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C83D437500107168E12647 /* QuickActionSettings.swift */; };
 		FA05D882203673A9FEE5F421 /* UninstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFBFA70EF62B67F7357E0E /* UninstallCoordinator.swift */; };
 		FA386C9B6DA24481565D506D /* ExtensionPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */; };
-		FAF6C108845548DDC7F978CB /* SnippetExpansionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102C22092D130BD8E1A07CD6 /* SnippetExpansionCoordinator.swift */; };
 		FB1D83A8BE027AC4F328D601 /* QuicklinkListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0935D49C0A0175E54E69682B /* QuicklinkListScreen.swift */; };
 		FCA73C81470EF9A50B016504 /* SettingsToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBC5A9553716C8F03ED0216 /* SettingsToolbarController.swift */; };
 		FD49FAFAA34FC1A41AFAC10F /* SettingsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDDA8820165672AF8464E25 /* SettingsComponents.swift */; };
@@ -436,7 +438,6 @@
 		0EDB1EEB97CC5F6B0B81FFD6 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		0F5AFB680B55BBAFF2207F99 /* NotesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesCoordinator.swift; sourceTree = "<group>"; };
 		0FE6F8E3FA640C6F2B1AA8FE /* CodexExecutableLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexExecutableLocator.swift; sourceTree = "<group>"; };
-		102C22092D130BD8E1A07CD6 /* SnippetExpansionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetExpansionCoordinator.swift; sourceTree = "<group>"; };
 		106F9FEF3F0C36E0C5686DA7 /* AIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIRequest.swift; sourceTree = "<group>"; };
 		112551581ECF83B53D405334 /* BackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsView.swift; sourceTree = "<group>"; };
 		121A2ACAEC4D2D25D3112634 /* LauncherItemsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherItemsSection.swift; sourceTree = "<group>"; };
@@ -450,6 +451,7 @@
 		164CB3E1BB5B7D87AF8E7023 /* CommandID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandID.swift; sourceTree = "<group>"; };
 		164DCBE855B7136AE08712D8 /* MarkdownInline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownInline.swift; sourceTree = "<group>"; };
 		17EA0B9FFCBAB10941EC7702 /* VisibilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibilityStore.swift; sourceTree = "<group>"; };
+		1847C927A1DA4EE0009201DF /* SnippetCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetCoordinator.swift; sourceTree = "<group>"; };
 		1868F87E31E20A4775C84E6A /* HyperKeyTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKeyTap.swift; sourceTree = "<group>"; };
 		188A6D3C5B6BC67716F15F83 /* PaletteState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteState.swift; sourceTree = "<group>"; };
 		197035E213BEBA67DDA3377B /* ClipboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardManager.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 		410684C9DEB3754962C20C9C /* ExtensionStoreClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStoreClient.swift; sourceTree = "<group>"; };
 		418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideView.swift; sourceTree = "<group>"; };
 		418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
+		41E419A4DA5AB5B3A87B80F2 /* SnippetsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsListView.swift; sourceTree = "<group>"; };
 		4395BACF833C810961A248F0 /* BarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarButton.swift; sourceTree = "<group>"; };
 		43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyAction.swift; sourceTree = "<group>"; };
 		445B0374FD5D74DBE23243CD /* PaletteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteScreen.swift; sourceTree = "<group>"; };
@@ -585,6 +588,7 @@
 		6AF26598BE61F114D5999541 /* NotesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesSettingsView.swift; sourceTree = "<group>"; };
 		6C045C66BB654E4CB407A673 /* AppActionsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActionsMenu.swift; sourceTree = "<group>"; };
 		6D594CB90475093D58A2AB1E /* NoteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSearch.swift; sourceTree = "<group>"; };
+		6E06AA30E7BA44BC211B667F /* SnippetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsScreen.swift; sourceTree = "<group>"; };
 		71B96B69CB4E52319BB3EC7D /* FileSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchService.swift; sourceTree = "<group>"; };
 		72DF1178CD8AD726AC6F9874 /* CalculatorCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCardView.swift; sourceTree = "<group>"; };
 		72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapModifier.swift; sourceTree = "<group>"; };
@@ -829,7 +833,9 @@
 			isa = PBXGroup;
 			children = (
 				A80495AE6BF7CE22BD6B20EE /* SnippetArgumentsPrompt.swift */,
-				102C22092D130BD8E1A07CD6 /* SnippetExpansionCoordinator.swift */,
+				1847C927A1DA4EE0009201DF /* SnippetCoordinator.swift */,
+				41E419A4DA5AB5B3A87B80F2 /* SnippetsListView.swift */,
+				6E06AA30E7BA44BC211B667F /* SnippetsScreen.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -2513,12 +2519,14 @@
 				939F3944AE8D36A8C337D46F /* Signposts.swift in Sources */,
 				B073D5A79D50982E89C30F20 /* Snippet.swift in Sources */,
 				903FFCACE52FFA25958AD832 /* SnippetArgumentsPrompt.swift in Sources */,
-				FAF6C108845548DDC7F978CB /* SnippetExpansionCoordinator.swift in Sources */,
+				1E48F2BED1C62873F424F180 /* SnippetCoordinator.swift in Sources */,
 				F8EC987B884BD2ED6A6690A9 /* SnippetKeywordListener.swift in Sources */,
 				2F38A89B3481A4C9A13F13A8 /* SnippetKeywordPolicy.swift in Sources */,
 				58D369977E702AD66F070913 /* SnippetMarkdownSerializer.swift in Sources */,
 				175DAAED3859A54861D8CEBC /* SnippetRepository.swift in Sources */,
 				3B02D6CE68E0E488955A19B5 /* SnippetTemplateEngine.swift in Sources */,
+				57784875AA132F7756399363 /* SnippetsListView.swift in Sources */,
+				96BC636877D935C5EB20BF7F /* SnippetsScreen.swift in Sources */,
 				3BC6CC35889FFC77D640C7CA /* SnippetsSettingsView.swift in Sources */,
 				7BDB7CF7F1352015F6AC96C3 /* SnippetsStore.swift in Sources */,
 				2F1161E2706CD883E9599000 /* SpaceGesture.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -52,10 +52,14 @@ final class AppCore {
 
     /// Set when a quicklink editor should open with Settings; the pane consumes it.
     var pendingQuicklinkEdit: QuicklinkEditRequest?
+    /// Set when a snippet editor should open with Settings; the pane consumes it.
+    var pendingSnippetEdit: SnippetEditRequest?
 
-    @ObservationIgnored private(set) lazy var snippetExpansion = SnippetExpansionCoordinator(
+    @ObservationIgnored private(set) lazy var snippetCoordinator = SnippetCoordinator(
         store: snippetsStore, listener: snippetListener, injector: textInjector,
         clipboardStore: clipboardStore, appIndex: appIndex, settings: settings,
+        windowController: windowController, paletteCoordinator: paletteCoordinator,
+        settingsCoordinator: settingsCoordinator,
         showMessage: { [unowned self] in self.showMessage($0) }, core: self)
     @ObservationIgnored private(set) lazy var quicklinkCoordinator = QuicklinkCoordinator(
         store: quicklinks, argumentSession: quicklinkArguments, settings: settings,
@@ -63,7 +67,7 @@ final class AppCore {
         visibility: visibility, ranking: launcherRanking, aliases: aliases,
         windowController: windowController,
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,
-        clipboardHistory: { [unowned self] in self.snippetExpansion.clipboardHistoryForExpansion() },
+        clipboardHistory: { [unowned self] in self.snippetCoordinator.clipboardHistoryForExpansion() },
         core: self)
 
     @ObservationIgnored private(set) lazy var paletteCoordinator = PaletteCoordinator(
@@ -105,7 +109,7 @@ final class AppCore {
         systemActionCoordinator: systemActionCoordinator,
         quicklinkCoordinator: quicklinkCoordinator,
         windowCommandCoordinator: windowCommandCoordinator,
-        snippetExpansion: snippetExpansion, fileSearchCoordinator: fileSearchCoordinator,
+        snippetCoordinator: snippetCoordinator, fileSearchCoordinator: fileSearchCoordinator,
         notesCoordinator: notesCoordinator, extensionCoordinator: extensionCoordinator,
         calendarCoordinator: calendarCoordinator,
         core: self)
@@ -223,6 +227,7 @@ final class AppCore {
             hotKeys.onCreateNote = { [weak self] in self?.notesCoordinator.createNote() }
             hotKeys.onSearchNotes = { [weak self] in self?.notesCoordinator.searchNotes() }
             hotKeys.onSearchFiles = { [weak self] in self?.fileSearchCoordinator.show() }
+            hotKeys.onSearchSnippets = { [weak self] in self?.snippetCoordinator.showSnippets() }
             hotKeys.onShowAIChat = { [weak self] in self?.aiChatCoordinator.showChat() }
             hotKeys.onQuickAction = { [weak self] in self?.quickActionCoordinator.run($0) }
             hotKeys.onJoinNextMeeting = { [weak self] in
@@ -267,14 +272,16 @@ final class AppCore {
 
             snippetsStore.onSnapshot = { [weak self] snapshot in
                 guard let self else { return }
-                self.snippetExpansion.applySnippetsLauncherPresence()
+                self.snippetCoordinator.applySnippetsLauncherPresence()
                 self.snippetListener.update(snapshot.records)
             }
             // Off out of the box, so an unused feature costs no load, watcher or tap.
             if settings.snippetsEnabled {
                 Task { await snippetsStore.start() }
-                snippetExpansion.startSnippetKeywordListener()
+                snippetCoordinator.startSnippetKeywordListener()
             }
+            // Unconditional: a disabled feature has to take its command rows down with it.
+            snippetCoordinator.applySnippetsLauncherPresence()
 
             observeFeatureSwitches()
 
@@ -320,9 +327,9 @@ final class AppCore {
             return quicklinks.quicklink(id: id)?.name
         case .extensionCommand(let entryID):
             return appIndex.apps.first { $0.kind == .extensionCommand && $0.id == entryID }?.name
-        case .togglePalette, .toggleClipboard, .toggleEmoji, .searchFiles, .systemAction,
-            .showNotes, .createNote, .searchNotes, .windowCommand, .joinNextMeeting, .mySchedule,
-            .createEvent, .aiChat, .quickAction:
+        case .togglePalette, .toggleClipboard, .toggleEmoji, .searchFiles, .searchSnippets,
+            .systemAction, .showNotes, .createNote, .searchNotes, .windowCommand, .joinNextMeeting,
+            .mySchedule, .createEvent, .aiChat, .quickAction:
             return nil
         }
     }
@@ -401,12 +408,12 @@ final class AppCore {
                 _ = $0.fileSearchScopes
                 _ = $0.fileSearchIgnorePatterns
             }, reproject: { $0.fileSearchCoordinator.applyPolicy() })
-        track({ _ = $0.snippetsEnabled }, reproject: { $0.snippetExpansion.applySnippetsEnabled() })
+        track({ _ = $0.snippetsEnabled }, reproject: { $0.snippetCoordinator.applySnippetsEnabled() })
         // Not a feature switch, but the same re-projection: a combo has the chord's ⇧ bit baked in.
         track({ _ = $0.hyperKeyIncludesShift }, reproject: { $0.applyHyperChord() })
         track(
             { _ = $0.snippetsShowInLauncher },
-            reproject: { $0.snippetExpansion.applySnippetsLauncherPresence() })
+            reproject: { $0.snippetCoordinator.applySnippetsLauncherPresence() })
         track({ _ = $0.appearance }, reproject: { $0.applyAppearance() })
     }
 

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -74,6 +74,7 @@ struct SettingsBackup: Codable {
         var createNote: HotKeyBinding?
         var searchNotes: HotKeyBinding?
         var searchFiles: HotKeyBinding?
+        var searchSnippets: HotKeyBinding?
         var joinNextMeeting: HotKeyBinding?
         var mySchedule: HotKeyBinding?
         var createEvent: HotKeyBinding?
@@ -156,6 +157,7 @@ extension SettingsBackup {
         hotkeys.createNote = hk.binding(for: .createNote)
         hotkeys.searchNotes = hk.binding(for: .searchNotes)
         hotkeys.searchFiles = hk.binding(for: .searchFiles)
+        hotkeys.searchSnippets = hk.binding(for: .searchSnippets)
         hotkeys.joinNextMeeting = hk.binding(for: .joinNextMeeting)
         hotkeys.mySchedule = hk.binding(for: .mySchedule)
         hotkeys.createEvent = hk.binding(for: .createEvent)
@@ -410,6 +412,7 @@ extension SettingsBackup {
         if let b = hotkeys.createNote { apply(b, .createNote) }
         if let b = hotkeys.searchNotes { apply(b, .searchNotes) }
         if let b = hotkeys.searchFiles { apply(b, .searchFiles) }
+        if let b = hotkeys.searchSnippets { apply(b, .searchSnippets) }
         if let b = hotkeys.joinNextMeeting { apply(b, .joinNextMeeting) }
         if let b = hotkeys.mySchedule { apply(b, .mySchedule) }
         if let b = hotkeys.createEvent { apply(b, .createEvent) }

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -96,7 +96,7 @@ final class CalendarCoordinator {
         let enabled = settings.calendarEnabled
         appIndex.setCommandsVisible(
             [.joinNextMeeting, .copyMeetingLink, .mySchedule, .openInCalendar, .createEvent],
-            enabled)
+            enabled && settings.calendarShowInLauncher)
         guard enabled else {
             store.stop()
             clock.stop()

--- a/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
+++ b/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
@@ -9,6 +9,7 @@ enum HotKeyAction: Hashable, Sendable {
     case createNote
     case searchNotes
     case searchFiles
+    case searchSnippets
     case joinNextMeeting
     case mySchedule
     case createEvent
@@ -35,6 +36,7 @@ enum HotKeyAction: Hashable, Sendable {
         case .createNote: "hotkey.createNote"
         case .searchNotes: "hotkey.searchNotes"
         case .searchFiles: "hotkey.searchFiles"
+        case .searchSnippets: "hotkey.searchSnippets"
         case .joinNextMeeting: "hotkey.joinNextMeeting"
         case .mySchedule: "hotkey.mySchedule"
         case .createEvent: "hotkey.createEvent"
@@ -54,6 +56,6 @@ enum HotKeyAction: Hashable, Sendable {
     static let builtInActions: [HotKeyAction] =
         [
             .togglePalette, .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes,
-            .searchFiles, .joinNextMeeting, .mySchedule, .createEvent, .aiChat
+            .searchFiles, .searchSnippets, .joinNextMeeting, .mySchedule, .createEvent, .aiChat
         ] + QuickAction.allCases.map(HotKeyAction.quickAction)
 }

--- a/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
+++ b/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
@@ -11,6 +11,7 @@ final class HotKeyManager {
     var onCreateNote: (() -> Void)?
     var onSearchNotes: (() -> Void)?
     var onSearchFiles: (() -> Void)?
+    var onSearchSnippets: (() -> Void)?
     var onJoinNextMeeting: (() -> Void)?
     var onShowSchedule: (() -> Void)?
     var onCreateEvent: (() -> Void)?
@@ -145,8 +146,8 @@ final class HotKeyManager {
             if binding == nil { set.remove(entryID) } else { set.insert(entryID) }
             UserDefaults.standard.set(Array(set), forKey: boundExtensionCommandKey)
         case .togglePalette, .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes,
-            .searchFiles, .joinNextMeeting, .mySchedule, .createEvent, .aiChat, .systemAction,
-            .windowCommand, .quickAction:
+            .searchFiles, .searchSnippets, .joinNextMeeting, .mySchedule, .createEvent, .aiChat,
+            .systemAction, .windowCommand, .quickAction:
             break
         }
         candidateActionsCache = nil
@@ -209,6 +210,8 @@ final class HotKeyManager {
             return CommandID.searchNotes.name
         case .searchFiles:
             return CommandID.searchFiles.name
+        case .searchSnippets:
+            return CommandID.searchSnippets.name
         case .joinNextMeeting:
             return CommandID.joinNextMeeting.name
         case .mySchedule:
@@ -263,6 +266,7 @@ final class HotKeyManager {
         case .createNote: onCreateNote?()
         case .searchNotes: onSearchNotes?()
         case .searchFiles: onSearchFiles?()
+        case .searchSnippets: onSearchSnippets?()
         case .joinNextMeeting: onJoinNextMeeting?()
         case .mySchedule: onShowSchedule?()
         case .createEvent: onCreateEvent?()

--- a/Tinycast/Features/Launcher/Model/CommandID.swift
+++ b/Tinycast/Features/Launcher/Model/CommandID.swift
@@ -21,6 +21,8 @@ enum CommandID: String, CaseIterable, Sendable {
     case searchNotes = "command:search-notes"
     case createQuicklink = "command:create-quicklink"
     case searchQuicklinks = "command:search-quicklinks"
+    case searchSnippets = "command:search-snippets"
+    case createSnippet = "command:create-snippet"
     case importQuicklinks = "command:import-quicklinks"
     case exportQuicklinks = "command:export-quicklinks"
     case exportSettings = "command:export-settings"
@@ -53,6 +55,8 @@ enum CommandID: String, CaseIterable, Sendable {
         case .searchNotes: return "Search Notes"
         case .createQuicklink: return "Create Quicklink"
         case .searchQuicklinks: return "Search Quicklinks"
+        case .searchSnippets: return "Search Snippets"
+        case .createSnippet: return "Create Snippet"
         case .importQuicklinks: return "Import Quicklinks"
         case .exportQuicklinks: return "Export Quicklinks"
         case .exportSettings: return "Export Settings"
@@ -87,6 +91,8 @@ enum CommandID: String, CaseIterable, Sendable {
         case .searchNotes: return "text.magnifyingglass"
         case .createQuicklink: return "link.badge.plus"
         case .searchQuicklinks: return Quicklink.sfSymbol
+        case .searchSnippets: return "curlybraces"
+        case .createSnippet: return "plus.rectangle.on.rectangle"
         case .importQuicklinks: return "square.and.arrow.down"
         case .exportQuicklinks: return "square.and.arrow.up"
         case .exportSettings: return "square.and.arrow.up"
@@ -114,6 +120,7 @@ enum CommandID: String, CaseIterable, Sendable {
     var hotKeyAction: HotKeyAction? {
         switch self {
         case .searchFiles: return .searchFiles
+        case .searchSnippets: return .searchSnippets
         case .clipboardHistory: return .toggleClipboard
         case .searchEmoji: return .toggleEmoji
         case .showNotes: return .showNotes

--- a/Tinycast/Features/Launcher/Service/VisibilityStore.swift
+++ b/Tinycast/Features/Launcher/Service/VisibilityStore.swift
@@ -73,7 +73,7 @@ final class VisibilityStore {
         case .settingsPane: isKindEnabled(.systemSettings)
         case .systemAction: isKindEnabled(.systemAction)
         case .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes, .searchFiles,
-            .joinNextMeeting, .mySchedule, .createEvent, .aiChat, .quickAction:
+            .searchSnippets, .joinNextMeeting, .mySchedule, .createEvent, .aiChat, .quickAction:
             isKindEnabled(.command)
         case .togglePalette, .customCommand, .windowCommand, .quicklink, .extensionCommand:
             true

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -11,7 +11,7 @@ final class LauncherCoordinator {
     private let systemActionCoordinator: SystemActionCoordinator
     private let quicklinkCoordinator: QuicklinkCoordinator
     private let windowCommandCoordinator: WindowCommandCoordinator
-    private let snippetExpansion: SnippetExpansionCoordinator
+    private let snippetCoordinator: SnippetCoordinator
     private let fileSearchCoordinator: FileSearchCoordinator
     private let notesCoordinator: NotesCoordinator
     private let extensionCoordinator: ExtensionCoordinator
@@ -28,7 +28,7 @@ final class LauncherCoordinator {
         systemActionCoordinator: SystemActionCoordinator,
         quicklinkCoordinator: QuicklinkCoordinator,
         windowCommandCoordinator: WindowCommandCoordinator,
-        snippetExpansion: SnippetExpansionCoordinator,
+        snippetCoordinator: SnippetCoordinator,
         fileSearchCoordinator: FileSearchCoordinator,
         notesCoordinator: NotesCoordinator,
         extensionCoordinator: ExtensionCoordinator,
@@ -43,7 +43,7 @@ final class LauncherCoordinator {
         self.systemActionCoordinator = systemActionCoordinator
         self.quicklinkCoordinator = quicklinkCoordinator
         self.windowCommandCoordinator = windowCommandCoordinator
-        self.snippetExpansion = snippetExpansion
+        self.snippetCoordinator = snippetCoordinator
         self.fileSearchCoordinator = fileSearchCoordinator
         self.notesCoordinator = notesCoordinator
         self.extensionCoordinator = extensionCoordinator
@@ -106,7 +106,7 @@ final class LauncherCoordinator {
             AppLauncher.openSettingsPane(bundleID: bundleID)
         case .snippet:
             let snippetID = String(app.id.dropFirst("snippet:".count))
-            snippetExpansion.expandSnippet(id: snippetID, targetApp: previous)
+            snippetCoordinator.expandSnippet(id: snippetID, targetApp: previous)
         case .command, .customCommand, .systemAction, .windowCommand, .quicklink,
             .extensionCommand, .meeting:
             break  // handled above
@@ -154,6 +154,11 @@ final class LauncherCoordinator {
             notesCoordinator.searchNotes()
         case .searchQuicklinks:
             paletteCoordinator.showPalette(mode: .quicklinks)
+        case .searchSnippets:
+            snippetCoordinator.showSnippets()
+        case .createSnippet:
+            paletteCoordinator.hidePalette(restoreFocus: false)
+            snippetCoordinator.editSnippet(nil)
         case .createQuicklink:
             paletteCoordinator.hidePalette(restoreFocus: false)
             quicklinkCoordinator.editQuicklink(nil)

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
@@ -60,14 +60,12 @@ final class QuicklinkCoordinator {
 
     // MARK: - Feature presence
 
-    /// The switch moves section and commands together; "show in launcher" hides only the section.
+    /// Either switch off means the feature reaches the launcher not at all — rows and commands.
     func applyQuicklinksPresence() {
-        let enabled = settings.quicklinksEnabled
-        appIndex.setQuicklinks(
-            enabled && settings.quicklinksShowInLauncher ? store.quicklinks : [])
+        let visible = settings.quicklinksEnabled && settings.quicklinksShowInLauncher
+        appIndex.setQuicklinks(visible ? store.quicklinks : [])
         appIndex.setCommandsVisible(
-            [.createQuicklink, .searchQuicklinks, .importQuicklinks, .exportQuicklinks],
-            enabled)
+            [.createQuicklink, .searchQuicklinks, .importQuicklinks, .exportQuicklinks], visible)
     }
 
     // MARK: - Opening

--- a/Tinycast/Features/Snippets/Settings/SnippetsSettingsView.swift
+++ b/Tinycast/Features/Snippets/Settings/SnippetsSettingsView.swift
@@ -5,11 +5,11 @@ struct SnippetsSettingsView: View {
     @Environment(SnippetsStore.self) private var snippetsStore
     @Environment(AppSettings.self) private var settings
 
-    @State private var editor: EditorTarget?
     @State private var pendingDeletion: StoredSnippet?
 
     var body: some View {
         @Bindable var settings = settings
+        @Bindable var core = core
         return Form {
             FeatureSwitchSection(
                 header: "Snippets",
@@ -20,7 +20,7 @@ struct SnippetsSettingsView: View {
                 // Enabling is also keyword-expansion consent, so it uses the confirming setter.
                 isEnabled: Binding(
                     get: { settings.snippetsEnabled },
-                    set: { core.snippetExpansion.setSnippetsEnabled($0) }),
+                    set: { core.snippetCoordinator.setSnippetsEnabled($0) }),
                 showsInLauncher: $settings.snippetsShowInLauncher)
 
             if settings.snippetsEnabled, core.snippetListener.status == .needsAccessibility {
@@ -40,14 +40,16 @@ struct SnippetsSettingsView: View {
             }
 
             Group {
+                shortcuts
                 library
                 libraryNotices
             }
             .settingsEnabled(settings.snippetsEnabled)
         }
         .formStyle(.grouped)
-        .sheet(item: $editor) { target in
-            SnippetEditorSheet(record: target.record)
+        // Presented from the pane, so the browser's Edit and Create rows can open it too.
+        .sheet(item: $core.pendingSnippetEdit) { request in
+            SnippetEditorSheet(record: request.record)
         }
         .alert(item: $pendingDeletion) { record in
             Alert(
@@ -61,6 +63,16 @@ struct SnippetsSettingsView: View {
         }
     }
 
+    private var shortcuts: some View {
+        Section {
+            SettingsRow(title: "Search Snippets") { ShortcutRecorder(action: .searchSnippets) }
+        } header: {
+            Text("Global Shortcut")
+        } footer: {
+            Text("Opens the snippets browser, whatever app you are in.")
+        }
+    }
+
     private var library: some View {
         Section {
             if sortedSnippets.isEmpty {
@@ -70,20 +82,20 @@ struct SnippetsSettingsView: View {
                 ForEach(sortedSnippets) { record in
                     SnippetSettingsRow(
                         record: record,
-                        onEdit: { editor = EditorTarget(record: record) },
+                        onEdit: { core.snippetCoordinator.editSnippet(record) },
                         onDelete: { pendingDeletion = record })
                 }
             }
 
             LabeledContent {
-                Button("Add…") { editor = EditorTarget(record: nil) }
+                Button("Add…") { core.snippetCoordinator.editSnippet(nil) }
             } label: {
                 Text("New Snippet")
                 Text("Give the snippet a searchable name and an optional expansion keyword.")
             }
 
             LabeledContent {
-                Button("Open Folder", action: core.snippetExpansion.revealSnippetsInFinder)
+                Button("Open Folder", action: core.snippetCoordinator.revealSnippetsInFinder)
                     .accessibilityHint("Reveals this Tinycast channel’s snippets folder in Finder.")
             } label: {
                 Text("Snippets Folder")
@@ -109,7 +121,7 @@ struct SnippetsSettingsView: View {
         }
 
         // The editor reports its own failures, so this covers the ones with no sheet behind.
-        if editor == nil, let operationError = snippetsStore.operationError {
+        if core.pendingSnippetEdit == nil, let operationError = snippetsStore.operationError {
             noticeSection(
                 "The snippet operation failed", operationError, tint: .red, retryHint: nil)
         }
@@ -159,7 +171,7 @@ struct SnippetsSettingsView: View {
     }
 }
 
-private struct EditorTarget: Identifiable {
+struct SnippetEditRequest: Identifiable {
     let id = UUID()
     /// nil for a snippet that has no file yet.
     let record: StoredSnippet?

--- a/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
@@ -1,17 +1,20 @@
 import AppKit
 
-/// Owns snippet expansion: the keyword listener, the argument prompt, delivery, feature presence.
+/// Owns the snippet flow: the keyword listener, the browser, the editor handoff, delivery, presence.
 @MainActor
-final class SnippetExpansionCoordinator {
+final class SnippetCoordinator {
     private let store: SnippetsStore
     private let listener: SnippetKeywordListener
     private let injector: TextInjector
     private let clipboardStore: ClipboardStore
     private let appIndex: AppIndex
     private let settings: AppSettings
+    private let windowController: PaletteWindowController
+    private let paletteCoordinator: PaletteCoordinator
+    private let settingsCoordinator: SettingsCoordinator
     /// Routed out so `MessageHUDController` stays owned by `AppCore`.
     private let showMessage: @MainActor (String) -> Void
-    /// The consent dialog only — never for state this type owns.
+    /// The consent dialog and the `pendingSnippetEdit` handoff to the Settings pane.
     private unowned let core: AppCore
 
     init(
@@ -21,6 +24,9 @@ final class SnippetExpansionCoordinator {
         clipboardStore: ClipboardStore,
         appIndex: AppIndex,
         settings: AppSettings,
+        windowController: PaletteWindowController,
+        paletteCoordinator: PaletteCoordinator,
+        settingsCoordinator: SettingsCoordinator,
         showMessage: @escaping @MainActor (String) -> Void,
         core: AppCore
     ) {
@@ -30,6 +36,9 @@ final class SnippetExpansionCoordinator {
         self.clipboardStore = clipboardStore
         self.appIndex = appIndex
         self.settings = settings
+        self.windowController = windowController
+        self.paletteCoordinator = paletteCoordinator
+        self.settingsCoordinator = settingsCoordinator
         self.showMessage = showMessage
         self.core = core
     }
@@ -67,8 +76,10 @@ final class SnippetExpansionCoordinator {
 
     // MARK: - Feature presence
 
+    /// Either switch off means the feature reaches the launcher not at all — rows and commands.
     func applySnippetsLauncherPresence() {
         let visible = settings.snippetsEnabled && settings.snippetsShowInLauncher
+        appIndex.setCommandsVisible([.searchSnippets, .createSnippet], visible)
         appIndex.updateSnippets(visible ? store.snippets : [])
     }
 
@@ -84,7 +95,26 @@ final class SnippetExpansionCoordinator {
         listener.stop()
         injector.cancelAutomaticExpansion()
         store.stop()
-        appIndex.updateSnippets([])
+        applySnippetsLauncherPresence()
+    }
+
+    // MARK: - Browsing and editing
+
+    /// The switch gates the browser, the way Search Files re-checks its own before opening.
+    func showSnippets() {
+        guard settings.snippetsEnabled else { return }
+        paletteCoordinator.showPalette(mode: .snippets)
+    }
+
+    /// Opens the Snippets pane with the editor showing `record`; nil is a new snippet.
+    func editSnippet(_ record: StoredSnippet?) {
+        core.pendingSnippetEdit = SnippetEditRequest(record: record)
+        settingsCoordinator.showSettings(tab: .snippets)
+    }
+
+    func showSnippetInFinder(_ record: StoredSnippet) {
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        AppLauncher.showInFinder(record.fileURL)
     }
 
     // MARK: - Expansion
@@ -119,6 +149,13 @@ final class SnippetExpansionCoordinator {
             history.insert(current, at: 0)
         }
         return history
+    }
+
+    /// The browser's ↵. The target has to be read before the panel hides, as the launcher's does.
+    func expandSnippetFromPalette(id: StoredSnippet.ID) {
+        let target = windowController.previousApp
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        expandSnippet(id: id, targetApp: target)
     }
 
     func expandSnippet(

--- a/Tinycast/Features/Snippets/UI/SnippetsListView.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetsListView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+struct SnippetsList: View {
+    let results: [StoredSnippet]
+    let selectedID: StoredSnippet.ID?
+    let scroll: ScrollIntent
+    let onSelect: (StoredSnippet) -> Void
+    let onActivate: () -> Void
+    let onActions: (StoredSnippet) -> Void
+
+    private var firstRowSelected: Bool {
+        selectedID != nil && selectedID == results.first?.id
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(results) { record in
+                        SnippetRow(record: record, selected: record.id == selectedID)
+                            .selectionFrame(record.id == selectedID)
+                            .contentShape(Rectangle())
+                            .onTapGesture { onSelect(record) }
+                            .simultaneousGesture(
+                                TapGesture(count: 2).onEnded {
+                                    onSelect(record)
+                                    onActivate()
+                                }
+                            )
+                            .onRightClick { onActions(record) }
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.xs)
+                .padding(.bottom, Theme.Spacing.md)
+                .hideNativeScrollers()
+                .scrollOriginAnchor()
+            }
+            .edgeDissolve()
+            .thinScrollbar()
+            .scrollFollowsSelection(
+                scroll, row: selectedID, atOrigin: firstRowSelected, proxy: proxy)
+        }
+    }
+}
+
+private struct SnippetRow: View {
+    let record: StoredSnippet
+    let selected: Bool
+    @State private var hovered = false
+
+    private var fill: Color {
+        if selected { return Theme.Colors.selection }
+        if hovered { return Theme.Colors.rowHover }
+        return .clear
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                .fill(Theme.Colors.controlSurface)
+                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .overlay(
+                    Image(systemName: "curlybraces")
+                        .font(.system(size: 12))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary))
+            Text(record.snippet.name)
+                .font(Theme.Typography.rowTitle)
+                .lineLimit(1)
+            Spacer(minLength: Theme.Spacing.lg)
+            if let keyword = record.snippet.keyword, !keyword.isEmpty {
+                Text(keyword)
+                    .font(Theme.Typography.keyCap)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous).fill(fill)
+        )
+        .armedHover($hovered)
+    }
+}
+
+struct SnippetPreview: View {
+    let record: StoredSnippet?
+
+    var body: some View {
+        if let record {
+            VStack(alignment: .leading, spacing: 0) {
+                // The raw template: expanding here would read the clipboard on every arrow key.
+                ScrollView {
+                    Text(record.snippet.text)
+                        .font(.system(.subheadline, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                SnippetInfoSection(record: record)
+            }
+            .padding(.horizontal, 12)
+        } else {
+            Color.clear
+        }
+    }
+}
+
+/// The "Information" block; everything in it is already in memory, so nothing is gathered off-main.
+private struct SnippetInfoSection: View {
+    let record: StoredSnippet
+
+    private struct InfoRow: Identifiable {
+        let label: String
+        let value: String
+        var id: String { label }
+    }
+
+    private var rows: [InfoRow] {
+        var rows = [InfoRow(label: "Name", value: record.snippet.name)]
+        if let keyword = record.snippet.keyword, !keyword.isEmpty {
+            rows.append(InfoRow(label: "Keyword", value: keyword))
+        }
+        rows.append(InfoRow(label: "File", value: record.fileURL.lastPathComponent))
+        rows.append(
+            InfoRow(label: "Characters", value: record.snippet.text.count.formatted()))
+        return rows
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Information")
+                .font(Theme.Typography.sectionHeader)
+                .foregroundStyle(.secondary)
+            VStack(spacing: 0) {
+                let rows = self.rows
+                ForEach(rows) { row in
+                    if row.id != rows.first?.id { Divider() }
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Text(row.label).foregroundStyle(.secondary)
+                        Spacer(minLength: Theme.Spacing.lg)
+                        Text(row.value).lineLimit(1).truncationMode(.middle)
+                    }
+                    .font(Theme.Typography.keyCap)
+                    .padding(.vertical, Theme.Spacing.xs)
+                }
+            }
+        }
+        .padding(.vertical, Theme.Spacing.md)
+    }
+}

--- a/Tinycast/Features/Snippets/UI/SnippetsScreen.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetsScreen.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// Search Snippets: the enabled library filtered by the search field, previewed before it pastes.
+struct SnippetsScreen: PaletteScreen {
+    let store: SnippetsStore
+    let core: AppCore
+    let vm: PaletteState
+    let openActions: () -> Void
+
+    /// A disabled snippet is off everywhere, so the browser lists exactly what the launcher does.
+    var rows: [StoredSnippet] {
+        let enabled = store.snippets.filter { $0.snippet.isEnabled }
+        let query = vm.query.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return enabled }
+        return enabled.filter { record in
+            record.snippet.name.localizedCaseInsensitiveContains(query)
+                || record.snippet.keyword?.localizedCaseInsensitiveContains(query) == true
+        }
+    }
+
+    let primaryActionTitle = "Paste Snippet"
+
+    private func record(at selection: Int) -> StoredSnippet? {
+        let rows = rows
+        return rows.indices.contains(selection) ? rows[selection] : nil
+    }
+
+    func actions(at selection: Int) -> PopoverMenuContent? {
+        guard let record = record(at: selection) else { return nil }
+        return SnippetActionsMenu.content(record: record, core: core)
+    }
+
+    func activate(at selection: Int) {
+        guard let record = record(at: selection) else { return }
+        core.snippetCoordinator.expandSnippetFromPalette(id: record.id)
+    }
+
+    func secondary(at selection: Int) -> Bool { false }
+
+    func body(selection: Int, scroll: ScrollIntent) -> AnyView {
+        AnyView(content(selection: selection, scroll: scroll))
+    }
+
+    @ViewBuilder
+    private func content(selection: Int, scroll: ScrollIntent) -> some View {
+        let rows = rows
+        if rows.isEmpty {
+            EmptyResults(text: emptyMessage)
+        } else {
+            let selected = record(at: selection)
+            HStack(spacing: 0) {
+                SnippetsList(
+                    results: rows, selectedID: selected?.id, scroll: scroll,
+                    onSelect: { record in
+                        vm.selection = rows.firstIndex(of: record) ?? 0
+                    },
+                    onActivate: { activate(at: vm.selection) },
+                    onActions: { record in
+                        if let index = rows.firstIndex(of: record) { vm.selection = index }
+                        openActions()
+                    }
+                )
+                .frame(width: Theme.Size.clipboardListWidth)
+                Rectangle().fill(Theme.Colors.separator).frame(width: Theme.Size.hairline)
+                SnippetPreview(record: selected)
+            }
+        }
+    }
+
+    /// An empty library and an over-narrow filter are different problems with different answers.
+    private var emptyMessage: String {
+        if store.state == .loading { return "Loading snippets…" }
+        return store.snippets.contains(where: { $0.snippet.isEnabled })
+            ? "No matching snippets" : "No snippets yet"
+    }
+}
+
+@MainActor
+enum SnippetActionsMenu {
+    static func content(record: StoredSnippet, core: AppCore) -> PopoverMenuContent {
+        PopoverMenuContent(
+            header: record.snippet.name,
+            items: [
+                PopoverMenuItem(title: "Paste Snippet", systemImage: "text.quote", shortcut: "↵") {
+                    core.snippetCoordinator.expandSnippetFromPalette(id: record.id)
+                },
+                PopoverMenuItem(title: "Edit Snippet", systemImage: "pencil") {
+                    core.paletteCoordinator.hidePalette(restoreFocus: false)
+                    core.snippetCoordinator.editSnippet(record)
+                },
+                PopoverMenuItem(title: "Create Snippet", systemImage: "plus") {
+                    core.paletteCoordinator.hidePalette(restoreFocus: false)
+                    core.snippetCoordinator.editSnippet(nil)
+                },
+                PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {
+                    core.snippetCoordinator.showSnippetInFinder(record)
+                }
+            ])
+    }
+}

--- a/Tinycast/Palette/PaletteMode.swift
+++ b/Tinycast/Palette/PaletteMode.swift
@@ -11,6 +11,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     case schedule
     case uninstall
     case quicklinks
+    case snippets
     /// Collects a quicklink's `{argument}` values; the request lives on the session.
     case quicklinkArguments
     /// A Raycast extension command rendering into the palette.
@@ -29,6 +30,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .schedule: return "calendar"
         case .uninstall: return "trash"
         case .quicklinks, .quicklinkArguments: return Quicklink.sfSymbol
+        case .snippets: return "curlybraces"
         case .extensionCommand: return "puzzlepiece.extension"
         }
     }
@@ -44,6 +46,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .schedule: return "Search your schedule…"
         case .uninstall: return "Filter files and folders by name…"
         case .quicklinks: return "Search quicklinks…"
+        case .snippets: return "Search snippets…"
         // Replaced by the pending argument's name; only reached if the session vanished mid-render.
         case .quicklinkArguments: return "Enter a value…"
         // Replaced by the command's own `searchBarPlaceholder` whenever it declares one.

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -235,6 +235,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             .environment(core.uninstall)
             .environment(core.quicklinks)
             .environment(core.quicklinkArguments)
+            .environment(core.snippetsStore)
             .environment(core.extensions)
             .environment(core.calendarStore)
             .environment(core.meetingClock)

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -19,6 +19,7 @@ struct RootPaletteView: View {
     @Environment(UninstallSession.self) private var uninstall
     @Environment(QuicklinkStore.self) private var quicklinks
     @Environment(QuicklinkArgumentSession.self) private var quicklinkArguments
+    @Environment(SnippetsStore.self) private var snippets
     @Environment(ExtensionManager.self) private var extensions
     @Environment(AppSettings.self) private var settings
     @FocusState private var searchFocused: Bool
@@ -56,6 +57,9 @@ struct RootPaletteView: View {
         case .quicklinks:
             return QuicklinkListScreen(
                 store: quicklinks, core: core, vm: vm, openActions: openActions)
+        case .snippets:
+            return SnippetsScreen(
+                store: snippets, core: core, vm: vm, openActions: openActions)
         case .emoji:
             return EmojiScreen(
                 index: emojiIndex, frequent: frequentEmoji, core: core, vm: vm,

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -118,8 +118,9 @@ nothing ticking.
 
 ## Commands
 
-All five leave the launcher when the feature is off, through `CalendarCoordinator.applyEnabled`,
-the `applyQuicklinksPresence` twin.
+All five leave the launcher when the feature is off **or** when "Show in launcher" is, through
+`CalendarCoordinator.applyEnabled`, the `applyQuicklinksPresence` twin. Their shortcuts, the join
+card and the menu bar are unaffected: only launcher search is.
 
 | Command | Does | Bindable |
 | --- | --- | --- |

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -49,9 +49,9 @@ but the guarantee that every decode runs through the initializer that masks devi
 `SettingsBackup.HotkeyBackup` stores the same values, so the backup file carries this shape too; only
 export → import within one build is guaranteed to round-trip.
 
-`hotkey.searchFiles`, `hotkey.toggleClipboard`, `hotkey.toggleEmoji`, `hotkey.showNotes`,
-`hotkey.createNote`, `hotkey.searchNotes`, `hotkey.joinNextMeeting`, `hotkey.mySchedule` and
-`hotkey.createEvent` are the built-in launcher commands with an action of their own, alongside `hotkey.togglePalette`, which has no command row. They are the only `CommandID`s whose
+`hotkey.searchFiles`, `hotkey.searchSnippets`, `hotkey.toggleClipboard`, `hotkey.toggleEmoji`,
+`hotkey.showNotes`, `hotkey.createNote`, `hotkey.searchNotes`, `hotkey.joinNextMeeting`,
+`hotkey.mySchedule` and `hotkey.createEvent` are the built-in launcher commands with an action of their own, alongside `hotkey.togglePalette`, which has no command row. They are the only `CommandID`s whose
 `hotKeyAction` is non-nil — which is what puts a recorder on their rows in Settings ▸ Commands, and a
 keycap on their launcher rows. Each is also reachable from its own feature pane, so it is one binding
 from two places, not two settings. `HotKeyManager` names them all through `CommandID`, so a conflict

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -77,6 +77,7 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 | `.schedule` | `ScheduleScreen` | `ScheduleList` (see [calendar.md](calendar.md)) |
 | `.uninstall` | `UninstallScreen` | `UninstallList` (see [uninstall.md](uninstall.md)) |
 | `.quicklinks` | `QuicklinkListScreen` | `QuicklinkList` |
+| `.snippets` | `SnippetsScreen` | `SnippetsList` + preview (see [snippets.md](snippets.md#search-snippets)) |
 | `.quicklinkArguments` | `QuicklinkArgumentsScreen` | `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt)) |
 | `.extensionCommand` | `ExtensionCommandScreen` | `ExtensionCommandView` (see [extensions.md](extensions.md)) |
 

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -24,7 +24,7 @@ provider protocol and the connections behind it.
   own window. Hiding there rather than at each caller is what keeps the two paths identical.
 - **Enabling is consent, and it is the only place Accessibility is requested.** The toggle confirms
   through `DialogController` first and then calls `Permissions.ensureAccessibility()`, the pattern
-  `SnippetExpansionCoordinator.setSnippetsEnabled` established. Everything else — a shortcut press, a
+  `SnippetCoordinator.setSnippetsEnabled` established. Everything else — a shortcut press, a
   delivery — uses `isAccessibilityTrusted()` and degrades to a HUD.
 - **Tinycast is never the target.** `QuickActionRunner.selection(in:using:)` refuses our own bundle
   identifier, and `TextInjector.targetAcceptsInjection` refuses it again before every event post,

--- a/docs/features/quicklinks.md
+++ b/docs/features/quicklinks.md
@@ -123,7 +123,8 @@ Tinycast's own dialog and leaves no partial state.
 Quicklinks are their own `AppEntry.Kind`, their own `AppIndex` slice and their own launcher section,
 between System Settings and Snippets. Only the **name** is indexed; the destination is not searchable
 (a URL is a subsequence of almost any query). Per-quicklink "Show in root search" filters the slice;
-the pane's "Show in launcher" hides the whole section.
+the pane's "Show in launcher" takes the section and the four Quicklink commands out of the
+launcher together, leaving shortcuts and the pane itself working.
 
 `Quicklink.precedes` is the one display order — pinned first in the order they were pinned, then the
 rest by name — and both the store and the launcher slice sort through it, so the two can never

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -1,7 +1,8 @@
 # Snippets
 
 Snippets are reusable plain-text templates stored as Markdown. They can be expanded from launcher
-results, or automatically when an enabled keyword is typed in another app.
+results, from the dedicated browser below, or automatically when an enabled keyword is typed in
+another app.
 
 ## Invariants
 
@@ -47,10 +48,10 @@ is the whole feature, keyword expansion included — there is no separate expans
 enabling it doubles as keyword-expansion consent: it confirms with an explanation first, then
 requests Accessibility, and it ships off. Switching it off is a full teardown — the keyword listener,
 the store and its watchers stop, and the launcher section disappears — while the files and the toggle
-states survive for re-enabling. "Show in launcher" only hides the launcher section; keyword expansion
-keeps working. `snippetsShowInLauncher` travels in settings backups; `snippetsEnabled` deliberately
-does not, so an import can never enable keystroke listening. `AppCore`'s settings sinks re-project on
-every change.
+states survive for re-enabling. "Show in launcher" takes the section and the two Snippet commands out
+of the launcher together; keyword expansion and the browser's shortcut keep working.
+`snippetsShowInLauncher` travels in settings backups; `snippetsEnabled` deliberately does not, so an
+import can never enable keystroke listening. `AppCore`'s settings sinks re-project on every change.
 
 ## Importing from Raycast
 
@@ -157,6 +158,10 @@ Its name and keyword are both searchable, scored in the same tiers as an app's n
 above an app only when it genuinely matches better. Launcher expansion may interactively request
 Accessibility because it begins from an explicit user action.
 
+`Search Snippets` and `Create Snippet` are launcher commands of their own, and either switch takes
+them out with the rows: "Show in launcher" off means the feature reaches launcher search not at all.
+The browser stays reachable by its global shortcut, and the editor from the pane.
+
 Automatic keyword expansion comes with the feature switch: enabling snippets in
 **Settings → Snippets** first shows an explanation, then stores the flag and requests Accessibility if
 it is missing. The flag is intentionally excluded from settings backups, so importing a backup cannot
@@ -185,6 +190,32 @@ duplicates resolve by file identity. Tinycast-tagged synthetic events are ignore
 Immediately before deleting a matched keyword and before inserting its expansion, automatic delivery
 re-checks consent, both permissions, Secure Event Input, the captured target app, and cancellation
 generation. A failed gate leaves the typed keyword untouched.
+
+## Search Snippets
+
+`PaletteMode.snippets` is a dedicated browser, reached by the `Search Snippets` command or by the
+global shortcut recorded in **Settings → Snippets**. Like Search Quicklinks it stays out of the Tab
+cycle and exits with Escape or a bare backspace, and like the clipboard it splits into a list and a
+preview.
+
+The list is every **enabled** snippet — a disabled one is absent here exactly as it is absent from the
+launcher — filtered by name *or* keyword. Substring matching, not the launcher's fuzzy scorer: this is
+a library being browsed rather than a query racing apps and commands for a rank.
+
+The preview shows the **raw template**, never an expansion. Expanding per selection would capture the
+clipboard, read the target's selected text and burn a `{uuid}` on every arrow key, and a snippet
+carrying `{argument}` would raise its prompt just to draw a pane. Beside it sits the name, keyword,
+file name and character count.
+
+↵ and the ⌘K menu's **Paste Snippet** both go through `SnippetCoordinator.expandSnippetFromPalette`,
+which reads `previousApp` before hiding the panel and then calls the same `expandSnippet` funnel a
+launcher row does — so template expansion, cursor placement, the Accessibility prompt, the
+confirmation HUD and the pasteboard lease are the ones described below, not a second copy of them.
+The rest of the menu is **Edit Snippet** and **Create Snippet**, which hand off to the pane's editor
+through `AppCore.pendingSnippetEdit`, and **Show in Finder**.
+
+`Create Snippet` is a launcher command as well as a menu row because the palette swallows ⌘K when a
+screen has no rows: an empty library would otherwise open a browser with nothing to do.
 
 ## Confirmation HUD
 


### PR DESCRIPTION
Closes #367.

## What this adds

`PaletteMode.snippets` — a dedicated Snippets surface with its own **Search snippets…** field, a list of every enabled snippet, and a preview beside it. Reached by the new `Search Snippets` command or by one global shortcut recorded in **Settings → Snippets**.

It is a sub-screen like Search Quicklinks: out of the Tab ring, left by Escape or a bare backspace.

## Reusing the expansion path, not copying it

↵ and ⌘K's **Paste Snippet** both call `SnippetCoordinator.expandSnippetFromPalette`, which reads `previousApp` before the panel hides and then enters the same `expandSnippet` funnel a launcher row does. Template expansion, cursor placement, the Accessibility prompt, the confirmation HUD and the pasteboard lease are therefore the ones snippets already had — there is no second delivery path to drift.

Typed-keyword expansion and the launcher's snippet rows are unchanged, and both the feature switch and each snippet's `enabled` flag are respected: a disabled snippet is absent here exactly as it is absent from the launcher.

## Two deliberate choices

**The preview shows the raw template, never an expansion.** Expanding per selection would capture the clipboard, read the target's selected text and burn a `{uuid}` on every arrow key — and a snippet carrying `{argument}` would raise its prompt just to draw a pane.

**`Create Snippet` is a launcher command, not only a ⌘K row.** `RootPaletteView` swallows ⌘K when a screen has no rows, so on an empty library the browser would otherwise open with nothing to do.

`SnippetExpansionCoordinator` is renamed `SnippetCoordinator`: it now owns browsing and the editor handoff as well as expansion.

## Second commit: a launcher-visibility bug this surfaced

Adding snippet commands exposed an existing defect. **"Show in launcher" gated a feature's item rows but never its built-in commands**, which were tied to the enable switch alone — so turning the toggle off emptied the section and left the commands in root search.

| Feature | Rows that lingered |
| --- | --- |
| Quicklinks | Create / Search / Import / Export Quicklinks |
| Calendar | Join Next Meeting, Copy Meeting Link, My Schedule, Open in Calendar, Create Event |

Calendar's meeting entries already obeyed `calendarShowInLauncher`; its five commands did not. Each presence function now computes one `visible` and feeds every call from it, so a feature's rows and its commands cannot disagree. Nothing outside launcher search moves — shortcuts still fire, and Calendar keeps its join card and menu bar.

Custom Commands, Window Management and Extensions were audited and were already correct: each contributes only item rows, gated on both switches.

## Verification

`./Scripts/run-tests.sh` (49 harnesses), `./Scripts/lint.sh`, the purity grep, and a Debug build all pass with no new warnings. `hotkey-test` gains the `searchSnippets` mapping and `palette-tab-test` gains `.snippets` as a sub-screen.

**Not verified by me:** the GUI flow itself. This shell has neither Accessibility nor Screen Recording, so I could not summon or screenshot the palette — the manual sweep in `docs/testing.md` is worth running before merge, particularly paste parity between the browser, a launcher row and a typed keyword.

Docs updated in the same commits: `snippets.md` (new **Search Snippets** section), `palette.md`, `hotkeys.md`, `quicklinks.md`, `calendar.md`, `quick-actions.md`.