### PR TITLE
Run on Intel Macs under macOS 26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ permissions:
 jobs:
   build:
     runs-on: macos-26
+    # Consumed by the `universal` job, so the channel identity is derived in exactly one place.
+    outputs:
+      full_version: ${{ steps.meta.outputs.full_version }}
+      display_name: ${{ steps.meta.outputs.display_name }}
+      bundle_id: ${{ steps.meta.outputs.bundle_id }}
     steps:
       - uses: actions/checkout@v7
 
@@ -90,13 +95,28 @@ jobs:
           BUNDLE_ID: ${{ steps.meta.outputs.bundle_id }}
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
+          # ARCHS pinned to what this channel has always shipped: trusting ARCHS_STANDARD is what
+          # let a thin arm64 build reach Intel users once already (compat/README.md).
           xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Release \
             -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            ARCHS=arm64 ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="Tinycast Self-Signed" \
             OTHER_CODE_SIGN_FLAGS="--timestamp=none" \
             PRODUCT_NAME="$DISPLAY_NAME" PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
             MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             build
+
+      # Apple silicon users pay for no Intel slice: assert the download stays thin.
+      - name: Assert the build is arm64-only
+        env:
+          DISPLAY_NAME: ${{ steps.meta.outputs.display_name }}
+        run: |
+          BIN="$RUNNER_TEMP/DerivedData/Build/Products/Release/${DISPLAY_NAME}.app/Contents/MacOS/${DISPLAY_NAME}"
+          SLICES="$(lipo -archs "$BIN")"
+          if [ "$SLICES" != "arm64" ]; then
+            echo "::error::expected arm64 alone, got '$SLICES'"
+            exit 1
+          fi
 
       # Two artifacts from one build: the DMG people download and the cask installs, and the zip
       # the in-app updater installs — it expands with `ditto` instead of mounting a volume.
@@ -235,3 +255,143 @@ jobs:
             }' > payload.json
           curl -fsS -X POST -H "Content-Type: application/json" -d @payload.json \
             "${DISCORD_WEBHOOK_URL}?with_components=true"
