### PR TITLE
Prompt for a custom command's arguments and stream its output live

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -123,13 +123,16 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
-                           Tinycast/Features/Quicklinks/Model/Quicklink.swift
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run palette-escape-test    Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteEscapeAction.swift \
-                           Tinycast/Features/Quicklinks/Model/Quicklink.swift
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run palette-tab-test       Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteTabAction.swift \
-                           Tinycast/Features/Quicklinks/Model/Quicklink.swift
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
                            Tinycast/Features/HotKeys/Model/HyperKey.swift \
@@ -171,8 +174,10 @@ run window-command-test    Tinycast/Features/WindowManagement/WindowCommand.swif
                            Tinycast/Features/WindowManagement/WindowActionMemory.swift
 run space-gesture-test     Tinycast/Features/WindowManagement/WindowCommand.swift \
                            Tinycast/Features/WindowManagement/SpaceGesture.swift
-run custom-command-test    Tinycast/Features/CustomCommands/Model/CustomCommand.swift \
-                           Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
+run custom-command-test    Tinycast/Platform/PseudoTerminal.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift \
+                           Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift \
+                           Tinycast/Features/CustomCommands/Service/CustomCommandArgumentSession.swift
 run uninstall-test         Tinycast/Features/Uninstall/Model/UninstallTarget.swift \
                            Tinycast/Features/Uninstall/Model/UninstallSearchRoot.swift \
                            Tinycast/Features/Uninstall/Model/UninstallRules.swift \

--- a/Tests/custom-command-test.swift
+++ b/Tests/custom-command-test.swift
@@ -68,29 +68,175 @@ struct CustomCommandTests {
         store.replace(with: [
             CustomCommand(
                 name: "Imported", command: "/usr/bin/true", loadsShellEnvironment: true,
-                requiresConfirmation: true, showsConfirmation: true)
+                requiresConfirmation: true, showsConfirmation: true,
+                arguments: [CustomCommandArgument(name: "  Query  ", isOptional: true)],
+                showsOutput: true)
         ])
         check(
             "import preserves every flag",
             store.commands.first?.loadsShellEnvironment == true
                 && store.commands.first?.requiresConfirmation == true
-                && store.commands.first?.showsConfirmation == true)
+                && store.commands.first?.showsConfirmation == true
+                && store.commands.first?.showsOutput == true)
+        check(
+            "import trims an argument name and keeps its optionality",
+            store.commands.first?.arguments == [
+                CustomCommandArgument(name: "Query", isOptional: true)
+            ])
+
+        store.replace(with: [
+            CustomCommand(
+                name: "Blanks", command: "/usr/bin/true",
+                arguments: [
+                    CustomCommandArgument(name: "Kept"), CustomCommandArgument(name: "   ")
+                ])
+        ])
+        check(
+            "a blank argument is dropped without losing the command",
+            store.commands.first?.arguments == [CustomCommandArgument(name: "Kept")])
+
+        // A command stored before arguments existed must still decode, not vanish with the whole set.
+        let legacy = Data(
+            """
+            [{"id":"\(UUID().uuidString)","name":"Legacy","command":"/usr/bin/true"}]
+            """.utf8)
+        defaults.set(legacy, forKey: "customCommands")
+        check(
+            "a record written before arguments existed still loads",
+            CustomCommandStore(defaults: defaults).commands.first?.name == "Legacy")
 
         // MARK: Runner
 
         let succeeded = await ShellCommandRunner.run("/usr/bin/true")
-        check("a zero exit reports success", succeeded == .success)
+        check("a zero exit reports success", succeeded.succeeded)
 
         let inHome = await ShellCommandRunner.run("test \"$PWD\" = \"$HOME\"")
-        check("commands start in the user's home directory", inHome == .success)
+        check("commands start in the user's home directory", inHome.succeeded)
 
         let marker = await ShellCommandRunner.run("test \"$TINYCAST\" = 1")
-        check("the TINYCAST marker is exported so a shell config can detect us", marker == .success)
+        check("the TINYCAST marker is exported so a shell config can detect us", marker.succeeded)
 
         let failed = await ShellCommandRunner.run("printf 'expected failure' >&2; exit 7")
         check(
             "a non-zero exit reports its status and stderr",
-            failed == .nonZeroExit(status: 7, stderr: "expected failure"))
+            failed.termination == .exited(status: 7) && failed.standardError == "expected failure")
+
+        // MARK: Streaming output
+
+        /// Drains a streamed run, returning everything it printed and how it ended.
+        func collect(_ session: ShellCommandSession) async -> (log: String, result: ShellCommandResult?) {
+            var log = ""
+            var result: ShellCommandResult?
+            for await event in session.events {
+                switch event {
+                case .output(let text): log += text
+                case .finished(let value): result = value
+                }
+            }
+            return (log.replacingOccurrences(of: "\r", with: ""), result)
+        }
+
+        let simple = await collect(ShellCommandRunner.stream("echo captured"))
+        check("a streamed run reports what it printed", simple.log.contains("captured"))
+        check("a streamed run reports a clean exit", simple.result?.succeeded == true)
+
+        // The reported bug: brew writes `==>` to stderr, and it must not be reordered behind stdout.
+        let ordered = await collect(
+            ShellCommandRunner.stream("printf 'one\\n'; printf 'two\\n' >&2; printf 'three\\n'"))
+        let places = ["one", "two", "three"].map { ordered.log.range(of: $0)?.lowerBound }
+        check(
+            "both streams keep the order they were written in",
+            places.allSatisfy { $0 != nil } && places[0]! < places[1]! && places[1]! < places[2]!)
+
+        // A pipe would block-buffer this and deliver it all at exit; a pty must not.
+        let live = ShellCommandRunner.stream("echo first; sleep 1; echo second")
+        let began = Date()
+        var firstOutputAt: TimeInterval?
+        for await event in live.events {
+            if case .output = event, firstOutputAt == nil {
+                firstOutputAt = Date().timeIntervalSince(began)
+            }
+        }
+        check(
+            "output arrives while the command is still running",
+            (firstOutputAt ?? .greatestFiniteMagnitude) < 0.5)
+
+        let statused = await collect(ShellCommandRunner.stream("exit 7"))
+        check(
+            "a streamed run reports its exit status",
+            statused.result?.termination == .exited(status: 7))
+
+        let multibyte = await collect(
+            ShellCommandRunner.stream("printf 'h\u{e9}llo w\u{f6}rld \u{2014} \u{fc}n\u{ef}code\\n'"))
+        check(
+            "a multi-byte character is never split into a replacement character",
+            multibyte.log.contains("h\u{e9}llo w\u{f6}rld \u{2014} \u{fc}n\u{ef}code")
+                && !multibyte.log.contains("\u{FFFD}"))
+
+        // Stop must reach the whole chain, not just the shell in front of it.
+        let stoppable = ShellCommandRunner.stream("sleep 43 & sleep 44")
+        Task {
+            try? await Task.sleep(for: .milliseconds(600))
+            stoppable.stop()
+        }
+        let stopped = await collect(stoppable)
+        check(
+            "a stopped run says so rather than reporting a signal",
+            stopped.result?.termination == .stopped)
+        try? await Task.sleep(for: .milliseconds(400))
+        let survivors = await collect(ShellCommandRunner.stream("pgrep -f 'sleep 4[34]' | wc -l"))
+        check(
+            "stopping kills the whole command tree, not just the shell",
+            survivors.log.trimmingCharacters(in: .whitespacesAndNewlines) == "0")
+
+        // MARK: Arguments
+
+        let positional = await collect(
+            ShellCommandRunner.stream(
+                "test \"$1\" = alpha && test \"$2\" = beta", arguments: ["alpha", "beta"]))
+        check("values arrive as positional parameters", positional.result?.succeeded == true)
+
+        // The whole reason values are passed positionally: shell syntax in one is inert.
+        let injected = await collect(
+            ShellCommandRunner.stream(
+                "printf '%s\\n' \"$1\"", arguments: ["; touch /tmp/tinycast-should-not-exist"]))
+        check(
+            "a value carrying shell syntax is data, not code",
+            injected.log.contains("; touch /tmp/tinycast-should-not-exist")
+                && !FileManager.default.fileExists(atPath: "/tmp/tinycast-should-not-exist"))
+
+        // MARK: Argument session
+
+        let session = CustomCommandArgumentSession()
+        session.begin(
+            command: CustomCommand(
+                name: "Search", command: "open \"$1$2\"",
+                arguments: [
+                    CustomCommandArgument(name: "Engine"),
+                    CustomCommandArgument(name: "Query", isOptional: true)
+                ]))
+        check("the form opens on the first argument", session.current?.name == "Engine")
+        check("the prompt names the pending argument", session.prompt == "Engine…")
+        check("more than one argument left means ↵ advances", !session.isLastArgument)
+        check("submitting an incomplete form yields nothing", session.submit("google") == nil)
+        check("the form advances to the next argument", session.current?.name == "Query")
+        check("one argument left means ↵ runs", session.isLastArgument)
+        check(
+            "an answered argument shows its value",
+            session.progress.map(\.value) == ["google", nil])
+
+        check("backspace hands the previous answer back", session.retreat() == "google")
+        check("retreating reopens that argument", session.current?.name == "Engine")
+        check("retreating past the first is refused", session.retreat() == nil)
+
+        _ = session.submit("google")
+        let completed = session.submit("swift")
+        check("the last answer completes the form", completed?.values == ["google", "swift"])
+        check("a full form has nothing left pending", session.current == nil)
+        check("submitting past the last argument is refused", session.submit("extra") == nil)
+
+        session.cancel()
+        check("cancelling ends the session", !session.isActive && session.prompt == nil)
 
         // MARK: Shell environment
 
@@ -108,18 +254,18 @@ struct CustomCommandTests {
             "tinycast_probe", loadingShellEnvironment: true)
         check(
             "loading the shell environment resolves an rc-file alias",
-            withEnvironment == .success)
+            withEnvironment.succeeded)
 
         // The exact symptom users reported: an alias that only exists in `.zshrc` is command-not-found.
         let withoutEnvironment = await ShellCommandRunner.run("tinycast_probe")
-        var notFoundStatus: Int32 = 0
-        if case .nonZeroExit(let status, _) = withoutEnvironment { notFoundStatus = status }
-        check("the default shell exits 127 on an rc-file alias", notFoundStatus == 127)
+        check(
+            "the default shell exits 127 on an rc-file alias",
+            withoutEnvironment.termination == .exited(status: 127))
 
         // The whole "an interactive shell can't block" argument rests on this: a config or command that prompts reads EOF.
         let prompted = await ShellCommandRunner.run(
             "read -r answer", loadingShellEnvironment: true)
-        check("a command reading stdin fails instead of hanging", prompted != .success)
+        check("a command reading stdin fails instead of hanging", !prompted.succeeded)
 
         unsetenv("ZDOTDIR")
 

--- a/Tests/custom-command-test.swift
+++ b/Tests/custom-command-test.swift
@@ -133,7 +133,11 @@ struct CustomCommandTests {
                 case .finished(let value): result = value
                 }
             }
-            return (log.replacingOccurrences(of: "\r", with: ""), result)
+            // A pty ends every line with CR LF, and the trailing newline is never part of the
+            // thing under test.
+            return (
+                log.replacingOccurrences(of: "\r", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines), result)
         }
 
         let simple = await collect(ShellCommandRunner.stream("echo captured"))
@@ -188,6 +192,65 @@ struct CustomCommandTests {
         check(
             "stopping kills the whole command tree, not just the shell",
             survivors.log.trimmingCharacters(in: .whitespacesAndNewlines) == "0")
+
+        // MARK: Working directory
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let atHome = await collect(ShellCommandRunner.stream("pwd"))
+        check("a command with no folder starts at home", atHome.log.hasSuffix(home))
+
+        let elsewhere = await collect(
+            ShellCommandRunner.stream("pwd", workingDirectory: "/usr/lib"))
+        check("a command runs in the folder it names", elsewhere.log.hasSuffix("/usr/lib"))
+
+        let tilde = await collect(ShellCommandRunner.stream("pwd", workingDirectory: "~/"))
+        check("a tilde path is expanded", tilde.log.hasSuffix(home))
+
+        // Silently running somewhere else would be worse than not running at all.
+        let gone = await collect(
+            ShellCommandRunner.stream("pwd", workingDirectory: "/nope/does/not/exist"))
+        var reportedMissing = false
+        if case .launchFailed(let reason) = gone.result?.termination {
+            reportedMissing = reason.contains("no longer exists")
+        }
+        check("a folder that has gone is reported, not ignored", reportedMissing)
+
+        let notADirectory = await ShellCommandRunner.run("pwd", workingDirectory: "/etc/hosts")
+        var rejectedFile = false
+        if case .launchFailed = notADirectory.termination { rejectedFile = true }
+        check("a file is not accepted as a working folder", rejectedFile)
+
+        // MARK: One-line report
+
+        let spoke = await ShellCommandRunner.run("echo first; echo 'all done'")
+        check("the report shows the command's last line", spoke.lastOutputLine == "all done")
+
+        let trailing = await ShellCommandRunner.run("printf 'only line\\n\\n\\n'")
+        check("trailing blank lines are skipped", trailing.lastOutputLine == "only line")
+
+        let mute = await ShellCommandRunner.run("true")
+        check("a silent command offers no line to report", mute.lastOutputLine == nil)
+
+        // MARK: Icon and folder round-trip
+
+        store.replace(with: [
+            CustomCommand(
+                name: "Iconned", command: "/usr/bin/true",
+                workingDirectory: "  ~/Developer  ", iconSymbol: "  hammer  ")
+        ])
+        check(
+            "an icon and a folder are trimmed and kept",
+            store.commands.first?.iconSymbol == "hammer"
+                && store.commands.first?.workingDirectory == "~/Developer")
+
+        store.replace(with: [
+            CustomCommand(name: "Bare", command: "/usr/bin/true", workingDirectory: "   ")
+        ])
+        check(
+            "a blank folder means home rather than an empty path",
+            store.commands.first?.workingDirectory == nil)
+        check("a command with no icon falls back to the shared glyph",
+            store.commands.first?.symbol == CustomCommand.sfSymbol)
 
         // MARK: Arguments
 

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		FA05D882203673A9FEE5F421 /* UninstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFBFA70EF62B67F7357E0E /* UninstallCoordinator.swift */; };
 		FA386C9B6DA24481565D506D /* ExtensionPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */; };
 		FB1D83A8BE027AC4F328D601 /* QuicklinkListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0935D49C0A0175E54E69682B /* QuicklinkListScreen.swift */; };
+		FB223F8BBD51465FD64BC1D2 /* SymbolPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F256977D955CC53C1D914E /* SymbolPicker.swift */; };
 		FCA73C81470EF9A50B016504 /* SettingsToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBC5A9553716C8F03ED0216 /* SettingsToolbarController.swift */; };
 		FD49FAFAA34FC1A41AFAC10F /* SettingsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDDA8820165672AF8464E25 /* SettingsComponents.swift */; };
 		FD4DDDCDC32AF921CDBCFB18 /* Paster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3B9645DB2293FA144B5AA2 /* Paster.swift */; };
@@ -709,6 +710,7 @@
 		A8247D97D304215156447FF3 /* ChatHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryView.swift; sourceTree = "<group>"; };
 		A8AD14D51F74D1891D5532B0 /* NoteSwitcherInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSwitcherInteraction.swift; sourceTree = "<group>"; };
 		A90559D7DB9F6F3874CAFCDE /* VolumeHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDView.swift; sourceTree = "<group>"; };
+		A9F256977D955CC53C1D914E /* SymbolPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolPicker.swift; sourceTree = "<group>"; };
 		AA7B3EB88881CEEFCE71448D /* Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Permissions.swift; sourceTree = "<group>"; };
 		AA99178E0DCF6CBB521FB098 /* WindowMover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowMover.swift; sourceTree = "<group>"; };
 		AAD838940E655559E32BE8EA /* UninstallPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallPlan.swift; sourceTree = "<group>"; };
@@ -1028,6 +1030,7 @@
 				4BEA1E122A8139A21E646FE2 /* RedactedText.swift */,
 				BEDDA8820165672AF8464E25 /* SettingsComponents.swift */,
 				64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */,
+				A9F256977D955CC53C1D914E /* SymbolPicker.swift */,
 				A1306524F57602D90FCF153C /* Theme.swift */,
 				ADD4CE330F75BC5FE5EAD99E /* Tooltip.swift */,
 				FA90C004E55AB1BBC12D9F96 /* VisualEffectView.swift */,
@@ -2584,6 +2587,7 @@
 				4C960C8F11556B3FC4EFF98F /* SupportWindowView.swift in Sources */,
 				9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */,
 				FF934DD9FBD8F26BAB72ACD1 /* SymbolImage.swift in Sources */,
+				FB223F8BBD51465FD64BC1D2 /* SymbolPicker.swift in Sources */,
 				71AA40FC4B8C57FFDE5F8DFC /* SystemAction.swift in Sources */,
 				A11EB7D1852FB3D56DDBE7C3 /* SystemActionCoordinator.swift in Sources */,
 				0047FE6A50E746CCF0FC6810 /* SystemActionRunner.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0047FE6A50E746CCF0FC6810 /* SystemActionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AEDBB526AB2C0406D8226D5 /* SystemActionRunner.swift */; };
+		005B39EF22378D1736CE5805 /* TerminalLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EAA357A9F0317320CFAADF /* TerminalLogView.swift */; };
 		00BA80B95E15859F0FDA6F16 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4F22647E4E1BA19F0FC520 /* AppVersion.swift */; };
 		00D813D3D99D0856E743168B /* ScreenTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C7C096F258D1EC8B42F818 /* ScreenTarget.swift */; };
 		0120AF7AB3AD249C484C8A03 /* ExtensionStoreResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7732FB0ED92C8FBFE22599CE /* ExtensionStoreResponse.swift */; };
@@ -119,10 +120,12 @@
 		464F93E1F16A3242396F32F9 /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */; };
 		478500C6465327947EBD9D61 /* RaycastSnippetImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80806A442BADAC390ECD993 /* RaycastSnippetImport.swift */; };
 		47A443F25878A27DE6DF24AA /* NoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAFF79E9897975CAC5EAC0E /* NoteEditorView.swift */; };
