### PR TITLE
Restart a running application from its Actions menu and ⌘R

### DIFF
--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -176,7 +176,9 @@
 		68FCC30764DD44ED72EFB6BA /* TinycastApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B629EC3B716FEE881BB0075 /* TinycastApp.swift */; };
 		691ADED3F9F3F730E1F36DB8 /* FileSearchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03757CDEFC14359CAEF4CE93 /* FileSearchSession.swift */; };
 		694B7E1A8C7C2D6DF26D3BF9 /* RaycastRuntime.generated.js in Resources */ = {isa = PBXBuildFile; fileRef = 74284B4E771DA0B2869C914E /* RaycastRuntime.generated.js */; };
+		695898F8FF98200F180FC2CA /* PaletteEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524404EF88622426B0AA4E33 /* PaletteEnvironment.swift */; };
 		6A0C45313C7B73349C7B17E0 /* ThinScrollbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A6748260B2DF011CCAFCEF /* ThinScrollbar.swift */; };
+		6AF8D4CB26C1B1F53C71B5E4 /* WindowReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C2657E7B3481A27821B4A5 /* WindowReader.swift */; };
 		6B3A9A37600C941DF38F9171 /* NOTICE.md in Resources */ = {isa = PBXBuildFile; fileRef = B36FACE26406FD2205FEF03E /* NOTICE.md */; };
 		6B8351E3D100E81F169BCFED /* UninstallPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD838940E655559E32BE8EA /* UninstallPlan.swift */; };
 		6BAE3112ED110F1363617A79 /* NoteTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F088EC0B4D97B3C9D0D0569 /* NoteTextView.swift */; };
@@ -240,6 +242,7 @@
 		935F7433BB0C0ECDE6FA3BF3 /* ClipboardScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */; };
 		939F3944AE8D36A8C337D46F /* Signposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9044F107ADD5896746DBC35 /* Signposts.swift */; };
 		94887F8E18AB2C08A8273897 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7B3EB88881CEEFCE71448D /* Permissions.swift */; };
+		9553DDEBD6FCC205069ED996 /* MenuPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF96A1566757811AD434C0F9 /* MenuPanel.swift */; };
 		9608AFDEDC3B330E64F53437 /* ExtensionStoreClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410684C9DEB3754962C20C9C /* ExtensionStoreClient.swift */; };
 		96BC636877D935C5EB20BF7F /* SnippetsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E06AA30E7BA44BC211B667F /* SnippetsScreen.swift */; };
 		97D71FF4C0D582828C6EC7F5 /* UpdateFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B475B5929CC0478EFAC7D8 /* UpdateFailure.swift */; };
@@ -549,6 +552,7 @@
 		50E2E570E54DEEF29FF2B65E /* NotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesView.swift; sourceTree = "<group>"; };
 		518429EDBFBEA0B866CCAA81 /* CalculatorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCoordinator.swift; sourceTree = "<group>"; };
 		52146CB01C791AB02518273D /* ExtensionCommandScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCommandScreen.swift; sourceTree = "<group>"; };
+		524404EF88622426B0AA4E33 /* PaletteEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteEnvironment.swift; sourceTree = "<group>"; };
 		525AE0062E8E8F00E21BAEF9 /* NotesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesWindowController.swift; sourceTree = "<group>"; };
 		52998BAB1D8287CF14E46EF0 /* SettingsBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBackup.swift; sourceTree = "<group>"; };
 		52BD814D567DFEFD303B1750 /* PaletteRowIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteRowIndex.swift; sourceTree = "<group>"; };
@@ -629,6 +633,7 @@
 		86545F54669A075FBDA5D1F1 /* CalculatorHistoryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryScreen.swift; sourceTree = "<group>"; };
 		87F282D4BBC2F147D3A98FFB /* ExtensionCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCleanup.swift; sourceTree = "<group>"; };
 		88499DF2F503F2A3A19DEF07 /* OverflowFade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverflowFade.swift; sourceTree = "<group>"; };
+		88C2657E7B3481A27821B4A5 /* WindowReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowReader.swift; sourceTree = "<group>"; };
 		8AC2CD86BAA6567B66B2B4DB /* FileSearchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchSettingsView.swift; sourceTree = "<group>"; };
 		8AFD491421DFE25892C0FC37 /* RaycastV1Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastV1Decoder.swift; sourceTree = "<group>"; };
 		8C39345D0335ACA895133ABD /* IconStyleMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStyleMonitor.swift; sourceTree = "<group>"; };
@@ -728,6 +733,7 @@
 		BE6972F177922B1EB8831735 /* OnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
 		BEDDA8820165672AF8464E25 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
 		BF36BDC9ACE867DCC2CCF746 /* SystemPromptEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptEditor.swift; sourceTree = "<group>"; };
+		BF96A1566757811AD434C0F9 /* MenuPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPanel.swift; sourceTree = "<group>"; };
 		BFB023D167225228757CC4B2 /* HealthTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthTicker.swift; sourceTree = "<group>"; };
 		C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteCoordinator.swift; sourceTree = "<group>"; };
 		C0599199132DAFBE12C59FBD /* MeetingDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDay.swift; sourceTree = "<group>"; };
@@ -1798,9 +1804,11 @@
 			isa = PBXGroup;
 			children = (
 				9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */,
+				BF96A1566757811AD434C0F9 /* MenuPanel.swift */,
 				C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */,
 				29A8B82DCB1B7D131BF0908A /* PaletteDropGuideController.swift */,
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
+				524404EF88622426B0AA4E33 /* PaletteEnvironment.swift */,
 				53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
@@ -1810,6 +1818,7 @@
 				9B107F5E532C8DE74430723B /* PaletteTabAction.swift */,
 				209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */,
 				D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */,
+				88C2657E7B3481A27821B4A5 /* WindowReader.swift */,
 			);
 			path = Palette;
 			sourceTree = "<group>";
@@ -2407,6 +2416,7 @@
 				AAFD2C9276D38719E85B675F /* Memo.swift in Sources */,
 				9E257392434C62CCC26C9B04 /* MenuBarLabel.swift in Sources */,
 				E6E929E9284E8AC361D64D6A /* MenuBarSummary.swift in Sources */,
+				9553DDEBD6FCC205069ED996 /* MenuPanel.swift in Sources */,
 				43DBCE7B5A84D0D6322124F5 /* MessageHUDController.swift in Sources */,
 				8D529C8F3AB579941067FE98 /* MessageHUDView.swift in Sources */,
 				8D20CD7B6918873960F84291 /* NoteDocument.swift in Sources */,