+
+  # macOS 26 is the last release to boot on Intel, so stable also ships a universal build under its
+  # own cask. Same tag, version, bundle id and signature — only the slices and filenames differ, so
+  # nothing here can change what the Apple silicon job above publishes.
+  universal:
+    needs: build
+    if: github.event.inputs.channel == 'stable'
+    runs-on: macos-26
+    env:
+      VERSION: ${{ needs.build.outputs.full_version }}
+      DISPLAY_NAME: ${{ needs.build.outputs.display_name }}
+      BUNDLE_ID: ${{ needs.build.outputs.bundle_id }}
+      CASK: tinycast-universal
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode 26
+        run: |
+          XCODE_PATH="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -n1)"
+          if [ -z "$XCODE_PATH" ]; then
+            echo "::error::No Xcode 26.x found on this runner. Installed Xcodes:"
+            ls /Applications | grep -i xcode || true
+            exit 1
+          fi
+          echo "Using $XCODE_PATH"
+          echo "DEVELOPER_DIR=$XCODE_PATH/Contents/Developer" >> "$GITHUB_ENV"
+
+      # The SAME identity as the thin build, and a hard failure if it is missing: the in-app updater
+      # compares the staged bundle's leaf certificate against the running app's before installing.
+      - name: Import signing certificate
+        env:
+          P12_BASE64: ${{ secrets.SIGNING_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.SIGNING_P12_PASSWORD }}
+        run: |
+          if [ -z "${P12_BASE64}" ]; then
+            echo "::error::SIGNING_P12_BASE64 not set — a differently-signed build cannot self-update."
+            exit 1
+          fi
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KPW="$(openssl rand -base64 24)"
+          echo "${P12_BASE64}" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KPW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KPW" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "${P12_PASSWORD}" -A -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KPW" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed 's/"//g')
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Build app
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Release \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="Tinycast Self-Signed" \
+            OTHER_CODE_SIGN_FLAGS="--timestamp=none" \
+            PRODUCT_NAME="$DISPLAY_NAME" PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+            MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            build
+
+      # A silently-dropped ARCHS override would publish a thin build under the universal name, which
+      # is the one mistake this whole channel exists to prevent.
+      - name: Assert both slices on the shipping binary
+        run: |
+          APP="$RUNNER_TEMP/DerivedData/Build/Products/Release/${DISPLAY_NAME}.app"
+          BIN="$APP/Contents/MacOS/${DISPLAY_NAME}"
+          SLICES="$(lipo -archs "$BIN")"
+          PLIST_MIN="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$APP/Contents/Info.plist")"
+          echo "arch=$SLICES LSMinimumSystemVersion=$PLIST_MIN"
+          if [ "$PLIST_MIN" != "26.0" ]; then
+            echo "::error::expected LSMinimumSystemVersion 26.0, got $PLIST_MIN"
+            exit 1
+          fi
+          for A in arm64 x86_64; do
+            case " $SLICES " in
+              *" $A "*) ;;
+              *) echo "::error::no $A slice — this is not a universal build"; exit 1 ;;
+            esac
+            MINOS="$(xcrun vtool -arch "$A" -show-build-version "$BIN" | awk '/minos/{print $2}')"
+            if [ "$MINOS" != "26.0" ]; then
+              echo "::error::$A: expected a macOS 26.0 floor, got minos=$MINOS"
+              exit 1
+            fi
+          done
+
+      - name: Package DMG and ZIP
+        run: |
+          APP="$RUNNER_TEMP/DerivedData/Build/Products/Release/${DISPLAY_NAME}.app"
+          STAGE="$(mktemp -d)"
+          cp -R "$APP" "$STAGE/"
+          ln -s /Applications "$STAGE/Applications"
+          mkdir -p dist
+          diskutil image create from "$STAGE" --format UDZO --volumeName "$DISPLAY_NAME" \
+            "dist/Tinycast-Universal-${VERSION}.dmg"
+          ditto -c -k --keepParent --sequesterRsrc "$APP" "dist/Tinycast-Universal-${VERSION}.zip"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Tinycast-Universal-${{ needs.build.outputs.full_version }}
+          path: dist/
+
+      # Upload, never create: the build job owns the release. Uploading second also keeps the thin
+      # zip first in the asset list, so clients predating architecture-aware selection still take it.
+      - name: Attach to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "v${VERSION}" \
+            "dist/Tinycast-Universal-${VERSION}.dmg" \
+            "dist/Tinycast-Universal-${VERSION}.zip"
+
+      - name: Update Homebrew cask
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${TAP_TOKEN}" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN secret not set — skipping cask bump."
+            exit 0
+          fi
+          SHA="$(shasum -a 256 "dist/Tinycast-Universal-${VERSION}.dmg" | awk '{print $1}')"
+          git clone --depth 1 "https://x-access-token:${TAP_TOKEN}@github.com/abue-ammar/homebrew-tinycast.git" tap
+          CASK_FILE="tap/Casks/${CASK}.rb"
+          if [ ! -f "$CASK_FILE" ]; then
+            echo "::error::$CASK_FILE not found in tap."
+            exit 1
+          fi
+          sed -i '' -E "s|^  version \".*\"|  version \"${VERSION}\"|" "$CASK_FILE"
+          sed -i '' -E "s|^  sha256 \".*\"|  sha256 \"${SHA}\"|" "$CASK_FILE"
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "Casks/${CASK}.rb"
+          if git diff --cached --quiet; then
+            echo "No cask changes to commit."
+          else
+            git commit -m "${CASK} ${VERSION}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -44,23 +44,31 @@ browser: JavaScriptCore ships with macOS, so that costs no extra binary size.
 
 ## Install
 
+First, add the tap:
+
 ```sh
 brew trust --tap abue-ammar/tinycast   # required for third-party taps
 brew tap abue-ammar/tinycast
-brew install --cask tinycast          # stable
-brew install --cask tinycast@beta     # beta  (installs side-by-side)
-brew install --cask tinycast-sequoia  # stable channel  (macOS 15 Sequoia)
 ```
 
-Tinycast also runs on macOS 15 Sequoia — install the `tinycast-sequoia` cask above.
+Then run the one line that matches your Mac:
 
-Each channel is a separate app (`Tinycast.app`, `Tinycast Beta.app`) with its own settings and
-permissions, so you can run stable next to the beta.
+| Your Mac | Install |
+| --- | --- |
+| Apple silicon, macOS 26 or newer | `brew install --cask tinycast` |
+| Intel, macOS 26 | `brew install --cask tinycast-universal` |
+| macOS 15 Sequoia | `brew install --cask tinycast-sequoia` |
 
