### PR TITLE
Summon the palette when a view command is launched by its own shortcut

### DIFF
--- a/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
@@ -147,6 +147,10 @@ final class ExtensionCoordinator {
         case .view:
             // Switch the palette over first, so the launching state is what the user sees.
             palette.prepare(mode: .extensionCommand)
+            // A shortcut fires while hidden, where a view command has nowhere to render.
+            if !paletteCoordinator.isVisible {
+                paletteCoordinator.showPalette(mode: .extensionCommand)
+            }
             Task { await extensions.run(owner, command: command, arguments: arguments) }
         case .noView, .menuBar:
             // A no-view command's own HUD is the feedback, so the palette gets out of the way.

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -309,6 +309,9 @@ A global shortcut binds to a **command**, not to an extension — a shortcut has
 run, and an extension is a set of commands. `HotKeyAction.extensionCommand` is keyed by the launcher
 entry id (`extension:<extension>/<command>`).
 
+A view command summons the palette when the shortcut fires while it is hidden, or it would load
+behind a closed window. A no-view command still hides it and reports through its HUD.
+
 Its index is not pruned at launch the way the UUID-keyed ones are: the installed set is scanned
 asynchronously and only while extensions are on, so at launch "not installed yet" and "gone" look
 identical, and pruning there would quietly drop a working binding. Uninstalling clears its own instead,


### PR DESCRIPTION
## Related issue

Closes #357.

## What changed

The `.view` branch of `ExtensionCoordinator.runExtensionCommand` only called
`palette.prepare(mode:)` — a state switch with no window in it. That is enough from the launcher,
where the palette is already up, but a global shortcut is only ever pressed while it's hidden, so
the command loaded and ran behind a closed panel until the next unrelated ⌥Space revealed it.

It now summons the palette when it isn't visible. `prepare` stays first so `showPalette` skips
re-preparing, and the guard leaves the launcher path untouched. `.noView` and `.menuBar` are
unchanged.

## Tested

Bound `kill-process` to a shortcut and pressed it with the palette hidden: the list appears at once.
Reverted the four lines, rebuilt, repeated — nothing appears, and the next ⌥Space shows it already
loaded, the reported symptom. Launcher path unchanged.

## Tests & validation

All 49 harnesses pass, Debug builds with no new warnings, `lint.sh` clean. No harness covers it:
`ExtensionCoordinator` is `@MainActor` wiring around a window controller, and the harnesses run
without a window server.

