### PR TITLE
Repaint an app's icon after a custom icon is pasted onto its bundle

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -146,7 +146,8 @@ run callout-test           Tinycast/Platform/Appearance.swift \
 run icon-cache-test        Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift
 run entry-icon-test        Tinycast/Platform/Appearance.swift \
-                           Tinycast/Platform/Images/IconCache.swift
+                           Tinycast/Platform/Images/IconCache.swift \
+                           Tinycast/Platform/Images/FileIconStamp.swift
 run ext-icon-test          Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift \
                            Tinycast/Platform/Compression/Zlib.swift \

--- a/Tests/entry-icon-test.swift
+++ b/Tests/entry-icon-test.swift
@@ -24,7 +24,8 @@ struct EntryIconTests {
     /// on it. Two icons that render differently but print the same would serve each other's bitmap.
     static func everyCasePrintsDistinctly() {
         let icons: [EntryIcon] = [
-            .file,
+            .file(stamp: 0),
+            .file(stamp: 1),
             .symbol("star"),
             .symbol("bolt"),
             .tintedSymbol(name: "star", tint: red),
@@ -54,7 +55,10 @@ struct EntryIconTests {
                 != EntryIcon.artwork(path: "/tmp/a.png", extent: 0.83),
             "one file at two extents differs")
         expect(
-            Set([EntryIcon.file, .symbol("star"), .file]).count == 2,
+            EntryIcon.file(stamp: 0) != EntryIcon.file(stamp: 1),
+            "one file at two stamps differs")
+        expect(
+            Set([EntryIcon.file(stamp: 0), .symbol("star"), .file(stamp: 0)]).count == 2,
             "hashing collapses only equal values")
     }
 
@@ -64,7 +68,7 @@ struct EntryIconTests {
     static func everyCaseDraws() {
         let url = URL(fileURLWithPath: "/System/Applications/Calculator.app")
         let cases: [(String, EntryIcon)] = [
-            ("file", .file),
+            ("file", .file(stamp: 0)),
             ("symbol", .symbol("star")),
             ("tintedSymbol", .tintedSymbol(name: "star", tint: red))
         ]
@@ -120,9 +124,42 @@ struct EntryIconTests {
         expect(IconCache.cached(warm, fileURL: url) != nil, "a drawn icon is reported warm")
     }
 
+    // MARK: - Restamping
+
+    /// The reported bug: an app whose icon changed on disk kept painting whatever was decoded first,
+    /// because the cache key was the path alone. Pasting an icon in Finder is this `Icon\r` write.
+    static func aChangedIconRetiresTheCachedBitmap() {
+        guard let bundle = makeBundle() else { return expect(false, "the fixture bundle writes") }
+        defer { try? FileManager.default.removeItem(at: bundle) }
+
+        let cold = FileIconStamp.value(for: bundle)
+        expect(FileIconStamp.value(for: bundle) == cold, "an untouched bundle keeps its stamp")
+        _ = IconCache.icon(for: .file(stamp: cold), fileURL: bundle)
+        expect(
+            IconCache.cached(.file(stamp: cold), fileURL: bundle) != nil, "the first decode is cached")
+
+        try? Data([0]).write(to: URL(fileURLWithPath: bundle.path + "/Icon\r"))
+        let warm = FileIconStamp.value(for: bundle)
+        expect(warm != cold, "gaining a custom icon moves the stamp")
+        expect(
+            IconCache.cached(.file(stamp: warm), fileURL: bundle) == nil,
+            "the moved stamp misses the bitmap decoded before the change")
+    }
+
     // MARK: - Helpers
 
     static func bitmap(_ image: NSImage) -> Data? { image.tiffRepresentation }
+
+    /// A directory shaped like an app bundle, which is all `NSWorkspace` needs to hand back an icon.
+    static func makeBundle() -> URL? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("entry-icon-test-\(UUID().uuidString).app")
+        guard
+            (try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true))
+                != nil
+        else { return nil }
+        return url
+    }
 
     /// A red square filling its canvas, so fitting it to an extent is visible in the result.
     static func writePNG() -> URL? {
@@ -185,6 +222,7 @@ struct EntryIconTests {
         oneFileAtTwoExtentsDiffers()
         askingTwiceIsStable()
         cacheOnlyLookupMatchesTheDrawnIcon()
+        aChangedIconRetiresTheCachedBitmap()
 
         print(failures == 0 ? "Entry icon tests passed" : "\(failures) tests failed")
         exit(failures == 0 ? 0 : 1)

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		E457BC709D195B8F5D0C2A79 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6DAC3B9FF387367C3FAB4 /* UninstallSession.swift */; };
 		E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E25B87C692D5FEE1FBF994 /* PanelTransition.swift */; };
 		E4C40AC649B871B08B7F1B6E /* QuickActionPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEF20B209EEEAB7ED97DF36 /* QuickActionPanel.swift */; };
+		E4C6F315EA0F0544D9E4BB08 /* FileIconStamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC39721B6964B279FB5D5DC3 /* FileIconStamp.swift */; };
 		E4E1403AA9A8ACE4A3D3581C /* MeetingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B330ABFC83721904159DDF2 /* MeetingEvent.swift */; };
 		E58AB83C608F8BBF99EAEB7E /* QuicklinkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856F65245B10433A230194E6 /* QuicklinkListView.swift */; };
 		E63AA3E7A400CB81FBFC3214 /* RaycastFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09A0608AC763EBC26216118 /* RaycastFormat.swift */; };