-Tinycast is self-signed. Installing via Homebrew clears the macOS quarantine flag for you
-automatically on every install and update, so there's nothing to run. (If you download the DMG
-directly from Releases instead, clear it once: `xattr -dr com.apple.quarantine
-"/Applications/Tinycast.app"`.)
+Not sure which you have? **Apple menu → About This Mac.** Homebrew checks too, and refuses the
+wrong one.
+
+Want early builds? `brew install --cask tinycast@beta` puts `Tinycast Beta.app` beside the stable
+app, with its own settings and permissions. Apple silicon, macOS 26+.
+
+Homebrew clears the macOS quarantine flag on every install and update, so there is nothing else to
+run. Downloading a DMG from [Releases](https://github.com/abue-ammar/tinycast/releases) instead?
+Tinycast is self-signed, so clear the flag once:
+`xattr -dr com.apple.quarantine "/Applications/Tinycast.app"`.
 
 ## Permissions
 

--- a/Scripts/release-notes.sh
+++ b/Scripts/release-notes.sh
@@ -55,6 +55,10 @@ CHANGELOG="$(printf '%s\n' "$GENERATED" | sed -E \
     printf '\n\n'
     printf '%s\n' "**Recommended:** install via Homebrew — it clears the quarantine flag automatically on every install and update, so there's nothing to run by hand:"
     printf '```sh\nbrew trust --tap abue-ammar/tinycast\nbrew install --cask abue-ammar/tinycast/%s\n```\n' "$CASK"
+    # The stable DMG is arm64-only; macOS 26 is the last release that boots on Intel.
+    if [ "$CHANNEL" = "stable" ]; then
+        printf '%s\n' "On an **Intel** Mac, install \`abue-ammar/tinycast/tinycast-universal\` instead — same app, built with both slices."
+    fi
     printf '%s\n' "This build is self-signed. If you download the DMG directly instead of using Homebrew, macOS will refuse to open it until you clear the quarantine flag once:"
     printf '```sh\nxattr -dr com.apple.quarantine "/Applications/%s.app"\n```\n' "$DISPLAY_NAME"
 } > "$BODY_OUT"

--- a/Tests/updates-test.swift
+++ b/Tests/updates-test.swift
@@ -21,6 +21,7 @@ struct UpdatesTests {
         roundTripsVersionsThroughJSON()
         derivesChannels()
         picksNewestForChannel()
+        picksTheZipThisMacCanRun()
         rejectsUnusableFeeds()
         offersOnlyWhatIsWorthInstalling()
         keepsOnlyTheChangelog()
@@ -126,18 +127,19 @@ struct UpdatesTests {
     }
 
     static func entry(
-        tag: String, prerelease: Bool, draft: Bool = false, asset: String? = "Tinycast-x.zip",
+        tag: String, prerelease: Bool, draft: Bool = false, assets: [String] = ["Tinycast-x.zip"],
         body: String = "Notes."
     ) -> String {
-        let assets = asset.map {
+        let list = assets.map {
             """
-            [{"name":"\($0)","size":1024,
-              "browser_download_url":"https://example.invalid/\($0)"}]
+            {"name":"\($0)","size":1024,
+             "browser_download_url":"https://example.invalid/\($0)"}
             """
         }
         return """
             {"tag_name":"\(tag)","prerelease":\(prerelease),"draft":\(draft),
-             "body":"\(body)","published_at":"2026-01-05T12:00:00Z","assets":\(assets ?? "[]")}
+             "body":"\(body)","published_at":"2026-01-05T12:00:00Z",
+             "assets":[\(list.joined(separator: ","))]}
             """
     }
 
@@ -148,7 +150,7 @@ struct UpdatesTests {
             entry(tag: "v0.4.0-beta.1", prerelease: true),
             entry(tag: "v0.4.0-beta.2", prerelease: true))
 
-        let stable = ReleaseFeed.newest(from: body, channel: .stable)
+        let stable = ReleaseFeed.newest(from: body, channel: .stable, architecture: .appleSilicon)
         expect(stable?.version == AppVersion("0.3.0"), "stable takes the newest release")
         expect(stable?.tag == "v0.3.0", "and keeps the tag as published")
         expect(stable?.notes == "Notes.", "and carries the release notes")
@@ -158,50 +160,87 @@ struct UpdatesTests {
             "and selects the zip asset")
         expect(stable?.publishedAt != nil, "and parses the ISO-8601 timestamp")
 
-        let beta = ReleaseFeed.newest(from: body, channel: .beta)
+        let beta = ReleaseFeed.newest(from: body, channel: .beta, architecture: .appleSilicon)
         expect(beta?.version == AppVersion("0.4.0-beta.2"), "beta takes the newest prerelease")
 
         expect(
-            ReleaseFeed.newest(from: body, channel: .development) == nil,
+            ReleaseFeed.newest(from: body, channel: .development, architecture: .appleSilicon) == nil,
             "a local build is offered nothing, however new the feed is")
     }
 
     static func rejectsUnusableFeeds() {
-        expect(ReleaseFeed.newest(from: Data(), channel: .stable) == nil, "an empty body yields nil")
         expect(
-            ReleaseFeed.newest(from: Data("not json".utf8), channel: .stable) == nil,
+            ReleaseFeed.newest(from: Data(), channel: .stable, architecture: .appleSilicon) == nil,
+            "an empty body yields nil")
+        expect(
+            ReleaseFeed.newest(
+                from: Data("not json".utf8), channel: .stable, architecture: .appleSilicon) == nil,
             "a malformed body yields nil rather than throwing")
-        expect(ReleaseFeed.newest(from: feed(), channel: .stable) == nil, "an empty feed yields nil")
+        expect(
+            ReleaseFeed.newest(from: feed(), channel: .stable, architecture: .appleSilicon) == nil,
+            "an empty feed yields nil")
 
         expect(
             ReleaseFeed.newest(
-                from: feed(entry(tag: "v0.3.0", prerelease: false, draft: true)), channel: .stable)
-                == nil,
+                from: feed(entry(tag: "v0.3.0", prerelease: false, draft: true)), channel: .stable,
+                architecture: .appleSilicon) == nil,
             "a draft is not installable")
         expect(
             ReleaseFeed.newest(
-                from: feed(entry(tag: "v0.3.0", prerelease: false, asset: nil)), channel: .stable)
-                == nil,
+                from: feed(entry(tag: "v0.3.0", prerelease: false, assets: [])), channel: .stable,
+                architecture: .appleSilicon) == nil,
             "a release with no assets is skipped")
         expect(
             ReleaseFeed.newest(
-                from: feed(entry(tag: "v0.3.0", prerelease: false, asset: "Tinycast-x.dmg")),
-                channel: .stable) == nil,
+                from: feed(entry(tag: "v0.3.0", prerelease: false, assets: ["Tinycast-x.dmg"])),
+                channel: .stable, architecture: .appleSilicon) == nil,
             "a DMG-only release is not installable, so it is not offered")
         expect(
             ReleaseFeed.newest(
-                from: feed(entry(tag: "nightly", prerelease: false)), channel: .stable) == nil,
+                from: feed(entry(tag: "nightly", prerelease: false)), channel: .stable,
+                architecture: .appleSilicon) == nil,
             "an unparseable tag is skipped")
         expect(
             ReleaseFeed.newest(
-                from: feed(entry(tag: "v0.3.0-beta.1", prerelease: false)), channel: .stable) == nil,
+                from: feed(entry(tag: "v0.3.0-beta.1", prerelease: false)), channel: .stable,
+                architecture: .appleSilicon) == nil,
             "a beta tag flagged as a release is mis-published, not an update")
 
         let mixed = feed(
             entry(tag: "v0.3.0", prerelease: false), entry(tag: "junk", prerelease: false))
         expect(
-            ReleaseFeed.newest(from: mixed, channel: .stable)?.version == AppVersion("0.3.0"),
+            ReleaseFeed.newest(from: mixed, channel: .stable, architecture: .appleSilicon)?.version
+                == AppVersion("0.3.0"),
             "one bad entry does not discard the whole feed")