+		47C7E1E33C5D70C3DBED15D5 /* CustomCommandArgumentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7F0F7172895889F1AF069 /* CustomCommandArgumentsScreen.swift */; };
 		47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */; };
 		48AE2C9989F8FA2AA99D2D61 /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B4495E56754B05B5F3551D /* CalcPercent.swift */; };
 		4C960C8F11556B3FC4EFF98F /* SupportWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44875ABECB1F1B648EC90F4 /* SupportWindowView.swift */; };
 		4D3E47D6F382933EB3B1AB2F /* ExtensionCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F282D4BBC2F147D3A98FFB /* ExtensionCleanup.swift */; };
+		4D462D0F116A5C04E4DEFCCF /* PseudoTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6A905C247E0A5C349125EA /* PseudoTerminal.swift */; };
 		4D8C05DD67FAB9F2DA1F31FB /* AIStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */; };
 		4DA03A170E95F0D08E3569F9 /* ExtensionColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0266BAF4643A4B5C41B600DE /* ExtensionColors.swift */; };
 		4E5F73461C417BE2B3472E6E /* WindowChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D61199EE7B60E91ACBDE2E2 /* WindowChrome.swift */; };
@@ -133,6 +136,7 @@
 		50A3CB2A348F8E03D467B169 /* ExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54C4540AD6F188A2455473F /* ExtensionRuntime.swift */; };
 		5188C7DF4F18DAA7227715F8 /* MarkdownBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B48420B83D612E01603A /* MarkdownBlock.swift */; };
 		5194FB6B47E004217CFD1ABB /* UninstallSearchRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54932083F6BC197453EA0C8 /* UninstallSearchRoot.swift */; };
+		51E8877F53ABA0E51B2493FA /* CommandOutputPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A6D9BE2BB5BA09A4A6FEAB /* CommandOutputPresenter.swift */; };
 		52C4F57BB26F420CCD22C1D7 /* PaletteWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */; };
 		52D95C1FF343FCD57D5425A0 /* ChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95EA1EBD6E4B5ECE149FA0 /* ChatSession.swift */; };
 		5332040ADB923832DCA06E5C /* CalculatorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518429EDBFBEA0B866CCAA81 /* CalculatorCoordinator.swift */; };
@@ -186,6 +190,7 @@
 		6C915A60C3C2F2682645C32B /* UpdateInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9188FA8A06EAE3E55FFCBC70 /* UpdateInstaller.swift */; };
 		6CDA82FD63F87D07E30E3F82 /* Zlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F097C9983DF27A99694C8BC5 /* Zlib.swift */; };
 		6DF29BAB73F545DA2DE63F9B /* APIKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48D823882DF192FBA253985 /* APIKeyStore.swift */; };
+		6E2C2F65456E0981FC548C55 /* CustomCommandArgumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0926BBB9980400F4E94D1942 /* CustomCommandArgumentsView.swift */; };
 		6FC9F74D9119AC25D178D748 /* ExtensionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */; };
 		71AA40FC4B8C57FFDE5F8DFC /* SystemAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE72CE02F853ACE956627347 /* SystemAction.swift */; };
 		7320E4B2ABFAE8C1D76A3526 /* ExtensionArgumentsAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154222C91EFDB4D4490B6CE2 /* ExtensionArgumentsAccessory.swift */; };
@@ -326,6 +331,7 @@
 		C385AEF3C8C5A6B2BACC1D9A /* OverflowFade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88499DF2F503F2A3A19DEF07 /* OverflowFade.swift */; };
 		C396379DCAD85611D4C6F587 /* UpdateDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD81541882CBCC5B06F718F /* UpdateDownloader.swift */; };
 		C4479572F65559306118A9F0 /* CodexTurnRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82DD04042376EBDEF3E84C /* CodexTurnRunner.swift */; };
+		C45CCAE9AE2D3BCAC2BF80BE /* CommandOutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E099C50FF0B6A0069CAC5BF /* CommandOutputView.swift */; };
 		C4B9E9B3E965BFDFD31EDC3D /* LauncherCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858E08BB313EC330C2D5E50C /* LauncherCoordinator.swift */; };
 		C567D5C8F8873CA595B1536A /* TextInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74904E7C8CE9B121B32594B9 /* TextInjector.swift */; };
 		C5F60D8681235B95DAA3314F /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */; };
@@ -371,6 +377,7 @@
 		DEBCF434AB244DAD43DB8A6A /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9F5F7226AD5A91835AF5C /* LaunchAtLogin.swift */; };
 		DFB25A4CDD35071B745F2EF9 /* DoubleTapModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */; };
 		E1A4472391E5AD3EE828202E /* RedactedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEA1E122A8139A21E646FE2 /* RedactedText.swift */; };
+		E1E5D35EBDC351E9E847EEAC /* CustomCommandArgumentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A4B1C5C0ABF77236778341 /* CustomCommandArgumentSession.swift */; };
 		E268D74F0DEFFA598E2D02AA /* OnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6972F177922B1EB8831735 /* OnboardingCard.swift */; };
 		E29056264B57A3F0EC5F5698 /* SupportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97986EE62AE844FFCCD27449 /* SupportCoordinator.swift */; };
 		E29CF7293742DDCAE030682C /* SupportReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE1ED405A53ECA5DED66AA1 /* SupportReminderStore.swift */; };
@@ -429,6 +436,7 @@
 		06B5C0B83C3645AC90639B85 /* AppleIntelligenceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceProvider.swift; sourceTree = "<group>"; };
 		08279257B0F5995E86FF2C03 /* EntryIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryIconView.swift; sourceTree = "<group>"; };
 		08A1D354C1785923E612848C /* RenderNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderNode.swift; sourceTree = "<group>"; };
+		0926BBB9980400F4E94D1942 /* CustomCommandArgumentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandArgumentsView.swift; sourceTree = "<group>"; };
 		0935D49C0A0175E54E69682B /* QuicklinkListScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkListScreen.swift; sourceTree = "<group>"; };
 		09511B0502D1B67F10604D3C /* MeetingSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSpan.swift; sourceTree = "<group>"; };
 		09633E6F9C37F89267341D1D /* VolumeHUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeHUDController.swift; sourceTree = "<group>"; };
@@ -440,6 +448,7 @@
 		0C3B9645DB2293FA144B5AA2 /* Paster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paster.swift; sourceTree = "<group>"; };
 		0D4F22647E4E1BA19F0FC520 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 		0DFEBE220187043060F7F286 /* ToolRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRunner.swift; sourceTree = "<group>"; };
+		0E099C50FF0B6A0069CAC5BF /* CommandOutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandOutputView.swift; sourceTree = "<group>"; };
 		0EDB1EEB97CC5F6B0B81FFD6 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		0F5AFB680B55BBAFF2207F99 /* NotesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesCoordinator.swift; sourceTree = "<group>"; };
 		0FE6F8E3FA640C6F2B1AA8FE /* CodexExecutableLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexExecutableLocator.swift; sourceTree = "<group>"; };
@@ -529,9 +538,11 @@
 		418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteDropGuideView.swift; sourceTree = "<group>"; };
 		418DA899A1546F3B4AC44777 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		41E419A4DA5AB5B3A87B80F2 /* SnippetsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsListView.swift; sourceTree = "<group>"; };
+		42A6D9BE2BB5BA09A4A6FEAB /* CommandOutputPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandOutputPresenter.swift; sourceTree = "<group>"; };
 		4395BACF833C810961A248F0 /* BarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarButton.swift; sourceTree = "<group>"; };
 		43F3BC11AD77D8A58671F83E /* HotKeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyAction.swift; sourceTree = "<group>"; };
 		445B0374FD5D74DBE23243CD /* PaletteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteScreen.swift; sourceTree = "<group>"; };
+		44A4B1C5C0ABF77236778341 /* CustomCommandArgumentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandArgumentSession.swift; sourceTree = "<group>"; };
 		45D4BA6E1BD8EB1F96A8927F /* Tinycast.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tinycast.entitlements; sourceTree = "<group>"; };
 		45EB979ECD44738BCD9E2F90 /* EmojiCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCoordinator.swift; sourceTree = "<group>"; };
 		463FE27F894A8777C8ACCF1D /* FileSearchList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchList.swift; sourceTree = "<group>"; };
@@ -544,6 +555,7 @@
 		4AA61A2FAF4E49E466DA8F37 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		4AEBAA9641BC6C279DB0123C /* CameraPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewController.swift; sourceTree = "<group>"; };
 		4BEA1E122A8139A21E646FE2 /* RedactedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactedText.swift; sourceTree = "<group>"; };
+		4C6A905C247E0A5C349125EA /* PseudoTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PseudoTerminal.swift; sourceTree = "<group>"; };
 		4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCurrency.swift; sourceTree = "<group>"; };
 		4D8553E1626E985013046C47 /* EventDraftFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDraftFields.swift; sourceTree = "<group>"; };
 		4DA7B926405DAC632C056418 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -677,6 +689,7 @@
 		9D134673CB1B563A3758FC37 /* UninstallRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRunner.swift; sourceTree = "<group>"; };
 		9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverArming.swift; sourceTree = "<group>"; };
 		9DE1ED405A53ECA5DED66AA1 /* SupportReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportReminderStore.swift; sourceTree = "<group>"; };
+		9EA7F0F7172895889F1AF069 /* CustomCommandArgumentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandArgumentsScreen.swift; sourceTree = "<group>"; };
 		9F1798C6CF803D5E1BB2FFE4 /* ChatTranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptView.swift; sourceTree = "<group>"; };
 		9F9A0A3867D1B8E1D3284471 /* ExtensionNodeShims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionNodeShims.swift; sourceTree = "<group>"; };
 		A061D1B64684905BA0E998C5 /* ChatHistoryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryScreen.swift; sourceTree = "<group>"; };
@@ -738,6 +751,7 @@
 		BFB023D167225228757CC4B2 /* HealthTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthTicker.swift; sourceTree = "<group>"; };
 		C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteCoordinator.swift; sourceTree = "<group>"; };
 		C0599199132DAFBE12C59FBD /* MeetingDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDay.swift; sourceTree = "<group>"; };
+		C2EAA357A9F0317320CFAADF /* TerminalLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLogView.swift; sourceTree = "<group>"; };
 		C3C83D437500107168E12647 /* QuickActionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionSettings.swift; sourceTree = "<group>"; };
 		C3E30EFA3197FC5EF1E85C21 /* BundleSignature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSignature.swift; sourceTree = "<group>"; };
 		C45190564C9D9F1722E83943 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -868,6 +882,7 @@
 				EB76FDBFE1E306C2A5B1A29B /* Memo.swift */,
 				E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */,
 				AA7B3EB88881CEEFCE71448D /* Permissions.swift */,
+				4C6A905C247E0A5C349125EA /* PseudoTerminal.swift */,
 				4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */,
 				A7C7C096F258D1EC8B42F818 /* ScreenTarget.swift */,
 				F9044F107ADD5896746DBC35 /* Signposts.swift */,
@@ -1259,7 +1274,12 @@
 		5FE244FEF839B69889F3DBA9 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				42A6D9BE2BB5BA09A4A6FEAB /* CommandOutputPresenter.swift */,
+				0E099C50FF0B6A0069CAC5BF /* CommandOutputView.swift */,
+				9EA7F0F7172895889F1AF069 /* CustomCommandArgumentsScreen.swift */,
+				0926BBB9980400F4E94D1942 /* CustomCommandArgumentsView.swift */,
 				FE41DC04958D7C2FF8C47F62 /* CustomCommandCoordinator.swift */,
+				C2EAA357A9F0317320CFAADF /* TerminalLogView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -1759,6 +1779,7 @@
 		B7F695C73111F7B44A3C240A /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				44A4B1C5C0ABF77236778341 /* CustomCommandArgumentSession.swift */,
 				FBFE3C41897391C14DB5A55C /* ShellCommandRunner.swift */,
 			);
 			path = Service;
@@ -2299,11 +2320,16 @@
 				4EBFBA1CC7DA9B22C396DBEC /* CommandArgumentsRow.swift in Sources */,
 				89872774514D83EC2BD60F1E /* CommandCatalog.swift in Sources */,
 				BEAAD72E748375E0039AC90F /* CommandID.swift in Sources */,
+				51E8877F53ABA0E51B2493FA /* CommandOutputPresenter.swift in Sources */,
+				C45CCAE9AE2D3BCAC2BF80BE /* CommandOutputView.swift in Sources */,
 				4640C7CC8DCA6E6FA49394A8 /* CommandsSettingsView.swift in Sources */,
 				2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */,
 				5A91C58340D02ED0939BCAE2 /* CurrencyFeed.swift in Sources */,
 				17F61DEF6389FBCFCCFB467C /* CurrencyRateStore.swift in Sources */,
 				8CC7A4A5D4205843219A81C8 /* CustomCommand.swift in Sources */,
+				E1E5D35EBDC351E9E847EEAC /* CustomCommandArgumentSession.swift in Sources */,
+				47C7E1E33C5D70C3DBED15D5 /* CustomCommandArgumentsScreen.swift in Sources */,
+				6E2C2F65456E0981FC548C55 /* CustomCommandArgumentsView.swift in Sources */,
 				11C3F9D5C786EF1D11787E0C /* CustomCommandCoordinator.swift in Sources */,
 				CCC775255627E23DC5B567AE /* CustomCommandEditorSheet.swift in Sources */,
 				AB500AC3DEBFF6EB1CE42812 /* DialogController.swift in Sources */,
@@ -2461,6 +2487,7 @@
 				94887F8E18AB2C08A8273897 /* Permissions.swift in Sources */,
 				22EE4D5AFAAA12E649666019 /* PermissionsSettingsView.swift in Sources */,
 				6C052B83FAE453D1011E3FB4 /* PopoverMenu.swift in Sources */,
+				4D462D0F116A5C04E4DEFCCF /* PseudoTerminal.swift in Sources */,
 				0D8A65A0A7A2188F56D576FF /* Quarantine.swift in Sources */,
 				D99DAF62B746E6009E1BFB1F /* QuickAction.swift in Sources */,
 				D4F49C93A33488D226BA8664 /* QuickActionCoordinator.swift in Sources */,
@@ -2563,6 +2590,7 @@
 				82D95EF7539498A9A484B3D1 /* SystemActionsSettingsView.swift in Sources */,
 				A41185C975CBF97A8C6EAC19 /* SystemPromptEditor.swift in Sources */,
 				410F1B5FFAA44378AC9EC2DB /* SystemSettingsSettingsView.swift in Sources */,