@@ -2432,6 +2442,7 @@
 				86C36C0885D5820E70184CF6 /* PaletteCoordinator.swift in Sources */,
 				8DCF330D30E59FFEE8C8E8CF /* PaletteDropGuideController.swift in Sources */,
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
+				695898F8FF98200F180FC2CA /* PaletteEnvironment.swift in Sources */,
 				8E30C461429C894907FAD94D /* PaletteEscapeAction.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
@@ -2590,6 +2601,7 @@
 				19B0314193376FD1E4AC11A5 /* WindowLayout.swift in Sources */,
 				0360C7038877B9CB656DB697 /* WindowManagementSettingsView.swift in Sources */,
 				A6A8CD2B71A15625F47498EA /* WindowMover.swift in Sources */,
+				6AF8D4CB26C1B1F53C71B5E4 /* WindowReader.swift in Sources */,
 				6CDA82FD63F87D07E30E3F82 /* Zlib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tinycast/DesignSystem/BarButton.swift
+++ b/Tinycast/DesignSystem/BarButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// A bar control's hover chrome. The footer's buttons are capsules; a header control takes the
-/// menu row's own corner instead, so every control along that row reads as one family.
+/// A bar control's hover chrome. `rounded` is the palette's own: footer pills and header pop-ups
+/// share `barControl`, so every control along either row reads as one family.
 enum BarButtonChrome {
     case capsule
     case rounded
@@ -12,7 +12,7 @@ enum BarButtonChrome {
             return AnyShape(Capsule())
         case .rounded:
             return AnyShape(
-                RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous))
+                RoundedRectangle(cornerRadius: Theme.Radius.barControl, style: .continuous))
         }
     }
 }

--- a/Tinycast/DesignSystem/PopoverMenu.swift
+++ b/Tinycast/DesignSystem/PopoverMenu.swift
@@ -49,7 +49,7 @@ struct PopoverMenuContent {
     let items: [PopoverMenuItem]
 }
 
-/// An in-window overlay menu, not a system popover, so it clips inside the palette.
+/// The palette's own menu, hosted by `MenuPanelController` in a window of its own.
 struct PopoverMenu: View {
     var header: String?
     let items: [PopoverMenuItem]
@@ -58,34 +58,75 @@ struct PopoverMenu: View {
     var width: CGFloat = Theme.Size.menuWidth
     let onActivate: (Int) -> Void
 
+    /// The palette arms this only once the pointer has moved of its own accord.
+    @Environment(PaletteState.self) private var palette
+    /// Set by the pointer so the reveal can tell its own move from a keyboard one.
+    @State private var pointerSelection: Int?
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            if let header {
-                Text(header)
-                    .font(Theme.Typography.sectionHeader)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .padding(.horizontal, Theme.Spacing.lg)
-                    .padding(.top, Theme.Spacing.xs)
-                    .padding(.bottom, Theme.Spacing.xs / 2)
-            }
-            // Index-as-id is stable: a menu's rows never reorder while it is open.
-            ForEach(items.indices, id: \.self) { index in
-                PopoverMenuRow(
-                    item: items[index],
-                    selected: index == selection,
-                    onHover: { selection = index },
-                    onActivate: { onActivate(index) }
-                )
-            }
+        VStack(alignment: .leading, spacing: Theme.Size.menuRowSpacing) {
+            if let header { headerLabel(header) }
+            rows
         }
         .padding(Theme.Spacing.sm)
         .frame(width: width)
-        // Glass carries its own elevation, so a drop shadow on top reads heavy.
         .glassEffect(
             .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)
         )
+    }
+
+    private func headerLabel(_ text: String) -> some View {
+        Text(text)
+            .font(Theme.Typography.sectionHeader)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.top, Theme.Spacing.xs)
+            .padding(.bottom, Theme.Spacing.xs / 2)
+    }
+
+    /// Rows alone scroll, under a header that keeps naming what they act on.
+    private var rows: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.Size.menuRowSpacing) {
+                    // Index-as-id is stable: a menu's rows never reorder while it is open.
+                    ForEach(items.indices, id: \.self) { index in
+                        PopoverMenuRow(item: items[index], selected: index == selection) {
+                            onActivate(index)
+                        }
+                        .id(index)
+                        .onContinuousHover { if case .active = $0 { hover(index) } }
+                    }
+                }
+            }
+            .frame(height: viewportHeight)
+            // `never`, not `hidden`: hidden still lets AppKit claim the scroller's gutter.
+            .scrollIndicators(.never)
+            .scrollBounceBehavior(.basedOnSize)
+            .overflowFade()
+            .onChange(of: selection) {
+                let byPointer = pointerSelection == selection
+                pointerSelection = nil
+                guard !byPointer else { return }
+                proxy.scrollTo(selection)
+            }
+        }
+    }
+
+    /// Exact, because every row is one known height: no measuring pass, and no greedy scroll view.
+    private var viewportHeight: CGFloat {
+        let count = CGFloat(items.count)
+        let pitch = Theme.Size.menuRowHeight + Theme.Size.menuRowSpacing
+        return min(count * pitch - Theme.Size.menuRowSpacing, Theme.Size.menuRowsMaxHeight)
+    }
+
+    /// Armed only once the pointer has moved of its own accord, so a scroll past it lights nothing.
+    private func hover(_ index: Int) {
+        guard palette.hoverHighlightArmed, index != selection else { return }
+        pointerSelection = index
+        selection = index
     }
 }
 
@@ -93,8 +134,6 @@ struct PopoverMenu: View {
 private struct PopoverMenuRow: View {
     let item: PopoverMenuItem
     let selected: Bool
-    /// Fired on enter, so the owner can move selection and share one highlight.
-    let onHover: () -> Void
     let onActivate: () -> Void
 
     var body: some View {
@@ -121,6 +160,7 @@ private struct PopoverMenuRow: View {
                 Text(item.title)
                     .font(Theme.Typography.menuRow)
                     .foregroundStyle(item.isDestructive ? Color.red : Color.primary)
+                    .lineLimit(1)
                 Spacer(minLength: Theme.Spacing.sm)
                 if let shortcut = item.shortcut {
                     HStack(spacing: Theme.Spacing.xxs) {
@@ -130,10 +170,11 @@ private struct PopoverMenuRow: View {
                     }
                 }
             }
-            // The icon slot is the tallest element, so it pins one height for every row.
             .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, Theme.Spacing.md)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // Stated, not padded: the height maths above counts rows, so a row is one exact height.
+            .frame(
+                maxWidth: .infinity, minHeight: Theme.Size.menuRowHeight,
+                maxHeight: Theme.Size.menuRowHeight, alignment: .leading)
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)
@@ -141,7 +182,6 @@ private struct PopoverMenuRow: View {
             )
         }
         .buttonStyle(.plain)
-        .onHover { if $0 { onHover() } }
     }
 }
 

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -129,9 +129,11 @@ enum Theme {
         /// Six rows and half of the seventh, so a capped menu reads as scrollable rather than
         /// clipped — and no ordinary menu length lands a hair over the cap and scrolls by a pixel.
         static let menuVisibleRows: CGFloat = 6.5
-        /// How tall a menu's rows may grow before they scroll, counted in rows so the cap can
-        /// never fall mid-row, and well inside the panel the menu overlays.
-        static var menuRowsMaxHeight: CGFloat { menuVisibleRows * (menuRowHeight + menuRowSpacing) }
+        /// Counted in rows so the cap never falls mid-row, rounded because a half-row of an odd
+        /// pitch gives a fractional window height and lands the glass edge on a half pixel.
+        static var menuRowsMaxHeight: CGFloat {
+            (menuVisibleRows * (menuRowHeight + menuRowSpacing)).rounded()
+        }
         /// A menu row's glyph slot, sized so symbol and app-icon rows read the same.
         static let menuIcon: CGFloat = 20
         /// A brand mark inside the menu icon slot, sized to the optical weight of a symbol.

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -31,6 +31,8 @@ enum Theme {
         static let menu: CGFloat = 6
         /// Hover highlight behind a popover menu row.
         static let menuRow: CGFloat = 10
+        /// A header pop-up button; the footer's action pills stay capsules.
+        static let barControl: CGFloat = 8
         static let menuPanel: CGFloat = 16
         /// The dialog and HUD surface, so a dialog reads as a sibling of the palette.
         static let dialog: CGFloat = 20

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -122,6 +122,16 @@ enum Theme {
         static let menuWidth: CGFloat = 276
         /// The clipboard type filter's menu; `menuWidth` is far too wide for five short rows.
         static let clipboardFilterMenuWidth: CGFloat = 200
+        /// A menu row, stated rather than padded into being: the cap below counts rows, so a row
+        /// has to be one known height or a capped menu lands mid-row.
+        static let menuRowHeight: CGFloat = menuIcon + Spacing.md * 2
+        static let menuRowSpacing: CGFloat = 1
+        /// Six rows and half of the seventh, so a capped menu reads as scrollable rather than
+        /// clipped — and no ordinary menu length lands a hair over the cap and scrolls by a pixel.
+        static let menuVisibleRows: CGFloat = 6.5
+        /// How tall a menu's rows may grow before they scroll, counted in rows so the cap can
+        /// never fall mid-row, and well inside the panel the menu overlays.
+        static var menuRowsMaxHeight: CGFloat { menuVisibleRows * (menuRowHeight + menuRowSpacing) }
         /// A menu row's glyph slot, sized so symbol and app-icon rows read the same.
         static let menuIcon: CGFloat = 20
         /// A brand mark inside the menu icon slot, sized to the optical weight of a symbol.

--- a/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
@@ -8,7 +8,13 @@ private enum Metrics {
     static let rowSpacing: CGFloat = 1
     /// Six rows and half of the seventh, so a long panel reads as scrollable rather than clipped.
     static let visibleRows: CGFloat = 6.5
-    static var maxHeight: CGFloat { visibleRows * (rowHeight + rowSpacing) }
+    /// Rounded: a fractional window height lands the glass edge on a half pixel and doubles the hairline.
+    static var maxHeight: CGFloat { (visibleRows * (rowHeight + rowSpacing)).rounded() }
+
+    /// Exact, because every row is one known height: no measuring pass, and no greedy scroll view.
+    static func height(rows: Int) -> CGFloat {
+        min(CGFloat(rows) * (rowHeight + rowSpacing) - rowSpacing, maxHeight)
+    }
 }
 
 /// One row of a running command's ⌘K panel. Its own type, not `PopoverMenuItem`: an extension names
@@ -28,6 +34,8 @@ struct ExtensionActionsPanel: View {
     @Binding var selection: Int
     let onActivate: (Int) -> Void
 
+    /// The palette arms this only once the pointer has moved of its own accord.
+    @Environment(PaletteState.self) private var palette
     /// A hovered row is already visible, so scrolling to it would drag the list from under the cursor.
     @State private var hoverSelection: Int?
 
@@ -52,21 +60,19 @@ struct ExtensionActionsPanel: View {
                             ExtensionActionRow(
                                 item: items[index],
                                 selected: index == selection,
-                                onHover: {
-                                    hoverSelection = index
-                                    selection = index
-                                },
                                 onActivate: { onActivate(index) }
                             )
                             .id(index)
+                            .onContinuousHover { if case .active = $0 { hover(index) } }
                         }
                     }
                 }
-                .frame(maxHeight: Metrics.maxHeight)
+                .frame(height: Metrics.height(rows: items.count))
                 // Without this a panel shorter than the cap rubber-bands against nothing.
                 .scrollBounceBehavior(.basedOnSize)
-                // None, like a real menu: `thinScrollbar` wants floating bars, the native one cuts glass.
-                .scrollIndicators(.hidden)
+                // `never`, not `hidden`: hidden still lets AppKit claim the scroller's gutter.
+                .scrollIndicators(.never)
+                .overflowFade()
                 .onChange(of: selection) {
                     let movedByPointer = hoverSelection == selection
                     hoverSelection = nil
@@ -78,10 +84,16 @@ struct ExtensionActionsPanel: View {
         }
         .padding(Theme.Spacing.sm)
         .frame(width: Metrics.width)
-        // Glass carries its own elevation, so a drop shadow on top reads heavy.
         .glassEffect(
             .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)
         )
+    }
+
+    /// Armed only once the pointer has moved of its own accord, so a scroll past it lights nothing.
+    private func hover(_ index: Int) {
+        guard palette.hoverHighlightArmed, index != selection else { return }
+        hoverSelection = index
+        selection = index
     }
 }
 
@@ -89,8 +101,6 @@ struct ExtensionActionsPanel: View {
 private struct ExtensionActionRow: View {
     let item: ExtensionActionItem
     let selected: Bool
-    /// Fired on enter, so the owner can move selection and share one highlight.
-    let onHover: () -> Void
     let onActivate: () -> Void
 
     var body: some View {
@@ -111,8 +121,10 @@ private struct ExtensionActionRow: View {
                 }
             }
             .padding(.horizontal, Theme.Spacing.md)
-            // Fixed, not padded: the cap above counts rows, so a row has to be one known height.
-            .frame(maxWidth: .infinity, minHeight: Metrics.rowHeight, alignment: .leading)
+            // Fixed, not padded: the height maths above counts rows, so a row is one exact height.
+            .frame(
+                maxWidth: .infinity, minHeight: Metrics.rowHeight, maxHeight: Metrics.rowHeight,
+                alignment: .leading)
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)
@@ -120,7 +132,6 @@ private struct ExtensionActionRow: View {
             )
         }
         .buttonStyle(.plain)
-        .onHover { if $0 { onHover() } }
     }
 
     /// A symbol is drawn here rather than handed to `ExtensionIconView`: the row's glyph is sized to

--- a/Tinycast/Features/Launcher/Service/AppLauncher.swift
+++ b/Tinycast/Features/Launcher/Service/AppLauncher.swift
@@ -66,6 +66,41 @@ enum AppLauncher {
         return !running.isEmpty
     }
 
+    /// Long enough for any app to exit, short enough that a quit the user is still deciding on
+    /// can't relaunch under them much later.
+    private static let exitGrace = Duration.seconds(5)
+
+    /// Quits every instance and reopens the bundle once they are all gone; a refused quit — a save
+    /// sheet the user cancels or leaves standing — relaunches nothing and leaves the app running.
+    @MainActor
+    static func restart(bundleID: String, url: URL) async {
+        let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        guard !running.isEmpty, await quitAwaitingExit(running) else { return }
+        launch(url)
+    }
+
+    /// Observes before it terminates, so an instance that exits at once can't outrun the wait.
+    @MainActor
+    private static func quitAwaitingExit(_ apps: [NSRunningApplication]) async -> Bool {
+        let center = NSWorkspace.shared.notificationCenter
+        let (exits, continuation) = AsyncStream.makeStream(of: pid_t.self)
+        let observer = center.addObserver(
+            of: NSWorkspace.shared, for: NSWorkspace.DidTerminateApplicationMessage.self
+        ) { continuation.yield($0.application.processIdentifier) }
+        defer { center.removeObserver(observer) }
+
+        var pending = Set(apps.map(\.processIdentifier))
+        for app in apps { app.terminate() }
+
+        let grace = Task { try? await Task.sleep(for: exitGrace); continuation.finish() }
+        defer { grace.cancel() }
+        for await pid in exits {
+            pending.remove(pid)
+            if pending.isEmpty { return true }
+        }
+        return false
+    }
+
     /// Finder is never a Quit All target: `terminate()` only makes it relaunch.
     private static let quitAllExclusions: Set<String> = ["com.apple.finder"]
 

--- a/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
+++ b/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
@@ -62,6 +62,12 @@ enum AppActionsMenu {
         if running, app.kind == .application {
             items.append(
                 PopoverMenuItem(
+                    title: "Restart Application", systemImage: "arrow.clockwise", shortcut: "⌘R"
+                ) {
+                    core.launcherCoordinator.restart(app)
+                })
+            items.append(
+                PopoverMenuItem(
                     title: "Quit Application", systemImage: "power", shortcut: "⌃⇧Q",
                     isDestructive: true
                 ) {

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -207,6 +207,14 @@ final class LauncherCoordinator {
         AppLauncher.showInFinder(app.url)
     }
 
+    /// Restarts the app behind an entry. Focus is never handed back: either the relaunch takes it,
+    /// or the quit was refused and the app that refused it is the one asking for it.
+    func restart(_ app: AppEntry) {
+        guard app.kind == .application, let bundleID = app.bundleID else { return }
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        Task { await AppLauncher.restart(bundleID: bundleID, url: app.url) }
+    }
+
     /// Quits the app behind an entry; a no-op (palette stays put) when it isn't running.
     func quit(_ app: AppEntry) {
         guard app.kind == .application, let bundleID = app.bundleID else { return }

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -7,7 +7,8 @@ struct LauncherScreen: PaletteScreen {
     let visibility: VisibilityStore
     let core: AppCore
     let vm: PaletteState
-    /// Sampled by `openActions`, so the Quit row can't appear or vanish while the menu is up.
+    /// Sampled by `openActions`, so the Restart and Quit rows can't appear or vanish while the
+    /// menu is up.
     let running: Bool
     /// The join card's meeting, resolved by the coordinator; nil unless one is due.
     let meeting: MeetingEvent?
@@ -194,12 +195,26 @@ struct LauncherScreen: PaletteScreen {
         return true
     }
 
-    /// ⌃⇧Q — the screen owns the chord, but only a running application has anything to quit.
-    func quit(at selection: Int) -> Bool {
+    /// The one guard both power chords share, so neither can drift from the rows it mirrors: they
+    /// are offered only for an `.application` entry `RunningAppsMonitor` reports running.
+    private func runningApplication(at selection: Int) -> AppEntry? {
         guard let app = entry(at: selection), app.kind == .application,
             core.runningApps.isRunning(app)
-        else { return false }
+        else { return nil }
+        return app
+    }
+
+    /// ⌃⇧Q — the screen owns the chord, but only a running application has anything to quit.
+    func quit(at selection: Int) -> Bool {
+        guard let app = runningApplication(at: selection) else { return false }
         core.launcherCoordinator.quit(app)
+        return true
+    }
+
+    /// ⌘R — mirrors the Restart Application row.
+    func restart(at selection: Int) -> Bool {
+        guard let app = runningApplication(at: selection) else { return false }
+        core.launcherCoordinator.restart(app)
         return true
     }
 
@@ -280,7 +295,7 @@ struct LauncherScreen: PaletteScreen {
         scrollToFollow()
     }
 
-    /// The sample `openActions` takes; only an app row can ever carry a Quit action.
+    /// The sample `openActions` takes; only an app row can ever carry the running-only actions.
     func isRunning(at selection: Int) -> Bool {
         guard let app = entry(at: selection) else { return false }
         return core.runningApps.isRunning(app)

--- a/Tinycast/Palette/MenuPanel.swift
+++ b/Tinycast/Palette/MenuPanel.swift
@@ -1,0 +1,117 @@
+import AppKit
+import SwiftUI
+
+/// The ⌘K menu's own window, so glass renders against the desktop and nothing clips it.
+final class MenuPanel: NSPanel {
+    weak var paletteState: PaletteState?
+
+    /// Key stays with the palette: its `onKeyPress` handlers drive this menu's selection.
+    override var canBecomeKey: Bool { false }
+
+    init() {
+        super.init(
+            contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered, defer: false)
+        isFloatingPanel = true
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = true
+        acceptsMouseMovedEvents = true
+        ignoresMouseEvents = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    }
+
+    /// Mirrors `PalettePanel`: rows light on real pointer movement, never on a scroll under it.
+    override func sendEvent(_ event: NSEvent) {
+        switch event.type {
+        case .mouseMoved: paletteState?.notePointerMoved(to: NSEvent.mouseLocation)
+        case .scrollWheel: paletteState?.disarmHoverHighlight(pointerAt: NSEvent.mouseLocation)
+        default: break
+        }
+        super.sendEvent(event)
+    }
+}
+
+/// Presents one menu at a time in a `MenuPanel` hung off a corner of the palette.
+@MainActor
+final class MenuPanelController {
+    /// Where a menu hangs from, in the palette's own terms.
+    enum Corner {
+        case bottomLeading
+        case bottomTrailing
+        case belowHeaderTrailing
+    }
+
+    private var panel: MenuPanel?
+    private var hosting: NSHostingView<AnyView>?
+    private weak var parent: NSWindow?
+
+    /// Inset from the palette's corners, so the menu's own corner isn't flush with the panel's.
+    private static let inset: CGFloat = 8
+
+    var isOpen: Bool { panel?.isVisible ?? false }
+
+    func show(_ content: AnyView, corner: Corner, parent: NSWindow, core: AppCore) {
+        let root = AnyView(content.paletteEnvironment(core))
+        let panel = ensurePanel(state: core.palette)
+        if let hosting {
+            hosting.rootView = root
+        } else {
+            let view = NSHostingView(rootView: root)
+            view.sizingOptions = [.intrinsicContentSize]
+            panel.contentView = view
+            hosting = view
+        }
+        self.parent = parent
+        layout(corner: corner, parent: parent)
+        guard panel.parent == nil else { return }
+        parent.addChildWindow(panel, ordered: .above)
+    }
+
+    /// Rebuilds the hosted tree in place: the panel keeps its window, so nothing flickers.
+    func update(_ content: AnyView, corner: Corner, core: AppCore) {
+        guard let hosting, let parent else { return }
+        hosting.rootView = AnyView(content.paletteEnvironment(core))
+        layout(corner: corner, parent: parent)
+    }
+
+    func hide() {
+        guard let panel else { return }
+        panel.parent?.removeChildWindow(panel)
+        panel.orderOut(nil)
+    }
+
+    private func ensurePanel(state: PaletteState) -> MenuPanel {
+        if let panel {
+            panel.paletteState = state
+            return panel
+        }
+        let panel = MenuPanel()
+        panel.paletteState = state
+        self.panel = panel
+        return panel
+    }
+
+    /// Sizes to the hosted menu, then seats it against the palette's frame in screen space.
+    private func layout(corner: Corner, parent: NSWindow) {
+        guard let panel, let hosting else { return }
+        let size = hosting.intrinsicContentSize
+        guard size.width > 0, size.height > 0 else { return }
+        let host = parent.frame
+        let origin: NSPoint =
+            switch corner {
+            case .bottomLeading:
+                NSPoint(x: host.minX + Self.inset, y: host.minY + Self.inset)
+            case .bottomTrailing:
+                NSPoint(x: host.maxX - Self.inset - size.width, y: host.minY + Self.inset)
+            case .belowHeaderTrailing:
+                NSPoint(
+                    x: host.maxX - Theme.Spacing.md * 2 - size.width,
+                    y: host.maxY - Theme.Size.headerPadding - Theme.Size.headerHeight - size.height)
+            }
+        let frame = NSRect(origin: origin, size: size)
+        // Every arrow key re-pushes the tree, and only the highlight moved.
+        guard panel.frame != frame else { return }
+        panel.setFrame(frame, display: true)
+    }
+}

--- a/Tinycast/Palette/MenuPanel.swift
+++ b/Tinycast/Palette/MenuPanel.swift
@@ -46,8 +46,8 @@ final class MenuPanelController {
     private var hosting: NSHostingView<AnyView>?
     private weak var parent: NSWindow?
 
-    /// Inset from the palette's corners, so the menu's own corner isn't flush with the panel's.
-    private static let inset: CGFloat = 8
+    /// `bottomBar`'s own padding: a menu's edge must line up with the button it hangs off.
+    private static let inset: CGFloat = Theme.Spacing.md
 
     var isOpen: Bool { panel?.isVisible ?? false }
 

--- a/Tinycast/Palette/PaletteEnvironment.swift
+++ b/Tinycast/Palette/PaletteEnvironment.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+extension View {
+    /// Every store a palette surface reads. Shared so a second hosted hierarchy — the ⌘K menu's
+    /// own window — cannot drift from the palette's own.
+    func paletteEnvironment(_ core: AppCore) -> some View {
+        self
+            .environment(core)
+            .environment(core.settings)
+            .environment(core.palette)
+            .environment(core.appIndex)
+            .environment(core.clipboardStore)
+            .environment(core.favorites)
+            .environment(core.visibility)
+            .environment(core.aliases)
+            .environment(core.calcHistory)
+            .environment(core.currencyRates)
+            .environment(core.emojiIndex)
+            .environment(core.frequentEmoji)
+            .environment(core.fileSearch)
+            .environment(core.runningApps)
+            .environment(core.hotKeys)
+            .environment(core.uninstall)
+            .environment(core.quicklinks)
+            .environment(core.quicklinkArguments)
+            .environment(core.snippetsStore)
+            .environment(core.extensions)
+            .environment(core.calendarStore)
+            .environment(core.meetingClock)
+    }
+}

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -216,29 +216,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     private func ensurePanel() -> PalettePanel {
         if let panel { return panel }
-        let root = RootPaletteView()
-            .environment(core)
-            .environment(core.settings)
-            .environment(core.palette)
-            .environment(core.appIndex)
-            .environment(core.clipboardStore)
-            .environment(core.favorites)
-            .environment(core.visibility)
-            .environment(core.aliases)
-            .environment(core.calcHistory)
-            .environment(core.currencyRates)
-            .environment(core.emojiIndex)
-            .environment(core.frequentEmoji)
-            .environment(core.fileSearch)
-            .environment(core.runningApps)
-            .environment(core.hotKeys)
-            .environment(core.uninstall)
-            .environment(core.quicklinks)
-            .environment(core.quicklinkArguments)
-            .environment(core.snippetsStore)
-            .environment(core.extensions)
-            .environment(core.calendarStore)
-            .environment(core.meetingClock)
+        let root = RootPaletteView().paletteEnvironment(core)
         let panel = PalettePanel(rootView: root)
         panel.delegate = self
         panel.paletteState = core.palette

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -31,6 +31,9 @@ struct RootPaletteView: View {
     @State private var selectionIsRunning = false
     /// Highlighted row of whichever menu is open; each open path sets where it starts.
     @State private var menuSelection = 0
+    @State private var menuPanel = MenuPanelController()
+    /// The palette's own window, reported by `WindowReader`; the menu hangs off its frame.
+    @State private var hostWindow: NSWindow?
     /// The pending scroll request; modes are exclusive, so one piece of state serves all.
     @State private var scroll = ScrollIntent(kind: .top)
 
@@ -217,30 +220,8 @@ struct RootPaletteView: View {
                 .gesture(DragGesture(minimumDistance: 0).onEnded { _ in closeMenus() })
                 .allowsHitTesting(menuOpen)
         }
-        .overlay(alignment: .bottomLeading) {
-            if openMenu == .app, let content = menuContent {
-                content.view()
-                    .padding(Self.menuInset)
-                    .transition(Self.menuTransition(.bottomLeading))
-            }
-        }
-        .overlay(alignment: .bottomTrailing) {
-            if openMenu == .actions, let content = menuContent {
-                content.view()
-                    .padding(Self.menuInset)
-                    .transition(Self.menuTransition(.bottomTrailing))
-            }
-        }
-        // Header menus hang from their buttons rather than a panel corner.
-        .overlay(alignment: .topTrailing) {
-            if openMenu == .clipboardFilter || openMenu == .aiModel, let content = menuContent {
-                content.view()
-                    .padding(.top, Theme.Size.headerPadding + Theme.Size.headerHeight)
-                    // Right edges flush with the button's, which sits inside the same trailing gutter.
-                    .padding(.trailing, Theme.Spacing.md * 2)
-                    .transition(Self.menuTransition(.topTrailing))
-            }
-        }
+        // The menu lives in its own window; this only reports the one to hang it from.
+        .background(WindowReader { hostWindow = $0 })
         // The window's frame is the size source, so the glass and clip stay matched.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Theme.Colors.panelScrim)
@@ -291,7 +272,11 @@ struct RootPaletteView: View {
         // One optional makes "exactly one menu" structural; this only mirrors it for the panel.
         .onChange(of: openMenu) {
             vm.menuOpen = menuOpen
+            syncMenuPanel(presenting: true)
         }
+        // The hosted tree is its own hierarchy, so the highlight has to be pushed into it.
+        .onChange(of: menuSelection) { syncMenuPanel(presenting: false) }
+        .onDisappear { menuPanel.hide() }
         .onAppear { searchFocused = true }
         // Several paths flip `paletteIsCollapsed`, so resize the window to match.
         .onChange(of: core.paletteCoordinator.paletteIsCollapsed) {
@@ -736,19 +721,34 @@ struct RootPaletteView: View {
     /// Every open path lands here, so the highlight is always stated rather than left behind.
     private func open(_ menu: OpenMenu, highlighting row: Int) {
         menuSelection = row
-        withAnimation(Self.menuAnimation) { openMenu = menu }
+        openMenu = menu
     }
 
     private func closeMenus() {
-        withAnimation(Self.menuAnimation) { openMenu = nil }
+        openMenu = nil
     }
 
-    /// Inset from the bottom corners, so the menu's own corner isn't clipped.
-    private static let menuInset: CGFloat = 8
-    private static let menuAnimation: Animation = .easeOut(duration: 0.14)
+    /// Drives the menu's window from the two pieces of state that decide what it shows.
+    private func syncMenuPanel(presenting: Bool) {
+        guard let content = menuContent, let corner = menuCorner else {
+            menuPanel.hide()
+            return
+        }
+        let view = AnyView(content.view())
+        if presenting, let hostWindow {
+            menuPanel.show(view, corner: corner, parent: hostWindow, core: core)
+        } else {
+            menuPanel.update(view, corner: corner, core: core)
+        }
+    }
 
-    private static func menuTransition(_ anchor: UnitPoint) -> AnyTransition {
-        .opacity.combined(with: .scale(scale: 0.96, anchor: anchor))
+    private var menuCorner: MenuPanelController.Corner? {
+        switch openMenu {
+        case .app: .bottomLeading
+        case .actions: .bottomTrailing
+        case .clipboardFilter, .aiModel: .belowHeaderTrailing
+        case nil: nil
+        }
     }
 
     // MARK: - Actions

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -27,7 +27,7 @@ struct RootPaletteView: View {
     @FocusState private var argumentFocused: String?
     /// Which in-window menu is open; at most one, so the state cannot disagree with itself.
     @State private var openMenu: OpenMenu?
-    /// Sampled once by `openActions`, so the Quit row can't appear while the menu is up.
+    /// Sampled once by `openActions`, so the running-only rows can't appear while the menu is up.
     @State private var selectionIsRunning = false
     /// Highlighted row of whichever menu is open; each open path sets where it starts.
     @State private var menuSelection = 0
@@ -445,6 +445,13 @@ struct RootPaletteView: View {
                 !isCollapsed, let launcher = screen as? LauncherScreen
             else { return .ignored }
             return launcher.quit(at: selection(in: launcher)) ? .handled : .ignored
+        }
+        // ⌘R mirrors the Restart Application row, on the same guard and the same compact-bar skip.
+        .onKeyPress(keys: ["r"], phases: .down) { press in
+            guard press.modifiers.contains(.command), !isCollapsed,
+                let launcher = screen as? LauncherScreen
+            else { return .ignored }
+            return launcher.restart(at: selection(in: launcher)) ? .handled : .ignored
         }
     }
 

--- a/Tinycast/Palette/WindowReader.swift
+++ b/Tinycast/Palette/WindowReader.swift
@@ -1,0 +1,16 @@
+import AppKit
+import SwiftUI
+
+/// Reports the `NSWindow` hosting a SwiftUI tree, for the AppKit surfaces that hang off its frame.
+struct WindowReader: NSViewRepresentable {
+    let onResolve: (NSWindow?) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        // Nil until the view enters the hierarchy, and a palette never moves between windows.
+        DispatchQueue.main.async { onResolve(view.window) }
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {}
+}

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -358,18 +358,27 @@ Application and System Settings results expose **Show in Finder** in their ⌘K 
 shortcut is available for them. `AppEntry.canRevealInFinder` is the one rule both the menu row and
 the key handler read, so the advertised chord can't drift from the behavior.
 
-## Quitting apps
+## Quitting and restarting apps
 
 `RunningAppsMonitor` (live from `NSWorkspace` launch/terminate notifications) drives both the row's
-running dot and the availability of the quit actions:
+running dot and the availability of the running-only actions:
 
-- **Quit Application** — the last row of an app's ⌘K Actions menu, shown only while that app is
+- **Quit Application** — a row of an app's ⌘K Actions menu, shown only while that app is
   running, also bound to **⌃⇧Q** on the selected row. The chord guard mirrors the menu row's
   condition (an `.application` entry that `RunningAppsMonitor` reports running) so the key never
   swallows a press it won't act on, and it's skipped in the compact bar, which shows no selection.
   `AppLauncher.quit(bundleID:)` terminates every instance of the bundle and reports whether
   anything was running; the palette only dismisses when something was, and it restores focus unless
   the app it just quit _was_ `previousApp`.
+- **Restart Application** — the row above it and **⌘R**, on the same guard: both chords resolve
+  their target through `LauncherScreen.runningApplication(at:)`, the single place that condition
+  lives. `AppLauncher.restart(bundleID:url:)` snapshots the running instances, subscribes to
+  `NSWorkspace.DidTerminateApplicationMessage` _before_ terminating so an instance that exits at
+  once can't outrun the wait, then reopens the bundle once every snapshotted PID has gone. The wait
+  is bounded by a five-second grace: a quit an app refuses, or one sitting behind a save sheet the
+  user leaves standing, relaunches nothing and leaves that app running. The palette dismisses the
+  moment the quit is asked for and never restores focus — either the relaunch takes it, or the app
+  that refused the quit is the one asking for it.
 - **Quit All Applications** a system action. `AppLauncher.quitAllTargets()` is the
   policy (every `.regular` app except Finder — `terminate()` only relaunches it — and Tinycast,
   excluded by PID because About/Settings temporarily flips it to `.regular`). `SystemActionCoordinator.quitAllApps()`
@@ -380,6 +389,6 @@ Both quits are graceful `NSRunningApplication.terminate()`, so an app with unsav
 its own save sheet.
 
 The ⌘K menu samples `isRunning` **once, when it opens** (`RootPaletteView.openActions()`), so an app
-launching or quitting elsewhere can't add or drop the Quit row while the menu is up — the same freeze
+launching or quitting elsewhere can't add or drop those two rows while the menu is up — the same freeze
 the rest of the menu already has ([palette.md](palette.md)). Only `LauncherList` observes
 `RunningAppsMonitor` live, for the running dot.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -274,7 +274,7 @@ the arrow outside it, and AppKit's own alternation over the field came straight 
 `RootPaletteView` holds a single `OpenMenu?` rather than a flag per menu, so "at most one is open" is
 structural instead of a pair of `onChange` handlers pushing each other closed. Three cases today —
 the ⌘K Actions menu (`.bottomTrailing`), the app menu (`.bottomLeading`) and the clipboard type
-filter (`.topTrailing`, hung under its header button). `menuContent` resolves the open case to one
+filter (`.belowHeaderTrailing`, hung under its header button). `menuContent` resolves the open case to one
 `PaletteMenuContent` — a row count, a row action and a view built on demand — so ↑/↓, plain ↵, Esc and
 the click-away catcher serve every menu without knowing which is up. A screen supplies its rows as a
 `PopoverMenuContent` through `actions(at:)` and the default `menuContent` wraps them; a screen whose
@@ -287,6 +287,21 @@ active filter.
 
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.
+
+### The menu's own window
+
+A menu is **not** an overlay inside the palette: `MenuPanelController` hosts it in a `MenuPanel`, a
+borderless non-activating `NSPanel` added as a **child window** of the palette's, which is what makes
+it follow a palette drag and vanish with it. Glass renders against the desktop rather than inside an
+already-blurred, clipped panel, and no menu can be cropped by `RootPaletteView`'s `clipShape` however
+long it grows. `MenuPanel.canBecomeKey` is `false` so the palette keeps key status and its
+`onKeyPress` handlers keep driving the highlight, and `MenuPanel.sendEvent` mirrors `PalettePanel`'s
+hover arming — rows light on real pointer movement, never on a scroll under a still cursor.
+
+The panel is a second SwiftUI hierarchy, so it observes nothing of `RootPaletteView`'s `@State`:
+`syncMenuPanel` pushes a rebuilt tree on every `openMenu` or `menuSelection` change, and
+`paletteEnvironment` injects the same stores into both hierarchies so they cannot drift.
+`WindowReader` reports the palette's `NSWindow`, which the menu's frame is placed against.
 
 ## Menu-open input freeze
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -84,6 +84,36 @@ Notes has no corner of its own: it clips to `panel`, so the two floating surface
 
 Always `RoundedRectangle(cornerRadius:, style: .continuous)` — continuous corners everywhere, never `.circular`.
 
+#### Concentric corners
+
+**Where two rounded corners sit adjacent and are seen together, the inner radius is the outer radius
+minus the gap between them.** Miss it and the curves stop being parallel: the inner corner reads
+tight or slack against the one behind it, which is visible long before anyone can name it.
+
+Inside a menu the rule holds exactly, and `menuRow` exists to keep it holding:
+
+| Outer | Gap | Inner |
+| --- | --- | --- |
+| `menuPanel 16` | `Spacing.sm 6` | `menuRow 10` |
+
+**Alignment to a control outranks it.** Every palette menu hangs off a button, and its edge lines up
+with that button's — `MenuPanel.inset` is `Spacing.md`, which is `bottomBar`'s own horizontal padding,
+and the header menus use `Spacing.md * 2` to meet the header button in its wider gutter. The buttons
+sit directly under the menus, so a 2pt disagreement there reads as broken padding, while the same 2pt
+against the panel's corner reads as almost nothing. Anchor to the control, then let the corner fall
+where it does: `panel 26` against an 8pt gap would want `menuPanel 18`, and it stays 16.
+
+**It applies only where corners actually meet.** A list row sits mid-panel with the header above and
+the bottom bar below, so it shares no corner with `panel` and has nothing to be concentric with —
+`row 10` is chosen for the row's own size and stays on the shared scale. Forcing the rule there would
+round every row to 18 for no reason.
+
+If a pair ever does need closing, **move the gap, not the curve** — but only once you have checked
+what else is anchored to that gap. A radius is shared by surfaces across several features, a
+placement constant is not: `Radius.menuPanel` alone dresses the ⌘K menu, the extensions actions
+panel, the shortcut-recorder callout and the Notes switcher, and `menuRow` is deliberately equal to
+`row` so a row pill is one shape everywhere.
+
 ### Size (`Theme.Size`)
 
 `panelWidth 750` · `panelHeight 475` · `headerHeight 44` · `bottomBarHeight 52` · `barButtonHeight 28` ·

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -74,7 +74,15 @@ section's closing padding). See "Section headers" below.
 
 ### Radius (`Theme.Radius`)
 
-`panel 26` · `row 10` · `card 10` · `dialog 20` · `menuPanel 16` · `menu 6` · `menuRow 10` · `thumbnail 6` · `keyCap 6` · `recorderKeyCap 4`
+`panel 26` · `row 10` · `card 10` · `dialog 20` · `menuPanel 16` · `menu 6` · `menuRow 10` · `barControl 8` · `thumbnail 6` · `keyCap 6` · `recorderKeyCap 4`
+
+`barControl` dresses the header pop-ups (type filter, AI model), which state a value and drop a menu
+the way a native pop-up button does — a rectangle, not a pill.
+
+**The footer action group stays a `Capsule`, and so do the buttons inside it.** It is the primary
+action, and the pill is the affordance saying so; squaring it off reads as a toolbar. The capsule
+also keeps the pair concentric for free — a capsule's radius is half its height, so the inner
+buttons land exactly `Spacing.xs` inside the wrapper without either radius being written down.
 
 Notes has no corner of its own: it clips to `panel`, so the two floating surfaces read as siblings.
 


### PR DESCRIPTION
## Related issue

None — follows on from the existing Quit Application action.

## What changed

**Restart Application** joins Quit in an app's ⌘K Actions menu, shown only while that app is running, and takes **⌘R** on the selected row.

The non-obvious part is the wait. `AppLauncher.restart(bundleID:url:)`:

1. Snapshots the running instances of the bundle.
2. Subscribes to `NSWorkspace.DidTerminateApplicationMessage` **before** terminating any of them — an instance that exits immediately would otherwise post its notification before the observer existed and the wait would hang out its full grace period.
3. Terminates every instance, then reopens the bundle once every snapshotted PID has gone.

`terminate()` is a request, not a command, so the wait is bounded by a five-second grace (`AppLauncher.exitGrace`). A quit the app refuses, or one sitting behind a save sheet the user leaves standing, relaunches nothing and leaves that app running. Five seconds is far more than any app needs to exit, and short enough that an app can't relaunch under the user long after they walked away from the decision.

Uses the macOS 26 typed `NotificationCenter` message API rather than a `Notification` stream, which keeps the observer closure `@MainActor` and the payload concretely typed. No polling.

Two smaller things:

- The palette never restores focus on restart — either the relaunch takes focus, or the quit was refused and the app that refused it is the one putting up the sheet.
- `LauncherScreen.quit(at:)` and `restart(at:)` now share one `runningApplication(at:)` guard, so neither chord can drift from the menu row it mirrors. That was duplicated before this change.

## Memory footprint

<!-- Required. Under 100 MB always, and back to baseline after the palette closes. -->

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

> **Not yet measured — this is why the PR is a draft.** Taking these numbers means restarting the running dev instance and driving the palette on a live desktop, which I did not want to do unasked. Nothing here allocates per-row or holds anything past the action: one `AsyncStream`, one `ObservationToken` removed in `defer`, and one `Task` cancelled in `defer`, all torn down before `restart` returns. The expectation is no movement against baseline, but that is a prediction and not a measurement.

## Demo

> **Outstanding.** A new menu row is a visual change, so this needs the side-by-side before/after the template asks for. Not recorded yet.

## Drawbacks

- **The five-second grace is a judgment call.** If an app puts up a save sheet and the user takes longer than that to answer it, the app quits but does not relaunch. The alternative — waiting indefinitely — risks relaunching an app minutes later, under a user who has moved on. The failure mode chosen here is the recoverable one (press Return to launch it again); it is a one-line change if the tradeoff should go the other way.
- **⌘R is claimed on the launcher screen only.** It falls through as `.ignored` when the selection is not a running application, so nothing else in the palette loses the chord. The app defines no ⌘R menu item, so there is nothing to shadow.
- **A restart triggered on Tinycast itself is not special-cased.** It behaves like any other app: Tinycast is quit and reopened. That seemed correct rather than worth blocking, but flagging it as a deliberate non-decision.

## Tests & validation

`./Scripts/run-tests.sh` — all 49 harnesses pass. `./Scripts/lint.sh` clean. Debug build with no new warnings. The `Model/` import check returns nothing.

No harness was added: `AppLauncher` is AppKit-facing and drives real processes, so it sits outside the pure-model layer the harnesses compile. Instead the shipped `AppLauncher.swift` was compiled standalone under `-swift-version 6` and driven against real applications:

| Case | Result |
| --- | --- |
| Running app (TextEdit) | Returned in 0.39 s, **old PID already gone at return**, relaunched under a new PID |
| Quit refused | Returned at 5.32 s, same PID still running, nothing relaunched |
| App not running | Returned in 0.00005 s, did nothing |

The refused-quit case needed a purpose-built app returning `.terminateCancel` from `applicationShouldTerminate` — the first attempt used TextEdit with an unsaved document, which turned out to prove nothing, because modern TextEdit autosaves and quits without prompting.

The "old PID already gone at return" assertion is the load-bearing one: it is what distinguishes a real wait from a `restart` that fires the relaunch before the app has actually exited.

**Not yet exercised by hand:** pressing ⌘R in the running palette. The handler is a line-for-line mirror of the proven ⌃⇧Q handler, and ⌘K/⌘P already establish that ⌘-letter chords reach these handlers past the focused search field — but that is verification by construction, not by keypress. Needs a pass of the launcher section of the manual sweep before this comes out of draft.