+    }
+
+    /// macOS 26 is the last release to boot on Intel, so a stable release carries a thin arm64 zip
+    /// and a universal one, and each Mac must be handed a build it can actually launch.
+    static func picksTheZipThisMacCanRun() {
+        let both = feed(
+            entry(
+                tag: "v0.3.0", prerelease: false,
+                assets: ["Tinycast-0.3.0.zip", "Tinycast-Universal-0.3.0.zip"]))
+        expect(
+            ReleaseFeed.newest(from: both, channel: .stable, architecture: .intel)?
+                .assetURL.absoluteString.contains("-Universal-") == true,
+            "Intel takes the universal zip, the only one with an x86_64 slice")
+        expect(
+            ReleaseFeed.newest(from: both, channel: .stable, architecture: .appleSilicon)?
+                .assetURL.absoluteString.contains("-Universal-") == false,
+            "Apple silicon prefers the thin zip, and never pays for the Intel slice")
+
+        let thinOnly = feed(entry(tag: "v0.3.0", prerelease: false, assets: ["Tinycast-0.3.0.zip"]))
+        expect(
+            ReleaseFeed.newest(from: thinOnly, channel: .stable, architecture: .intel) == nil,
+            "Intel is offered nothing rather than an arm64 build it cannot launch")
+
+        let universalOnly = feed(
+            entry(tag: "v0.3.0", prerelease: false, assets: ["Tinycast-Universal-0.3.0.zip"]))
+        expect(
+            ReleaseFeed.newest(from: universalOnly, channel: .stable, architecture: .appleSilicon)?
+                .version == AppVersion("0.3.0"),
+            "Apple silicon falls back to the universal zip when it is the only one published")
     }
 
     static func offersOnlyWhatIsWorthInstalling() {
@@ -272,7 +311,7 @@ struct UpdatesTests {
                 entry(
                     tag: "v0.3.0", prerelease: false, body: "Changes.\\n\\n<!-- tinycast:install -->\\nBrew.")
             ),
-            channel: .stable)?.notes
+            channel: .stable, architecture: .appleSilicon)?.notes
         expect(feedNotes == "Changes.", "the feed stores the cut summary, so the cache holds it too")
     }
 

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 		C4B9E9B3E965BFDFD31EDC3D /* LauncherCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858E08BB313EC330C2D5E50C /* LauncherCoordinator.swift */; };
 		C567D5C8F8873CA595B1536A /* TextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74904E7C8CE9B121B32594B9 /* TextInjector.swift */; };
 		C5F60D8681235B95DAA3314F /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */; };