@@ -751,6 +752,7 @@
 		C975F928132D3DAB1BB569F0 /* AISettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsStore.swift; sourceTree = "<group>"; };
 		CBCCFC1039C315D2F74418FE /* UpdateWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateWindowView.swift; sourceTree = "<group>"; };
 		CBFF39C46E98D0808B188E2E /* FileSearchIgnoreList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchIgnoreList.swift; sourceTree = "<group>"; };
+		CC39721B6964B279FB5D5DC3 /* FileIconStamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconStamp.swift; sourceTree = "<group>"; };
 		CC67BADEB6FEC76C88585361 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
 		CCCBDD92DEAD780A1DC423CA /* ExtensionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionScreen.swift; sourceTree = "<group>"; };
 		CEEF20B209EEEAB7ED97DF36 /* QuickActionPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionPanel.swift; sourceTree = "<group>"; };
@@ -1929,6 +1931,7 @@
 		DD0FEE8E2D95BD51907D383E /* Images */ = {
 			isa = PBXGroup;
 			children = (
+				CC39721B6964B279FB5D5DC3 /* FileIconStamp.swift */,
 				E5CBCCE63360E4590CF5884A /* IconCache.swift */,
 				8C39345D0335ACA895133ABD /* IconStyleMonitor.swift */,
 				36C6775BBA0FC6F134296606 /* ImageThumbnail.swift */,
@@ -2363,6 +2366,7 @@
 				330540BBA991E36DD4C4BF53 /* ExtensionsSettingsView.swift in Sources */,
 				75EF3CFF00A2215D57A4FBFF /* FavoriteSlots.swift in Sources */,
 				555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */,
+				E4C6F315EA0F0544D9E4BB08 /* FileIconStamp.swift in Sources */,
 				345D1FCC2085BD0D699DD236 /* FileSearchCoordinator.swift in Sources */,
 				5970306ABC24B03028E66D45 /* FileSearchIgnoreList.swift in Sources */,
 				D3F07F4AEBEAA489EDCD0763 /* FileSearchList.swift in Sources */,

--- a/Tinycast/DesignSystem/PopoverMenu.swift
+++ b/Tinycast/DesignSystem/PopoverMenu.swift
@@ -174,7 +174,8 @@ private struct PopoverMenuRow: View {
             // Stated, not padded: the height maths above counts rows, so a row is one exact height.
             .frame(
                 maxWidth: .infinity, minHeight: Theme.Size.menuRowHeight,
-                maxHeight: Theme.Size.menuRowHeight, alignment: .leading)
+                maxHeight: Theme.Size.menuRowHeight, alignment: .leading
+            )
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)

--- a/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
@@ -124,7 +124,8 @@ private struct ExtensionActionRow: View {
             // Fixed, not padded: the height maths above counts rows, so a row is one exact height.
             .frame(
                 maxWidth: .infinity, minHeight: Metrics.rowHeight, maxHeight: Metrics.rowHeight,
-                alignment: .leading)
+                alignment: .leading
+            )
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -82,6 +82,8 @@ struct AppEntry: Identifiable, Hashable, Sendable {
     var alternateNames: [String] = []
     /// `CFBundleExecutable`, matched literally as a last resort. Applications only.
     var executableName: String?
+    /// Moves when the bundle's icon changes on disk, retiring the cached bitmap. Applications only.
+    var iconStamp: Int = 0
     /// Set by the feature that produced the entry when its glyph isn't derivable from `kind`.
     var iconOverride: EntryIcon?
     /// What this entry comes from — an extension's title. Labels the row, and matches weakly.
@@ -128,7 +130,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
 
     /// Derived from the kind alone: synthetic entries get a symbol tile, everything else its file.
     private var defaultIcon: EntryIcon {
-        guard kind.descriptor.isSymbolIcon else { return .file }
+        guard kind.descriptor.isSymbolIcon else { return .file(stamp: iconStamp) }
         return .symbol(symbolName ?? kindSymbol)
     }
 
@@ -400,7 +402,7 @@ final class AppIndex {
                         // A binary named after the app adds nothing the display name lacks.
                         executableName: executable.flatMap {
                             $0.caseInsensitiveCompare(name) == .orderedSame ? nil : $0
-                        }))
+                        }, iconStamp: FileIconStamp.value(for: url)))
             }
             // Slice order is section order, so the flat selection maps 1:1 onto rows.
             let apps = result.sorted {

--- a/Tinycast/Features/Launcher/Service/AppLauncher.swift
+++ b/Tinycast/Features/Launcher/Service/AppLauncher.swift
@@ -92,7 +92,9 @@ enum AppLauncher {
         var pending = Set(apps.map(\.processIdentifier))
         for app in apps { app.terminate() }
 
-        let grace = Task { try? await Task.sleep(for: exitGrace); continuation.finish() }
+        let grace = Task {
+            try? await Task.sleep(for: exitGrace); continuation.finish()
+        }
         defer { grace.cancel() }
         for await pid in exits {
             pending.remove(pid)

--- a/Tinycast/Platform/Images/FileIconStamp.swift
+++ b/Tinycast/Platform/Images/FileIconStamp.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A file's icon identity on disk. Pasting a custom icon onto a bundle writes `Icon\r` inside it and
+/// flips a FinderInfo bit, so the bundle's own contents never have to move for its icon to change.
+enum FileIconStamp {
+    private static let keys: Set<URLResourceKey> = [
+        .contentModificationDateKey, .attributeModificationDateKey, .fileSizeKey
+    ]
+
+    static func value(for url: URL) -> Int {
+        var hasher = Hasher()
+        combine(url, into: &hasher)
+        combine(URL(fileURLWithPath: url.path + "/Icon\r"), into: &hasher)
+        return hasher.finalize()
+    }
+
+    /// A path that does not exist contributes nothing, so gaining or losing `Icon\r` moves the stamp.
+    private static func combine(_ url: URL, into hasher: inout Hasher) {
+        guard let values = try? url.resourceValues(forKeys: keys) else { return }
+        hasher.combine(values.contentModificationDate)
+        hasher.combine(values.attributeModificationDate)
+        hasher.combine(values.fileSize)
+    }
+}

--- a/Tinycast/Platform/Images/IconCache.swift
+++ b/Tinycast/Platform/Images/IconCache.swift
@@ -44,7 +44,8 @@ struct SymbolTint: Hashable, Sendable {
 /// What a row draws. A feature sets one rather than adding a branch to `AppEntry`, and `artwork`
 /// carries its extent because the size is the caller's decision, judged against `appIconExtent`.
 enum EntryIcon: Hashable, Sendable {
-    case file
+    /// The stamp is `FileIconStamp`'s: it moves when the file's icon does, retiring the old bitmap.
+    case file(stamp: Int)
     case symbol(String)
     case tintedSymbol(name: String, tint: SymbolTint)
     case artwork(path: String, extent: CGFloat)
@@ -73,7 +74,9 @@ enum IconCache {
     private static let fittedGeneration = Mutex(IconCacheGeneration())
 
     /// Cache-only lookups (never decode) so a row can paint an already-warm icon on the same frame.
-    static func cached(forFile path: String) -> NSImage? { cache.object(forKey: fileKey(path)) }
+    static func cached(forFile path: String, stamp: Int = 0) -> NSImage? {
+        cache.object(forKey: fileKey(path, stamp))
+    }
     static func cachedSymbol(named name: String, tint: SymbolTint? = nil) -> NSImage? {
         cache.object(forKey: symbolKey(name, tint))
     }
@@ -150,11 +153,11 @@ enum IconCache {
     }
 
     /// Returns the decode directly, so a purge mid-decode can't strand a placeholder.
-    static func loadAsync(forFile path: String) async -> NSImage? {
-        if let cached = cached(forFile: path) { return cached }
+    static func loadAsync(forFile path: String, stamp: Int = 0) async -> NSImage? {
+        if let cached = cached(forFile: path, stamp: stamp) { return cached }
         return await Task.detached(priority: .userInitiated) { () -> Decoded in
             guard FileManager.default.fileExists(atPath: path) else { return Decoded(image: nil) }
-            return Decoded(image: icon(forFile: path))
+            return Decoded(image: icon(forFile: path, stamp: stamp))
         }.value.image
     }
     static func loadSymbolAsync(named name: String, tint: SymbolTint? = nil) async -> NSImage? {
@@ -164,8 +167,8 @@ enum IconCache {
         }.value.image
     }
 
-    static func icon(forFile path: String) -> NSImage {
-        let key = fileKey(path)
+    static func icon(forFile path: String, stamp: Int = 0) -> NSImage {
+        let key = fileKey(path, stamp)
         if let cached = cache.object(forKey: key) { return cached }
         let (icon, cost) = downsampled(NSWorkspace.shared.icon(forFile: path))
         cache.setObject(icon, forKey: key, cost: cost)
@@ -265,7 +268,7 @@ enum IconCache {
     /// One switch, so a row never has to know which of these paths its entry wants.
     static func icon(for source: EntryIcon, fileURL: URL) -> NSImage {
         switch source {
-        case .file: return icon(forFile: fileURL.path)
+        case .file(let stamp): return icon(forFile: fileURL.path, stamp: stamp)
         case .symbol(let name): return symbolIcon(named: name)
         case .tintedSymbol(let name, let tint): return symbolIcon(named: name, tint: tint)
         case .artwork(let path, let extent): return artwork(atPath: path, extent: extent)
@@ -274,7 +277,7 @@ enum IconCache {
 
     static func cached(_ source: EntryIcon, fileURL: URL) -> NSImage? {
         switch source {
-        case .file: return cached(forFile: fileURL.path)
+        case .file(let stamp): return cached(forFile: fileURL.path, stamp: stamp)
         case .symbol(let name): return cachedSymbol(named: name)
         case .tintedSymbol(let name, let tint): return cachedSymbol(named: name, tint: tint)
         case .artwork(let path, let extent): return cachedArtwork(atPath: path, extent: extent)
@@ -283,7 +286,7 @@ enum IconCache {
 
     static func loadAsync(_ source: EntryIcon, fileURL: URL) async -> NSImage? {
         switch source {
-        case .file: return await loadAsync(forFile: fileURL.path)
+        case .file(let stamp): return await loadAsync(forFile: fileURL.path, stamp: stamp)
         case .symbol(let name): return await loadSymbolAsync(named: name)
         case .tintedSymbol(let name, let tint): return await loadSymbolAsync(named: name, tint: tint)
         case .artwork(let path, let extent):
@@ -324,7 +327,9 @@ enum IconCache {
         }
     }
 
-    private static func fileKey(_ path: String) -> NSString { key("file:" + path) }
+    private static func fileKey(_ path: String, _ stamp: Int) -> NSString {
+        key("file:\(stamp):\(path)")
+    }
     private static func fittedKey(_ path: String) -> NSString { key("fit:" + path) }
 
     private static func fittedIcon(forFile path: String) -> Decoded {

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -302,6 +302,13 @@ paths; see the command in `development.md`.
 Launcher icons use a persistent 32 MB cost-capped `NSCache`. Fitted file-row icons use a separate
 transient 8 MB cache that is purged when its palette list disappears (`IconCache`).
 
+A file-icon key carries a `FileIconStamp` as well as the path — the bundle's own modification and
+attribute dates plus its `Icon\r` — because pasting a custom icon in Finder leaves the bundle's
+contents alone, so a path-only key served the bitmap decoded first for the rest of the session.
+`AppIndex.scan` reads the stamp off-main into `AppEntry.iconStamp`, `EntryIcon.file` carries it, and
+because it is part of `iconKey` the re-scan on the next palette open re-decodes exactly the apps
+whose icon moved.
+
 ## Favorites
 
 `FavoritesStore.keys` is the order — the array *is* the ranking, and it only shows while the query is

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -98,7 +98,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `ext-store-test` | `Extensions/Model/` — the registry model and both registry APIs' parsers |
 | `ext-test` | the extension runtime end to end — boots a real bundle in JavaScriptCore and renders it |
 | `ext-icon-test` | `Extensions/Service/ExtensionIconCache.swift` — artwork sizing and its fallback |
-| `entry-icon-test` | `EntryIcon` — that each case draws, caches and prints apart from the others |
+| `entry-icon-test` | `EntryIcon` — that each case draws, caches and prints apart from the others, and that a moved `FileIconStamp` retires the bitmap decoded before it |
 | `settings-backup-test` | `Settings/AppSettingsKey.swift`, `Backup/Model/SettingsBackupCoverage.swift` |
 | `updates-test` | `Updates/Model/` — version precedence, channel filtering, install route, readiness |
 | `support-test` | `Support/Model/` — when the support reminder comes due, and a clock moved backwards |


### PR DESCRIPTION
## Related issue

Closes #366

## What changed

The file icon cache was keyed on the path alone (`file:<path>`), and nothing ever invalidated a file
icon — `IconCache.invalidateStyled()` only fires for an appearance or icon-style change. So the first
bitmap decoded for an app was served for the rest of the session.

That is exactly what a custom icon breaks. Pasting one in Finder writes `Icon\r` *inside* the bundle
and flips a FinderInfo bit on it, so the bundle's own contents never move — there is no signal a
path-keyed cache could have noticed even if it had looked.

- **`Platform/Images/FileIconStamp.swift`** (new) — a file's icon identity on disk: the content- and
  attribute-modification dates and size of the bundle, hashed together with the same three for its
  `Icon\r`. Both halves are load-bearing: the bundle's dates catch the bit being flipped and the icon
  file appearing or vanishing, the `Icon\r` stat catches the artwork being rewritten in place.
- **`EntryIcon.file` → `.file(stamp:)`**, and the cache key becomes `file:<stamp>:<path>`. A changed
  icon lands on a different key instead of being handed the bitmap decoded before the change.
- **`AppEntry.iconStamp`**, read during `AppIndex.scan` — off-main, where the scan already builds a
  `Bundle` per app.

The one thing worth pointing at in the diff: no new signal or invalidation path was needed. The stamp
travels inside `iconSource`, which is already interpolated into `AppEntry.iconKey`, which is already
what `AppIconView` keys its `.task(id:)` on. So the re-scan on every launcher open re-fires the icon
load for exactly the apps whose icon moved, and leaves every other row alone.

## Memory footprint

Not measured — the diff adds no allocation path. Both cache cost limits are untouched, the stamp is
an `Int` on a struct the index already holds one of per app, and nothing new is retained. A moved
stamp retires one cached bitmap and decodes one to replace it, which is the same cost as the first
decode of that row.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | n/a    |
| Palette open            | n/a    |
| Feature in use (peak)   | n/a    |
| Palette closed, settled | n/a    |

Leak-tested: no.

## Demo

No visual change to any surface — the same icon is drawn, just no longer a stale one.

## Drawbacks

**This does not fix every way the reported symptom can happen.** The generic folder in #366 is what
LaunchServices itself returns when a bundle's custom-icon flag is set but the icon behind it cannot
be read — verified by reproducing it on a copy of Ghostty.app, both by emptying `Icon\r` and by
deleting it with the flag left in place. In that state every client gets the folder, Finder included,
and no cache key can help; clearing the stale flag with `xattr -d com.apple.FinderInfo <app>` is the
fix. This PR covers the other half — a real icon change that Tinycast simply never picked up — and
that is the half that is ours.

Tinycast could paper over the first case too, by falling back to the bundle's declared `.icns` when
LaunchServices hands back the generic folder for an `.app`. Left out on purpose: it would make
Tinycast disagree with Finder about a genuinely broken bundle.

Two stats per app bundle per scan, measured at ~4 ms for 82 bundles, inside a scan that is already
off-main and much heavier. Re-stamping `/Applications` twice three seconds apart moved zero stamps,
so it does not churn the cache on its own.

## Tests & validation

`./Scripts/run-tests.sh` — all 49 harnesses pass. `entry-icon-test` gains
`aChangedIconRetiresTheCachedBitmap`, which decodes an icon, writes `Icon\r`, and asserts the moved
stamp misses the bitmap decoded before the change; its existing cases were updated for the new
`EntryIcon` shape, including one file at two stamps reading as two icons.

By hand, against a real copy of `/Applications/Ghostty.app` driven through `NSWorkspace.setIcon` —
the same call Finder's Get Info paste makes:

```
setIcon -> true
stamp moved: true
bitmap changed: true
old stamp still serves the old bitmap: true
clearing moves the stamp again: true
```

Debug builds with no new warnings, `./Scripts/lint.sh` is clean, and the `Features/*/Model/` AppKit
import check returns nothing.