+				005B39EF22378D1736CE5805 /* TerminalLogView.swift in Sources */,
 				ABB5079A94F6ACDB276BA461 /* TextDiffEngine.swift in Sources */,
 				C567D5C8F8873CA595B1536A /* TextInjector.swift in Sources */,
 				85FF7D441BD782A29EDD95A8 /* TextTranslator.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -41,6 +41,7 @@ final class AppCore {
     let activationPolicy = ActivationPolicy()
     let uninstall = UninstallSession()
     let quicklinkArguments = QuicklinkArgumentSession()
+    let customCommandArguments = CustomCommandArgumentSession()
     let notesStore: NotesStore
     let extensions: ExtensionManager
     let chatHistory: ChatHistoryStore
@@ -91,10 +92,11 @@ final class AppCore {
         settings: settings, paletteCoordinator: paletteCoordinator, windowMover: windowMover,
         spaceSwitcher: spaceSwitcher)
     @ObservationIgnored private(set) lazy var customCommandCoordinator = CustomCommandCoordinator(
-        store: customCommands, settings: settings, appIndex: appIndex,
+        store: customCommands, argumentSession: customCommandArguments, settings: settings,
+        appIndex: appIndex,
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,
         hotKeys: hotKeys, favorites: favorites, visibility: visibility,
-        ranking: launcherRanking, aliases: aliases, core: self)
+        ranking: launcherRanking, aliases: aliases, activationPolicy: activationPolicy, core: self)
     @ObservationIgnored private(set) lazy var notesCoordinator = NotesCoordinator(
         store: notesStore,
         settings: settings,
@@ -467,7 +469,7 @@ final class AppCore {
             isRunningExtension: extensions.running != nil,
             isUninstalling: uninstall.isTrashing,
             isRecordingHotKey: hotKeys.recordingAction != nil,
-            isPromptingForArguments: quicklinkArguments.isActive,
+            isPromptingForArguments: quicklinkArguments.isActive || customCommandArguments.isActive,
             isShowingDialog: isShowingDialog,
             isPaletteVisible: paletteCoordinator.isVisible)
     }

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -301,6 +301,7 @@ final class AppCore {
         if onboardingCoordinator.focusExisting() { return }
         if updateCoordinator.focusExisting() { return }
         if supportCoordinator.focusExisting() { return }
+        if customCommandCoordinator.focusOutputWindow() { return }
         paletteCoordinator.showPalette(mode: .launcher, restoreAnyMode: true)
     }
 

--- a/Tinycast/DesignSystem/SymbolPicker.swift
+++ b/Tinycast/DesignSystem/SymbolPicker.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// A grid of SF Symbols with an "Automatic" escape hatch, for any editor that lets a row carry its
+/// own glyph. The symbols are the caller's: what reads as a quicklink is not what reads as a script.
+struct SymbolPicker: View {
+    @Binding var selection: String?
+    /// Drawn on the Automatic row, and what the row falls back to when nothing is picked.
+    let fallback: String
+    let symbols: [String]
+    let onPick: () -> Void
+
+    private static let cell: CGFloat = 30
+    private static let cellHeight: CGFloat = 26
+    private static let columnCount = 6
+
+    private var columns: [GridItem] {
+        Array(repeating: GridItem(.fixed(Self.cell), spacing: Theme.Spacing.sm), count: Self.columnCount)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            Button {
+                selection = nil
+                onPick()
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    SymbolImage(name: fallback, size: 14)
+                    Text("Automatic")
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            Divider()
+            LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
+                ForEach(symbols, id: \.self) { symbol in
+                    Button {
+                        selection = symbol
+                        onPick()
+                    } label: {
+                        SymbolImage(name: symbol, size: 15)
+                            .frame(width: Self.cell, height: Self.cellHeight)
+                            .background(
+                                RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                                    .fill(selection == symbol ? Theme.Colors.selection : Color.clear)
+                            )
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .frame(width: Self.width)
+    }
+
+    private static let width: CGFloat = 244
+}

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -287,6 +287,9 @@ enum Theme {
         static let success = Color.green
         /// Progress tint: the message pill's spinner while the work behind it is still running.
         static let progress = Color.blue
+        /// The command output window's page: a flat surface the log sits directly on.
+        static let terminalSurface = adaptive(
+            dark: .srgbInk(0.07, alpha: 1), light: .srgbInk(0.99, alpha: 1))
     }
 }
 

--- a/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+++ b/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
@@ -39,12 +39,17 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     var arguments: [CustomCommandArgument]
     /// Captures what the command prints and opens the output window once it exits.
     var showsOutput: Bool
+    /// Where the command runs; nil is the home directory. Kept abbreviated, so a `~` path survives
+    /// a home directory that moves.
+    var workingDirectory: String?
+    /// The launcher glyph; nil falls back to the shared terminal symbol.
+    var iconSymbol: String?
 
     init(
         id: UUID = UUID(), name: String, command: String,
         loadsShellEnvironment: Bool = false, requiresConfirmation: Bool = false,
         showsConfirmation: Bool = false, arguments: [CustomCommandArgument] = [],
-        showsOutput: Bool = false
+        showsOutput: Bool = false, workingDirectory: String? = nil, iconSymbol: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -54,7 +59,12 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
         self.showsConfirmation = showsConfirmation
         self.arguments = arguments
         self.showsOutput = showsOutput
+        self.workingDirectory = workingDirectory
+        self.iconSymbol = iconSymbol
     }
+
+    /// The glyph every surface draws for this command.
+    var symbol: String { iconSymbol ?? Self.sfSymbol }
 
     var entryID: String { Self.entryIDPrefix + id.uuidString.lowercased() }
 
@@ -66,7 +76,7 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     // Hand-written, so an added field keeps stored commands and older backups readable.
     private enum CodingKeys: String, CodingKey {
         case id, name, command, loadsShellEnvironment, requiresConfirmation, showsConfirmation
-        case arguments, showsOutput
+        case arguments, showsOutput, workingDirectory, iconSymbol
     }
 
     init(from decoder: Decoder) throws {
@@ -83,6 +93,16 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
         arguments =
             try container.decodeIfPresent([CustomCommandArgument].self, forKey: .arguments) ?? []
         showsOutput = try container.decodeIfPresent(Bool.self, forKey: .showsOutput) ?? false
+        workingDirectory = try container.decodeIfPresent(String.self, forKey: .workingDirectory)
+        iconSymbol = try container.decodeIfPresent(String.self, forKey: .iconSymbol)
+    }
+}
+
+extension String {
+    /// Trimmed, and nil when that leaves nothing — an empty optional field means "unset", not "".
+    fileprivate var cleanedPathComponent: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty || trimmed.contains("\0") ? nil : trimmed
     }
 }
 
@@ -166,6 +186,8 @@ final class CustomCommandStore {
         value.name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         value.command = draft.command.trimmingCharacters(in: .whitespacesAndNewlines)
         value.arguments = CustomCommandArgument.sanitized(draft.arguments)
+        value.workingDirectory = draft.workingDirectory?.cleanedPathComponent
+        value.iconSymbol = draft.iconSymbol?.cleanedPathComponent
         guard !value.name.isEmpty else { throw CustomCommandValidationError.emptyName }
         guard !value.command.isEmpty else { throw CustomCommandValidationError.emptyCommand }
         guard !value.name.contains("\0"), !value.command.contains("\0") else {
@@ -202,6 +224,8 @@ final class CustomCommandStore {
             cleaned.name = value.name.trimmingCharacters(in: .whitespacesAndNewlines)
             cleaned.command = value.command.trimmingCharacters(in: .whitespacesAndNewlines)
             cleaned.arguments = CustomCommandArgument.sanitized(value.arguments)
+            cleaned.workingDirectory = value.workingDirectory?.cleanedPathComponent
+            cleaned.iconSymbol = value.iconSymbol?.cleanedPathComponent
             let foldedName = cleaned.name.folding(options: [.caseInsensitive], locale: .current)
             guard !cleaned.name.isEmpty, !cleaned.command.isEmpty, !cleaned.name.contains("\0"),
                 !cleaned.command.contains("\0"), ids.insert(cleaned.id).inserted,

--- a/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+++ b/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+/// One value asked for before the command runs. Values are passed positionally — the first arrives
+/// as `$1` — so what the user types is never spliced into the command text and re-parsed by zsh.
+struct CustomCommandArgument: Codable, Hashable, Sendable {
+    var name: String
+    /// An optional argument may be submitted empty; a required one holds ↵ until it has a value.
+    var isOptional: Bool
+
+    init(name: String, isOptional: Bool = false) {
+        self.name = name
+        self.isOptional = isOptional
+    }
+
+    /// A blank name is dropped rather than rejected, so an import can't lose the whole command.
+    static func sanitized(_ arguments: [CustomCommandArgument]) -> [CustomCommandArgument] {
+        arguments.compactMap { argument in
+            var cleaned = argument
+            cleaned.name = argument.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !cleaned.name.isEmpty, !cleaned.name.contains("\0") else { return nil }
+            return cleaned
+        }
+    }
+}
+
 struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     static let entryIDPrefix = "custom-command:"
     /// One glyph for every custom command, so every surface reads as the same thing.
@@ -12,11 +35,16 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     var loadsShellEnvironment: Bool
     var requiresConfirmation: Bool
     var showsConfirmation: Bool
+    /// Prompted for in order before the run; empty for the commands that take no input.
+    var arguments: [CustomCommandArgument]
+    /// Captures what the command prints and opens the output window once it exits.
+    var showsOutput: Bool
 
     init(
         id: UUID = UUID(), name: String, command: String,
         loadsShellEnvironment: Bool = false, requiresConfirmation: Bool = false,
-        showsConfirmation: Bool = false
+        showsConfirmation: Bool = false, arguments: [CustomCommandArgument] = [],
+        showsOutput: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -24,6 +52,8 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
         self.loadsShellEnvironment = loadsShellEnvironment
         self.requiresConfirmation = requiresConfirmation
         self.showsConfirmation = showsConfirmation
+        self.arguments = arguments
+        self.showsOutput = showsOutput
     }
 
     var entryID: String { Self.entryIDPrefix + id.uuidString.lowercased() }
@@ -31,6 +61,28 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     static func id(fromEntryID entryID: String) -> UUID? {
         guard entryID.hasPrefix(entryIDPrefix) else { return nil }
         return UUID(uuidString: String(entryID.dropFirst(entryIDPrefix.count)))
+    }
+
+    // Hand-written, so an added field keeps stored commands and older backups readable.
+    private enum CodingKeys: String, CodingKey {
+        case id, name, command, loadsShellEnvironment, requiresConfirmation, showsConfirmation
+        case arguments, showsOutput
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        command = try container.decode(String.self, forKey: .command)
+        loadsShellEnvironment =
+            try container.decodeIfPresent(Bool.self, forKey: .loadsShellEnvironment) ?? false
+        requiresConfirmation =
+            try container.decodeIfPresent(Bool.self, forKey: .requiresConfirmation) ?? false
+        showsConfirmation =
+            try container.decodeIfPresent(Bool.self, forKey: .showsConfirmation) ?? false
+        arguments =
+            try container.decodeIfPresent([CustomCommandArgument].self, forKey: .arguments) ?? []
+        showsOutput = try container.decodeIfPresent(Bool.self, forKey: .showsOutput) ?? false
     }
 }
 
@@ -113,6 +165,7 @@ final class CustomCommandStore {
         var value = draft
         value.name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         value.command = draft.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        value.arguments = CustomCommandArgument.sanitized(draft.arguments)
         guard !value.name.isEmpty else { throw CustomCommandValidationError.emptyName }
         guard !value.command.isEmpty else { throw CustomCommandValidationError.emptyCommand }
         guard !value.name.contains("\0"), !value.command.contains("\0") else {
@@ -148,6 +201,7 @@ final class CustomCommandStore {
             var cleaned = value
             cleaned.name = value.name.trimmingCharacters(in: .whitespacesAndNewlines)
             cleaned.command = value.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            cleaned.arguments = CustomCommandArgument.sanitized(value.arguments)
             let foldedName = cleaned.name.folding(options: [.caseInsensitive], locale: .current)
             guard !cleaned.name.isEmpty, !cleaned.command.isEmpty, !cleaned.name.contains("\0"),
                 !cleaned.command.contains("\0"), ids.insert(cleaned.id).inserted,

--- a/Tinycast/Features/CustomCommands/Service/CustomCommandArgumentSession.swift
+++ b/Tinycast/Features/CustomCommands/Service/CustomCommandArgumentSession.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// The custom command waiting on its argument values, filled one at a time in the palette's own
+/// search field. docs/features/custom-commands.md
+@MainActor
+@Observable
+final class CustomCommandArgumentSession {
+    private struct Request {
+        let command: CustomCommand
+        /// Positional and append-only: `values[0]` is the command's `$1`.
+        var values: [String]
+    }
+
+    private var request: Request?
+
+    var isActive: Bool { request != nil }
+    var command: CustomCommand? { request?.command }
+
+    /// The argument being asked for; nil once every one has an answer.
+    var current: CustomCommandArgument? {
+        guard let request, request.command.arguments.indices.contains(request.values.count) else {
+            return nil
+        }
+        return request.command.arguments[request.values.count]
+    }
+
+    /// True when submitting runs rather than advances, which is what the ↵ pill announces.
+    var isLastArgument: Bool {
+        guard let request else { return false }
+        return request.values.count == request.command.arguments.count - 1
+    }
+
+    /// Nil once nothing is pending, which leaves the mode's own placeholder in the search field.
+    var prompt: String? { current.map { "\($0.name)…" } }
+
+    /// Every argument in order, paired with what has been entered so far — the form's own rows.
+    var progress: [(argument: CustomCommandArgument, value: String?)] {
+        guard let request else { return [] }
+        return request.command.arguments.enumerated().map { index, argument in
+            (argument, index < request.values.count ? request.values[index] : nil)
+        }
+    }
+
+    func begin(command: CustomCommand) {
+        request = Request(command: command, values: [])
+    }
+
+    /// Records `value`, returning the command and its full argument list once the last one lands.
+    func submit(_ value: String) -> (command: CustomCommand, values: [String])? {
+        guard var request, current != nil else { return nil }
+        request.values.append(value)
+        self.request = request
+        guard request.values.count == request.command.arguments.count else { return nil }
+        return (request.command, request.values)
+    }
+
+    /// Steps back, returning the held value so the field refills; nil at the first argument.
+    func retreat() -> String? {
+        guard var request, !request.values.isEmpty else { return nil }
+        let previous = request.values.removeLast()
+        self.request = request
+        return previous
+    }
+
+    func cancel() {
+        request = nil
+    }
+}

--- a/Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
+++ b/Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
@@ -1,37 +1,83 @@
 import Darwin
 import Foundation
 
-enum ShellCommandOutcome: Sendable, Equatable {
-    case success
-    case launchFailure(String)
-    case nonZeroExit(status: Int32, stderr: String?)
+/// How a run ended. `launchFailed` means the shell never started, so nothing was captured.
+enum ShellCommandTermination: Sendable, Equatable {
+    case exited(status: Int32)
+    case launchFailed(String)
+    /// The reader pressed Stop. Kept apart from the status, which a signalled shell reports as 143
+    /// or 15 depending on what it was doing — neither of which is worth showing anyone.
+    case stopped
+
+    /// A signal death reports the signal as its status, so it fails here like any non-zero exit.
+    var succeeded: Bool { self == .exited(status: 0) }
+}
+
+enum ShellCommandEvent: Sendable {
+    case output(String)
+    case finished(ShellCommandResult)
+}
+
+/// A command running now: what it is printing, and the handle that ends it. `stop` is deliberately
+/// not the stream's cancellation — abandoning the events must never kill the reader's command.
+struct ShellCommandSession: Sendable {
+    let events: AsyncStream<ShellCommandEvent>
+    let stop: @Sendable () -> Void
+}
+
+/// A finished run. `standardError` is the tail kept for the failure dialog, and only the
+/// non-streaming path fills it — a streamed run reports everything through its events instead.
+struct ShellCommandResult: Sendable, Equatable {
+    let termination: ShellCommandTermination
+    let standardError: String?
+
+    var succeeded: Bool { termination.succeeded }
+
+    init(termination: ShellCommandTermination, standardError: String? = nil) {
+        self.termination = termination
+        self.standardError = standardError
+    }
 }
 
 enum ShellCommandRunner {
-    private static let stderrLimit = 8 * 1024
+    /// Only ever surfaces on failure, where the last few lines are the whole story.
+    private static let standardErrorLimit = 8 * 1024
+    private static let shell = "/bin/zsh"
+    /// Big enough that a chatty command needs few reads, small enough to stay live.
+    private static let readSize = 16 * 1024
+    /// Coalesces bursts so a flood cannot drive a redraw per line.
+    private static let flushInterval: Duration = .milliseconds(40)
+    /// A prompt or a progress bar never ends a line; past this it is shown anyway.
+    private static let unlinedLimit = 4 * 1024
+    /// How long a stopped command is given to leave politely before it is killed.
+    private static let stopGrace: DispatchTimeInterval = .seconds(2)
     /// `waitUntilExit` blocks, so it stays off the cooperative pool; concurrent, not serial.
     private static let queue = DispatchQueue(
         label: "com.tinycast.shell-command", qos: .userInitiated, attributes: .concurrent)
 
-    /// Defaults to the fast path, so forgetting it gets the cheap shell, not the config.
+    /// Fire-and-forget: nothing is kept but the error tail a failure dialog needs. A command whose
+    /// output is shown goes through `stream` instead.
     nonisolated static func run(
-        _ command: String, loadingShellEnvironment: Bool = false
-    ) async -> ShellCommandOutcome {
+        _ command: String, arguments: [String] = [], loadingShellEnvironment: Bool = false
+    ) async -> ShellCommandResult {
         await withCheckedContinuation { continuation in
             queue.async {
                 continuation.resume(
-                    returning: execute(command, loadingShellEnvironment: loadingShellEnvironment))
+                    returning: execute(
+                        command, arguments: arguments,
+                        loadingShellEnvironment: loadingShellEnvironment))
             }
         }
     }
 
     nonisolated private static func execute(
-        _ command: String, loadingShellEnvironment: Bool
-    ) -> ShellCommandOutcome {
+        _ command: String, arguments: [String], loadingShellEnvironment: Bool
+    ) -> ShellCommandResult {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        // zsh reads `.zshrc` only for interactive shells, so `-l` alone sees no aliases.
-        process.arguments = [loadingShellEnvironment ? "-ilc" : "-lc", command]
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = shellArguments(
+            command: command, arguments: arguments,
+            loadingShellEnvironment: loadingShellEnvironment)
         process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
         // Lets a shell config skip slow sections when Tinycast is the caller.
         process.environment = ProcessInfo.processInfo.environment.merging(["TINYCAST": "1"]) { _, new in
@@ -39,29 +85,178 @@ enum ShellCommandRunner {
         }
         // Load-bearing: a config that prompts reads EOF and moves on, never hanging.
         process.standardInput = FileHandle.nullDevice
-        process.standardOutput = FileHandle.nullDevice
 
-        let capture = makeStderrCapture()
-        process.standardError = capture?.handle ?? FileHandle.nullDevice
-        defer { capture?.remove() }
+        let errors = StreamCapture.make()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errors?.handle ?? FileHandle.nullDevice
+        defer { errors?.remove() }
 
         do {
             try process.run()
         } catch {
-            return .launchFailure(error.localizedDescription)
+            return ShellCommandResult(termination: .launchFailed(error.localizedDescription))
         }
         process.waitUntilExit()
 
-        guard process.terminationReason == .exit, process.terminationStatus == 0 else {
-            return .nonZeroExit(
-                status: process.terminationStatus,
-                stderr: capture?.readSuffix(limit: stderrLimit))
-        }
-        return .success
+        return ShellCommandResult(
+            termination: .exited(status: process.terminationStatus),
+            standardError: errors?.readSuffix(limit: standardErrorLimit))
     }
 
-    /// Immutable, confined to one `execute` on `queue`, and only read after `waitUntilExit`.
-    private final class StderrCapture: @unchecked Sendable {
+    // MARK: - Streaming
+
+    /// Runs the command under a pseudo-terminal and reports what it prints as it prints it.
+    /// See `PseudoTerminal` for why a pipe cannot do this.
+    nonisolated static func stream(
+        _ command: String, arguments: [String] = [], loadingShellEnvironment: Bool = false
+    ) -> ShellCommandSession {
+        var environment = ProcessInfo.processInfo.environment
+        environment["TINYCAST"] = "1"
+        // A terminal makes tools colour their output; the window renders those codes rather than
+        // showing them, so this asks for the colour it can draw and nothing fancier.
+        environment["TERM"] = "xterm-256color"
+
+        let terminal = PseudoTerminal.spawn(
+            executable: shell,
+            arguments: shellArguments(
+                command: command, arguments: arguments,
+                loadingShellEnvironment: loadingShellEnvironment),
+            environment: environment,
+            workingDirectory: FileManager.default.homeDirectoryForCurrentUser.path)
+
+        guard let terminal else {
+            return ShellCommandSession(
+                events: AsyncStream { continuation in
+                    continuation.yield(
+                        .finished(
+                            ShellCommandResult(
+                                termination: .launchFailed("The shell could not be started."))))
+                    continuation.finish()
+                },
+                stop: {})
+        }
+
+        let stopped = StopFlag()
+        let events = AsyncStream<ShellCommandEvent> { continuation in
+            queue.async {
+                drain(terminal, stopped: stopped, into: continuation)
+            }
+        }
+        return ShellCommandSession(
+            events: events,
+            stop: { [weak stopFlag = stopped] in
+                stopFlag?.mark()
+                terminal.signalSession(SIGTERM)
+                // The backstop, for a command that ignores a polite ask.
+                queue.asyncAfter(deadline: .now() + stopGrace) {
+                    terminal.signalSession(SIGKILL)
+                }
+            })
+    }
+
+    /// One queue, one reader: the decode buffer is touched from here alone, so it needs no lock.
+    nonisolated private static func drain(
+        _ terminal: PseudoTerminal, stopped: StopFlag,
+        into continuation: AsyncStream<ShellCommandEvent>.Continuation
+    ) {
+        var decoder = TerminalTextDecoder()
+        var buffer = [UInt8](repeating: 0, count: readSize)
+        var lastYield = ContinuousClock().now
+
+        while true {
+            // Zero is EOF; -1 with EIO is what a pty master returns once its child is gone.
+            let count = read(terminal.parentEnd, &buffer, readSize)
+            guard count > 0 else { break }
+            decoder.append(buffer, count: count)
+            let due = ContinuousClock().now - lastYield >= flushInterval
+            if let text = decoder.take(force: due) {
+                continuation.yield(.output(text))
+                lastYield = ContinuousClock().now
+            }
+        }
+        if let text = decoder.take(force: true) { continuation.yield(.output(text)) }
+
+        let status = terminal.wait()
+        terminal.close()
+        continuation.yield(
+            .finished(
+                ShellCommandResult(
+                    termination: stopped.isSet ? .stopped : .exited(status: status))))
+        continuation.finish()
+    }
+
+    /// Set from the main actor and read on the drain queue, so the flag carries its own lock.
+    private final class StopFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        var isSet: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+
+        func mark() {
+            lock.lock()
+            value = true
+            lock.unlock()
+        }
+    }
+
+    /// Holds bytes back to whole lines: a newline is always a scalar boundary, so a read landing
+    /// mid-character can never be decoded into a replacement character.
+    private struct TerminalTextDecoder {
+        private var pending: [UInt8] = []
+
+        mutating func append(_ bytes: [UInt8], count: Int) {
+            pending.append(contentsOf: bytes[0..<count])
+        }
+
+        /// `force` flushes what is there regardless — at exit, and for a prompt that never ends a
+        /// line. Even then the tail is cut at a scalar boundary rather than mid-character.
+        mutating func take(force: Bool) -> String? {
+            guard !pending.isEmpty else { return nil }
+            var end = pending.lastIndex(of: 0x0A).map { $0 + 1 }
+            if end == nil {
+                guard force || pending.count >= unlinedLimit else { return nil }
+                end = scalarBoundary(before: pending.count)
+            }
+            guard let end, end > 0 else { return nil }
+            // Latin-1 cannot fail, so output written in some other encoding still reaches the reader.
+            let bytes = Array(pending[0..<end])
+            pending.removeFirst(end)
+            return String(bytes: bytes, encoding: .utf8) ?? String(bytes: bytes, encoding: .isoLatin1)
+        }
+
+        /// Walks back over at most three continuation bytes to the start of a whole character.
+        private func scalarBoundary(before index: Int) -> Int {
+            var boundary = index
+            var stepped = 0
+            while boundary > 0, stepped < 4, pending[boundary - 1] & 0xC0 == 0x80 {
+                boundary -= 1
+                stepped += 1
+            }
+            // A lead byte only holds back when its own sequence is still incomplete.
+            guard boundary > 0 else { return index }
+            let lead = pending[boundary - 1]
+            let width = lead >= 0xF0 ? 4 : lead >= 0xE0 ? 3 : lead >= 0xC0 ? 2 : 1
+            return index - boundary + 1 >= width ? index : boundary - 1
+        }
+    }
+
+    /// `$0` names the caller and the user's values follow as `$1`, `$2` — never spliced into the
+    /// command text, where zsh would re-parse them as syntax.
+    nonisolated private static func shellArguments(
+        command: String, arguments: [String], loadingShellEnvironment: Bool
+    ) -> [String] {
+        // zsh reads `.zshrc` only for interactive shells, so `-l` alone sees no aliases.
+        [loadingShellEnvironment ? "-ilc" : "-lc", command, "tinycast"] + arguments
+    }
+
+    /// A temp file rather than a `Pipe`: nothing drains a pipe until `waitUntilExit` returns, so a
+    /// command that outran the buffer would deadlock. Immutable, confined to one `execute` on
+    /// `queue`, and only read after the process is gone.
+    private final class StreamCapture: @unchecked Sendable {
         let url: URL
         let handle: FileHandle
 
@@ -76,7 +271,9 @@ enum ShellCommandRunner {
             let start = end > UInt64(limit) ? end - UInt64(limit) : 0
             try? handle.seek(toOffset: start)
             guard let data = try? handle.readToEnd(), !data.isEmpty else { return nil }
-            return String(decoding: data, as: UTF8.self)
+            // A byte-offset tail can open mid-scalar; dropping the orphans avoids a leading U+FFFD.
+            let body = start > 0 ? data.drop { $0 & 0xC0 == 0x80 } : data[...]
+            return String(decoding: body, as: UTF8.self)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .nilIfEmpty
         }
@@ -85,21 +282,21 @@ enum ShellCommandRunner {
             try? handle.close()
             try? FileManager.default.removeItem(at: url)
         }
-    }
 
-    nonisolated private static func makeStderrCapture() -> StderrCapture? {
-        let template = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tinycast-command-stderr.XXXXXX").path
-        var bytes = Array(template.utf8CString)
-        let descriptor = bytes.withUnsafeMutableBufferPointer { buffer in
-            mkstemp(buffer.baseAddress!)
+        static func make() -> StreamCapture? {
+            let template = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tinycast-command-stream.XXXXXX").path
+            var bytes = Array(template.utf8CString)
+            let descriptor = bytes.withUnsafeMutableBufferPointer { buffer in
+                mkstemp(buffer.baseAddress!)
+            }
+            guard descriptor >= 0 else { return nil }
+            let path = String(
+                decoding: bytes.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+            return StreamCapture(
+                url: URL(fileURLWithPath: path),
+                handle: FileHandle(fileDescriptor: descriptor, closeOnDealloc: true))
         }
-        guard descriptor >= 0 else { return nil }
-        let path = String(
-            decoding: bytes.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
-        return StderrCapture(
-            url: URL(fileURLWithPath: path),
-            handle: FileHandle(fileDescriptor: descriptor, closeOnDealloc: true))
     }
 }
 

--- a/Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
+++ b/Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift
@@ -25,16 +25,30 @@ struct ShellCommandSession: Sendable {
     let stop: @Sendable () -> Void
 }
 
-/// A finished run. `standardError` is the tail kept for the failure dialog, and only the
-/// non-streaming path fills it — a streamed run reports everything through its events instead.
+/// A finished run. Both tails are filled only by the non-streaming path — a streamed run reports
+/// everything through its events instead.
 struct ShellCommandResult: Sendable, Equatable {
     let termination: ShellCommandTermination
+    /// Kept short: all it feeds is the one-line report a finished command shows.
+    let standardOutput: String?
     let standardError: String?
 
     var succeeded: Bool { termination.succeeded }
 
-    init(termination: ShellCommandTermination, standardError: String? = nil) {
+    /// What a command said about itself, for a report with room for one line.
+    var lastOutputLine: String? {
+        standardOutput?
+            .split(whereSeparator: \.isNewline).last
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    init(
+        termination: ShellCommandTermination, standardOutput: String? = nil,
+        standardError: String? = nil
+    ) {
         self.termination = termination
+        self.standardOutput = standardOutput
         self.standardError = standardError
     }
 }
@@ -42,6 +56,8 @@ struct ShellCommandResult: Sendable, Equatable {
 enum ShellCommandRunner {
     /// Only ever surfaces on failure, where the last few lines are the whole story.
     private static let standardErrorLimit = 8 * 1024
+    /// Only the last line is ever shown, so this is a generous bound on one of them.
+    private static let standardOutputLimit = 4 * 1024
     private static let shell = "/bin/zsh"
     /// Big enough that a chatty command needs few reads, small enough to stay live.
     private static let readSize = 16 * 1024
@@ -58,27 +74,33 @@ enum ShellCommandRunner {
     /// Fire-and-forget: nothing is kept but the error tail a failure dialog needs. A command whose
     /// output is shown goes through `stream` instead.
     nonisolated static func run(
-        _ command: String, arguments: [String] = [], loadingShellEnvironment: Bool = false
+        _ command: String, arguments: [String] = [], loadingShellEnvironment: Bool = false,
+        workingDirectory: String? = nil
     ) async -> ShellCommandResult {
         await withCheckedContinuation { continuation in
             queue.async {
                 continuation.resume(
                     returning: execute(
                         command, arguments: arguments,
-                        loadingShellEnvironment: loadingShellEnvironment))
+                        loadingShellEnvironment: loadingShellEnvironment,
+                        workingDirectory: workingDirectory))
             }
         }
     }
 
     nonisolated private static func execute(
-        _ command: String, arguments: [String], loadingShellEnvironment: Bool
+        _ command: String, arguments: [String], loadingShellEnvironment: Bool,
+        workingDirectory: String?
     ) -> ShellCommandResult {
+        guard let directory = resolvedWorkingDirectory(workingDirectory) else {
+            return ShellCommandResult(termination: .launchFailed(missingDirectory(workingDirectory)))
+        }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
         process.arguments = shellArguments(
             command: command, arguments: arguments,
             loadingShellEnvironment: loadingShellEnvironment)
-        process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
         // Lets a shell config skip slow sections when Tinycast is the caller.
         process.environment = ProcessInfo.processInfo.environment.merging(["TINYCAST": "1"]) { _, new in
             new
@@ -86,10 +108,14 @@ enum ShellCommandRunner {
         // Load-bearing: a config that prompts reads EOF and moves on, never hanging.
         process.standardInput = FileHandle.nullDevice
 
+        let output = StreamCapture.make()
         let errors = StreamCapture.make()
-        process.standardOutput = FileHandle.nullDevice
+        process.standardOutput = output?.handle ?? FileHandle.nullDevice
         process.standardError = errors?.handle ?? FileHandle.nullDevice
-        defer { errors?.remove() }
+        defer {
+            output?.remove()
+            errors?.remove()
+        }
 
         do {
             try process.run()
@@ -100,6 +126,7 @@ enum ShellCommandRunner {
 
         return ShellCommandResult(
             termination: .exited(status: process.terminationStatus),
+            standardOutput: output?.readSuffix(limit: standardOutputLimit),
             standardError: errors?.readSuffix(limit: standardErrorLimit))
     }
 
@@ -108,7 +135,8 @@ enum ShellCommandRunner {
     /// Runs the command under a pseudo-terminal and reports what it prints as it prints it.
     /// See `PseudoTerminal` for why a pipe cannot do this.
     nonisolated static func stream(
-        _ command: String, arguments: [String] = [], loadingShellEnvironment: Bool = false
+        _ command: String, arguments: [String] = [], loadingShellEnvironment: Bool = false,
+        workingDirectory: String? = nil
     ) -> ShellCommandSession {
         var environment = ProcessInfo.processInfo.environment
         environment["TINYCAST"] = "1"
@@ -116,21 +144,24 @@ enum ShellCommandRunner {
         // showing them, so this asks for the colour it can draw and nothing fancier.
         environment["TERM"] = "xterm-256color"
 
-        let terminal = PseudoTerminal.spawn(
-            executable: shell,
-            arguments: shellArguments(
-                command: command, arguments: arguments,
-                loadingShellEnvironment: loadingShellEnvironment),
-            environment: environment,
-            workingDirectory: FileManager.default.homeDirectoryForCurrentUser.path)
+        let directory = resolvedWorkingDirectory(workingDirectory)
+        let terminal = directory.flatMap {
+            PseudoTerminal.spawn(
+                executable: shell,
+                arguments: shellArguments(
+                    command: command, arguments: arguments,
+                    loadingShellEnvironment: loadingShellEnvironment),
+                environment: environment, workingDirectory: $0)
+        }
 
         guard let terminal else {
+            let reason =
+                directory == nil
+                ? missingDirectory(workingDirectory) : "The shell could not be started."
             return ShellCommandSession(
                 events: AsyncStream { continuation in
                     continuation.yield(
-                        .finished(
-                            ShellCommandResult(
-                                termination: .launchFailed("The shell could not be started."))))
+                        .finished(ShellCommandResult(termination: .launchFailed(reason))))
                     continuation.finish()
                 },
                 stop: {})
@@ -242,6 +273,25 @@ enum ShellCommandRunner {
             let width = lead >= 0xF0 ? 4 : lead >= 0xE0 ? 3 : lead >= 0xC0 ? 2 : 1
             return index - boundary + 1 >= width ? index : boundary - 1
         }
+    }
+
+    /// The directory the command starts in: its own when it names one, the home directory
+    /// otherwise. Nil when the named one is gone, which is reported rather than silently ignored —
+    /// running a command somewhere it did not expect is worse than not running it.
+    nonisolated private static func resolvedWorkingDirectory(_ path: String?) -> String? {
+        guard let path, !path.isEmpty else {
+            return FileManager.default.homeDirectoryForCurrentUser.path
+        }
+        let expanded = (path as NSString).expandingTildeInPath
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: expanded, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else { return nil }
+        return expanded
+    }
+
+    nonisolated private static func missingDirectory(_ path: String?) -> String {
+        "The folder “\(path ?? "")” no longer exists."
     }
 
     /// `$0` names the caller and the user's values follow as `$1`, `$2` — never spliced into the

--- a/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
@@ -80,7 +80,7 @@ private struct CustomCommandSettingsRow: View {
 
     var body: some View {
         SettingsRow(title: command.name, subtitle: command.command) {
-            Image(systemName: CustomCommand.sfSymbol)
+            Image(systemName: command.symbol)
         } trailing: {
             ShortcutRecorder(action: .customCommand(id: command.id))
 

--- a/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
@@ -11,7 +11,17 @@ struct CustomCommandEditorSheet: View {
     @State private var loadsShellEnvironment: Bool
     @State private var requiresConfirmation: Bool
     @State private var showsConfirmation: Bool
+    @State private var showsOutput: Bool
+    @State private var arguments: [ArgumentDraft]
     @State private var errorMessage: String?
+
+    /// Identity the persisted argument has no need for, so removing a row above one being typed
+    /// into doesn't move its field editor.
+    private struct ArgumentDraft: Identifiable {
+        let id = UUID()
+        var name: String
+        var isOptional: Bool
+    }
 
     init(command: CustomCommand?) {
         self.command = command
@@ -20,6 +30,11 @@ struct CustomCommandEditorSheet: View {
         _loadsShellEnvironment = State(initialValue: command?.loadsShellEnvironment ?? false)
         _requiresConfirmation = State(initialValue: command?.requiresConfirmation ?? false)
         _showsConfirmation = State(initialValue: command?.showsConfirmation ?? false)
+        _showsOutput = State(initialValue: command?.showsOutput ?? false)
+        _arguments = State(
+            initialValue: (command?.arguments ?? []).map {
+                ArgumentDraft(name: $0.name, isOptional: $0.isOptional)
+            })
     }
 
     var body: some View {
@@ -56,6 +71,8 @@ struct CustomCommandEditorSheet: View {
                 .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
 
+            argumentsSection
+
             VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
                 optionToggle(
                     "Load shell environment", isOn: $loadsShellEnvironment,
@@ -66,6 +83,9 @@ struct CustomCommandEditorSheet: View {
                 optionToggle(
                     "Show confirmation", isOn: $showsConfirmation,
                     detail: "Confirm on screen after the command succeeds.")
+                optionToggle(
+                    "Show output", isOn: $showsOutput,
+                    detail: "Open a window with everything the command printed when it finishes.")
             }
 
             if let errorMessage {
@@ -89,6 +109,51 @@ struct CustomCommandEditorSheet: View {
         .frame(width: Theme.Size.editorSheetWidth)
     }
 
+    private var argumentsSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack {
+                Text("Arguments")
+                    .font(.callout.weight(.medium))
+                Spacer()
+                Button("Add") { arguments.append(ArgumentDraft(name: "", isOptional: false)) }
+                    .controlSize(.small)
+            }
+            ForEach($arguments) { $argument in
+                HStack(spacing: Theme.Spacing.sm) {
+                    Text("$\(position(of: argument.id))")
+                        .font(.callout.monospaced())
+                        .foregroundStyle(.secondary)
+                        .frame(width: Self.positionWidth, alignment: .leading)
+                    TextField("Argument name", text: $argument.name)
+                        .textFieldStyle(.roundedBorder)
+                    Toggle("Optional", isOn: $argument.isOptional)
+                        .toggleStyle(.checkbox)
+                    Button {
+                        arguments.removeAll { $0.id == argument.id }
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Remove this argument")
+                }
+            }
+            Text(
+                arguments.isEmpty
+                    ? "Add one to be asked for a value before the command runs."
+                    : "Asked for in order, then passed to the command as $1, $2 …"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private static let positionWidth: CGFloat = 22
+
+    /// The shell variable the row's value lands in; blank names are dropped, but only on save.
+    private func position(of id: UUID) -> Int {
+        (arguments.firstIndex { $0.id == id } ?? 0) + 1
+    }
+
     private func optionToggle(
         _ title: String, isOn: Binding<Bool>, detail: String
     ) -> some View {
@@ -110,7 +175,11 @@ struct CustomCommandEditorSheet: View {
             id: command?.id ?? UUID(), name: name, command: shellCommand,
             loadsShellEnvironment: loadsShellEnvironment,
             requiresConfirmation: requiresConfirmation,
-            showsConfirmation: showsConfirmation)
+            showsConfirmation: showsConfirmation,
+            arguments: arguments.map {
+                CustomCommandArgument(name: $0.name, isOptional: $0.isOptional)
+            },
+            showsOutput: showsOutput)
         do {
             if command == nil {
                 try core.customCommandCoordinator.addCustomCommand(draft)

--- a/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Add / edit sheet for a single custom command, presented from the Commands pane.
@@ -13,6 +14,9 @@ struct CustomCommandEditorSheet: View {
     @State private var showsConfirmation: Bool
     @State private var showsOutput: Bool
     @State private var arguments: [ArgumentDraft]
+    @State private var workingDirectory: String
+    @State private var iconSymbol: String?
+    @State private var showingIconPicker = false
     @State private var errorMessage: String?
 
     /// Identity the persisted argument has no need for, so removing a row above one being typed
@@ -35,6 +39,8 @@ struct CustomCommandEditorSheet: View {
             initialValue: (command?.arguments ?? []).map {
                 ArgumentDraft(name: $0.name, isOptional: $0.isOptional)
             })
+        _workingDirectory = State(initialValue: command?.workingDirectory ?? "")
+        _iconSymbol = State(initialValue: command?.iconSymbol)
     }
 
     var body: some View {
@@ -42,11 +48,14 @@ struct CustomCommandEditorSheet: View {
             Text(command == nil ? "Add Custom Command" : "Edit Custom Command")
                 .font(.title2.weight(.bold))
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                Text("Name")
-                    .font(.callout.weight(.medium))
-                TextField("Sleep Displays", text: $name)
-                    .textFieldStyle(.roundedBorder)
+            HStack(alignment: .bottom, spacing: Theme.Spacing.lg) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                    Text("Name")
+                        .font(.callout.weight(.medium))
+                    TextField("Sleep Displays", text: $name)
+                        .textFieldStyle(.roundedBorder)
+                }
+                iconField
             }
 
             VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -70,6 +79,8 @@ struct CustomCommandEditorSheet: View {
             Text("Example: /usr/bin/pmset displaysleepnow")
                 .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
+
+            workingDirectoryField
 
             argumentsSection
 
@@ -107,6 +118,75 @@ struct CustomCommandEditorSheet: View {
         }
         .padding(Theme.Spacing.xxl)
         .frame(width: Theme.Size.editorSheetWidth)
+    }
+
+    private static let iconSymbols = [
+        "terminal", "hammer", "wrench", "gearshape", "bolt", "arrow.clockwise", "trash",
+        "shippingbox", "cube", "server.rack", "externaldrive", "internaldrive", "cloud",
+        "arrow.up.circle", "arrow.down.circle", "doc.text", "folder", "magnifyingglass",
+        "ladybug", "chevron.left.forwardslash.chevron.right", "network", "lock", "key",
+        "display", "speaker.wave.2", "moon", "sun.max", "power", "clock", "calendar",
+        "chart.bar", "flame",
+    ]
+
+    private var iconField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Icon")
+                .font(.callout.weight(.medium))
+            Button {
+                showingIconPicker = true
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    SymbolImage(name: iconSymbol ?? CustomCommand.sfSymbol, size: 14)
+                    Text(iconSymbol == nil ? "Automatic" : "Custom")
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                .frame(width: Self.iconFieldWidth)
+            }
+            .popover(isPresented: $showingIconPicker, arrowEdge: .bottom) {
+                SymbolPicker(
+                    selection: $iconSymbol, fallback: CustomCommand.sfSymbol,
+                    symbols: Self.iconSymbols
+                ) {
+                    showingIconPicker = false
+                }
+            }
+        }
+    }
+
+    private static let iconFieldWidth: CGFloat = 130
+
+    private var workingDirectoryField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Run In")
+                .font(.callout.weight(.medium))
+            HStack(spacing: Theme.Spacing.sm) {
+                TextField("Home folder", text: $workingDirectory)
+                    .textFieldStyle(.roundedBorder)
+                Button("Choose…", action: chooseWorkingDirectory)
+            }
+            Text("The folder the command starts in. Leave empty for your home folder.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func chooseWorkingDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Choose"
+        panel.message = "Choose the folder this command runs in."
+        if !workingDirectory.isEmpty {
+            panel.directoryURL = URL(
+                fileURLWithPath: (workingDirectory as NSString).expandingTildeInPath)
+        }
+        // Tinycast is an accessory app, so the panel opens behind the frontmost app without this.
+        NSApp.activate(ignoringOtherApps: true)
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        workingDirectory = (url.path as NSString).abbreviatingWithTildeInPath
     }
 
     private var argumentsSection: some View {
@@ -179,7 +259,7 @@ struct CustomCommandEditorSheet: View {
             arguments: arguments.map {
                 CustomCommandArgument(name: $0.name, isOptional: $0.isOptional)
             },
-            showsOutput: showsOutput)
+            showsOutput: showsOutput, workingDirectory: workingDirectory, iconSymbol: iconSymbol)
         do {
             if command == nil {
                 try core.customCommandCoordinator.addCustomCommand(draft)

--- a/Tinycast/Features/CustomCommands/UI/CommandOutputPresenter.swift
+++ b/Tinycast/Features/CustomCommands/UI/CommandOutputPresenter.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// How a run ended, once it has.
+struct CommandOutcome: Sendable {
+    let summary: String
+    /// The nudge for a failure the reader can fix, when the exit status names one.
+    let hint: String?
+    let succeeded: Bool
+    let finishedAt: Date
+}
+
+/// One run of one command, from the moment it starts.
+struct CommandRun: Identifiable, Sendable {
+    let id = UUID()
+    /// Which custom command this was, so the window can run it again.
+    let commandID: UUID
+    let name: String
+    /// The shell text, shown under the name — "brew" alone says nothing about what ran.
+    let commandText: String
+    let startedAt: Date
+    /// Everything printed so far, for copying and for a redraw from scratch.
+    var log = ""
+    /// The most recent append, and a counter for it: one step on means the view can add just this
+    /// rather than walk the whole log to work out what changed.
+    var delta = ""
+    var revision = 0
+    /// Bumped when the head of `log` is dropped, which is the text view's cue to redraw whole.
+    var generation = 0
+    /// Nil while the command is still running.
+    var outcome: CommandOutcome?
+
+    var isRunning: Bool { outcome == nil }
+}
+
+/// The window a command's output lands in, from launch to exit. One window, reused: a second run
+/// replaces what it shows rather than stacking another, so a held-down hotkey can't paper the
+/// screen. A superseded run is not cancelled — only the Stop button ends a command.
+@MainActor
+@Observable
+final class CommandOutputPresenter {
+    /// Past this the head is dropped: the tail is where a command says how it went.
+    private static let logLimit = 256 * 1024
+
+    private(set) var run: CommandRun?
+
+    @ObservationIgnored private let activation: ActivationPolicy
+    @ObservationIgnored private let rerun: (UUID) -> Void
+    @ObservationIgnored private let stop: (UUID) -> Void
+    @ObservationIgnored private let openSettings: () -> Void
+    @ObservationIgnored private lazy var window = AppWindowController(
+        title: "Command Output", contentSize: CommandOutputView.initialSize, resizable: true,
+        autosaveName: "CommandOutputWindow", activation: activation)
+
+    init(
+        activation: ActivationPolicy, rerun: @escaping (UUID) -> Void,
+        stop: @escaping (UUID) -> Void, openSettings: @escaping () -> Void
+    ) {
+        self.activation = activation
+        self.rerun = rerun
+        self.stop = stop
+        self.openSettings = openSettings
+    }
+
+    /// Opens the window on an empty, running command and returns the id the run reports against.
+    @discardableResult
+    func begin(commandID: UUID, name: String, commandText: String) -> UUID {
+        let run = CommandRun(
+            commandID: commandID, name: name, commandText: commandText, startedAt: Date())
+        self.run = run
+        window.show { CommandOutputView(presenter: self) }
+        return run.id
+    }
+
+    func append(_ text: String, to id: UUID) {
+        guard var run, run.id == id else { return }
+        run.log += text
+        run.delta = text
+        run.revision += 1
+        if run.log.utf8.count > Self.logLimit {
+            run.log = String(run.log.suffix(Self.logLimit / 2))
+            // The delta no longer describes the change, so the view is told to redraw instead.
+            run.generation += 1
+        }
+        self.run = run
+    }
+
+    func finish(_ outcome: CommandOutcome, for id: UUID) {
+        guard var run, run.id == id else { return }
+        run.outcome = outcome
+        self.run = run
+    }
+
+    // MARK: - Actions the window offers
+
+    func runAgain() {
+        guard let run else { return }
+        rerun(run.commandID)
+    }
+
+    func stopRunning() {
+        guard let run, run.isRunning else { return }
+        stop(run.id)
+    }
+
+    func showCommandSettings() {
+        openSettings()
+    }
+}

--- a/Tinycast/Features/CustomCommands/UI/CommandOutputPresenter.swift
+++ b/Tinycast/Features/CustomCommands/UI/CommandOutputPresenter.swift
@@ -105,4 +105,9 @@ final class CommandOutputPresenter {
     func showCommandSettings() {
         openSettings()
     }
+
+    /// Re-raise an open output window; false when none is up, so a reopen falls through.
+    func focusExisting() -> Bool {
+        window.focus()
+    }
 }

--- a/Tinycast/Features/CustomCommands/UI/CommandOutputPresenter.swift
+++ b/Tinycast/Features/CustomCommands/UI/CommandOutputPresenter.swift
@@ -17,6 +17,7 @@ struct CommandRun: Identifiable, Sendable {
     let name: String
     /// The shell text, shown under the name — "brew" alone says nothing about what ran.
     let commandText: String
+    let symbol: String
     let startedAt: Date
     /// Everything printed so far, for copying and for a redraw from scratch.
     var log = ""
@@ -63,9 +64,10 @@ final class CommandOutputPresenter {
 
     /// Opens the window on an empty, running command and returns the id the run reports against.
     @discardableResult
-    func begin(commandID: UUID, name: String, commandText: String) -> UUID {
+    func begin(commandID: UUID, name: String, commandText: String, symbol: String) -> UUID {
         let run = CommandRun(
-            commandID: commandID, name: name, commandText: commandText, startedAt: Date())
+            commandID: commandID, name: name, commandText: commandText, symbol: symbol,
+            startedAt: Date())
         self.run = run
         window.show { CommandOutputView(presenter: self) }
         return run.id

--- a/Tinycast/Features/CustomCommands/UI/CommandOutputView.swift
+++ b/Tinycast/Features/CustomCommands/UI/CommandOutputView.swift
@@ -1,0 +1,167 @@
+import AppKit
+import SwiftUI
+
+/// The output window: what ran, what it is printing, and how it ended. One flat surface with no
+/// rules — the log is the page, and the chrome is separated by space and weight rather than lines.
+struct CommandOutputView: View {
+    let presenter: CommandOutputPresenter
+
+    static let initialSize = CGSize(width: 720, height: 460)
+
+    var body: some View {
+        Group {
+            if let run = presenter.run {
+                VStack(alignment: .leading, spacing: 0) {
+                    header(run)
+                    TerminalLogView(run: run)
+                    footer(run)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Theme.Colors.terminalSurface)
+    }
+
+    // MARK: - Header
+
+    private func header(_ run: CommandRun) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.md) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                Text(run.name)
+                    .font(.headline)
+                Text(run.commandText)
+                    .font(Theme.Typography.code)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: Theme.Spacing.md)
+            actions(run)
+        }
+        // Less on top: the transparent title bar already contributes its own height above this.
+        .padding(.top, Theme.Spacing.md)
+        .padding(.horizontal, Theme.Spacing.xxl)
+        .padding(.bottom, Theme.Spacing.lg)
+    }
+
+    /// Copy always; the second slot is Stop while it runs and Run Again once it has — one control
+    /// for one job, so the header never has to fit both.
+    private func actions(_ run: CommandRun) -> some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            CopyLogButton(log: run.log)
+            if run.isRunning {
+                iconButton("stop.fill", help: "Stop") { presenter.stopRunning() }
+            } else {
+                iconButton("arrow.clockwise", help: "Run Again") { presenter.runAgain() }
+            }
+        }
+    }
+
+    private func iconButton(
+        _ symbol: String, help: String, action: @escaping () -> Void
+    ) -> some View {
+        BarButton(chrome: .rounded, action: action) {
+            Image(systemName: symbol)
+                .font(Theme.Typography.bar)
+                .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .tooltip(help)
+    }
+
+    // MARK: - Footer
+
+    private func footer(_ run: CommandRun) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Circle()
+                .fill(statusTint(run))
+                .frame(width: Self.statusDot, height: Self.statusDot)
+            if let outcome = run.outcome {
+                Text(outcome.summary)
+                Text("·")
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                Text(CommandDuration.text(from: run.startedAt, to: outcome.finishedAt))
+            } else {
+                Text("Running")
+                Text("·")
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                elapsed(from: run.startedAt)
+            }
+            Spacer(minLength: Theme.Spacing.md)
+            if let outcome = run.outcome {
+                Text(outcome.finishedAt, format: .dateTime.hour().minute().second())
+                    .monospacedDigit()
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+        }
+        .font(.callout)
+        .foregroundStyle(Theme.Colors.textSecondary)
+        .overlay(alignment: .topLeading) { hint(run) }
+        .padding(.horizontal, Theme.Spacing.xxl)
+        .padding(.vertical, Theme.Spacing.lg)
+    }
+
+    /// Ticks itself rather than being driven by a timer the window would have to own.
+    private func elapsed(from start: Date) -> some View {
+        TimelineView(.periodic(from: start, by: 1)) { context in
+            Text(CommandDuration.text(from: start, to: context.date))
+                .monospacedDigit()
+        }
+    }
+
+    /// Sits above the footer rather than in it: the nudge is a sentence, and the bar is a line.
+    @ViewBuilder
+    private func hint(_ run: CommandRun) -> some View {
+        if let hint = run.outcome?.hint {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text(hint)
+                Button("Open Settings") { presenter.showCommandSettings() }
+                    .buttonStyle(.link)
+            }
+            .font(.callout)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            .fixedSize()
+            .alignmentGuide(.top) { $0[.bottom] + Theme.Spacing.md }
+        }
+    }
+
+    private static let statusDot: CGFloat = 7
+
+    private func statusTint(_ run: CommandRun) -> Color {
+        guard let outcome = run.outcome else { return Theme.Colors.progress }
+        return outcome.succeeded ? Theme.Colors.success : Theme.Colors.destructive
+    }
+}
+
+/// Copies the whole log, then shows a checkmark long enough to be believed.
+private struct CopyLogButton: View {
+    let log: String
+    @State private var copiedAt: Date?
+
+    var body: some View {
+        BarButton(chrome: .rounded) {
+            Paster.copyPlainText(log)
+            copiedAt = Date()
+        } label: {
+            Image(systemName: copiedAt == nil ? "square.on.square" : "checkmark")
+                .font(Theme.Typography.bar)
+                .foregroundStyle(copiedAt == nil ? Theme.Colors.textSecondary : Theme.Colors.success)
+        }
+        .tooltip("Copy Output")
+        .task(id: copiedAt) {
+            guard copiedAt != nil else { return }
+            try? await Task.sleep(for: .seconds(Theme.Duration.copyFeedback))
+            copiedAt = nil
+        }
+    }
+}
+
+/// Elapsed time, in the one place a duration becomes text.
+enum CommandDuration {
+    static func text(from start: Date, to end: Date) -> String {
+        let seconds = max(0, end.timeIntervalSince(start))
+        if seconds < 10 { return String(format: "%.1fs", seconds) }
+        if seconds < 60 { return "\(Int(seconds))s" }
+        let whole = Int(seconds)
+        return "\(whole / 60)m \(whole % 60)s"
+    }
+}

--- a/Tinycast/Features/CustomCommands/UI/CommandOutputView.swift
+++ b/Tinycast/Features/CustomCommands/UI/CommandOutputView.swift
@@ -26,6 +26,8 @@ struct CommandOutputView: View {
 
     private func header(_ run: CommandRun) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.md) {
+            SymbolImage(name: run.symbol, size: Self.headerGlyph)
+                .foregroundStyle(Theme.Colors.textSecondary)
             VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
                 Text(run.name)
                     .font(.headline)
@@ -125,6 +127,7 @@ struct CommandOutputView: View {
     }
 
     private static let statusDot: CGFloat = 7
+    private static let headerGlyph: CGFloat = 15
 
     private func statusTint(_ run: CommandRun) -> Color {
         guard let outcome = run.outcome else { return Theme.Colors.progress }

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandArgumentsScreen.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandArgumentsScreen.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// The form shown before a custom command with arguments runs.
+struct CustomCommandArgumentsScreen: PaletteScreen {
+    /// The form has no list of its own: every value is typed into the palette's search field.
+    struct Row: Identifiable { let id: Int }
+
+    let session: CustomCommandArgumentSession
+    let core: AppCore
+    let vm: PaletteState
+
+    var rows: [Row] { [] }
+
+    var primaryActionTitle: String { session.isLastArgument ? "Run Command" : "Next" }
+
+    /// A required argument holds ↵ until it has a value, which also hides the footer pill.
+    func hasPrimaryAction(at selection: Int) -> Bool {
+        guard let current = session.current else { return false }
+        return current.isOptional || !vm.query.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    func secondary(at selection: Int) -> Bool { false }
+
+    func activate(at selection: Int) {
+        guard hasPrimaryAction(at: selection) else { return }
+        core.customCommandCoordinator.submitCustomCommandArgument(vm.query)
+        // More to answer: clear the field so the next argument starts on an empty one.
+        if session.isActive { vm.query = "" }
+    }
+
+    func body(selection: Int, scroll: ScrollIntent) -> AnyView {
+        AnyView(CustomCommandArgumentsView(session: session))
+    }
+}

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandArgumentsView.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandArgumentsView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// What the argument form shows: the command it will run, and one row per value it still wants.
+/// docs/features/custom-commands.md
+struct CustomCommandArgumentsView: View {
+    let session: CustomCommandArgumentSession
+
+    private static let markSize: CGFloat = 11
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+            if let command = session.command {
+                header(command)
+            }
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                ForEach(Array(session.progress.enumerated()), id: \.offset) { index, entry in
+                    row(entry.argument, value: entry.value, position: index + 1)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Theme.Spacing.md * 2)
+        .padding(.top, Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func header(_ command: CustomCommand) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text(command.name)
+                .font(Theme.Typography.rowTitle.weight(.semibold))
+            Text(command.command)
+                .font(Theme.Typography.code)
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    /// `position` is the shell variable the value lands in, so the row explains the script it feeds.
+    private func row(
+        _ argument: CustomCommandArgument, value: String?, position: Int
+    ) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: value == nil ? "circle" : "checkmark.circle.fill")
+                .font(.system(size: Self.markSize))
+                .foregroundStyle(value == nil ? Theme.Colors.textTertiary : Theme.Colors.success)
+            Text("$\(position)")
+                .font(Theme.Typography.code)
+                .foregroundStyle(Theme.Colors.textTertiary)
+            Text(argument.name)
+                .font(Theme.Typography.rowTrailing)
+                .foregroundStyle(Theme.Colors.textSecondary)
+            if let value {
+                Text(value.isEmpty ? "—" : value)
+                    .font(Theme.Typography.rowTrailing)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            } else if argument.isOptional {
+                Text("optional")
+                    .font(Theme.Typography.keyCap)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
@@ -1,9 +1,10 @@
 import AppKit
 
-/// Owns custom commands: the library, the one run funnel with its gate, and a deletion's cleanup.
+/// Owns custom commands: the library, the one run funnel with its gates, and a deletion's cleanup.
 @MainActor
 final class CustomCommandCoordinator {
     private let store: CustomCommandStore
+    private let argumentSession: CustomCommandArgumentSession
     private let settings: AppSettings
     private let appIndex: AppIndex
     private let paletteCoordinator: PaletteCoordinator
@@ -15,9 +16,20 @@ final class CustomCommandCoordinator {
     private let aliases: AliasStore
     /// Dialog and message-HUD presentation only — never for state this type owns.
     private unowned let core: AppCore
+    /// Built on first use: most installs never turn output on, and it holds a window.
+    private lazy var outputPresenter = CommandOutputPresenter(
+        activation: activationPolicy,
+        rerun: { [unowned self] in self.runCustomCommand(id: $0) },
+        stop: { [unowned self] in self.stopOutputRun(id: $0) },
+        openSettings: { [unowned self] in self.settingsCoordinator.showSettings(tab: .commands) })
+    private let activationPolicy: ActivationPolicy
+    /// The live streaming run, so Stop has something to signal. Superseding never touches it — only
+    /// the button ends a command.
+    private var liveRun: (id: UUID, stop: @Sendable () -> Void)?
 
     init(
         store: CustomCommandStore,
+        argumentSession: CustomCommandArgumentSession,
         settings: AppSettings,
         appIndex: AppIndex,
         paletteCoordinator: PaletteCoordinator,
@@ -27,9 +39,11 @@ final class CustomCommandCoordinator {
         visibility: VisibilityStore,
         ranking: LauncherRankingStore,
         aliases: AliasStore,
+        activationPolicy: ActivationPolicy,
         core: AppCore
     ) {
         self.store = store
+        self.argumentSession = argumentSession
         self.settings = settings
         self.appIndex = appIndex
         self.paletteCoordinator = paletteCoordinator
@@ -39,6 +53,7 @@ final class CustomCommandCoordinator {
         self.visibility = visibility
         self.ranking = ranking
         self.aliases = aliases
+        self.activationPolicy = activationPolicy
         self.core = core
     }
 
@@ -79,11 +94,36 @@ final class CustomCommandCoordinator {
 
     // MARK: - Running
 
-    /// The one funnel for palette and hotkey, so the confirmation can't be bypassed.
+    /// The one funnel for palette and hotkey, so neither the argument form nor the confirmation
+    /// can be bypassed.
     func runCustomCommand(id: UUID) {
         // Also the feature switch: with it off a registered hotkey must run nothing.
         guard settings.customCommandsEnabled else { return }
         guard let command = store.command(id: id) else { return }
+        guard command.arguments.isEmpty else {
+            argumentSession.begin(command: command)
+            // Never a restored mode: this screen is always a fresh prompt, never a resumed one.
+            paletteCoordinator.showPalette(mode: .customCommandArguments)
+            return
+        }
+        perform(command, arguments: [])
+    }
+
+    /// ↵ in the argument form. Returns false while more arguments remain.
+    @discardableResult
+    func submitCustomCommandArgument(_ value: String) -> Bool {
+        guard let filled = argumentSession.submit(value) else { return false }
+        argumentSession.cancel()
+        perform(filled.command, arguments: filled.values)
+        return true
+    }
+
+    func cancelCustomCommandArguments() {
+        argumentSession.cancel()
+    }
+
+    private func perform(_ command: CustomCommand, arguments: [String]) {
+        guard settings.customCommandsEnabled else { return }
         if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: false) }
         Task {
             if command.requiresConfirmation {
@@ -96,17 +136,45 @@ final class CustomCommandCoordinator {
                         tone: .neutral, confirmRole: .standard)
                 else { return }
             }
-            let outcome = await ShellCommandRunner.run(
-                command.command, loadingShellEnvironment: command.loadsShellEnvironment)
-            guard outcome != .success else {
-                // On finish, not start, so a slow command confirms late rather than early.
-                if command.showsConfirmation {
-                    core.showMessage("Ran \(command.name)")
-                }
+            guard !command.showsOutput else {
+                await streamOutput(of: command, arguments: arguments)
                 return
             }
-            await presentCustomCommandFailure(command: command, outcome: outcome)
+            let result = await ShellCommandRunner.run(
+                command.command, arguments: arguments,
+                loadingShellEnvironment: command.loadsShellEnvironment)
+            await report(command, result: result)
         }
+    }
+
+    /// Opens the window before the first byte, so a long command is visible while it works.
+    private func streamOutput(of command: CustomCommand, arguments: [String]) async {
+        let session = ShellCommandRunner.stream(
+            command.command, arguments: arguments,
+            loadingShellEnvironment: command.loadsShellEnvironment)
+        let runID = outputPresenter.begin(
+            commandID: command.id, name: command.name, commandText: command.command)
+        liveRun = (runID, session.stop)
+        defer { if liveRun?.id == runID { liveRun = nil } }
+
+        for await event in session.events {
+            switch event {
+            case .output(let text):
+                outputPresenter.append(text, to: runID)
+            case .finished(let result):
+                outputPresenter.finish(
+                    CommandOutcome(
+                        summary: summary(of: result),
+                        hint: shellEnvironmentHint(command: command, result: result),
+                        succeeded: result.succeeded, finishedAt: Date()),
+                    for: runID)
+            }
+        }
+    }
+
+    private func stopOutputRun(id: UUID) {
+        guard let liveRun, liveRun.id == id else { return }
+        liveRun.stop()
     }
 
     private func removeCustomCommandReferences(ids: Set<UUID>, entryIDs: Set<String>) {
@@ -123,32 +191,51 @@ final class CustomCommandCoordinator {
         }
     }
 
-    private func presentCustomCommandFailure(
-        command: CustomCommand, outcome: ShellCommandOutcome
-    ) async {
-        let message: String
-        // `127` is "command not found", where a config-only alias lands.
-        var suggestsShellEnvironment = false
-        switch outcome {
-        case .success:
+    // MARK: - Reporting
+
+    /// Only the non-streaming path reaches here: a window that already says how the run ended must
+    /// not also raise a dialog saying it again.
+    private func report(_ command: CustomCommand, result: ShellCommandResult) async {
+        guard !result.succeeded else {
+            // On finish, not start, so a slow command confirms late rather than early.
+            if command.showsConfirmation { core.showMessage("Ran \(command.name)") }
             return
-        case .launchFailure(let detail):
-            message = "The shell could not be started.\n\n\(detail)"
-        case .nonZeroExit(let status, let stderr):
-            suggestsShellEnvironment = status == 127 && !command.loadsShellEnvironment
-            message =
-                "The command exited with status \(status)."
-                + (stderr.map { "\n\n" + $0 } ?? "")
-                + (suggestsShellEnvironment
-                    ? "\n\nIf this is a shell alias or function, turn on Load Shell Environment for "
-                        + "this command." : "")
         }
+        let hint = shellEnvironmentHint(command: command, result: result)
         guard
             await core.reportFailure(
-                title: "“\(command.name)” Failed", message: message,
-                symbol: CustomCommand.sfSymbol,
-                recovery: suggestsShellEnvironment ? "Open Settings…" : nil)
+                title: "“\(command.name)” Failed",
+                message: failureMessage(command: command, result: result),
+                symbol: CustomCommand.sfSymbol, recovery: hint == nil ? nil : "Open Settings…")
         else { return }
         settingsCoordinator.showSettings(tab: .commands)
+    }
+
+    private func summary(of result: ShellCommandResult) -> String {
+        switch result.termination {
+        case .launchFailed: return "The shell could not be started."
+        case .stopped: return "Stopped"
+        case .exited(let status):
+            return status == 0 ? "Finished successfully." : "The command exited with status \(status)."
+        }
+    }
+
+    private func failureMessage(command: CustomCommand, result: ShellCommandResult) -> String {
+        var parts = [summary(of: result)]
+        if case .launchFailed(let detail) = result.termination { parts.append(detail) }
+        if let standardError = result.standardError { parts.append(standardError) }
+        if let hint = shellEnvironmentHint(command: command, result: result) { parts.append(hint) }
+        return parts.joined(separator: "\n\n")
+    }
+
+    /// `127` is "command not found", where a config-only alias lands — but equally a plain typo, so
+    /// this is gated on the status alone rather than on grepping stderr.
+    private func shellEnvironmentHint(
+        command: CustomCommand, result: ShellCommandResult
+    ) -> String? {
+        guard case .exited(status: 127) = result.termination, !command.loadsShellEnvironment else {
+            return nil
+        }
+        return "If this is a shell alias or function, turn on Load Shell Environment for this command."
     }
 }

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
@@ -16,7 +16,7 @@ final class CustomCommandCoordinator {
     private let aliases: AliasStore
     /// Dialog and message-HUD presentation only — never for state this type owns.
     private unowned let core: AppCore
-    /// Built on first use: most installs never turn output on, and it holds a window.
+    /// Built on first use; the window inside it waits for a run that actually shows output.
     private lazy var outputPresenter = CommandOutputPresenter(
         activation: activationPolicy,
         rerun: { [unowned self] in self.runCustomCommand(id: $0) },
@@ -120,6 +120,11 @@ final class CustomCommandCoordinator {
 
     func cancelCustomCommandArguments() {
         argumentSession.cancel()
+    }
+
+    /// A Dock click while a command is running belongs to its window, not to a fresh launcher.
+    func focusOutputWindow() -> Bool {
+        outputPresenter.focusExisting()
     }
 
     private func perform(_ command: CustomCommand, arguments: [String]) {

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
@@ -137,7 +137,7 @@ final class CustomCommandCoordinator {
                     await core.confirm(
                         title: command.name,
                         message: "Are you sure you want to run this command?\n\n\(command.command)",
-                        symbol: CustomCommand.sfSymbol, confirmTitle: "Run",
+                        symbol: command.symbol, confirmTitle: "Run",
                         tone: .neutral, confirmRole: .standard)
                 else { return }
             }
@@ -147,7 +147,8 @@ final class CustomCommandCoordinator {
             }
             let result = await ShellCommandRunner.run(
                 command.command, arguments: arguments,
-                loadingShellEnvironment: command.loadsShellEnvironment)
+                loadingShellEnvironment: command.loadsShellEnvironment,
+                workingDirectory: command.workingDirectory)
             await report(command, result: result)
         }
     }
@@ -156,9 +157,11 @@ final class CustomCommandCoordinator {
     private func streamOutput(of command: CustomCommand, arguments: [String]) async {
         let session = ShellCommandRunner.stream(
             command.command, arguments: arguments,
-            loadingShellEnvironment: command.loadsShellEnvironment)
+            loadingShellEnvironment: command.loadsShellEnvironment,
+            workingDirectory: command.workingDirectory)
         let runID = outputPresenter.begin(
-            commandID: command.id, name: command.name, commandText: command.command)
+            commandID: command.id, name: command.name, commandText: command.command,
+            symbol: command.symbol)
         liveRun = (runID, session.stop)
         defer { if liveRun?.id == runID { liveRun = nil } }
 
@@ -202,8 +205,11 @@ final class CustomCommandCoordinator {
     /// not also raise a dialog saying it again.
     private func report(_ command: CustomCommand, result: ShellCommandResult) async {
         guard !result.succeeded else {
-            // On finish, not start, so a slow command confirms late rather than early.
-            if command.showsConfirmation { core.showMessage("Ran \(command.name)") }
+            // What the command said about itself beats a bare "it ran"; the name is the fallback
+            // for one that printed nothing. On finish, not start, so a slow one reports late.
+            if command.showsConfirmation {
+                core.showMessage(result.lastOutputLine ?? "Ran \(command.name)")
+            }
             return
         }
         let hint = shellEnvironmentHint(command: command, result: result)
@@ -211,7 +217,7 @@ final class CustomCommandCoordinator {
             await core.reportFailure(
                 title: "“\(command.name)” Failed",
                 message: failureMessage(command: command, result: result),
-                symbol: CustomCommand.sfSymbol, recovery: hint == nil ? nil : "Open Settings…")
+                symbol: command.symbol, recovery: hint == nil ? nil : "Open Settings…")
         else { return }
         settingsCoordinator.showSettings(tab: .commands)
     }

--- a/Tinycast/Features/CustomCommands/UI/TerminalLogView.swift
+++ b/Tinycast/Features/CustomCommands/UI/TerminalLogView.swift
@@ -1,0 +1,180 @@
+import AppKit
+import SwiftUI
+
+/// The log itself. An `NSTextView` rather than a `Text`: a quarter-megabyte of output re-laid-out
+/// on every append is seconds of work, and only the text system appends in place.
+struct TerminalLogView: NSViewRepresentable {
+    let run: CommandRun
+
+    private static let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+    private static let inset = CGSize(width: Theme.Spacing.xxl, height: Theme.Spacing.xs)
+    /// Within this of the bottom counts as following along, matching the chat transcript's band.
+    private static let tailSlack = Theme.Spacing.chatFollowTailSlack
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        /// What is on screen. A new run and a trimmed log both make the drawn text wrong, and
+        /// neither is visible from the revision alone — Run Again starts a fresh run back at zero.
+        var runID: UUID?
+        var generation = -1
+        var revision = 0
+        var interpreter = ANSIInterpreter()
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
+        textView.isEditable = false
+        textView.drawsBackground = false
+        textView.textContainerInset = Self.inset
+        // Zeroed so the inset alone sets the left edge, lining the log up with the header text.
+        textView.textContainer?.lineFragmentPadding = 0
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView,
+            let storage = textView.textStorage
+        else { return }
+        let coordinator = context.coordinator
+        let following = isAtBottom(scrollView)
+
+        let isSameRun = coordinator.runID == run.id && coordinator.generation == run.generation
+        guard !isSameRun || run.revision != coordinator.revision else { return }
+
+        // One step on is the streaming case and costs only the new text. Anything else — Run Again
+        // starting a fresh run, a trim, a window reopened onto a finished one — is drawn whole.
+        let isAppend = isSameRun && run.revision == coordinator.revision + 1
+        if !isAppend {
+            coordinator.interpreter = ANSIInterpreter()
+            storage.setAttributedString(NSAttributedString())
+        }
+        coordinator.runID = run.id
+        coordinator.generation = run.generation
+        coordinator.revision = run.revision
+        coordinator.interpreter.render(isAppend ? run.delta : run.log, into: storage, font: Self.font)
+        if following { textView.scrollToEndOfDocument(nil) }
+    }
+
+    /// A reader who scrolled up is left alone; arriving back at the end resumes the follow.
+    private func isAtBottom(_ scrollView: NSScrollView) -> Bool {
+        guard let documentView = scrollView.documentView else { return true }
+        let visible = scrollView.contentView.bounds
+        return visible.maxY >= documentView.frame.height - Self.tailSlack
+    }
+}
+
+/// Turns a terminal's byte stream into attributed text: SGR colour carried across chunks, a
+/// carriage return rewinding the line it lands on, and everything else it emits dropped.
+struct ANSIInterpreter {
+    private var colour: NSColor = .labelColor
+    private var isBold = false
+    private var isDim = false
+    /// A control sequence can be split across reads, so a partial one waits for the rest.
+    private var partial = ""
+
+    mutating func render(_ text: String, into storage: NSTextStorage, font: NSFont) {
+        var run = ""
+        var characters = Array(partial + text)[...]
+        partial = ""
+
+        func flush() {
+            guard !run.isEmpty else { return }
+            storage.append(NSAttributedString(string: run, attributes: attributes(font)))
+            run = ""
+        }
+
+        while let character = characters.first {
+            characters = characters.dropFirst()
+            switch character {
+            case "\u{1B}":
+                guard let sequence = Self.take(&characters) else {
+                    // Truncated mid-sequence: hold it back rather than printing the escape.
+                    partial = "\u{1B}" + String(characters)
+                    characters = characters.prefix(0)
+                    continue
+                }
+                flush()
+                apply(sequence)
+            case "\r":
+                // A progress bar redraws its line in place; appending the frames would stack them.
+                flush()
+                rewindLine(in: storage)
+            default:
+                run.append(character)
+            }
+        }
+        flush()
+    }
+
+    private func attributes(_ font: NSFont) -> [NSAttributedString.Key: Any] {
+        let face = isBold ? NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask) : font
+        return [.font: face, .foregroundColor: isDim ? colour.withAlphaComponent(0.6) : colour]
+    }
+
+    /// Reads one CSI/OSC body; nil when the sequence has not all arrived yet.
+    private static func take(_ characters: inout ArraySlice<Character>) -> String? {
+        guard let introducer = characters.first else { return nil }
+        characters = characters.dropFirst()
+        guard introducer == "[" else {
+            // OSC and the rest carry no meaning here; swallow to their terminator.
+            while let character = characters.first, character != "\u{07}", character != "\u{1B}" {
+                characters = characters.dropFirst()
+            }
+            return ""
+        }
+        var body = ""
+        while let character = characters.first {
+            characters = characters.dropFirst()
+            body.append(character)
+            if character.isLetter { return body }
+        }
+        return nil
+    }
+
+    private mutating func apply(_ sequence: String) {
+        // Only SGR is drawn; cursor moves and erases have no meaning in a document.
+        guard sequence.hasSuffix("m") else { return }
+        let codes = sequence.dropLast().split(separator: ";", omittingEmptySubsequences: false)
+            .map { Int($0) ?? 0 }
+        var index = 0
+        while index < max(codes.count, 1) {
+            let code = codes.isEmpty ? 0 : codes[index]
+            switch code {
+            case 0: colour = .labelColor; isBold = false; isDim = false
+            case 1: isBold = true
+            case 2: isDim = true
+            case 22: isBold = false; isDim = false
+            case 30...37: colour = Self.palette[code - 30]
+            case 90...97: colour = Self.palette[code - 90]
+            case 39: colour = .labelColor
+            // Extended colour carries its own parameters; skipping them keeps the rest in step.
+            case 38, 48: index += codes.count > index + 1 && codes[index + 1] == 5 ? 2 : 4
+            default: break
+            }
+            index += 1
+        }
+    }
+
+    /// Deletes back to the start of the last line, which is what a bare carriage return means.
+    private func rewindLine(in storage: NSTextStorage) {
+        let text = storage.string as NSString
+        guard text.length > 0 else { return }
+        let lineStart = text.range(
+            of: "\n", options: .backwards, range: NSRange(location: 0, length: text.length))
+        let start = lineStart.location == NSNotFound ? 0 : lineStart.location + 1
+        guard start < text.length else { return }
+        storage.deleteCharacters(in: NSRange(location: start, length: text.length - start))
+    }
+
+    /// System colours so the log stays legible in both appearances, unlike raw terminal values —
+    /// orange stands in for yellow, which is unreadable on a light background.
+    private static let palette: [NSColor] = [
+        .secondaryLabelColor, .systemRed, .systemGreen, .systemOrange,
+        .systemBlue, .systemPurple, .systemTeal, .labelColor
+    ]
+}

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -262,7 +262,7 @@ final class AppIndex {
             AppEntry(
                 id: command.entryID, name: command.name,
                 url: URL(string: "tinycast://custom-command/" + command.id.uuidString)!,
-                bundleID: nil, kind: .customCommand)
+                bundleID: nil, kind: .customCommand, symbolName: command.iconSymbol)
         }
         .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         guard entries != customCommandEntries else { return }

--- a/Tinycast/Features/Quicklinks/Settings/QuicklinkEditorSheet.swift
+++ b/Tinycast/Features/Quicklinks/Settings/QuicklinkEditorSheet.swift
@@ -137,6 +137,14 @@ struct QuicklinkEditorSheet: View {
         .fixedSize()
     }
 
+    private static let iconSymbols = [
+        "globe", "folder", "doc.text", "link", "star", "bookmark", "magnifyingglass", "cart",
+        "envelope", "message", "calendar", "clock", "checklist", "chart.bar", "hammer", "wrench",
+        "ladybug", "terminal", "chevron.left.forwardslash.chevron.right", "cloud", "server.rack",
+        "lock", "person.2", "building.2", "graduationcap", "book", "music.note", "play.rectangle",
+        "photo", "paintbrush", "creditcard", "map"
+    ]
+
     private var iconField: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             Text("Icon")
@@ -153,7 +161,9 @@ struct QuicklinkEditorSheet: View {
                 .frame(width: 150)
             }
             .popover(isPresented: $showingIconPicker, arrowEdge: .bottom) {
-                QuicklinkIconPicker(selection: $iconSymbol, automatic: automaticSymbol) {
+                SymbolPicker(
+                    selection: $iconSymbol, fallback: automaticSymbol, symbols: Self.iconSymbols
+                ) {
                     showingIconPicker = false
                 }
             }
@@ -241,57 +251,3 @@ struct QuicklinkEditorSheet: View {
 }
 
 /// A small fixed grid, not a symbol browser; "Automatic" is first, being the better default.
-private struct QuicklinkIconPicker: View {
-    @Binding var selection: String?
-    let automatic: String
-    let onPick: () -> Void
-
-    private static let symbols = [
-        "globe", "folder", "doc.text", "link", "star", "bookmark", "magnifyingglass", "cart",
-        "envelope", "message", "calendar", "clock", "checklist", "chart.bar", "hammer", "wrench",
-        "ladybug", "terminal", "chevron.left.forwardslash.chevron.right", "cloud", "server.rack",
-        "lock", "person.2", "building.2", "graduationcap", "book", "music.note", "play.rectangle",
-        "photo", "paintbrush", "creditcard", "map"
-    ]
-
-    private let columns = Array(repeating: GridItem(.fixed(30), spacing: Theme.Spacing.sm), count: 6)
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
-            Button {
-                selection = nil
-                onPick()
-            } label: {
-                HStack(spacing: Theme.Spacing.sm) {
-                    SymbolImage(name: automatic, size: 14)
-                    Text("Automatic")
-                    Spacer(minLength: 0)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            Divider()
-            LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
-                ForEach(Self.symbols, id: \.self) { symbol in
-                    Button {
-                        selection = symbol
-                        onPick()
-                    } label: {
-                        SymbolImage(name: symbol, size: 15)
-                            .frame(width: 30, height: 26)
-                            .background(
-                                RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
-                                    .fill(
-                                        selection == symbol
-                                            ? Theme.Colors.selection : Color.clear)
-                            )
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-        }
-        .padding(Theme.Spacing.md)
-        .frame(width: 244)
-    }
-}

--- a/Tinycast/Palette/PaletteEnvironment.swift
+++ b/Tinycast/Palette/PaletteEnvironment.swift
@@ -23,6 +23,7 @@ extension View {
             .environment(core.uninstall)
             .environment(core.quicklinks)
             .environment(core.quicklinkArguments)
+            .environment(core.customCommandArguments)
             .environment(core.snippetsStore)
             .environment(core.extensions)
             .environment(core.calendarStore)

--- a/Tinycast/Palette/PaletteMode.swift
+++ b/Tinycast/Palette/PaletteMode.swift
@@ -14,10 +14,15 @@ enum PaletteMode: String, CaseIterable, Identifiable {
     case snippets
     /// Collects a quicklink's `{argument}` values; the request lives on the session.
     case quicklinkArguments
+    /// Collects a custom command's positional arguments, likewise held on its own session.
+    case customCommandArguments
     /// A Raycast extension command rendering into the palette.
     case extensionCommand
 
     var id: String { rawValue }
+
+    /// One value at a time into the search field, so ↵ still acts with no rows to select.
+    var isArgumentForm: Bool { self == .quicklinkArguments || self == .customCommandArguments }
     var systemImage: String {
         switch self {
         case .launcher: return "magnifyingglass"
@@ -30,6 +35,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .schedule: return "calendar"
         case .uninstall: return "trash"
         case .quicklinks, .quicklinkArguments: return Quicklink.sfSymbol
+        case .customCommandArguments: return CustomCommand.sfSymbol
         case .snippets: return "curlybraces"
         case .extensionCommand: return "puzzlepiece.extension"
         }
@@ -48,7 +54,7 @@ enum PaletteMode: String, CaseIterable, Identifiable {
         case .quicklinks: return "Search quicklinks…"
         case .snippets: return "Search snippets…"
         // Replaced by the pending argument's name; only reached if the session vanished mid-render.
-        case .quicklinkArguments: return "Enter a value…"
+        case .quicklinkArguments, .customCommandArguments: return "Enter a value…"
         // Replaced by the command's own `searchBarPlaceholder` whenever it declares one.
         case .extensionCommand: return "Search…"
         }

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -236,6 +236,13 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 core.palette.selection = 0
                 return true
             }
+            if core.palette.mode == .customCommandArguments,
+                let previous = core.customCommandArguments.retreat()
+            {
+                core.palette.query = previous
+                core.palette.selection = 0
+                return true
+            }
             if core.palette.mode == .aiHistory {
                 core.palette.prepare(mode: .ai)
                 return true

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -19,6 +19,7 @@ struct RootPaletteView: View {
     @Environment(UninstallSession.self) private var uninstall
     @Environment(QuicklinkStore.self) private var quicklinks
     @Environment(QuicklinkArgumentSession.self) private var quicklinkArguments
+    @Environment(CustomCommandArgumentSession.self) private var customCommandArguments
     @Environment(SnippetsStore.self) private var snippets
     @Environment(ExtensionManager.self) private var extensions
     @Environment(AppSettings.self) private var settings
@@ -57,6 +58,9 @@ struct RootPaletteView: View {
             return QuicklinkArgumentsScreen(
                 session: quicklinkArguments, core: core, vm: vm,
                 scrollToTop: { scroll = ScrollIntent(kind: .top) })
+        case .customCommandArguments:
+            return CustomCommandArgumentsScreen(
+                session: customCommandArguments, core: core, vm: vm)
         case .quicklinks:
             return QuicklinkListScreen(
                 store: quicklinks, core: core, vm: vm, openActions: openActions)
@@ -190,9 +194,9 @@ struct RootPaletteView: View {
         let screen = screen
         let count = screen.rows.count
         let sel = selection(count: count)
-        // The argument form has no rows to count, but ↵ still does something.
+        // The argument forms have no rows to count, but ↵ still does something.
         let showActionGroup =
-            (count > 0 || vm.mode == .quicklinkArguments) && screen.hasPrimaryAction(at: sel)
+            (count > 0 || vm.mode.isArgumentForm) && screen.hasPrimaryAction(at: sel)
 
         // One header position, so focus survives the swap. See docs/features/palette.md.
         return Group {
@@ -258,8 +262,11 @@ struct RootPaletteView: View {
             if vm.mode != .extensionCommand, extensions.running != nil, !extensions.isAuthorizing {
                 Task { await extensions.stop() }
             }
-            // Same for a half-filled argument form: leaving the screen abandons the pending open.
+            // Same for a half-filled argument form: leaving the screen abandons the pending run.
             if vm.mode != .quicklinkArguments { core.quicklinkCoordinator.cancelQuicklinkArguments() }
+            if vm.mode != .customCommandArguments {
+                core.customCommandCoordinator.cancelCustomCommandArguments()
+            }
         }
         // `prepare` may change nothing, so this intent still snaps the scroll to the origin.
         .onChange(of: vm.resetToken) {
@@ -576,6 +583,9 @@ struct RootPaletteView: View {
         // The field is only wide enough for the caret while argument fields are beside it.
         if headerAccessory != nil, vm.mode != .ai { return "" }
         if vm.mode == .quicklinkArguments { return quicklinkArguments.prompt }
+        if vm.mode == .customCommandArguments {
+            return customCommandArguments.prompt ?? vm.mode.placeholder
+        }
         // Inside a running command the search bar belongs to the extension.
         if vm.mode == .extensionCommand, let placeholder = extensionScreen.searchPlaceholder {
             return placeholder

--- a/Tinycast/Platform/PseudoTerminal.swift
+++ b/Tinycast/Platform/PseudoTerminal.swift
@@ -1,0 +1,114 @@
+import Darwin
+import Foundation
+
+/// A command running under its own pseudo-terminal, as its own session leader.
+///
+/// A pipe is not enough for either half of what the output window promises. libc block-buffers
+/// stdout the moment it is not a terminal, so a chatty command delivers nothing until it exits, and
+/// stderr — which stays unbuffered — overtakes the stdout it followed. A pty restores line
+/// buffering, and with it both live output and the order a terminal would show. Being a session
+/// leader is separately what lets one signal reach the whole `a && b && c` chain rather than only
+/// the shell in front of it.
+final class PseudoTerminal: @unchecked Sendable {
+    /// Everything the command writes to any of its three descriptors arrives here.
+    let parentEnd: Int32
+    let processID: pid_t
+
+    private init(parentEnd: Int32, processID: pid_t) {
+        self.parentEnd = parentEnd
+        self.processID = processID
+    }
+
+    static func spawn(
+        executable: String, arguments: [String], environment: [String: String],
+        workingDirectory: String
+    ) -> PseudoTerminal? {
+        // POSIX names these the master and slave ends; these are the same two descriptors.
+        var parentEnd: Int32 = 0
+        var childEnd: Int32 = 0
+        var settings = terminalSettings()
+        guard openpty(&parentEnd, &childEnd, nil, &settings, nil) == 0 else { return nil }
+
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        // The whole point: the child leads its own session, so `kill(-pid)` reaches every descendant.
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID))
+
+        var actions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&actions)
+        posix_spawn_file_actions_addchdir(&actions, workingDirectory)
+        for descriptor in Int32(0)...Int32(2) {
+            posix_spawn_file_actions_adddup2(&actions, childEnd, descriptor)
+        }
+        posix_spawn_file_actions_addclose(&actions, parentEnd)
+        posix_spawn_file_actions_addclose(&actions, childEnd)
+
+        defer {
+            posix_spawnattr_destroy(&attributes)
+            posix_spawn_file_actions_destroy(&actions)
+        }
+
+        var processID: pid_t = 0
+        let argv = CStringArray([executable] + arguments)
+        let envp = CStringArray(environment.map { "\($0.key)=\($0.value)" })
+        let status = posix_spawn(
+            &processID, executable, &actions, &attributes, argv.pointers, envp.pointers)
+        Darwin.close(childEnd)
+        guard status == 0, processID > 0 else {
+            Darwin.close(parentEnd)
+            return nil
+        }
+        // Stands in for the `/dev/null` stdin a pipe run gets: a command that prompts reads EOF and
+        // moves on instead of waiting on a terminal that will never answer.
+        var endOfTransmission: UInt8 = 0x04
+        _ = write(parentEnd, &endOfTransmission, 1)
+        return PseudoTerminal(parentEnd: parentEnd, processID: processID)
+    }
+
+    /// Signals the session rather than the process — the negative pid is what reaches the children.
+    func signalSession(_ signal: Int32) {
+        guard processID > 0 else { return }
+        kill(-processID, signal)
+    }
+
+    /// Blocks until the command exits. A signalled death reports the signal, the way a shell does.
+    func wait() -> Int32 {
+        var status: Int32 = 0
+        while waitpid(processID, &status, 0) < 0 && errno == EINTR {}
+        if status & 0x7F != 0 { return 128 + (status & 0x7F) }
+        return (status >> 8) & 0xFF
+    }
+
+    func close() {
+        Darwin.close(parentEnd)
+    }
+
+    /// Canonical so the kernel hands us whole lines, echo off so the EOF byte never comes back as
+    /// text, and no output post-processing beyond the CR the window strips anyway.
+    private static func terminalSettings() -> termios {
+        var settings = termios()
+        cfmakeraw(&settings)
+        settings.c_lflag = tcflag_t(ICANON | ISIG)
+        settings.c_oflag = tcflag_t(OPOST | ONLCR)
+        return settings
+    }
+}
+
+/// Owns the `strdup`ed argv/envp for one spawn. The array has to outlive the `posix_spawn` call, so
+/// it is a real allocation rather than a Swift array's temporary buffer.
+private final class CStringArray {
+    let pointers: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+    private let count: Int
+
+    init(_ values: [String]) {
+        count = values.count
+        pointers = .allocate(capacity: count + 1)
+        for (index, value) in values.enumerated() { pointers[index] = strdup(value) }
+        pointers[count] = nil
+    }
+
+    deinit {
+        for index in 0..<count { free(pointers[index]) }
+        pointers.deallocate()
+    }
+}

--- a/docs/features/custom-commands.md
+++ b/docs/features/custom-commands.md
@@ -52,7 +52,7 @@ The command text is deliberately not searchable. Only the user-facing name enter
 - `/bin/zsh -lc <command>`, or `/bin/zsh -ilc <command>` when the command's **Load shell
   environment** flag is on
 - `tinycast` as `$0`, then the collected argument values as `$1`, `$2`, …
-- the user's home directory as the working directory
+- the command's own **Run In** folder, or the home directory when it names none
 - standard input reading EOF immediately
 - `TINYCAST=1` added to the inherited environment
 - up to 8 KiB of standard error retained for a failure dialog
@@ -171,6 +171,25 @@ the success pill is skipped for the same reason.
 - **Stop is the one exception** to "Tinycast never kills a running command". Only the button does it;
   a second command superseding the window never touches the first.
 
+### Run In
+
+Each command may name the folder it starts in; empty means the home directory, which is what every
+command did before. The path is stored abbreviated, so a `~` one survives a home directory that
+moves, and expanded at run time.
+
+A folder that has gone is **reported rather than ignored** — `resolvedWorkingDirectory` returns nil
+and the run fails with the path in the message. Falling back to home would run a command somewhere it
+did not expect, which is worse than not running it. A path that exists but is a file is refused the
+same way.
+
+### Icon
+
+A command may carry its own SF Symbol; without one it draws `CustomCommand.sfSymbol`, the shared
+terminal glyph. `CustomCommand.symbol` is the one place that fallback lives, and every surface reads
+it — the launcher row, the Settings list, the confirmation and failure dialogs, and the output
+window's header. The picker is `DesignSystem/SymbolPicker`, shared with the quicklink editor, which
+supplies its own symbol list: what reads as a quicklink is not what reads as a script.
+
 ### Needs confirmation
 
 `CustomCommandCoordinator.runCustomCommand(id:)` is the one funnel both palette activation and the global hotkey reach,
@@ -181,6 +200,13 @@ glyph the command's launcher row uses, and reads neutral rather than destructive
 user wrote themselves wants a deliberate second tap, not a red alarm. The gate is Tinycast's own
 dialog, not an `NSAlert` ([ui.md](../ui.md#dialogs--hud)): presentation is `async` with no nested run loop,
 and the presenter itself refuses a second dialog while one is up, so a held shortcut can't stack them.
+
+### Show confirmation
+
+The pill shows the command's **last line of output**, falling back to `Ran <name>` for one that
+printed nothing — a command that says "3 files cleaned" is worth more than one that says it ran. Only
+the non-streaming path fills this: `run` keeps a 4 KiB stdout tail purely to find that line, and a
+command showing its output reports through the window instead.
 
 ### Reporting
 

--- a/docs/features/custom-commands.md
+++ b/docs/features/custom-commands.md
@@ -2,7 +2,9 @@
 
 Custom commands let users add a searchable name and a shell command in **Settings → Custom
 Commands**. They appear in the launcher's Custom Commands section, share the normal fuzzy ranking,
-and run from Return, a favorite slot, or an optional global shortcut.
+and run from Return, a favorite slot, or an optional global shortcut. A command may declare
+[arguments](#arguments) it is asked for first, and may [show what it printed](#show-output) when it
+finishes.
 
 The pane carries the feature switch — off out of the box — and its launcher-visibility companion,
 both in `AppSettings` and in settings backups. Switching the feature off empties the launcher section and makes
@@ -12,11 +14,15 @@ without re-registering. "Show in launcher" only hides the section; shortcuts kee
 
 ## Invariants
 
-- **`Model/CustomCommand.swift` and `Service/ShellCommandRunner.swift` stay free of AppKit and SwiftUI**
-  (Foundation plus Darwin for `mkstemp`) so `custom-command-test` can compile them standalone. That is why
-  the confirmation gate lives in `CustomCommandCoordinator` and not in the runner.
+- **`Model/CustomCommand.swift`, `Service/ShellCommandRunner.swift` and
+  `Service/CustomCommandArgumentSession.swift` stay free of AppKit and SwiftUI** (Foundation plus Darwin
+  for `mkstemp`) so `custom-command-test` can compile them standalone. That is why the confirmation gate
+  lives in `CustomCommandCoordinator` and not in the runner.
 - A command that runs arbitrary shell is a security surface: the confirmation step cannot be bypassed, and
   an import of executable commands warns before it applies.
+- **An argument value is never spliced into the command text.** It is handed to zsh as a positional
+  parameter, so a value carrying `;`, backticks or `$(…)` is data the script reads, never syntax the
+  shell runs. `custom-command-test` asserts this directly.
 
 ## Ownership and persistence
 
@@ -45,14 +51,18 @@ The command text is deliberately not searchable. Only the user-facing name enter
 
 - `/bin/zsh -lc <command>`, or `/bin/zsh -ilc <command>` when the command's **Load shell
   environment** flag is on
+- `tinycast` as `$0`, then the collected argument values as `$1`, `$2`, …
 - the user's home directory as the working directory
-- standard input and output connected to `/dev/null`
+- standard input reading EOF immediately
 - `TINYCAST=1` added to the inherited environment
 - up to 8 KiB of standard error retained for a failure dialog
+- standard output discarded
+
+**Show output** takes a different route entirely — see [Show output](#show-output). Nothing else does.
 
 No Terminal window or pseudo-terminal is created. `waitUntilExit` blocks for the whole life of the
 command, so it runs on a private concurrent `DispatchQueue` rather than a cooperative-pool thread a
-long `brew upgrade` would hold for minutes.
+long `brew upgrade` would hold for minutes. The streaming path blocks the same queue on `read`.
 
 ### Load shell environment
 
@@ -69,14 +79,97 @@ all. `TINYCAST=1` exists so an rc file can skip those sections: `[[ -n $TINYCAST
 Measured cost: ~10 ms for `-lc`, ~65 ms for `-ilc` against a real-world `~/.zshrc` (~11 ms against a
 minimal one — the interactive shell itself is ~2 ms, the rest is the user's own config).
 
-Interactive prompts still cannot block. Standard input is `/dev/null`, so a `read` gets EOF and
+Interactive prompts still cannot block. Standard input is `/dev/null` — or, under **Show output**, a
+pty already sent EOF — so a `read` gets EOF and
 returns non-zero, and a launchd-launched app has no controlling terminal, so `/dev/tty` fails with
 `device not configured`. A dev build launched _from a terminal_ inherits that terminal's tty, so an rc
-file reading `/dev/tty` can hang there but not for real users. There is **no timeout** — Tinycast
-never kills a running command, and a command outlives Tinycast quitting.
+file reading `/dev/tty` can hang there but not for real users. There is **no timeout** — Tinycast never kills a
+running command except through the output window's Stop button, and a command outlives Tinycast
+quitting.
 
 Because standard error surfaces only on a non-zero exit and only its last 8 KiB, rc-file startup noise
 is dropped while the actual error survives.
+
+### Arguments
+
+A command may declare an ordered list of arguments, each a name and an optional/required flag. Running
+one opens `PaletteMode.customCommandArguments` — the same shape as the quicklink argument prompt: the
+palette's own search field _is_ the input, one argument at a time, with the field's placeholder naming
+the pending one and the body listing every argument, its `$n` slot, and what has been answered. ↵
+advances, a bare backspace steps back and refills the field, and Escape abandons the run. `↵` is held
+while a required argument is empty, which also hides the footer pill.
+
+Because the form is a palette mode rather than a header accessory, **every entry point gets it** —
+launcher row, favorite slot and global hotkey alike — through the one `runCustomCommand(id:)` funnel.
+That is the whole reason it is not an inline strip beside the search field the way an extension
+command's arguments are: a hotkey has no selected row to hang one off.
+
+Values reach zsh as **positional parameters**, never as text substituted into the command:
+
+```
+/bin/zsh -lc '<command>' tinycast <value1> <value2> …
+```
+
+so the script reads them as `$1`, `$2`, and a value containing `; rm -rf ~` is a string, not a second
+command. An optional argument submitted empty still occupies its slot, so `$2` never becomes `$3`.
+`CustomCommandArgumentSession` owns the pending run; it holds values positionally for the same reason,
+which is why two arguments may share a name without colliding.
+
+### Show output
+
+Off by default. With it on the run goes through `ShellCommandRunner.stream` and a
+`PseudoTerminal` instead of `run` and a pipe, the window opens **before the first byte**, and the log
+fills in as the command prints it.
+
+#### Why a pty and not a pipe
+
+A pipe cannot deliver either half of what this promises, and both failures were measured rather than
+assumed:
+
+- **Nothing is live.** libc switches stdout from line-buffered to fully buffered the moment it is not
+  a terminal. A command printing a line every 0.4 s delivered all four lines within 20 ms of each
+  other, at exit.
+- **The order is wrong.** stderr stays unbuffered while stdout does not, so stderr overtakes the
+  stdout it followed. `print` / `write(stderr)` / `print` came out as 2, 1, 3 — through a *single
+  merged pipe*. Merging is not enough; only a terminal restores line buffering, and with it the
+  order. Under a pty the same command printed 1, 2, 3.
+
+`PseudoTerminal` also spawns with `POSIX_SPAWN_SETSID`, which is what makes Stop honest: the command
+leads its own session, so one `kill(-pid)` reaches the whole `a && b && c` chain. `Process.terminate`
+signals only zsh — a `sleep` started behind it survives, verified.
+
+The pty's stdin gets an EOT byte at spawn, which keeps the invariant a `/dev/null` stdin gave the
+pipe path: a command that prompts reads EOF and moves on rather than waiting on a terminal that will
+never answer.
+
+#### What the window shows
+
+One flat surface, no rules. The command's name, the shell text under it (`brew` alone says nothing
+about what ran), the log, and a footer with a status dot, the outcome and the elapsed time. Copy is
+always there; the second control is **Stop** while it runs and **Run Again** once it has.
+
+Because a terminal makes tools colour their output, `ANSIInterpreter` renders SGR colour rather than
+printing the escapes — that is what replaces the old red-stderr tint, which was a mistake: stderr is
+where most tools log progress, so colouring it as an error made a successful `brew update` look
+broken. A bare carriage return rewinds its line, so a progress bar redraws in place instead of
+stacking a line per frame.
+
+The log is an `NSTextView` and only the undrawn tail is appended; a quarter-megabyte of output
+re-laid-out per line is seconds of work. The run publishes each append as an explicit `delta` and
+`revision`, so the view adds just that when it is exactly one step behind and redraws from the whole
+log otherwise — a new run, a trim, or a window reopened onto a finished one. Past 256 KiB the head is dropped. Following the tail stops
+when the reader scrolls up and resumes when they reach the bottom, the same band the chat transcript
+uses.
+
+**The window replaces the failure dialog rather than joining it**, so a run is never reported twice;
+the success pill is skipped for the same reason.
+
+#### Consequences worth knowing
+
+- **rc-file noise is now visible.** With **Load shell environment** on, anything `~/.zshrc` writes
+  reaches the log. The guard is the documented `[[ -n $TINYCAST ]] && return`.
+- **Stop is the one exception** to "Tinycast never kills a running command". Only the button does it;
+  a second command superseding the window never touches the first.
 
 ### Needs confirmation
 
@@ -91,8 +184,9 @@ and the presenter itself refuses a second dialog while one is up, so a held shor
 
 ### Reporting
 
-Tinycast dismisses an open palette before starting a custom command. A zero exit status is silent; a
-launch failure or non-zero status opens a Tinycast dialog with the bounded error detail. When the
+Tinycast dismisses an open palette before starting a custom command. With **Show output** off, a zero
+exit status is silent; a launch failure or non-zero status opens a Tinycast dialog with the bounded
+error detail. When the
 status is 127 and **Load shell environment** is off, the dialog adds a one-line hint and an **Open
 Settings…** button that lands on the Commands pane — the hint is gated on the status alone, not
 on grepping stderr, since 127 is equally a plain typo. The command string itself is never logged.
@@ -107,3 +201,11 @@ Foundation-only harness. Verify by hand:
 3. Pressing the command's hotkey while its dialog is up does not stack a second dialog.
 4. A gated command triggered by hotkey with no palette open still confirms.
 5. An rc-file-only alias with the flag off shows the 127 hint, and **Open Settings…** opens the pane.
+6. A command with arguments triggered by hotkey opens the argument form, not the command.
+7. A gated command with arguments asks for every value first, and confirms only once.
+8. Running a second output-showing command reuses the one window and does **not** kill the first.
+9. A long command's output appears while it runs, not at the end; scrolling up stops the follow.
+10. Stop during `brew update` leaves nothing behind — check with `pgrep -f brew`.
+11. **Run Again clears the log before the new run prints.** The view draws deltas, so it keys what
+    it has drawn on the run's id as well as the trim counter — a fresh run starts back at revision
+    zero, and keying on the counter alone left the previous run's output on screen.

--- a/docs/features/custom-commands.md
+++ b/docs/features/custom-commands.md
@@ -206,6 +206,7 @@ Foundation-only harness. Verify by hand:
 8. Running a second output-showing command reuses the one window and does **not** kill the first.
 9. A long command's output appears while it runs, not at the end; scrolling up stops the follow.
 10. Stop during `brew update` leaves nothing behind — check with `pgrep -f brew`.
-11. **Run Again clears the log before the new run prints.** The view draws deltas, so it keys what
+11. Clicking the Dock icon while a command runs raises the output window, not the launcher.
+12. **Run Again clears the log before the new run prints.** The view draws deltas, so it keys what
     it has drawn on the run's id as well as the trim counter — a fresh run starts back at revision
     zero, and keying on the counter alone left the previous run's output on screen.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -79,6 +79,7 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 | `.quicklinks` | `QuicklinkListScreen` | `QuicklinkList` |
 | `.snippets` | `SnippetsScreen` | `SnippetsList` + preview (see [snippets.md](snippets.md#search-snippets)) |
 | `.quicklinkArguments` | `QuicklinkArgumentsScreen` | `QuicklinkArgumentsView` (see [quicklinks.md](quicklinks.md#the-argument-prompt)) |
+| `.customCommandArguments` | `CustomCommandArgumentsScreen` | `CustomCommandArgumentsView` (see [custom-commands.md](custom-commands.md#arguments)) |
 | `.extensionCommand` | `ExtensionCommandScreen` | `ExtensionCommandView` (see [extensions.md](extensions.md)) |
 
 Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab rings the three
@@ -100,12 +101,14 @@ clipboard hand the query over, since one search narrows either list; crossing ch
 fresh screen in both directions, because that field holds a half-written message rather than a query
 — seeding a composer from a search reads as noise, and a draft dropped into a filter matches nothing.
 
-The argument screen is the one mode where the search field is not a search field: it _is_ the current
-argument's input, so its placeholder names that argument and ↵ submits rather than activating a row.
-Its own state lives on `AppCore.quicklinkArguments`, the way `.uninstall`'s target lives on
-`UninstallSession`, and leaving the mode cancels the pending open. A bare backspace steps back an
-argument before it falls through to the usual exit-to-launcher; Escape erases the half-typed answer
-first, and a second press hides the palette, which ends the pending open with it.
+The two argument screens — `.quicklinkArguments` and `.customCommandArguments`, together
+`PaletteMode.isArgumentForm` — are the modes where the search field is not a search field: it _is_ the
+current argument's input, so its placeholder names that argument and ↵ submits rather than activating
+a row. Neither has rows, which is why `isArgumentForm` is what keeps the ↵ pill drawn. Their state
+lives on `AppCore.quicklinkArguments` and `AppCore.customCommandArguments`, the way `.uninstall`'s
+target lives on `UninstallSession`, and leaving the mode cancels the pending open or run. A bare
+backspace steps back an argument before it falls through to the usual exit-to-launcher; Escape erases
+the half-typed answer first, and a second press hides the palette, ending the pending work with it.
 
 ### Inline command arguments
 


### PR DESCRIPTION
## Related issue

Closes #360

## What changed

Both halves of the issue: a custom command can declare **arguments** it is asked for before it runs,
and can **show what it prints** while it prints it.

### Arguments

Collected in a new `PaletteMode.customCommandArguments`, the same shape as the quicklink prompt — the
palette's own search field is the input, one argument at a time, with the body listing each argument,
its `$n` slot and what has been answered. ↵ advances, a bare backspace steps back and refills, Escape
abandons; ↵ is held while a required argument is empty.

A palette mode rather than an inline strip beside the search field, because **a global hotkey has no
selected row to hang a strip off**. This way the launcher row, a favorite slot and a shortcut all
reach the prompt through the one `runCustomCommand(id:)` funnel.

Values reach zsh as **positional parameters**, never substituted into the command text:

```
/bin/zsh -lc '<command>' tinycast <value1> <value2> …
```

so a value containing `; rm -rf ~` is a string the script reads, not a second command.

### Show output

Runs the command under a **pseudo-terminal** rather than a pipe. A pipe cannot deliver either half of
what this promises, and both failures were measured rather than assumed:

| | Merged pipe | Pseudo-terminal |
| --- | --- | --- |
| `print` / `write(stderr)` / `print` | came out **2, 1, 3** | **1, 2, 3** |
| A line printed every 0.4s | all 4 landed within 20ms, **at exit** | landed 0.4s apart, live |

libc switches stdout to block buffering the moment it is not a terminal, while stderr stays
unbuffered — so merging the two into one pipe fixes neither the order nor the lag. Only a terminal
restores line buffering.

`PseudoTerminal` spawns with `POSIX_SPAWN_SETSID`, which is also what makes **Stop** honest: the
command leads its own session, so one `kill(-pid)` reaches the whole `a && b && c` chain.
`Process.terminate` signals only zsh — a `sleep` started behind it survives, verified. An EOT byte at
spawn preserves the invariant a `/dev/null` stdin gave the pipe path, so a command that prompts still
reads EOF instead of hanging.

The window is one flat surface with no rules: the command's name, the shell text under it (`brew`
alone says nothing about what ran), the log, and a footer with a status dot, the outcome and elapsed
time. Copy is always there; the second control is **Stop** while running and **Run Again** after.

`ANSIInterpreter` renders SGR colour instead of printing the escapes, and a bare carriage return
rewinds its line so a progress bar redraws in place rather than stacking a line per frame.

## Non-obvious bits in the diff

- **Colour replaces the red stderr tint, which was a mistake.** stderr is where most tools log
  *progress*, so tinting it red made a successful `brew update` look broken.
- **The log view keys drawn state on the run's id, not just a trim counter.** It appends deltas; a
  fresh run starts back at revision zero, so keying on the counter alone left the previous run's
  output on screen after Run Again — and would later have spliced the two logs together.
- **Superseding never kills.** Only the Stop button ends a command; a second output command just
  takes the window.
- **`run()` keeps its pipe.** The non-streaming path wants no tty precisely so tools stay uncoloured
  and the failure dialog's stderr tail is clean.

## Memory footprint

Not measured — I don't have a profiling session for this build, and I'd rather leave the table honest
than fill it with numbers I didn't take.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no.

What I can say about the shape: the log is capped at 256 KiB with the head dropped past that, the pty
is closed and the child reaped on every exit path including launch failure, and the output window is
built on first use so an install that never turns Show output on allocates none of it.

## Drawbacks

- **stdout and stderr are no longer distinguishable.** One pty means one stream. That is the price of
  correct ordering, and it is what a terminal does.
- **rc-file noise is now visible.** With **Load shell environment** on, anything `~/.zshrc` writes to
  stderr reaches the log. The guard is the documented `[[ -n $TINYCAST ]] && return`.
- **Stop is an exception to a documented invariant** — "Tinycast never kills a running command" now
  reads "except through the output window's Stop button".
- **Tools see a terminal**, so some will behave differently than they did behind a pipe (colour,
  progress bars, occasionally pagers).
- Not covered by an automated test: the Run Again redraw. The harnesses compile Foundation-only
  sources and the presenter holds an `AppWindowController`, so it is manual check 11 instead.

## Tests & validation

`./Scripts/run-tests.sh` — all 49 harnesses pass. `custom-command-test` gained `PseudoTerminal.swift`
and `CustomCommandArgumentSession.swift` and now covers:

- both streams keep the order they were written in
- output arrives while the command is still running
- stopping kills the whole command tree, not just the shell
- a stopped run reports `.stopped` rather than a signal status
- a multi-byte character is never split into a replacement character
- values arrive as positional parameters, and a value carrying shell syntax is data, not code
- a blank argument is dropped without losing the command; an import trims argument names
- a record written before `arguments` existed still decodes — without this, upgrading would have
  wiped every stored command
- the full argument-session state machine: advance, retreat, complete, cancel

By hand: `brew-clean` with Show output on; scroll-up pausing the follow; Stop during `brew update`
with `pgrep -f brew` after; Run Again; Copy; a Show-output-off command still reporting through the
failure dialog with its 127 hint. Light and dark checked by rendering the window offscreen.

Debug build has no new warnings; `./Scripts/lint.sh` is clean; the `Features/*/Model/` import grep is
clean.