+		C64E1E78A80C4742745CB235 /* ReleaseArchitecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E3B7CDDB6A9D790548648B /* ReleaseArchitecture.swift */; };
 		C7468FBE50BAEC5084D4DB17 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848E14DE51403235A82BC287 /* AIProvider.swift */; };
 		C9A7290682E9D0881713C009 /* ExtensionGridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85C82C66132C7723272E873 /* ExtensionGridGeometry.swift */; };
 		CA6BA9C381351D0B2CADFB9D /* IconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CBCCE63360E4590CF5884A /* IconCache.swift */; };
@@ -575,6 +576,7 @@
 		622E1F1C01B954DCA2199BCD /* ScrollIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollIntent.swift; sourceTree = "<group>"; };
 		628B4CFFCFB20ABEEA33A4D5 /* SpaceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitcher.swift; sourceTree = "<group>"; };
 		62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
+		63E3B7CDDB6A9D790548648B /* ReleaseArchitecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseArchitecture.swift; sourceTree = "<group>"; };
 		6420FE45699DC3E53907CAE3 /* AIInstructions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInstructions.swift; sourceTree = "<group>"; };
 		648F0F43FEEE537F6451756B /* SelectionReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReveal.swift; sourceTree = "<group>"; };
 		64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolImage.swift; sourceTree = "<group>"; };
@@ -1160,6 +1162,7 @@
 			isa = PBXGroup;
 			children = (
 				0D4F22647E4E1BA19F0FC520 /* AppVersion.swift */,
+				63E3B7CDDB6A9D790548648B /* ReleaseArchitecture.swift */,
 				198E4EC8AECAAD0D90C4BA50 /* ReleaseChannel.swift */,
 				D28281DFC434C75F8A594635 /* ReleaseFeed.swift */,
 				31757FAE5F3E9E06D9B77DCA /* ReleaseNotes.swift */,
@@ -2481,6 +2484,7 @@
 				E1A4472391E5AD3EE828202E /* RedactedText.swift in Sources */,
 				3E2E0C5B564C828D7ECA2759 /* RegionCurrency.swift in Sources */,
 				D6D8169527668572F0073F94 /* RelaunchRunner.swift in Sources */,
+				C64E1E78A80C4742745CB235 /* ReleaseArchitecture.swift in Sources */,
 				21812A1B54A4DFDC88604C16 /* ReleaseChannel.swift in Sources */,
 				DDFF8A9F420A4733DFA32A07 /* ReleaseFeed.swift in Sources */,
 				607D38D86E7C4763DD28C8D0 /* ReleaseNotes.swift in Sources */,

--- a/Tinycast/Features/Updates/Model/ReleaseArchitecture.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseArchitecture.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Which slice of a release a build can run. macOS 26 is the last release to boot on Intel, so the
+/// stable channel publishes a thin arm64 artifact and a universal one beside it.
+enum ReleaseArchitecture: Sendable {
+    case appleSilicon
+    case intel
+
+    /// Resolved per slice at compile time, so a universal binary reports the one macOS launched.
+    static var current: ReleaseArchitecture {
+        #if arch(x86_64)
+            .intel
+        #else
+            .appleSilicon
+        #endif
+    }
+}

--- a/Tinycast/Features/Updates/Model/ReleaseFeed.swift
+++ b/Tinycast/Features/Updates/Model/ReleaseFeed.swift
@@ -16,10 +16,18 @@ enum ReleaseFeed {
     /// Where releases come from, and what every `@handle` and `#304` in their notes points at.
     static let repository = "abue-ammar/tinycast"
 
-    /// The newest release this channel accepts, ignoring drafts and anything without a zip.
-    static func newest(from data: Data, channel: ReleaseChannel) -> AvailableRelease? {
+    /// The filename the release workflow gives the universal artifact — the only one with an
+    /// x86_64 slice, and so the only one an Intel Mac can install.
+    private static let universalMarker = "-Universal-"
+
+    /// The newest release this channel accepts, ignoring drafts and anything without a usable zip.
+    static func newest(
+        from data: Data, channel: ReleaseChannel, architecture: ReleaseArchitecture
+    ) -> AvailableRelease? {
         guard let entries = try? JSONDecoder().decode([Entry].self, from: data) else { return nil }
-        return entries.compactMap { release(from: $0, channel: channel) }.max { $0.version < $1.version }
+        return entries
+            .compactMap { release(from: $0, channel: channel, architecture: architecture) }
+            .max { $0.version < $1.version }
     }
 
     /// The release worth offering: strictly newer than what is running, and not one already skipped.
@@ -31,14 +39,14 @@ enum ReleaseFeed {
         return release
     }
 
-    private static func release(from entry: Entry, channel: ReleaseChannel) -> AvailableRelease? {
+    private static func release(
+        from entry: Entry, channel: ReleaseChannel, architecture: ReleaseArchitecture
+    ) -> AvailableRelease? {
         guard !entry.draft, channel.accepts(prerelease: entry.prerelease),
             let version = AppVersion(entry.tagName),
             // A tag disagreeing with the prerelease flag is a mis-published release, not an update.
             version.isPrerelease == entry.prerelease,
-            // The zip, never the DMG: the updater expands an archive rather than mounting a volume,
-            // so a release published without one is not something this app can install.
-            let asset = entry.assets.first(where: { $0.name.hasSuffix(".zip") })
+            let asset = asset(from: entry.assets, for: architecture)
         else { return nil }
         return AvailableRelease(
             version: version,
@@ -47,6 +55,19 @@ enum ReleaseFeed {
             assetURL: asset.browserDownloadURL,
             assetSize: asset.size,
             publishedAt: entry.publishedAt.flatMap { try? Date($0, strategy: .iso8601) })
+    }
+
+    /// The zip this Mac can install — never the DMG, since the updater expands an archive rather
+    /// than mounting a volume. Intel is offered nothing before a thin build it cannot launch.
+    private static func asset(
+        from assets: [Entry.Asset], for architecture: ReleaseArchitecture
+    ) -> Entry.Asset? {
+        let zips = assets.filter { $0.name.hasSuffix(".zip") }
+        let universal = zips.first { $0.name.contains(universalMarker) }
+        switch architecture {
+        case .intel: return universal
+        case .appleSilicon: return zips.first { !$0.name.contains(universalMarker) } ?? universal
+        }
     }
 
     private struct Entry: Decodable {

--- a/Tinycast/Features/Updates/Service/UpdateCheckStore.swift
+++ b/Tinycast/Features/Updates/Service/UpdateCheckStore.swift
@@ -82,7 +82,7 @@ final class UpdateCheckStore {
         isChecking = true
         defer { isChecking = false }
         guard let data = await Self.body() else { return false }
-        latest = ReleaseFeed.newest(from: data, channel: channel)
+        latest = ReleaseFeed.newest(from: data, channel: channel, architecture: .current)
         lastCheckedAt = Date()
         persist()
         return true

--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -14,6 +14,10 @@ release feed the website already reads is the feed the app reads.
 - **The archive is a zip, never the DMG.** A zip expands with `ditto`; a DMG would have to be mounted,
   which means a volume, a Spotlight handle and a detach that can fail. A release published without a
   zip is not installable and is not offered.
+- **The zip is chosen by architecture.** A stable release carries a thin arm64 zip and a
+  `-Universal-` one. Intel takes the universal zip and is offered *nothing* if it is missing, since a
+  thin build would install and then refuse to launch; Apple silicon prefers the thin zip and falls
+  back to universal.
 - **Nobody ever runs `xattr`.** An archive Tinycast fetched itself is not quarantined — macOS sets
   that flag for sandboxed downloaders and for apps that opt in with `LSFileQuarantineEnabled`, and
   Tinycast is neither. `Quarantine` checks anyway through `getxattr`/`removexattr` rather than the
@@ -71,6 +75,10 @@ to nil, which is deliberate — the repo also publishes `v0.9.7-sequoia` for the
 rejecting the tag is what keeps a beta install from drifting onto the Sequoia build. A release whose
 tag disagrees with its `prerelease` flag is treated as mis-published and skipped.
 
+The Intel build is *not* a channel. It shares the stable tag, version, bundle id and signature, so it
+resolves to `.stable` like any other; `ReleaseArchitecture` picks its asset, and nothing about
+identity changes. That is why it needed none of the machinery the Sequoia channel did.
+
 ## Checking
 
 `UpdateCheckStore` copies `CurrencyRateStore`: a private `.ephemeral`, `urlCache = nil` session, a
@@ -111,7 +119,10 @@ setting, clipboard entry, note or snippet is affected by an update, by `brew upg
 ## Releasing into it
 
 `.github/workflows/release.yml` publishes two assets from one build: the DMG people download by hand
-and the cask installs, and `Tinycast-<version>.zip` for the updater. The zip is made with
+and the cask installs, and `Tinycast-<version>.zip` for the updater. A stable run adds a
+`Tinycast-Universal-<version>` pair from its `universal` job, uploaded second so the thin zip stays
+first in the asset list — builds predating architecture-aware selection take whichever comes first.
+The zip is made with
 
 ```sh
 ditto -c -k --keepParent --sequesterRsrc "$APP" "dist/$ZIP_FILE"

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,9 +28,15 @@ zip is produced with `ditto -c -k --keepParent --sequesterRsrc` — the only zip
 signature verifiable, which matters because the updater refuses any bundle whose leaf certificate does
 not match the running app's.
 
+A stable release publishes two more from the `universal` job, `Tinycast-Universal-<version>.dmg` and
+`.zip`, built from the same commit at the same version and bundle id but with both slices. They are
+uploaded *after* the thin pair, which keeps the thin zip first in the asset list so builds predating
+architecture-aware selection keep choosing it.
+
 Three things a release must keep true, or the updater skips it:
 
-- **It carries a `.zip` asset.** A DMG-only release is not installable and is not offered.
+- **It carries a `.zip` asset this Mac can run.** A DMG-only release is not installable and is not
+  offered, and an Intel build is offered nothing rather than a thin arm64 zip.
 - **The tag parses as `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-beta.N`,** and agrees with the
   `prerelease` flag. `v0.9.7-sequoia` deliberately parses as neither, which is what keeps beta
   installs off the macOS 15 build.
@@ -79,6 +85,13 @@ It builds on a `macos-26` runner with Xcode 26 and publishes a GitHub Release ta
 `v<full-version>` with a versioned DMG and zip asset, marked prerelease for beta. On success it also
 bumps the matching cask in the tap and announces the release on Discord.
 
+A stable run then fans out to a second job, `universal`, which rebuilds the same commit with
+`ARCHS="arm64 x86_64"` and attaches `Tinycast-Universal-<version>.dmg` / `.zip` to the release the
+first job created, then bumps `tinycast-universal`. macOS 26 is the last release that boots on Intel,
+and those Macs need both slices. Both jobs pin `ARCHS` explicitly and assert the slices on the
+shipping binary: trusting `ARCHS_STANDARD` is what shipped a thin arm64 build to Intel users once
+already, and it also keeps the Apple silicon download from silently gaining a slice it never needs.
+
 ### Release notes
 
 `Scripts/release-notes.sh` composes the release body, and CI runs it just before `gh release create`.
@@ -108,10 +121,16 @@ pings `@everyone`.
 
 ### Homebrew tap automation
 
-The release job's final step rewrites the `version` + `sha256` of the channel's cask (`tinycast` or
-`tinycast@beta`) in the [`homebrew-tinycast`](https://github.com/abue-ammar/homebrew-tinycast) tap and
-pushes. It needs a `HOMEBREW_TAP_TOKEN` repo secret — a fine-grained PAT with **Contents: read/write**
-on the tap repo. Without the secret the step logs a warning and skips; the release still publishes.
+Each job's final step rewrites the `version` + `sha256` of its cask (`tinycast`, `tinycast@beta` or
+`tinycast-universal`) in the [`homebrew-tinycast`](https://github.com/abue-ammar/homebrew-tinycast) tap
+and pushes. It needs a `HOMEBREW_TAP_TOKEN` repo secret — a fine-grained PAT with **Contents:
+read/write** on the tap repo. Without the secret the step logs a warning and skips; the release still
+publishes. The `sed` is anchored to `^  version` / `^  sha256`, so a cask's two-space indent on those
+lines is load-bearing.
+
+The three macOS 26 / macOS 15 casks all install `Tinycast.app` under `com.tinycast.app`, so they
+`conflicts_with` one another and Homebrew routes each Mac by `depends_on`: `tinycast` requires
+`arch: :arm64`, `tinycast-universal` takes the Intel Macs, and `tinycast-sequoia` covers macOS 15.
 
 ## Website
 

--- a/website/content/docs/install.md
+++ b/website/content/docs/install.md
@@ -3,8 +3,8 @@ title: Install
 description: Homebrew, the release channels, and the one manual step a direct download needs.
 ---
 
-Tinycast needs **macOS 26 or later**. There is a separate cask for macOS 15 Sequoia — see
-[Older macOS](#older-macos).
+Tinycast needs **macOS 26 or later**, on Apple silicon or Intel. There is a separate cask for macOS
+15 Sequoia — see [Older macOS](#older-macos).
 
 ## Homebrew
 
@@ -19,15 +19,30 @@ brew install --cask abue-ammar/tinycast/tinycast
 `brew trust` is required once for any third-party tap; Homebrew refuses to install from an untrusted
 tap without it.
 
+### Intel Macs
+
+macOS 26 Tahoe is the last release that boots on Intel, so stable ships twice from the same build.
+The command above installs a lean Apple-silicon-only build; on an Intel Mac, install the universal
+cask instead:
+
+```bash
+brew install --cask abue-ammar/tinycast/tinycast-universal
+```
+
+You do not have to work out which you need — `tinycast` refuses to install on Intel, and both casks
+give you the same `Tinycast.app`. The universal build runs on Apple silicon too; it is simply the
+larger download.
+
 ### Channels
 
 Each channel is a **separate application** with its own bundle identifier, settings, permissions and
 login item. They run side by side, so you can keep stable installed while trying a beta.
 
-| Channel | Cask            | App                 |
-| ------- | --------------- | ------------------- |
-| Stable  | `tinycast`      | `Tinycast.app`      |
-| Beta    | `tinycast@beta` | `Tinycast Beta.app` |
+| Channel | Cask                 | App                 |
+| ------- | -------------------- | ------------------- |
+| Stable  | `tinycast`           | `Tinycast.app`      |
+| Stable  | `tinycast-universal` | `Tinycast.app`      |
+| Beta    | `tinycast@beta`      | `Tinycast Beta.app` |
 
 ```bash
 brew install --cask abue-ammar/tinycast/tinycast@beta
@@ -35,7 +50,8 @@ brew install --cask abue-ammar/tinycast/tinycast@beta
 
 Because the channels are separate apps, installing the beta does not upgrade your stable install and
 does not share its settings. To move settings across, use
-[Backup](/docs/reference/backup).
+[Backup](/docs/reference/backup). The two stable casks are the *same* app, so they cannot be
+installed at once — Homebrew picks the right one for your Mac.
 
 ### Older macOS
 

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -43,6 +43,13 @@ export const channels = [
     note: "Recommended",
   },
   {
+    id: "universal",
+    label: "Intel",
+    command:
+      "brew trust --tap abue-ammar/tinycast && brew install --cask abue-ammar/tinycast/tinycast-universal",
+    note: "Intel Macs",
+  },
+  {
     id: "beta",
     label: "Beta",
     command:


### PR DESCRIPTION
## Why

macOS 26 Tahoe is the last release that boots on Intel, but the stable DMG is arm64-only, so those Macs cannot install Tinycast at all.

Verified rather than assumed: `lipo -archs` on the shipped `Tinycast-0.10.2.zip` binary reports **`arm64`** alone, even though `ARCHS` resolves to `arm64 x86_64` locally. CI genuinely publishes a thin build. This repo has been bitten by the same thing before — `compat/README.md` records a thin arm64 DMG reaching Intel users up to `v0.9.4-sequoia`.

## What

A universal build published beside the thin one, under its own cask.

It shares the **same tag, version, bundle id and signing identity** as the stable release, so it is not a new channel — `AppVersion`, `ReleaseChannel` and the release-notes tooling are all untouched. That is why this needed none of the machinery the Sequoia channel did (no branch, no source patch, no tag suffix).

- **`release.yml`** — new `universal` job (`needs: build`, stable only) building `ARCHS="arm64 x86_64"`, asserting both slices and the 26.0 floor, then *uploading* `Tinycast-Universal-<ver>.dmg`/`.zip` to the release the build job created.
- **`ReleaseFeed`** + new `ReleaseArchitecture` — the updater picks its zip by architecture. Intel takes the `-Universal-` zip and is offered **nothing** when it is missing, since a thin build would install and then refuse to launch. Apple silicon prefers the thin zip.
- **Install section** rewritten around a table mapping each Mac to one command, and it now states the macOS baseline the README never actually did.

## The Apple silicon build is unchanged

Same bundle id, app name, artifact names, identity flags and update path. The one edit to the existing job is pinning `ARCHS=arm64` — a no-op on the artifact (confirmed it already ships arm64-only) that stops a future runner or Xcode bump silently doubling first-class users' download. Its assertion enforces that.

Universal assets upload *second*, so the thin zip stays first in the asset list and builds predating architecture-aware selection keep choosing it.

## Verification

- All 49 harnesses pass; `lint.sh` clean; Debug build has no new warnings; Model-layer import check clean; website `tsc` clean.
- Built the app universal locally: **both slices, `minos 26.0`** on each, `LSMinimumSystemVersion 26.0`. No source changes were needed to compile for x86_64.
- Confirmed the new test genuinely runs by inverting an assertion and watching it fail, then restored it.

## Not verified

Launch on real Intel Tahoe hardware. CI asserts the slices, which is the failure mode that can be caught automatically; someone on an Intel Mac should confirm launch.

## Ordering

Needs the tap PR, and `tinycast-universal` only resolves once a stable release has run the new job — see the note there.