### PR TITLE
Answer time zones, business days and the spelled-out phrasings the calculator was missing

### DIFF
--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -821,6 +821,12 @@ struct CalcTests {
         expectNil("is what % of")
         expectNil("tip on")
 
+        // A pasted non-breaking space still reaches the zone table, since the gate scans for
+        // whitespace rather than a literal space. Arithmetic splits on " + " and never did.
+        expectDisplayAt("time\u{a0}in\u{a0}tokyo", "9:18 AM")
+        expectDisplayAt("time\u{9}in\u{9}tokyo", "9:18 AM")
+        expectDisplayAt("time\u{2009}in\u{2009}tokyo", "9:18 AM")
+
         // The ordinal dot German and Austrian dates write after the day
         expectDisplayAt("28. aug + 3", "31 August")
         expectDisplayAt("28. august + 3", "31 August")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -610,8 +610,12 @@ struct CalcTests {
         expectDisplay("10$", "835.00 INR", region: "INR")
         expectDisplay("1 btc", "5,010,000.00 INR", region: "INR")
         expectCopy("1 usd", "83.50 INR", region: "INR")
-        // Nothing to say: the region names the currency written, one nobody quotes, or none at all
-        expectDisplay("1 usd", "1.00 USD", region: "USD")
+        // The region names the currency written, so the dollar pairs with the euro instead
+        expectDisplay("1 usd", "0.92 EUR", region: "USD")
+        expectBadges("1 usd", source: "US Dollar", target: "Euro", region: "USD")
+        expectDisplay("1 eur", "1.09 USD", region: "EUR")
+        expectBadges("1 eur", source: "Euro", target: "US Dollar", region: "EUR")
+        // Nothing to say: the region names one nobody quotes, or none at all
         expectDisplay("1 usd", "1.00 USD", region: "NPR")
         expectDisplay("1 usd", "1.00 USD", region: "ZZZ")
         expectDisplay("1 usd", "1.00 USD")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -812,6 +812,15 @@ struct CalcTests {
         // An impossible day still earns no card
         expectNilAt("30.2.27 + 1")
 
+        // Malformed input a fuzzer found: both of these read past the end of the token array
+        expectNil("round is next round to")
+        expectNilAt(": from to at sf")
+        expectNil("round to")
+        expectNil("round 5 to")
+        expectNilAt(": at sf")
+        expectNil("is what % of")
+        expectNil("tip on")
+
         // The ordinal dot German and Austrian dates write after the day
         expectDisplayAt("28. aug + 3", "31 August")
         expectDisplayAt("28. august + 3", "31 August")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -785,6 +785,14 @@ struct CalcTests {
         expectDisplayAt("time in 90 min", "1:48 AM")
         expectDisplayAt("time in 4 hours in san francisco", "9:18 PM (yesterday)")
 
+        // A bare offset on a clock answer is hours, the unit the answer already implies
+        expectDisplayAt("time in tokyo + 2", "11:18 AM")
+        expectDisplayAt("time in tokyo - 2", "7:18 AM (tomorrow)")
+        expectDisplayAt("5pm london in sf + 3", "12:00 PM")
+        // Only the offset implies it: a bare number is still no zone, and plain math is untouched
+        expectNilAt("time in 4")
+        expectDisplay("5 + 3", "8")
+
         // Accented spellings resolve, since the identifiers carry none
         expectDisplayAt("time in são paulo", "9:18 PM (yesterday)")
         expectDisplayAt("time in sao paulo", "9:18 PM (yesterday)")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -773,6 +773,45 @@ struct CalcTests {
         expectNil("monday in 3 kg")
         expectDisplay("10 in in cm", "25.4 cm")
 
+        // A zone's offset from the Mac's own
+        expectDisplayAt("diff paris", "2:18 AM (+2h)")
+        expectDisplayAt("time diff tokyo", "9:18 AM (+9h)")
+        expectDisplayAt("diff kolkata", "5:48 AM (+5h 30m)")
+        expectBadgesAt("diff paris", source: "UTC", target: "Paris")
+        expectNil("diff xyzzy")
+
+        // A duration where a zone would go, and both at once
+        expectDisplayAt("time in 4 hours", "4:18 AM")
+        expectDisplayAt("time in 90 min", "1:48 AM")
+        expectDisplayAt("time in 4 hours in san francisco", "9:18 PM (yesterday)")
+
+        // Accented spellings resolve, since the identifiers carry none
+        expectDisplayAt("time in são paulo", "9:18 PM (yesterday)")
+        expectDisplayAt("time in sao paulo", "9:18 PM (yesterday)")
+        expectDisplayAt("time in zürich", "2:18 AM")
+
+        // A bare number takes the unit its moment implies
+        expectDisplayAt("3:45pm + 5", "24 July at 8:45 PM")
+        expectDisplayAt("3:45pm - 2", "24 July at 1:45 PM")
+        expectDisplayAt("august 5 + 5", "10 August")
+        expectDisplayAt("august 5 - 5", "31 July")
+
+        // A named moment earns a card once it carries a time or a qualifier
+        expectDisplayAt("tomorrow at 9am", "25 July at 9:00 AM")
+        expectDisplayAt("next monday", "27 July")
+        expectDisplayAt("last friday", "17 July")
+        expectBadgesAt("tomorrow at 9am", source: "Friday, 24 July", target: "Saturday")
+        // A lone date word is still an app search
+        expectNilAt("tomorrow")
+        expectNilAt("today")
+
+        // Spoken function and operator names
+        expectDisplay("square root of 625", "25")
+        expectDisplay("square root of 64", "8")
+        expectDisplay("cube root of 27", "3")
+        expectDisplay("2 power 10", "1,024")
+        expectDisplay("2 power 3 power 2", "512")
+
         // Business days skip weekends. The clock is Fri 2026-07-24, so every hop crosses one.
         expectDisplayAt("today + 1 business day", "27 July")
         expectDisplayAt("today + 5 business days", "31 July")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -808,6 +808,16 @@ struct CalcTests {
         // An impossible day still earns no card
         expectNilAt("30.2.27 + 1")
 
+        // The ordinal dot German and Austrian dates write after the day
+        expectDisplayAt("28. aug + 3", "31 August")
+        expectDisplayAt("28. august + 3", "31 August")
+        expectDisplayAt("28.aug + 3", "31 August")
+        expectDisplayAt("1. jan + 1", "2 January, 2027")
+        expectDisplayAt("28. aug 2027 + 3", "31 August, 2027")
+        expectBadgesAt("28. aug + 3", source: "Friday, 28 August", target: "Monday")
+        // Only a trailing dot is an ordinal, so a decimal day is still not a date
+        expectNilAt("28.5 aug + 1")
+
         // Accented spellings resolve, since the identifiers carry none
         expectDisplayAt("time in são paulo", "9:18 PM (yesterday)")
         expectDisplayAt("time in sao paulo", "9:18 PM (yesterday)")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -563,7 +563,10 @@ struct CalcTests {
         // A trailing suffix reports through the same conversion the group uses.
         expectError("($10 + $5) to npr", "No exchange rate for NPR.")
         expectError("(1kg + 500g) to usd", "Cannot convert Weight to Currency.")
-        expectNil("20 eur to usd * 30")  // mid-expression `to` needs parens or a trailing suffix
+        // A mid-expression `to` converts before it adds; `* 30` stays ambiguous, so it needs parens
+        expectNil("20 eur to usd * 30")
+        expectNil("20 eur to usd / 2")
+        expectDisplay("20 eur to usd + 5 usd", "26.74 USD")
         expectDisplay("$10 +", "10.00 USD")
         expectBadges("$10 +", source: "Expression", target: "US Dollar")
         // Juxtaposition multiplies on either side of the amount, same as an explicit "*"
@@ -642,6 +645,126 @@ struct CalcTests {
         expectSnapshotThrows(
             "feed reported failure",
             fiat: Data(#"{"success":false,"source":"USD","quotes":{"USDEUR":0.9}}"#.utf8))
+
+        // Slashed rate spellings — the tokenizer keeps a known `unit/unit` whole
+        expectDisplay("100 km/h to mph", "62.13711922 mph")
+        expectDisplay("60 mph in km/h", "96.56064 km/h")
+        expectDisplay("5 m/s to km/h", "18 km/h")
+        expectDisplay("100 km/h", "62.13711922 mph")
+        expectExpression("100 km/h to mph", "100 km/h")
+        expectBadges("5 m/s to km/h", source: "Meters per Second", target: "Kilometers per Hour")
+        expectDisplay("100 mbit/s to mbps", "100 Mbps")
+        // An unknown pairing leaves the slash as division, so ordinary arithmetic is untouched
+        expectDisplay("10/2", "5")
+        expectDisplay("6/2(1+2)", "9")
+        expectDisplay("10 m / 2", "5 m")
+        expectNil("1 km/x")
+
+        // Workdays are 8 hours; weekends and holidays are a calendar's business, not a unit's
+        expectDisplay("55h in workdays", "6.875 workdays")
+        expectDisplay("3 workdays in hours", "24 hr")
+        expectDisplay("2 businessdays to hours", "16 hr")
+        expectBadges("55h in workdays", source: "Hours", target: "Workdays")
+
+        // The rest of the trig set, plus the constants that come with it
+        expectDisplay("cot(1)", "0.6420926159")
+        expectDisplay("sec(1)", "1.850815718")
+        expectDisplay("csc(1)", "1.188395106")
+        expectDisplay("asin(1)", "1.570796327")
+        expectDisplay("acos(1)", "0")
+        expectDisplay("arctan(1)", "0.7853981634")
+        expectDisplay("sinh(1)", "1.175201194")
+        expectDisplay("tanh(0)", "0")
+        expectDisplay("cbrt(27)", "3")
+        expectDisplay("log2(1024)", "10")
+        expectDisplay("exp(0)", "1")
+        expectDisplay("sign(-5)", "-1")
+        expectDisplay("trunc(3.7)", "3")
+        expectDisplay("2 tau", "12.56637061")
+        expectDisplay("phi * 2", "3.236067977")
+        // `sec` is also seconds, and a unit position still wins
+        expectDisplay("10 sec to min", "0.1666666667 min")
+        expectDisplay("30 sec + 1 min", "1.5 min")
+
+        // Percentage and ratio phrasings
+        expectDisplay("15% tip on 42", "6.3")
+        expectDisplay("20% tip of 80", "16")
+        expectDisplay("50 is what % of 200", "25%")
+        expectDisplay("30 is 20% of what", "150")
+        expectDisplay("ratio of 3 to 5", "3 : 5")
+        expectDisplay("ratio of 4 to 6", "2 : 3")
+        expectDisplay("ratio of 1920 to 1080", "16 : 9")
+        expectBadges("15% tip on 42", source: "Expression", target: "Result")
+
+        // List aggregates and snapping, both of which need the comma token
+        expectDisplay("average of 10, 20, 30", "20")
+        expectDisplay("avg of 1 and 2 and 3", "2")
+        expectDisplay("sum of 10, 20, 30", "60")
+        expectDisplay("max of 4, 9, 2", "9")
+        expectDisplay("min of 4, 9, 2", "2")
+        expectDisplay("sum of 2*3, 4", "10")
+        expectDisplay("round 47 to nearest 5", "45")
+        expectDisplay("round 12.3 to nearest 0.5", "12.5")
+        // A comma between digits is still a grouping separator, and one operand is not a list
+        expectDisplay("1,000 + 234", "1,234")
+        expectNil("average of 5")
+        expectNil("10,5")
+
+        // Timespans break a duration into the units that fit it
+        expectDisplay("145 mins to timespan", "2 hr 25 min")
+        expectDisplay("8700 s to timespan", "2 hr 25 min")
+        expectDisplay("90000 s to timespan", "1 day 1 hr")
+        expectDisplay("55 h to timespan", "2 day 7 hr")
+        expectDisplay("1000000 s to timespan", "1 wk 4 day 13 hr 46 min 40 s")
+        expectBadges("145 mins to timespan", source: "Minutes", target: "Timespan")
+        expectNil("10 km to timespan")
+
+        // Time zones. The clock is UTC-pinned, so every one of these is exact.
+        expectDisplayAt("time in tokyo", "9:18 AM")
+        expectDisplayAt("time in sf", "5:18 PM (yesterday)")
+        expectDisplayAt("what time is it in london", "1:18 AM")
+        expectDisplayAt("time in kolkata", "5:48 AM")
+        expectDisplayAt("time in utc", "12:18 AM")
+        expectBadgesAt("time in tokyo", source: "UTC", target: "Tokyo")
+        expectBadgesAt("time in sf", source: "UTC", target: "Los Angeles")
+        // A named source zone overrides the Mac's own, so neither side has to be local
+        expectDisplayAt("5pm london in sf", "9:00 AM")
+        expectDisplayAt("9:30am in nyc", "5:30 AM")
+        expectDisplayAt("5pm in tokyo", "2:00 AM (tomorrow)")
+        expectBadgesAt("5pm london in sf", source: "London", target: "Los Angeles")
+        // Aliases cover what the identifiers don't spell, and DST is Foundation's own answer
+        expectDisplayAt("time in nyc", "8:18 PM (yesterday)")
+        expectDisplayAt("time in cet", "2:18 AM")
+        // A zone name never outranks a unit or a currency, and a non-zone stays a search
+        expectDisplay("1 cup to ml", "236.5882365 mL")
+        expectNil("time in xyzzy")
+        expectNil("in tokyo")
+        expectNil("time")
+
+        // IATA airport codes, which Foundation has no notion of
+        expectDisplayAt("time in vie", "2:18 AM")
+        expectDisplayAt("time in lhr", "1:18 AM")
+        expectDisplayAt("time in nrt", "9:18 AM")
+        expectDisplayAt("time in sfo", "5:18 PM (yesterday)")
+        expectBadgesAt("time in vie", source: "UTC", target: "Vienna")
+        expectDisplayAt("5pm vie in nrt", "12:00 AM (tomorrow)")
+        // `mad` stays the Moroccan dirham, and `ist` stays India Standard Time
+        expectError("10 mad to usd", "No exchange rate for MAD.")
+        expectBadgesAt("time in ist", source: "UTC", target: "Kolkata")
+
+        // A conversion mid-expression, which used to need parentheses
+        expectDisplay("10kg to lb + 3lb", "25.04622622 lb")
+        expectDisplay("10kg to lb - 1lb", "21.04622622 lb")
+        expectDisplay("100 km/h to mph + 3mph", "65.13711922 mph")
+        expectDisplay("10km to mi + 3mi", "9.213711922 mi")
+        expectDisplay("10kg to lb + 3lb + 1lb", "26.04622622 lb")
+        expectDisplay("10km to mi + 3mi to km", "14.828032 km")
+        expectDisplay("10kg to lb + 3", "25.04622622 lb")
+        expectError("1kg to m + 3", "Cannot convert Weight to Length.")
+        // A trailing `to` still converts the whole expression rather than the last operand
+        expectDisplay("10kg + 500g to lb", "23.14853753 lb")
+        expectDisplay("1kg + 1kg to g", "2,000 g")
+        expectDisplay("2hr + 30min to min", "150 min")
 
         print("\n\(passes) passed, \(failures) failed")
         exit(failures == 0 ? 0 : 1)

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -753,6 +753,26 @@ struct CalcTests {
         expectError("10 mad to usd", "No exchange rate for MAD.")
         expectBadgesAt("time in ist", source: "UTC", target: "Kolkata")
 
+        // A trailing offset shifts a zone answer, so the whole thing stays one query
+        expectDisplayAt("5pm london in sf", "9:00 AM")
+        expectDisplayAt("5pm london in sf + 2h", "11:00 AM")
+        expectDisplayAt("5pm london in sf - 1 hour", "8:00 AM")
+        expectDisplayAt("5pm london in sf + 30 min", "9:30 AM")
+        expectBadgesAt("5pm london in sf + 2h", source: "London", target: "Los Angeles")
+        // A unit conversion is not a zone offset, and neither is a bare sum
+        expectDisplay("1 cup to ml", "236.5882365 mL")
+        expectNil("5pm london in sf + 2 kg")
+
+        // `<weekday> in <n> weeks` answers that weekday inside the week it lands in
+        expectDisplayAt("monday in 3 weeks", "10 August")
+        expectDisplayAt("monday in 1 week", "27 July")
+        expectDisplayAt("tuesday in 2 weeks", "4 August")
+        expectDisplayAt("friday in 2 weeks", "7 August")
+        expectBadgesAt("monday in 3 weeks", source: "Friday, 24 July", target: "Monday")
+        // A month is not a weekday, and `in` still reaches the unit path
+        expectNil("monday in 3 kg")
+        expectDisplay("10 in in cm", "25.4 cm")
+
         // Business days skip weekends. The clock is Fri 2026-07-24, so every hop crosses one.
         expectDisplayAt("today + 1 business day", "27 July")
         expectDisplayAt("today + 5 business days", "31 July")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -793,6 +793,21 @@ struct CalcTests {
         expectNilAt("time in 4")
         expectDisplay("5 + 3", "8")
 
+        // Dotted dates are day-first, the convention that writes them
+        expectDisplayAt("19.2.27 + 3", "22 February, 2027")
+        expectDisplayAt("19.02.2027 + 3", "22 February, 2027")
+        expectDisplayAt("19.2.27 - 3", "16 February, 2027")
+        expectDisplayAt("31.12.26 + 1", "1 January, 2027")
+        expectDisplayAt("19.2.27 + 3 weeks", "12 March, 2027")
+        expectBadgesAt("19.2.27 + 3", source: "Friday, 19 February, 2027", target: "Monday")
+        // A decimal is not a date, and a version number is not one either
+        expectDisplay("1.5 + 3", "4.5")
+        expectDisplay("99.99 + 0.01", "100")
+        expectNilAt("1.2.3 + 1")
+        expectNilAt("1.5.5 + 3")
+        // An impossible day still earns no card
+        expectNilAt("30.2.27 + 1")
+
         // Accented spellings resolve, since the identifiers carry none
         expectDisplayAt("time in são paulo", "9:18 PM (yesterday)")
         expectDisplayAt("time in sao paulo", "9:18 PM (yesterday)")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -853,6 +853,24 @@ struct CalcTests {
         expectNilAt("today")
         expectNilAt("tomorrow")
 
+        // Date arithmetic chains left to right, however many terms it carries
+        expectDisplayAt("17.2.26 + 100 week days - 4 + 2", "5 July")
+        expectDisplayAt("17.2.26 + 100 weekdays", "7 July")
+        expectDisplayAt("17.2.26 + 100 weekdays - 4", "3 July")
+        expectDisplayAt("today + 3 weeks - 2 days", "12 August")
+        expectDisplayAt("today + 5 + 2", "31 July")
+        expectDisplayAt("today + 1 day + 1 day + 1 day", "27 July")
+        expectDisplayAt("now + 90 min + 30 min", "24 July at 2:18 AM")
+        expectDisplayAt("3:45pm + 5 - 2", "24 July at 6:45 PM")
+        expectBadgesAt("17.2.26 + 100 week days - 4 + 2", source: "Tuesday, 17 February", target: "Sunday")
+        // Every term must be a duration, so a unit or a stray word still earns no card
+        expectNilAt("today + 3 weeks - kg")
+        expectNilAt("today + 5 - abc")
+        // Two moments are still a difference, and letter-free operands are still arithmetic
+        expectDisplayAt("jul 4 - today", "345 days")
+        expectDisplay("5 + 3 - 2", "6")
+        expectDisplay("5/2 - 1/2", "2")
+
         // Accented spellings resolve, since the identifiers carry none
         expectDisplayAt("time in são paulo", "9:18 PM (yesterday)")
         expectDisplayAt("time in sao paulo", "9:18 PM (yesterday)")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -812,11 +812,27 @@ struct CalcTests {
         expectDisplayAt("28. aug + 3", "31 August")
         expectDisplayAt("28. august + 3", "31 August")
         expectDisplayAt("28.aug + 3", "31 August")
-        expectDisplayAt("1. jan + 1", "2 January, 2027")
+        // Nearest, not next: from July, January is six months back rather than six ahead
+        expectDisplayAt("1. jan + 1", "2 January")
         expectDisplayAt("28. aug 2027 + 3", "31 August, 2027")
         expectBadgesAt("28. aug + 3", source: "Friday, 28 August", target: "Monday")
         // Only a trailing dot is an ordinal, so a decimal day is still not a date
         expectNilAt("28.5 aug + 1")
+
+        // A written day is its own reason for a card: the weekday is why you typed it
+        expectDisplayAt("25. aug", "25 August")
+        expectDisplayAt("25 aug", "25 August")
+        expectDisplayAt("aug 25", "25 August")
+        expectDisplayAt("25.8.27", "25 August, 2027")
+        expectDisplayAt("1. jan", "1 January")
+        expectBadgesAt("25. aug", source: "Friday, 24 July", target: "Tuesday")
+        // A bare date takes the year it is nearest, so it agrees with the same date plus a shift
+        expectDisplayAt("25. aug + 3", "28 August")
+        // A month or a relative word alone is still an app search
+        expectNilAt("july")
+        expectNilAt("aug")
+        expectNilAt("today")
+        expectNilAt("tomorrow")
 
         // Accented spellings resolve, since the identifiers carry none
         expectDisplayAt("time in são paulo", "9:18 PM (yesterday)")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -368,8 +368,8 @@ struct CalcTests {
             "days till july", source: "Friday, 24 July", target: "Thursday, 1 July, 2027")
         expectDisplayAt("days until tomorrow", "1 day")
         expectDisplayAt("weeks till 9april", "37 weeks")  // 259 / 7
-        expectDisplayAt("today + 3 weeks", "Friday, 14 August")
-        expectDisplayAt("now + 90 min", "Friday, 24 July at 1:48 AM")
+        expectDisplayAt("today + 3 weeks", "14 August")
+        expectDisplayAt("now + 90 min", "24 July at 1:48 AM")
         expectDisplayAt("jul 4 - today", "345 days")
         expectBadgesAt("jul 4 - today", source: "Sunday, 4 July, 2027", target: "Friday, 24 July")
         // Arithmetic with spaced operators must still be plain math, not date math
@@ -436,7 +436,7 @@ struct CalcTests {
         expectBadges("255 to hex", source: "Decimal", target: "Hexadecimal")
         expectBadges("0xff to decimal", source: "Hexadecimal", target: "Decimal")
         expectBadges("3*3", source: "Expression", target: "Result")
-        expectBadges("20% off 500", source: "Expression", target: "Result")
+        expectBadges("20% off 500", source: "Expression", target: "Discounted")
 
         // days since — past elapsed, against the fixed clock (Fri 2026-07-24)
         expectDisplayAt("days since 9jul", "15 days")
@@ -444,7 +444,8 @@ struct CalcTests {
         expectDisplayAt("weeks since 3jul", "3 weeks")
         expectDisplayAt("days since yesterday", "1 day")
         // Date ± duration now carries the resolved start as a source badge
-        expectBadgesAt("today + 3 weeks", source: "Friday, 24 July", target: "Result")
+        // The answer's weekday is the badge, so the date itself does not repeat it
+        expectBadgesAt("today + 3 weeks", source: "Friday, 24 July", target: "Friday")
 
         // Currency — against the fixed `fx` table below (1 USD = 0.92 EUR = 0.79 GBP = 157 JPY)
         expectDisplay("1 euro to dollars", "1.09 USD")
@@ -694,7 +695,7 @@ struct CalcTests {
         expectDisplay("ratio of 3 to 5", "3 : 5")
         expectDisplay("ratio of 4 to 6", "2 : 3")
         expectDisplay("ratio of 1920 to 1080", "16 : 9")
-        expectBadges("15% tip on 42", source: "Expression", target: "Result")
+        expectBadges("15% tip on 42", source: "Expression", target: "Tip")
 
         // List aggregates and snapping, both of which need the comma token
         expectDisplay("average of 10, 20, 30", "20")
@@ -753,24 +754,28 @@ struct CalcTests {
         expectBadgesAt("time in ist", source: "UTC", target: "Kolkata")
 
         // Business days skip weekends. The clock is Fri 2026-07-24, so every hop crosses one.
-        expectDisplayAt("today + 1 business day", "Monday, 27 July")
-        expectDisplayAt("today + 5 business days", "Friday, 31 July")
-        expectDisplayAt("today - 1 business day", "Thursday, 23 July")
-        expectDisplayAt("today - 3 business days", "Tuesday, 21 July")
-        expectDisplayAt("tomorrow + 10 work days", "Friday, 7 August")
-        expectDisplayAt("today + 15 workdays", "Friday, 14 August")
-        expectDisplayAt("today + 5 weekdays", "Friday, 31 July")
+        expectDisplayAt("today + 1 business day", "27 July")
+        expectDisplayAt("today + 5 business days", "31 July")
+        expectDisplayAt("today - 1 business day", "23 July")
+        expectDisplayAt("today - 3 business days", "21 July")
+        expectDisplayAt("tomorrow + 10 work days", "7 August")
+        expectDisplayAt("today + 15 workdays", "14 August")
+        expectDisplayAt("today + 5 weekdays", "31 July")
+        // Raycast's own shape: the weekday rides the badge rather than the date
+        expectBadgesAt("today + 5 business days", source: "Friday, 24 July", target: "Friday")
+        expectBadgesAt("today + 1 business day", source: "Friday, 24 July", target: "Monday")
         // The duration may lead, with `from` naming the anchor or `ago` implying today
-        expectDisplayAt("5 weekdays from now", "Friday, 31 July")
-        expectDisplayAt("10 business days from today", "Friday, 7 August")
-        expectDisplayAt("3 days from today", "Monday, 27 July")
-        expectDisplayAt("2 weeks ago", "Friday, 10 July")
-        expectDisplayAt("3 days ago", "Tuesday, 21 July")
+        expectDisplayAt("5 weekdays from now", "31 July")
+        expectDisplayAt("10 business days from today", "7 August")
+        expectDisplayAt("3 days from today", "27 July")
+        expectDisplayAt("2 weeks ago", "10 July")
+        expectDisplayAt("3 days ago", "21 July")
+        expectBadgesAt("5 weekdays from now", source: "Friday, 24 July", target: "Friday")
         // A month name with both a day and a year
-        expectDisplayAt("august 26 2026 + 15 workdays", "Wednesday, 16 September")
-        expectDisplayAt("august 26 2026 + 15 days", "Thursday, 10 September")
-        expectDisplayAt("26 august 2026 + 1 day", "Thursday, 27 August")
-        expectDisplayAt("august 26 2027 + 1 day", "Friday, 27 August, 2027")
+        expectDisplayAt("august 26 2026 + 15 workdays", "16 September")
+        expectDisplayAt("august 26 2026 + 15 days", "10 September")
+        expectDisplayAt("26 august 2026 + 1 day", "27 August")
+        expectDisplayAt("august 26 2027 + 1 day", "27 August, 2027")
         // The 8-hour unit is a different thing, and keeps answering as one
         expectDisplay("55h in workdays", "6.875 workdays")
         expectDisplay("3 workdays in hours", "24 hr")

--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -752,6 +752,30 @@ struct CalcTests {
         expectError("10 mad to usd", "No exchange rate for MAD.")
         expectBadgesAt("time in ist", source: "UTC", target: "Kolkata")
 
+        // Business days skip weekends. The clock is Fri 2026-07-24, so every hop crosses one.
+        expectDisplayAt("today + 1 business day", "Monday, 27 July")
+        expectDisplayAt("today + 5 business days", "Friday, 31 July")
+        expectDisplayAt("today - 1 business day", "Thursday, 23 July")
+        expectDisplayAt("today - 3 business days", "Tuesday, 21 July")
+        expectDisplayAt("tomorrow + 10 work days", "Friday, 7 August")
+        expectDisplayAt("today + 15 workdays", "Friday, 14 August")
+        expectDisplayAt("today + 5 weekdays", "Friday, 31 July")
+        // The duration may lead, with `from` naming the anchor or `ago` implying today
+        expectDisplayAt("5 weekdays from now", "Friday, 31 July")
+        expectDisplayAt("10 business days from today", "Friday, 7 August")
+        expectDisplayAt("3 days from today", "Monday, 27 July")
+        expectDisplayAt("2 weeks ago", "Friday, 10 July")
+        expectDisplayAt("3 days ago", "Tuesday, 21 July")
+        // A month name with both a day and a year
+        expectDisplayAt("august 26 2026 + 15 workdays", "Wednesday, 16 September")
+        expectDisplayAt("august 26 2026 + 15 days", "Thursday, 10 September")
+        expectDisplayAt("26 august 2026 + 1 day", "Thursday, 27 August")
+        expectDisplayAt("august 26 2027 + 1 day", "Friday, 27 August, 2027")
+        // The 8-hour unit is a different thing, and keeps answering as one
+        expectDisplay("55h in workdays", "6.875 workdays")
+        expectDisplay("3 workdays in hours", "24 hr")
+        expectNil("5 from 10")
+
         // A conversion mid-expression, which used to need parentheses
         expectDisplay("10kg to lb + 3lb", "25.04622622 lb")
         expectDisplay("10kg to lb - 1lb", "21.04622622 lb")

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42664C60B760276FBAAD61 /* EmojiSettingsView.swift */; };
 		0D8A65A0A7A2188F56D576FF /* Quarantine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4984C964DC144E213DF4F63 /* Quarantine.swift */; };
 		0DD808F80666846F4E74BAD8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23591B301A183579098AA019 /* OnboardingView.swift */; };
+		0F667981DF990EF41626F052 /* CalcDateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955FBE410967A64A05A2DA3D /* CalcDateFormatters.swift */; };
 		0F6F56C49B3D2CBA233F12F3 /* CodexAppServerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7355ACD6D1BE7BC7FCA26BD2 /* CodexAppServerClient.swift */; };
 		0FC4608F65D69D465EFBBCE0 /* CalcFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E582B93EFB1A2AA85B048A87 /* CalcFormatter.swift */; };
 		106AF34CEAEB08CBCC924118 /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273827EB5CC04F1951C40387 /* VolumeLevel.swift */; };
@@ -676,6 +677,7 @@
 		943495E91C0D09B633746515 /* ChatGPTSubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTSubscriptionManager.swift; sourceTree = "<group>"; };
 		94507F8F095D3EBD1A9B3007 /* DialogController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogController.swift; sourceTree = "<group>"; };
 		951E746BA1AD25D167A1775F /* SystemSettingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsSettingsView.swift; sourceTree = "<group>"; };
+		955FBE410967A64A05A2DA3D /* CalcDateFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcDateFormatters.swift; sourceTree = "<group>"; };
 		95BFA41B0D7F369A8CF1E013 /* HyperKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperKey.swift; sourceTree = "<group>"; };
 		95E3AA9E226F39DBB232501F /* RaycastImportV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportV2.swift; sourceTree = "<group>"; };
 		976A1F05AD82DB8A04B3C3F9 /* MessageHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageHUDView.swift; sourceTree = "<group>"; };
@@ -931,6 +933,7 @@
 			isa = PBXGroup;
 			children = (
 				2B0F5891A80B604FBE21897B /* CalcCurrency.swift */,
+				955FBE410967A64A05A2DA3D /* CalcDateFormatters.swift */,
 				38A97022BE0F95B5D19F0C26 /* CalcDateTime.swift */,
 				7817B7A8760B36FDA43F48FC /* CalcEngine.swift */,
 				E582B93EFB1A2AA85B048A87 /* CalcFormatter.swift */,
@@ -2290,6 +2293,7 @@
 				0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */,
 				9E514EA8EB0408653AC3D1D9 /* BundleSignature.swift in Sources */,
 				B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */,
+				0F667981DF990EF41626F052 /* CalcDateFormatters.swift in Sources */,
 				ADE29D44A9504AC24FC17E72 /* CalcDateTime.swift in Sources */,
 				309B1313B6B40D1342362492 /* CalcEngine.swift in Sources */,
 				0FC4608F65D69D465EFBBCE0 /* CalcFormatter.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395BACF833C810961A248F0 /* BarButton.swift */; };
 		089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ABE4AF80DD5F5F8E91F63E /* SpotlightNames.swift */; };
 		0A086C5452FD9FCE68AF4E46 /* InputSourceSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCD070CDE64691E5F6ED28D /* InputSourceSwitcher.swift */; };
+		0B16FB98CFD5FC242DB69E70 /* CalcTimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA109C429A1E4E7E2B55BDC /* CalcTimeZone.swift */; };
 		0B9C941402B85C69A33200C2 /* UninstallProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A48095F6487DEE76663F88 /* UninstallProtection.swift */; };
 		0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42664C60B760276FBAAD61 /* EmojiSettingsView.swift */; };
 		0D8A65A0A7A2188F56D576FF /* Quarantine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4984C964DC144E213DF4F63 /* Quarantine.swift */; };
@@ -652,6 +653,7 @@
 		88C2657E7B3481A27821B4A5 /* WindowReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowReader.swift; sourceTree = "<group>"; };
 		8AC2CD86BAA6567B66B2B4DB /* FileSearchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchSettingsView.swift; sourceTree = "<group>"; };
 		8AFD491421DFE25892C0FC37 /* RaycastV1Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastV1Decoder.swift; sourceTree = "<group>"; };
+		8BA109C429A1E4E7E2B55BDC /* CalcTimeZone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcTimeZone.swift; sourceTree = "<group>"; };
 		8C39345D0335ACA895133ABD /* IconStyleMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconStyleMonitor.swift; sourceTree = "<group>"; };
 		8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		8D0371F4748011D45C185444 /* TextTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTranslator.swift; sourceTree = "<group>"; };
@@ -935,6 +937,7 @@
 				F77FF4F18AAA5D514A674878 /* CalcParser.swift */,
 				92B4495E56754B05B5F3551D /* CalcPercent.swift */,
 				4EF9F16C3F5567240FF03122 /* CalcQuantity.swift */,
+				8BA109C429A1E4E7E2B55BDC /* CalcTimeZone.swift */,
 				CC67BADEB6FEC76C88585361 /* CalcUnits.swift */,
 				E5C7F0C39D24F068A8F84864 /* CurrencyData.generated.swift */,
 				AE35B5E7B1CC94F759116097 /* CurrencyFeed.swift */,
@@ -2293,6 +2296,7 @@
 				2A7F775568D6F50A7AF4C587 /* CalcParser.swift in Sources */,
 				48AE2C9989F8FA2AA99D2D61 /* CalcPercent.swift in Sources */,
 				208FFC22E116E53E7BF3D147 /* CalcQuantity.swift in Sources */,
+				0B16FB98CFD5FC242DB69E70 /* CalcTimeZone.swift in Sources */,
 				5B5BCDD482A9058D38C49314 /* CalcUnits.swift in Sources */,
 				137A3474D4734DF43E6412D2 /* CalculatorCardView.swift in Sources */,
 				5332040ADB923832DCA06E5C /* CalculatorCoordinator.swift in Sources */,

--- a/Tinycast/Features/Calculator/Model/CalcDateFormatters.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateFormatters.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Reuses `DateFormatter`s across calls: building one costs ~160 µs against ~0.5 µs to reuse it,
+/// and a date card formats up to four times. Keyed by everything a formatter is configured with.
+enum CalcDateFormatters {
+    private struct Key: Hashable {
+        let pattern: String
+        let zone: String
+        let locale: String
+        let calendar: Calendar.Identifier
+    }
+
+    /// Cleared wholesale rather than evicted: the keys are a handful of patterns and one zone.
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var cache: [Key: DateFormatter] = [:]
+
+    static func string(from date: Date, calendar: Calendar, zone: TimeZone, pattern: String) -> String {
+        let locale = calendar.locale ?? Locale(identifier: "en_US")
+        let key = Key(
+            pattern: pattern, zone: zone.identifier, locale: locale.identifier,
+            calendar: calendar.identifier)
+
+        lock.lock()
+        defer { lock.unlock() }
+        if let formatter = cache[key] { return formatter.string(from: date) }
+
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = zone
+        // Follow the injected calendar's locale so weekday/month names match the user's language.
+        formatter.locale = locale
+        formatter.dateFormat = pattern
+        // A zone table plus a few patterns, so the ceiling is bounded by what the grammars format.
+        if cache.count >= 64 { cache.removeAll(keepingCapacity: true) }
+        cache[key] = formatter
+        return formatter.string(from: date)
+    }
+}

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -358,7 +358,8 @@ enum CalcDateTime {
         let right = String(query[opRange.upperBound...])
         // Grammar C shifts a moment, so nearest keeps `25. aug` and `25. aug + 3` in one year.
         // Grammar D measures to one, where the documented forward bias still decides the year.
-        let shifts = parseDurationPhrase(right) != nil || Int(right.trimmingCharacters(in: .whitespaces)) != nil
+        let shifts =
+            parseDurationPhrase(right) != nil || Int(right.trimmingCharacters(in: .whitespaces)) != nil
         guard
             let base = parseMoment(
                 left, now: now, calendar: calendar, bias: shifts ? .nearest : .future)

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -477,6 +477,16 @@ enum CalcDateTime {
                 return Moment(date: date, hasTime: false)
             }
         }
+        // Dotted dates are day-first, the convention that writes them: `19.2.27` is 19 February.
+        // A written year is what separates one from a version number, so `1.2.3` stays a search.
+        if atom.contains(".") {
+            let parts = atom.split(separator: ".").map(String.init)
+            guard parts.count == 3, let day = Int(parts[0]), let month = Int(parts[1]),
+                let year = Int(parts[2]), parts[2].count == 2 || parts[2].count == 4,
+                let date = makeDate(fullYear(year), month, day, calendar)
+            else { return nil }
+            return Moment(date: date, hasTime: false)
+        }
         return nil
     }
 

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Natural-language date/time for the card. Four grammars; see docs/features/calculator.md.
 enum CalcDateTime {
     /// Which occurrence of a bare, recurring date/time a phrase resolves to.
-    private enum MomentBias { case future, past }
+    private enum MomentBias { case future, past, nearest }
 
     static func evaluate(
         _ raw: String, now: Date = Date(), calendar: Calendar = .current
@@ -23,9 +23,11 @@ enum CalcDateTime {
             query.contains(" from ") || query.hasSuffix(" ago") || query.contains(" ago ")
         let hasIn = query.contains(" in ")
         // A lone `tomorrow` is an app search, so a named moment needs a qualifier to earn a card.
+        // A written day is qualifier enough: nobody types `25. aug` looking for an app.
         let isBareMoment =
             query.contains(" at ")
             || ["next ", "last "].contains { query.hasPrefix($0) }
+            || namesADay(query)
         guard hasUntil || hasSince || hasArith || hasFromAgo || hasIn || isBareMoment else {
             return nil
         }
@@ -51,6 +53,23 @@ enum CalcDateTime {
         return nil
     }
 
+    /// A day number beside a month, which no app search looks like — `25. aug`, `aug 25`, `25.8.27`.
+    private static func namesADay(_ query: String) -> Bool {
+        let atoms = atomize(query)
+        guard atoms.count == 2 || atoms.count == 3 else { return atoms.count == 1 && isDottedDate(atoms) }
+        let months = atoms.filter { monthByName[$0] != nil }.count
+        let days = atoms.filter { ordinalDay($0) != nil }.count
+        return months == 1 && days == atoms.count - 1
+    }
+
+    /// `25.8.27` on its own: three dotted parts, which cannot be read as one number.
+    private static func isDottedDate(_ atoms: [String]) -> Bool {
+        guard let only = atoms.first else { return false }
+        let parts = only.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3, parts[2].count == 2 || parts[2].count == 4 else { return false }
+        return parts.allSatisfy { Int($0) != nil }
+    }
+
     /// `next monday`, `tomorrow`, `tomorrow at 9am` — a moment named without any arithmetic.
     private static func bareMoment(
         _ query: String, echo: String, now: Date, calendar: Calendar
@@ -64,7 +83,9 @@ enum CalcDateTime {
             clock = parsed
             phrase = String(phrase[..<range.lowerBound])
         }
-        guard let moment = parseMoment(phrase, now: now, calendar: calendar) else { return nil }
+        // No `till` or `since` to lean on, so a bare date takes the year it is nearest.
+        guard let moment = parseMoment(phrase, now: now, calendar: calendar, bias: .nearest)
+        else { return nil }
 
         var date = moment.date
         var hasTime = moment.hasTime
@@ -286,7 +307,13 @@ enum CalcDateTime {
 
         let left = String(query[..<opRange.lowerBound])
         let right = String(query[opRange.upperBound...])
-        guard let base = parseMoment(left, now: now, calendar: calendar) else { return nil }
+        // Grammar C shifts a moment, so nearest keeps `25. aug` and `25. aug + 3` in one year.
+        // Grammar D measures to one, where the documented forward bias still decides the year.
+        let shifts = parseDurationPhrase(right) != nil || Int(right.trimmingCharacters(in: .whitespaces)) != nil
+        guard
+            let base = parseMoment(
+                left, now: now, calendar: calendar, bias: shifts ? .nearest : .future)
+        else { return nil }
 
         // A bare number takes the unit the moment implies: hours off a clock, days off a date.
         if let count = Int(right.trimmingCharacters(in: .whitespaces)) {
@@ -504,11 +531,13 @@ enum CalcDateTime {
             if date <= now, let next = shift(date, days: 1, calendar: calendar) { date = next }
         case .past:
             if date > now, let prev = shift(date, days: -1, calendar: calendar) { date = prev }
+        case .nearest:
+            break
         }
         return Moment(date: date, hasTime: true)
     }
 
-    /// The given day of `month`, resolved to the upcoming or most recent year by `bias`.
+    /// The given day of `month`, resolved to the upcoming, most recent, or nearest year by `bias`.
     private static func monthDayMoment(
         month: Int, day: Int, now: Date, calendar: Calendar, bias: MomentBias = .future
     ) -> Moment? {
@@ -524,6 +553,9 @@ enum CalcDateTime {
             if thisYear <= sod { return Moment(date: thisYear, hasTime: false) }
             guard let lastYear = makeDate(year - 1, month, day, calendar) else { return nil }
             return Moment(date: lastYear, hasTime: false)
+        // A date days behind is likelier the one meant than the same date a year out.
+        case .nearest:
+            return Moment(date: thisYear, hasTime: false)
         }
     }
 

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -22,7 +22,13 @@ enum CalcDateTime {
         let hasFromAgo =
             query.contains(" from ") || query.hasSuffix(" ago") || query.contains(" ago ")
         let hasIn = query.contains(" in ")
-        guard hasUntil || hasSince || hasArith || hasFromAgo || hasIn else { return nil }
+        // A lone `tomorrow` is an app search, so a named moment needs a qualifier to earn a card.
+        let isBareMoment =
+            query.contains(" at ")
+            || ["next ", "last "].contains { query.hasPrefix($0) }
+        guard hasUntil || hasSince || hasArith || hasFromAgo || hasIn || isBareMoment else {
+            return nil
+        }
 
         if hasUntil, let result = parseUntil(query, echo: echo, now: now, calendar: calendar) {
             return result
@@ -39,7 +45,62 @@ enum CalcDateTime {
         if hasIn, let result = parseWeekdayIn(query, echo: echo, now: now, calendar: calendar) {
             return result
         }
+        if isBareMoment, let result = bareMoment(query, echo: echo, now: now, calendar: calendar) {
+            return result
+        }
         return nil
+    }
+
+    /// `next monday`, `tomorrow`, `tomorrow at 9am` — a moment named without any arithmetic.
+    private static func bareMoment(
+        _ query: String, echo: String, now: Date, calendar: Calendar
+    ) -> CalcResult? {
+        var phrase = query
+        var clock: (hour: Int, minute: Int)?
+        // `at 9am` rides along, so the answer keeps the time it was given.
+        if let range = phrase.range(of: " at ") {
+            let tail = String(phrase[range.upperBound...]).trimmingCharacters(in: .whitespaces)
+            guard let parsed = parseMeridiemClock(tail) else { return nil }
+            clock = parsed
+            phrase = String(phrase[..<range.lowerBound])
+        }
+        guard let moment = parseMoment(phrase, now: now, calendar: calendar) else { return nil }
+
+        var date = moment.date
+        var hasTime = moment.hasTime
+        if let clock {
+            guard
+                let set = calendar.date(
+                    bySettingHour: clock.hour, minute: clock.minute, second: 0, of: date)
+            else { return nil }
+            date = set
+            hasTime = true
+        }
+
+        return CalcResult(
+            expression: echo,
+            sourceBadge: dateString(now, now: now, calendar: calendar),
+            targetBadge: weekdayName(date, calendar: calendar),
+            payload: .value(
+                display: answerString(date, hasTime: hasTime, now: now, calendar: calendar),
+                copyText: answerString(date, hasTime: hasTime, now: now, calendar: calendar)))
+    }
+
+    /// `9am`, `5:30pm`, `14:00` as a wall clock, with no bias applied.
+    private static func parseMeridiemClock(_ text: String) -> (hour: Int, minute: Int)? {
+        var body = text
+        var meridiem: String?
+        for suffix in ["am", "pm"] where body.hasSuffix(suffix) {
+            meridiem = suffix
+            body.removeLast(2)
+        }
+        body = body.trimmingCharacters(in: .whitespaces)
+        guard let (hour, minute) = parseClock(body) else { return nil }
+        guard let meridiem else {
+            return (0...23).contains(hour) ? (hour, minute) : nil
+        }
+        guard (1...12).contains(hour) else { return nil }
+        return (meridiem == "pm" ? (hour % 12) + 12 : hour % 12, minute)
     }
 
     /// `monday in 3 weeks` — that weekday, in the week the duration lands in.
@@ -226,6 +287,26 @@ enum CalcDateTime {
         let left = String(query[..<opRange.lowerBound])
         let right = String(query[opRange.upperBound...])
         guard let base = parseMoment(left, now: now, calendar: calendar) else { return nil }
+
+        // A bare number takes the unit the moment implies: hours off a clock, days off a date.
+        if let count = Int(right.trimmingCharacters(in: .whitespaces)) {
+            let component: Calendar.Component = base.hasTime ? .hour : .day
+            guard op == "+" || count != .min else { return nil }
+            guard
+                let result = calendar.date(
+                    byAdding: component, value: op == "-" ? -count : count, to: base.date)
+            else { return nil }
+            return CalcResult(
+                expression: echo,
+                sourceBadge: momentString(
+                    base.date, hasTime: base.hasTime, now: now, calendar: calendar),
+                targetBadge: weekdayName(result, calendar: calendar),
+                payload: .value(
+                    display: answerString(
+                        result, hasTime: base.hasTime, now: now, calendar: calendar),
+                    copyText: answerString(
+                        result, hasTime: base.hasTime, now: now, calendar: calendar)))
+        }
 
         // C: moment ± duration → a new moment.
         if let duration = parseDurationPhrase(right) {

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -21,7 +21,8 @@ enum CalcDateTime {
         let hasArith = query.contains(" + ") || query.contains(" - ")
         let hasFromAgo =
             query.contains(" from ") || query.hasSuffix(" ago") || query.contains(" ago ")
-        guard hasUntil || hasSince || hasArith || hasFromAgo else { return nil }
+        let hasIn = query.contains(" in ")
+        guard hasUntil || hasSince || hasArith || hasFromAgo || hasIn else { return nil }
 
         if hasUntil, let result = parseUntil(query, echo: echo, now: now, calendar: calendar) {
             return result
@@ -35,7 +36,39 @@ enum CalcDateTime {
         if hasFromAgo, let result = parseOffset(query, echo: echo, now: now, calendar: calendar) {
             return result
         }
+        if hasIn, let result = parseWeekdayIn(query, echo: echo, now: now, calendar: calendar) {
+            return result
+        }
         return nil
+    }
+
+    /// `monday in 3 weeks` — that weekday, in the week the duration lands in.
+    private static func parseWeekdayIn(
+        _ query: String, echo: String, now: Date, calendar: Calendar
+    ) -> CalcResult? {
+        guard let range = query.range(of: " in ") else { return nil }
+        let head = String(query[..<range.lowerBound]).trimmingCharacters(in: .whitespaces)
+        guard let weekday = weekdayByName[head],
+            let duration = parseDurationPhrase(String(query[range.upperBound...])),
+            !duration.subDay, !duration.businessDays,
+            let landing = calendar.date(
+                byAdding: duration.component, value: duration.count,
+                to: calendar.startOfDay(for: now))
+        else { return nil }
+
+        // The weekday inside the landing week, so `monday in 3 weeks` is that week's Monday.
+        guard let week = calendar.dateInterval(of: .weekOfYear, for: landing),
+            let result = shift(
+                week.start, days: (weekday - calendar.firstWeekday + 7) % 7, calendar: calendar)
+        else { return nil }
+
+        return CalcResult(
+            expression: echo,
+            sourceBadge: dateString(now, now: now, calendar: calendar),
+            targetBadge: weekdayName(result, calendar: calendar),
+            payload: .value(
+                display: answerString(result, hasTime: false, now: now, calendar: calendar),
+                copyText: answerString(result, hasTime: false, now: now, calendar: calendar)))
     }
 
     /// `5 weekdays from now`, `3 days from today`, `2 weeks ago` — the duration leads.

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -364,43 +364,15 @@ enum CalcDateTime {
                 left, now: now, calendar: calendar, bias: shifts ? .nearest : .future)
         else { return nil }
 
-        // A bare number takes the unit the moment implies: hours off a clock, days off a date.
-        if let count = Int(right.trimmingCharacters(in: .whitespaces)) {
-            let component: Calendar.Component = base.hasTime ? .hour : .day
-            guard op == "+" || count != .min else { return nil }
-            guard
-                let result = calendar.date(
-                    byAdding: component, value: op == "-" ? -count : count, to: base.date)
-            else { return nil }
+        // C: moment ± duration, chained left to right — every term after the first shifts again.
+        if let shifted = applyShifts(op, right, to: base, calendar: calendar) {
+            let display = answerString(
+                shifted.date, hasTime: shifted.hasTime, now: now, calendar: calendar)
             return CalcResult(
                 expression: echo,
                 sourceBadge: momentString(
                     base.date, hasTime: base.hasTime, now: now, calendar: calendar),
-                targetBadge: weekdayName(result, calendar: calendar),
-                payload: .value(
-                    display: answerString(
-                        result, hasTime: base.hasTime, now: now, calendar: calendar),
-                    copyText: answerString(
-                        result, hasTime: base.hasTime, now: now, calendar: calendar)))
-        }
-
-        // C: moment ± duration → a new moment.
-        if let duration = parseDurationPhrase(right) {
-            // Negating Int.min traps; degrade to no card on that edge.
-            guard op == "+" || duration.count != .min else { return nil }
-            let signed = op == "-" ? -duration.count : duration.count
-            let shifted =
-                duration.businessDays
-                ? addBusinessDays(signed, to: base.date, calendar: calendar)
-                : calendar.date(byAdding: duration.component, value: signed, to: base.date)
-            guard let result = shifted else { return nil }
-            let hasTime = base.hasTime || duration.subDay
-            let display = answerString(result, hasTime: hasTime, now: now, calendar: calendar)
-            let sourceBadge = momentString(
-                base.date, hasTime: base.hasTime, now: now, calendar: calendar)
-            return CalcResult(
-                expression: echo, sourceBadge: sourceBadge,
-                targetBadge: weekdayName(result, calendar: calendar),
+                targetBadge: weekdayName(shifted.date, calendar: calendar),
                 payload: .value(display: display, copyText: display))
         }
 
@@ -422,6 +394,71 @@ enum CalcDateTime {
             sourceBadge: dateString(base.date, now: now, calendar: calendar),
             targetBadge: dateString(other.date, now: now, calendar: calendar),
             payload: .value(display: "\(days) \(word)", copyText: "\(days) \(word)"))
+    }
+
+    /// Every `± <term>` after the first operator, applied in written order. Nil unless all of them
+    /// are durations, so grammar D still sees a trailing moment as one.
+    private static func applyShifts(
+        _ firstOperator: Character, _ tail: String, to base: Moment, calendar: Calendar
+    ) -> Moment? {
+        var moment = base
+        var op = firstOperator
+        var rest = Substring(tail)
+
+        while true {
+            let (term, nextOperator, remainder) = splitTerm(rest)
+            guard let shifted = shift(moment, by: term, op: op, calendar: calendar) else {
+                return nil
+            }
+            moment = shifted
+            guard let nextOperator else { return moment }
+            op = nextOperator
+            rest = remainder
+        }
+    }
+
+    /// The text up to the next spaced `+` / `-`, that operator, and whatever follows it.
+    private static func splitTerm(
+        _ text: Substring
+    ) -> (term: String, nextOperator: Character?, remainder: Substring) {
+        let plus = text.range(of: " + ")
+        let minus = text.range(of: " - ")
+        let next: (Range<Substring.Index>, Character)?
+        switch (plus, minus) {
+        case (let p?, let m?): next = p.lowerBound < m.lowerBound ? (p, "+") : (m, "-")
+        case (let p?, nil): next = (p, "+")
+        case (nil, let m?): next = (m, "-")
+        default: next = nil
+        }
+        guard let (range, op) = next else { return (String(text), nil, text) }
+        return (String(text[..<range.lowerBound]), op, text[range.upperBound...])
+    }
+
+    /// One term against a moment: a spelled duration, or a bare number in the moment's own unit.
+    private static func shift(
+        _ moment: Moment, by term: String, op: Character, calendar: Calendar
+    ) -> Moment? {
+        let trimmed = term.trimmingCharacters(in: .whitespaces)
+        if let count = Int(trimmed) {
+            // Negating Int.min traps; degrade to no card on that edge.
+            guard op == "+" || count != .min else { return nil }
+            let component: Calendar.Component = moment.hasTime ? .hour : .day
+            guard
+                let date = calendar.date(
+                    byAdding: component, value: op == "-" ? -count : count, to: moment.date)
+            else { return nil }
+            return Moment(date: date, hasTime: moment.hasTime)
+        }
+
+        guard let duration = parseDurationPhrase(trimmed), op == "+" || duration.count != .min
+        else { return nil }
+        let signed = op == "-" ? -duration.count : duration.count
+        let date =
+            duration.businessDays
+            ? addBusinessDays(signed, to: moment.date, calendar: calendar)
+            : calendar.date(byAdding: duration.component, value: signed, to: moment.date)
+        guard let date else { return nil }
+        return Moment(date: date, hasTime: moment.hasTime || duration.subDay)
     }
 
     // MARK: - Moment parsing

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -379,9 +379,9 @@ enum CalcDateTime {
         guard let year = Int(c) else { return nil }
         let month: Int
         let day: Int
-        if let named = monthByName[a], let value = Int(b) {
+        if let named = monthByName[a], let value = ordinalDay(b) {
             (month, day) = (named, value)
-        } else if let named = monthByName[b], let value = Int(a) {
+        } else if let named = monthByName[b], let value = ordinalDay(a) {
             (month, day) = (named, value)
         } else {
             return nil
@@ -420,10 +420,10 @@ enum CalcDateTime {
         _ a: String, _ b: String, now: Date, calendar: Calendar, bias: MomentBias
     ) -> Moment? {
         // number + month  /  month + number  →  a day in that month
-        if let month = monthByName[b], let day = Int(a) {
+        if let month = monthByName[b], let day = ordinalDay(a) {
             return monthDayMoment(month: month, day: day, now: now, calendar: calendar, bias: bias)
         }
-        if let month = monthByName[a], let day = Int(b) {
+        if let month = monthByName[a], let day = ordinalDay(b) {
             return monthDayMoment(month: month, day: day, now: now, calendar: calendar, bias: bias)
         }
         // clock + am/pm  →  a time today (or tomorrow if it has passed)
@@ -692,6 +692,11 @@ enum CalcDateTime {
         }
         flush()
         return atoms
+    }
+
+    /// A day number, with the ordinal dot German and Austrian dates write: `28. aug`.
+    private static func ordinalDay(_ atom: String) -> Int? {
+        Int(atom.hasSuffix(".") ? String(atom.dropLast()) : atom)
     }
 
     private static func parseClock(_ atom: String) -> (hour: Int, minute: Int)? {

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -14,7 +14,11 @@ enum CalcDateTime {
         let query = echo.lowercased()
         guard !query.isEmpty else { return nil }
 
-        // Cheap gate: our grammars always carry a connector, so app searches skip all the parsing.
+        // Cheap gate: every grammar carries a digit or a connector, so an app search stops here
+        // before anything allocates. `namesADay` atomizes, so it runs only past the digit check.
+        let hasDigit = query.contains(where: \.isNumber)
+        guard hasDigit || query.contains(" ") else { return nil }
+
         let hasUntil =
             query.contains(" till ") || query.contains(" until ") || query.contains(" til ")
         let hasSince = query.contains(" since ")
@@ -26,8 +30,8 @@ enum CalcDateTime {
         // A written day is qualifier enough: nobody types `25. aug` looking for an app.
         let isBareMoment =
             query.contains(" at ")
-            || ["next ", "last "].contains { query.hasPrefix($0) }
-            || namesADay(query)
+            || query.hasPrefix("next ") || query.hasPrefix("last ")
+            || (hasDigit && namesADay(query))
         guard hasUntil || hasSince || hasArith || hasFromAgo || hasIn || isBareMoment else {
             return nil
         }
@@ -680,13 +684,7 @@ enum CalcDateTime {
     }
 
     private static func format(_ date: Date, calendar: Calendar, pattern: String) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.timeZone = calendar.timeZone
-        // Follow the injected calendar's locale so weekday/month names match the user's language.
-        formatter.locale = calendar.locale ?? Locale(identifier: "en_US")
-        formatter.dateFormat = pattern
-        return formatter.string(from: date)
+        CalcDateFormatters.string(from: date, calendar: calendar, zone: calendar.timeZone, pattern: pattern)
     }
 
     // MARK: - Low-level helpers

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -14,23 +14,19 @@ enum CalcDateTime {
         let query = echo.lowercased()
         guard !query.isEmpty else { return nil }
 
-        // Cheap gate: every grammar carries a digit or a connector, so an app search stops here
-        // before anything allocates. `namesADay` atomizes, so it runs only past the digit check.
-        let hasDigit = query.contains(where: \.isNumber)
-        guard hasDigit || query.contains(" ") else { return nil }
-
-        let hasUntil =
-            query.contains(" till ") || query.contains(" until ") || query.contains(" til ")
-        let hasSince = query.contains(" since ")
-        let hasArith = query.contains(" + ") || query.contains(" - ")
-        let hasFromAgo =
-            query.contains(" from ") || query.hasSuffix(" ago") || query.contains(" ago ")
-        let hasIn = query.contains(" in ")
+        // Cheap gate: one pass over the words rather than a scan per keyword, since an app search
+        // pays this on every keystroke. `namesADay` atomizes, so a digit has to earn it first.
+        let signals = keywordSignals(query)
+        let hasDigit = signals.contains(.digit)
+        let hasUntil = signals.contains(.until)
+        let hasSince = signals.contains(.since)
+        let hasArith = signals.contains(.arithmetic)
+        let hasFromAgo = signals.contains(.fromAgo)
+        let hasIn = signals.contains(.inWord)
         // A lone `tomorrow` is an app search, so a named moment needs a qualifier to earn a card.
         // A written day is qualifier enough: nobody types `25. aug` looking for an app.
         let isBareMoment =
-            query.contains(" at ")
-            || query.hasPrefix("next ") || query.hasPrefix("last ")
+            signals.contains(.at) || signals.contains(.nextOrLast)
             || (hasDigit && namesADay(query))
         guard hasUntil || hasSince || hasArith || hasFromAgo || hasIn || isBareMoment else {
             return nil
@@ -55,6 +51,55 @@ enum CalcDateTime {
             return result
         }
         return nil
+    }
+
+    private struct Signals: OptionSet {
+        let rawValue: Int
+        static let digit = Signals(rawValue: 1 << 0)
+        static let until = Signals(rawValue: 1 << 1)
+        static let since = Signals(rawValue: 1 << 2)
+        static let arithmetic = Signals(rawValue: 1 << 3)
+        static let fromAgo = Signals(rawValue: 1 << 4)
+        static let inWord = Signals(rawValue: 1 << 5)
+        static let at = Signals(rawValue: 1 << 6)
+        static let nextOrLast = Signals(rawValue: 1 << 7)
+    }
+
+    /// One walk of the query, so the gate costs a single pass rather than ten substring scans.
+    private static func keywordSignals(_ query: String) -> Signals {
+        var signals: Signals = []
+        var word = ""
+        var index = 0
+        var isFirst = true
+
+        func classify(_ word: String, isFirst: Bool, isLast: Bool) {
+            switch word {
+            case "till", "until", "til": if !isFirst, !isLast { signals.insert(.until) }
+            case "since": if !isFirst, !isLast { signals.insert(.since) }
+            case "+", "-": if !isFirst, !isLast { signals.insert(.arithmetic) }
+            case "from": if !isFirst, !isLast { signals.insert(.fromAgo) }
+            case "ago": if !isFirst { signals.insert(.fromAgo) }
+            case "in": if !isFirst, !isLast { signals.insert(.inWord) }
+            case "at": if !isFirst, !isLast { signals.insert(.at) }
+            case "next", "last": if isFirst { signals.insert(.nextOrLast) }
+            default: break
+            }
+        }
+
+        for character in query {
+            if character.isNumber { signals.insert(.digit) }
+            if character.isWhitespace {
+                classify(word, isFirst: isFirst, isLast: false)
+                isFirst = isFirst && word.isEmpty
+                if !word.isEmpty { isFirst = false }
+                word = ""
+            } else {
+                word.append(character)
+            }
+            index += 1
+        }
+        classify(word, isFirst: isFirst, isLast: true)
+        return signals
     }
 
     /// A day number beside a month, which no app search looks like — `25. aug`, `aug 25`, `25.8.27`.
@@ -509,7 +554,7 @@ enum CalcDateTime {
             }
         }
         // Dotted dates are day-first, the convention that writes them: `19.2.27` is 19 February.
-        // A written year is what separates one from a version number, so `1.2.3` stays a search.
+        // A 2- or 4-digit tail rejects most version numbers; `1.2.24` is genuinely both.
         if atom.contains(".") {
             let parts = atom.split(separator: ".").map(String.init)
             guard parts.count == 3, let day = Int(parts[0]), let month = Int(parts[1]),

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -69,12 +69,12 @@ enum CalcDateTime {
         guard let result = shifted else { return nil }
 
         let hasTime = anchor.hasTime && duration.subDay
-        let display = momentString(result, hasTime: hasTime, now: now, calendar: calendar)
+        let display = answerString(result, hasTime: hasTime, now: now, calendar: calendar)
         return CalcResult(
             expression: echo,
             sourceBadge: momentString(
                 anchor.date, hasTime: hasTime, now: now, calendar: calendar),
-            targetBadge: "Result",
+            targetBadge: weekdayName(result, calendar: calendar),
             payload: .value(
                 display: display, copyText: display))
     }
@@ -205,11 +205,12 @@ enum CalcDateTime {
                 : calendar.date(byAdding: duration.component, value: signed, to: base.date)
             guard let result = shifted else { return nil }
             let hasTime = base.hasTime || duration.subDay
-            let display = momentString(result, hasTime: hasTime, now: now, calendar: calendar)
+            let display = answerString(result, hasTime: hasTime, now: now, calendar: calendar)
             let sourceBadge = momentString(
                 base.date, hasTime: base.hasTime, now: now, calendar: calendar)
             return CalcResult(
-                expression: echo, sourceBadge: sourceBadge, targetBadge: "Result",
+                expression: echo, sourceBadge: sourceBadge,
+                targetBadge: weekdayName(result, calendar: calendar),
                 payload: .value(display: display, copyText: display))
         }
 
@@ -495,6 +496,17 @@ enum CalcDateTime {
         return hasTime ? "\(day) at \(timeString(date, calendar: calendar))" : day
     }
 
+    /// The weekday moves to the badge, so an answered moment leads with the date itself.
+    private static func answerString(
+        _ date: Date, hasTime: Bool, now: Date, calendar: Calendar
+    ) -> String {
+        let sameYear =
+            calendar.component(.year, from: date) == calendar.component(.year, from: now)
+        let day = format(
+            date, calendar: calendar, pattern: sameYear ? "d MMMM" : "d MMMM, yyyy")
+        return hasTime ? "\(day) at \(timeString(date, calendar: calendar))" : day
+    }
+
     private static func dateString(_ date: Date, now: Date, calendar: Calendar) -> String {
         let sameYear =
             calendar.component(.year, from: date) == calendar.component(.year, from: now)
@@ -504,6 +516,11 @@ enum CalcDateTime {
 
     private static func timeString(_ date: Date, calendar: Calendar) -> String {
         format(date, calendar: calendar, pattern: "h:mm a")
+    }
+
+    /// The answer's own weekday, which the date itself never spells out.
+    private static func weekdayName(_ date: Date, calendar: Calendar) -> String {
+        format(date, calendar: calendar, pattern: "EEEE")
     }
 
     private static func format(_ date: Date, calendar: Calendar, pattern: String) -> String {

--- a/Tinycast/Features/Calculator/Model/CalcDateTime.swift
+++ b/Tinycast/Features/Calculator/Model/CalcDateTime.swift
@@ -19,7 +19,9 @@ enum CalcDateTime {
             query.contains(" till ") || query.contains(" until ") || query.contains(" til ")
         let hasSince = query.contains(" since ")
         let hasArith = query.contains(" + ") || query.contains(" - ")
-        guard hasUntil || hasSince || hasArith else { return nil }
+        let hasFromAgo =
+            query.contains(" from ") || query.hasSuffix(" ago") || query.contains(" ago ")
+        guard hasUntil || hasSince || hasArith || hasFromAgo else { return nil }
 
         if hasUntil, let result = parseUntil(query, echo: echo, now: now, calendar: calendar) {
             return result
@@ -30,7 +32,51 @@ enum CalcDateTime {
         if hasArith, let result = parseArithmetic(query, echo: echo, now: now, calendar: calendar) {
             return result
         }
+        if hasFromAgo, let result = parseOffset(query, echo: echo, now: now, calendar: calendar) {
+            return result
+        }
         return nil
+    }
+
+    /// `5 weekdays from now`, `3 days from today`, `2 weeks ago` — the duration leads.
+    private static func parseOffset(
+        _ query: String, echo: String, now: Date, calendar: Calendar
+    ) -> CalcResult? {
+        let durationText: String
+        let anchorText: String
+        let sign: Int
+        if let range = query.range(of: " from ") {
+            durationText = String(query[..<range.lowerBound])
+            anchorText = String(query[range.upperBound...])
+            sign = 1
+        } else if query.hasSuffix(" ago") {
+            durationText = String(query.dropLast(4))
+            anchorText = "today"
+            sign = -1
+        } else {
+            return nil
+        }
+
+        guard let duration = parseDurationPhrase(durationText), duration.count != .min,
+            let anchor = parseMoment(anchorText, now: now, calendar: calendar)
+        else { return nil }
+
+        let signed = duration.count * sign
+        let shifted =
+            duration.businessDays
+            ? addBusinessDays(signed, to: anchor.date, calendar: calendar)
+            : calendar.date(byAdding: duration.component, value: signed, to: anchor.date)
+        guard let result = shifted else { return nil }
+
+        let hasTime = anchor.hasTime && duration.subDay
+        let display = momentString(result, hasTime: hasTime, now: now, calendar: calendar)
+        return CalcResult(
+            expression: echo,
+            sourceBadge: momentString(
+                anchor.date, hasTime: hasTime, now: now, calendar: calendar),
+            targetBadge: "Result",
+            payload: .value(
+                display: display, copyText: display))
     }
 
     // MARK: - Grammar A: duration until a moment
@@ -153,10 +199,11 @@ enum CalcDateTime {
             // Negating Int.min traps; degrade to no card on that edge.
             guard op == "+" || duration.count != .min else { return nil }
             let signed = op == "-" ? -duration.count : duration.count
-            guard
-                let result = calendar.date(
-                    byAdding: duration.component, value: signed, to: base.date)
-            else { return nil }
+            let shifted =
+                duration.businessDays
+                ? addBusinessDays(signed, to: base.date, calendar: calendar)
+                : calendar.date(byAdding: duration.component, value: signed, to: base.date)
+            guard let result = shifted else { return nil }
             let hasTime = base.hasTime || duration.subDay
             let display = momentString(result, hasTime: hasTime, now: now, calendar: calendar)
             let sourceBadge = momentString(
@@ -203,9 +250,29 @@ enum CalcDateTime {
             return parseSingle(atoms[0], now: now, calendar: calendar, bias: bias)
         case 2:
             return parsePair(atoms[0], atoms[1], now: now, calendar: calendar, bias: bias)
+        case 3:
+            return parseTriple(atoms[0], atoms[1], atoms[2], calendar: calendar)
         default:
             return nil
         }
+    }
+
+    /// `august 26 2026` / `26 august 2026` — a month name with both a day and a year.
+    private static func parseTriple(
+        _ a: String, _ b: String, _ c: String, calendar: Calendar
+    ) -> Moment? {
+        guard let year = Int(c) else { return nil }
+        let month: Int
+        let day: Int
+        if let named = monthByName[a], let value = Int(b) {
+            (month, day) = (named, value)
+        } else if let named = monthByName[b], let value = Int(a) {
+            (month, day) = (named, value)
+        } else {
+            return nil
+        }
+        guard let date = makeDate(fullYear(year), month, day, calendar) else { return nil }
+        return Moment(date: date, hasTime: false)
     }
 
     private static func parseSingle(
@@ -386,11 +453,19 @@ enum CalcDateTime {
         let count: Int
         let component: Calendar.Component
         let subDay: Bool
+        /// Weekend days are skipped rather than counted, so the result lands Mon–Fri.
+        var businessDays = false
     }
 
     /// `<n> <unit>` for date arithmetic; weeks fold to days so `date(byAdding:)` stays DST-safe.
     private static func parseDurationPhrase(_ phrase: String) -> DurationPhrase? {
         let atoms = atomize(phrase)
+        // "business days" / "work days" are two atoms after the count, one word or two.
+        if atoms.count >= 2, let count = Int(atoms[0]),
+            businessDayPhrases.contains(atoms.dropFirst().joined())
+        {
+            return DurationPhrase(count: count, component: .day, subDay: false, businessDays: true)
+        }
         guard atoms.count == 2, let count = Int(atoms[0]) else { return nil }
         switch atoms[1] {
         case "s", "sec", "secs", "second", "seconds":
@@ -511,6 +586,25 @@ enum CalcDateTime {
         calendar.date(byAdding: .day, value: days, to: date)
     }
 
+    /// Steps day by day, counting only Mon–Fri. Public holidays are deliberately not modelled.
+    private static func addBusinessDays(_ count: Int, to date: Date, calendar: Calendar) -> Date? {
+        guard abs(count) <= 10_000 else { return nil }
+        let step = count < 0 ? -1 : 1
+        var remaining = abs(count)
+        var cursor = date
+        while remaining > 0 {
+            guard let next = shift(cursor, days: step, calendar: calendar) else { return nil }
+            cursor = next
+            if !isWeekend(cursor, calendar: calendar) { remaining -= 1 }
+        }
+        return cursor
+    }
+
+    private static func isWeekend(_ date: Date, calendar: Calendar) -> Bool {
+        let weekday = calendar.component(.weekday, from: date)
+        return weekday == 1 || weekday == 7
+    }
+
     /// Expand a 2-digit year the way date pickers do; 4-digit years pass through.
     private static func fullYear(_ year: Int) -> Int {
         if year >= 100 { return year }
@@ -522,6 +616,11 @@ enum CalcDateTime {
         "apr": 4, "may": 5, "june": 6, "jun": 6, "july": 7, "jul": 7, "august": 8, "aug": 8,
         "september": 9, "sep": 9, "sept": 9, "october": 10, "oct": 10, "november": 11, "nov": 11,
         "december": 12, "dec": 12
+    ]
+
+    private static let businessDayPhrases: Set<String> = [
+        "businessday", "businessdays", "workday", "workdays", "workingday", "workingdays",
+        "weekday", "weekdays"
     ]
 
     /// Gregorian weekday numbers (Sunday = 1).

--- a/Tinycast/Features/Calculator/Model/CalcEngine.swift
+++ b/Tinycast/Features/Calculator/Model/CalcEngine.swift
@@ -50,6 +50,9 @@ enum CalcEngine {
         // Date/time first: `hrs till july` carries no digit, so it precedes the numeric reject.
         if let dateTime = CalcDateTime.evaluate(query, now: now, calendar: calendar) { return dateTime }
 
+        // Before tokenizing: `5pm ldn in sf` is words, which the tokenizer would reject.
+        if let zone = CalcTimeZone.evaluate(query, now: now, calendar: calendar) { return zone }
+
         guard let tokens = CalcTokenizer.tokenize(query), !tokens.isEmpty else { return nil }
 
         if let partial = partialResult(
@@ -79,6 +82,8 @@ enum CalcEngine {
         }
 
         if let base = baseConversion(tokens, query: query) { return base }
+
+        if let span = timespanConversion(tokens, query: query) { return span }
 
         // Conversions run before the numeric reject below: `m to ft`, `day s` carry no digit.
         if let conversion = CalcUnits.parseConversion(tokens) ?? CalcUnits.parseUnitPairConversion(tokens) {
@@ -231,6 +236,8 @@ enum CalcEngine {
                 return String(op)
             case .arrow:
                 return "->"
+            case .comma:
+                return ","
             }
         }.joined(separator: " ")
     }
@@ -241,6 +248,27 @@ enum CalcEngine {
             sourceBadge: result.sourceBadge,
             targetBadge: result.targetBadge,
             payload: result.payload)
+    }
+
+    // MARK: - Timespans
+
+    private static func timespanConversion(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard tokens.count >= 3, case .ident(let target) = tokens[tokens.count - 1],
+            target == "timespan" || target == "duration",
+            CalcUnits.isConnector(tokens[tokens.count - 2]),
+            case .ident(let unitName) = tokens[tokens.count - 3],
+            let unit = CalcUnits.byName[unitName], unit.category == .time,
+            let amount = CalcParser.evaluate(Array(tokens[0..<(tokens.count - 3)]))
+        else { return nil }
+
+        let seconds = amount * unit.factor
+        guard seconds.isFinite else { return nil }
+        let text = CalcFormatter.timespan(seconds)
+        return CalcResult(
+            expression: "\(CalcFormatter.display(amount)) \(unit.symbol)",
+            sourceBadge: unit.name,
+            targetBadge: "Timespan",
+            payload: .value(display: text, copyText: text))
     }
 
     // MARK: - Number bases

--- a/Tinycast/Features/Calculator/Model/CalcFormatter.swift
+++ b/Tinycast/Features/Calculator/Model/CalcFormatter.swift
@@ -45,6 +45,27 @@ enum CalcFormatter {
         return "\(feetPart) \(inchPart)"
     }
 
+    /// Seconds as the largest units that fit: `8,700` → `2 hr 25 min`.
+    static func timespan(_ seconds: Double) -> String {
+        guard seconds.isFinite else { return display(seconds) }
+        let sign = seconds < 0 ? "-" : ""
+        var remainder = abs(seconds).rounded()
+        var parts: [String] = []
+        for step in timespanSteps where remainder >= step.seconds {
+            let count = (remainder / step.seconds).rounded(.towardZero)
+            remainder -= count * step.seconds
+            parts.append("\(grouped(String(format: "%.0f", count))) \(step.symbol)")
+        }
+        // Sub-second input has no whole part to show, so it keeps its own precision.
+        if parts.isEmpty { return "\(display(seconds)) s" }
+        return sign + parts.joined(separator: " ")
+    }
+
+    /// Weeks are the largest step: a month is not a fixed number of seconds.
+    private static let timespanSteps: [(seconds: Double, symbol: String)] = [
+        (604800, "wk"), (86400, "day"), (3600, "hr"), (60, "min"), (1, "s")
+    ]
+
     /// Insert `,` every three integer digits. Exponent-form strings pass through untouched.
     static func grouped(_ text: String) -> String {
         guard !text.contains("e"), !text.contains("E") else { return text }

--- a/Tinycast/Features/Calculator/Model/CalcParser.swift
+++ b/Tinycast/Features/Calculator/Model/CalcParser.swift
@@ -10,6 +10,8 @@ enum CalcToken: Equatable, Sendable {
     case ident(String)
     case op(Character)  // + - * / ^ ! % ( )
     case arrow  // -> or →
+    /// Only `CalcPercent`'s list forms accept one; every other path rejects it.
+    case comma
 }
 
 enum CalcTokenizer {
@@ -101,6 +103,12 @@ enum CalcTokenizer {
                             continue
                         }
                     }
+                    // A slashed rate ("km/h") is one unit, so it must beat the division operator.
+                    if let rate = slashedUnit(chars, i) {
+                        tokens.append(.ident(rate.name))
+                        i = rate.end
+                        continue
+                    }
                 }
                 var text = ""
                 while i < chars.count {
@@ -137,6 +145,8 @@ enum CalcTokenizer {
             switch ch {
             case "+", "(", ")", "!", "%", "^":
                 tokens.append(.op(ch))
+            case ",":
+                tokens.append(.comma)
             case "*", "×":
                 tokens.append(.op("*"))
             case "/", "÷":
@@ -161,6 +171,19 @@ enum CalcTokenizer {
             i += 1
         }
         return tokens
+    }
+
+    /// Only a spelling the table resolves, so `6/2(1+2)` keeps dividing.
+    private static func slashedUnit(_ chars: [Character], _ start: Int) -> (name: String, end: Int)? {
+        var numeratorEnd = start
+        while numeratorEnd < chars.count, chars[numeratorEnd].isLetter { numeratorEnd += 1 }
+        guard numeratorEnd < chars.count, chars[numeratorEnd] == "/" else { return nil }
+        var denominatorEnd = numeratorEnd + 1
+        while denominatorEnd < chars.count, chars[denominatorEnd].isLetter { denominatorEnd += 1 }
+        guard denominatorEnd > numeratorEnd + 1 else { return nil }
+        let name = String(chars[start..<denominatorEnd]).lowercased()
+        guard CalcUnits.byName[name] != nil else { return nil }
+        return (name, denominatorEnd)
     }
 
     /// Whether the `k` at `index` is a thousands suffix rather than Kelvin or a unit's head.
@@ -203,10 +226,19 @@ enum CalcParser {
     fileprivate static let functions: [String: @Sendable (Double) -> Double] = [
         "sqrt": { sqrt($0) }, "log": { log10($0) }, "ln": { log($0) }, "sin": { sin($0) },
         "cos": { cos($0) }, "tan": { tan($0) }, "abs": { abs($0) }, "floor": { floor($0) },
-        "ceil": { ceil($0) }, "round": { $0.rounded() }
+        "ceil": { ceil($0) }, "round": { $0.rounded() },
+        "cot": { 1 / tan($0) }, "sec": { 1 / cos($0) }, "csc": { 1 / sin($0) },
+        "asin": { asin($0) }, "acos": { acos($0) }, "atan": { atan($0) },
+        "arcsin": { asin($0) }, "arccos": { acos($0) }, "arctan": { atan($0) },
+        "sinh": { sinh($0) }, "cosh": { cosh($0) }, "tanh": { tanh($0) },
+        "asinh": { asinh($0) }, "acosh": { acosh($0) }, "atanh": { atanh($0) },
+        "cbrt": { cbrt($0) }, "exp": { exp($0) }, "log2": { log2($0) },
+        "sign": { $0 > 0 ? 1 : ($0 < 0 ? -1 : 0) }, "trunc": { $0.rounded(.towardZero) }
     ]
 
-    fileprivate static let constants: [String: Double] = ["pi": .pi, "π": .pi, "e": M_E]
+    fileprivate static let constants: [String: Double] = [
+        "pi": .pi, "π": .pi, "e": M_E, "tau": 2 * .pi, "τ": 2 * .pi, "phi": (1 + sqrt(5.0)) / 2
+    ]
 
     /// Factorial for non-negative integers; 170! is the last value representable as a Double.
     static func factorial(_ value: Double) -> Double? {

--- a/Tinycast/Features/Calculator/Model/CalcParser.swift
+++ b/Tinycast/Features/Calculator/Model/CalcParser.swift
@@ -215,11 +215,39 @@ enum CalcTokenizer {
 /// Precedence-climbing evaluator, no AST; nil for anything malformed or non-finite.
 enum CalcParser {
     static func evaluate(_ tokens: [CalcToken]) -> Double? {
-        var parser = Parser(tokens: tokens)
+        var parser = Parser(tokens: spelledFunctions(tokens))
         guard let result = parser.parseExpression(minBP: 0), parser.isAtEnd,
             result.effective.isFinite
         else { return nil }
         return result.effective
+    }
+
+    /// Folds the spoken function names into the symbol ones before any parsing sees them.
+    private static func spelledFunctions(_ tokens: [CalcToken]) -> [CalcToken] {
+        var folded: [CalcToken] = []
+        var index = 0
+        while index < tokens.count {
+            // `square root of 625` is `sqrt 625`; the trailing `of` would otherwise multiply.
+            if index + 1 < tokens.count, tokens[index] == .ident("square"),
+                tokens[index + 1] == .ident("root")
+            {
+                folded.append(.ident("sqrt"))
+                index += 2
+                if index < tokens.count, tokens[index] == .ident("of") { index += 1 }
+                continue
+            }
+            if index + 1 < tokens.count, tokens[index] == .ident("cube"),
+                tokens[index + 1] == .ident("root")
+            {
+                folded.append(.ident("cbrt"))
+                index += 2
+                if index < tokens.count, tokens[index] == .ident("of") { index += 1 }
+                continue
+            }
+            folded.append(tokens[index])
+            index += 1
+        }
+        return folded
     }
 
     // Capture-free closures, not C function refs, so every entry infers `@Sendable` in Swift 5.
@@ -322,6 +350,9 @@ private struct Parser {
         // Spelled-out only: "%" is already percent, and "20% - 5" gives no local signal.
         case .ident("mod"):
             return BinaryOp(op: "%", bindingPower: Self.mulBP, rightBindingPower: Self.mulBP + 1)
+        // Spoken form of `^`, right-associative like the symbol it spells.
+        case .ident("power"):
+            return BinaryOp(op: "^", bindingPower: 30, rightBindingPower: 30)
         case .op("^"):
             return BinaryOp(op: "^", bindingPower: 30, rightBindingPower: 30)  // right-associative: 2^3^2 = 512
         default: return nil

--- a/Tinycast/Features/Calculator/Model/CalcPercent.swift
+++ b/Tinycast/Features/Calculator/Model/CalcPercent.swift
@@ -4,6 +4,9 @@ import Foundation
 enum CalcPercent {
     static func evaluate(_ tokens: [CalcToken], query: String) -> CalcResult? {
         parseOff(tokens, query: query) ?? parseAsPercentOf(tokens, query: query)
+            ?? parseTip(tokens, query: query) ?? parseWhatPercentOf(tokens, query: query)
+            ?? parseIsPercentOfWhat(tokens, query: query) ?? parseRatio(tokens, query: query)
+            ?? parseAggregate(tokens, query: query) ?? parseRoundToNearest(tokens, query: query)
     }
 
     /// `<pct>% off <value>` → the value reduced by pct percent (`20% off 500` → 400).
@@ -36,5 +39,111 @@ enum CalcPercent {
             sourceBadge: "Expression",
             targetBadge: "Result",
             payload: .value(display: display, copyText: copy))
+    }
+
+    /// The tip alone, not the total: it is the number the phrase asks for.
+    private static func parseTip(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard let tip = tokens.firstIndex(of: .ident("tip")), tip >= 2,
+            tokens[tip - 1] == .op("%"), tip + 1 < tokens.count,
+            tokens[tip + 1] == .ident("on") || tokens[tip + 1] == .ident("of"),
+            let pct = CalcParser.evaluate(Array(tokens[0..<(tip - 1)])),
+            let bill = CalcParser.evaluate(Array(tokens[(tip + 2)...]))
+        else { return nil }
+        let amount = bill * pct / 100
+        guard amount.isFinite else { return nil }
+        return card(query, CalcFormatter.display(amount), CalcFormatter.copyText(amount))
+    }
+
+    private static func parseWhatPercentOf(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard let isIdx = tokens.firstIndex(of: .ident("is")), isIdx + 3 < tokens.count,
+            tokens[isIdx + 1] == .ident("what"), tokens[isIdx + 2] == .op("%"),
+            tokens[isIdx + 3] == .ident("of"),
+            let x = CalcParser.evaluate(Array(tokens[0..<isIdx])),
+            let y = CalcParser.evaluate(Array(tokens[(isIdx + 4)...])), y != 0
+        else { return nil }
+        let ratio = x / y * 100
+        guard ratio.isFinite else { return nil }
+        return card(query, "\(CalcFormatter.display(ratio))%", "\(CalcFormatter.copyText(ratio))%")
+    }
+
+    private static func parseIsPercentOfWhat(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard tokens.count >= 6, tokens.last == .ident("what"),
+            tokens[tokens.count - 2] == .ident("of"), tokens[tokens.count - 3] == .op("%"),
+            let isIdx = tokens.firstIndex(of: .ident("is")),
+            let x = CalcParser.evaluate(Array(tokens[0..<isIdx])),
+            let pct = CalcParser.evaluate(Array(tokens[(isIdx + 1)..<(tokens.count - 3)])),
+            pct != 0
+        else { return nil }
+        let whole = x / (pct / 100)
+        guard whole.isFinite else { return nil }
+        return card(query, CalcFormatter.display(whole), CalcFormatter.copyText(whole))
+    }
+
+    /// Integers only, so the reduced pair stays exact.
+    private static func parseRatio(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard tokens.count >= 5, tokens[0] == .ident("ratio"), tokens[1] == .ident("of"),
+            let toIdx = tokens.firstIndex(of: .ident("to")),
+            let a = CalcParser.evaluate(Array(tokens[2..<toIdx])),
+            let b = CalcParser.evaluate(Array(tokens[(toIdx + 1)...])),
+            a.rounded() == a, b.rounded() == b, abs(a) <= 1e15, abs(b) <= 1e15, a != 0 || b != 0
+        else { return nil }
+        let divisor = greatestCommonDivisor(abs(a), abs(b))
+        guard divisor > 0 else { return nil }
+        let text = "\(CalcFormatter.display(a / divisor)) : \(CalcFormatter.display(b / divisor))"
+        return card(query, text, text)
+    }
+
+    private static func greatestCommonDivisor(_ a: Double, _ b: Double) -> Double {
+        var (x, y) = (a, b)
+        while y > 0 { (x, y) = (y, x.truncatingRemainder(dividingBy: y)) }
+        return x
+    }
+
+    private static func parseAggregate(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard tokens.count >= 3, case .ident(let name) = tokens[0],
+            let reduce = aggregates[name], tokens[1] == .ident("of")
+        else { return nil }
+        let values = splitList(Array(tokens[2...]))
+        guard values.count >= 2, let result = reduce(values), result.isFinite else { return nil }
+        return card(query, CalcFormatter.display(result), CalcFormatter.copyText(result))
+    }
+
+    /// Snaps to a step, not to a digit count, so `nearest 5` means multiples of 5.
+    private static func parseRoundToNearest(_ tokens: [CalcToken], query: String) -> CalcResult? {
+        guard tokens.count >= 5, tokens[0] == .ident("round"),
+            let toIdx = tokens.firstIndex(of: .ident("to")), tokens[toIdx + 1] == .ident("nearest"),
+            let value = CalcParser.evaluate(Array(tokens[1..<toIdx])),
+            let step = CalcParser.evaluate(Array(tokens[(toIdx + 2)...])), step != 0
+        else { return nil }
+        let result = (value / step).rounded() * step
+        guard result.isFinite else { return nil }
+        return card(query, CalcFormatter.display(result), CalcFormatter.copyText(result))
+    }
+
+    private static let aggregates: [String: @Sendable ([Double]) -> Double?] = [
+        "average": { $0.reduce(0, +) / Double($0.count) },
+        "avg": { $0.reduce(0, +) / Double($0.count) },
+        "mean": { $0.reduce(0, +) / Double($0.count) },
+        "sum": { $0.reduce(0, +) },
+        "total": { $0.reduce(0, +) },
+        "min": { $0.min() }, "max": { $0.max() }
+    ]
+
+    /// Each run is evaluated whole, so `sum of 2*3, 4` stays two operands.
+    private static func splitList(_ tokens: [CalcToken]) -> [Double] {
+        var values: [Double] = []
+        var current: [CalcToken] = []
+        for token in tokens {
+            if token == .comma || token == .ident("and") {
+                guard let value = CalcParser.evaluate(current) else { return [] }
+                values.append(value)
+                current = []
+            } else {
+                current.append(token)
+            }
+        }
+        guard let last = CalcParser.evaluate(current) else { return [] }
+        values.append(last)
+        return values
     }
 }

--- a/Tinycast/Features/Calculator/Model/CalcPercent.swift
+++ b/Tinycast/Features/Calculator/Model/CalcPercent.swift
@@ -18,7 +18,9 @@ enum CalcPercent {
         else { return nil }
         let result = base * (1 - pct / 100)
         guard result.isFinite else { return nil }
-        return card(query, CalcFormatter.display(result), CalcFormatter.copyText(result))
+        return card(
+            query, CalcFormatter.display(result), CalcFormatter.copyText(result),
+            target: "Discounted")
     }
 
     /// `<x> as % of <y>` → x / y × 100, rendered as a percentage (`50 as % of 200` → 25%).
@@ -30,14 +32,18 @@ enum CalcPercent {
         else { return nil }
         let ratio = x / y * 100
         guard ratio.isFinite else { return nil }
-        return card(query, "\(CalcFormatter.display(ratio))%", "\(CalcFormatter.copyText(ratio))%")
+        return card(
+            query, "\(CalcFormatter.display(ratio))%", "\(CalcFormatter.copyText(ratio))%",
+            target: "Percentage")
     }
 
-    private static func card(_ query: String, _ display: String, _ copy: String) -> CalcResult {
+    private static func card(
+        _ query: String, _ display: String, _ copy: String, target: String = "Result"
+    ) -> CalcResult {
         CalcResult(
             expression: query.split(whereSeparator: \.isWhitespace).joined(separator: " "),
             sourceBadge: "Expression",
-            targetBadge: "Result",
+            targetBadge: target,
             payload: .value(display: display, copyText: copy))
     }
 
@@ -51,7 +57,8 @@ enum CalcPercent {
         else { return nil }
         let amount = bill * pct / 100
         guard amount.isFinite else { return nil }
-        return card(query, CalcFormatter.display(amount), CalcFormatter.copyText(amount))
+        return card(
+            query, CalcFormatter.display(amount), CalcFormatter.copyText(amount), target: "Tip")
     }
 
     private static func parseWhatPercentOf(_ tokens: [CalcToken], query: String) -> CalcResult? {
@@ -63,7 +70,9 @@ enum CalcPercent {
         else { return nil }
         let ratio = x / y * 100
         guard ratio.isFinite else { return nil }
-        return card(query, "\(CalcFormatter.display(ratio))%", "\(CalcFormatter.copyText(ratio))%")
+        return card(
+            query, "\(CalcFormatter.display(ratio))%", "\(CalcFormatter.copyText(ratio))%",
+            target: "Percentage")
     }
 
     private static func parseIsPercentOfWhat(_ tokens: [CalcToken], query: String) -> CalcResult? {
@@ -76,7 +85,8 @@ enum CalcPercent {
         else { return nil }
         let whole = x / (pct / 100)
         guard whole.isFinite else { return nil }
-        return card(query, CalcFormatter.display(whole), CalcFormatter.copyText(whole))
+        return card(
+            query, CalcFormatter.display(whole), CalcFormatter.copyText(whole), target: "Total")
     }
 
     /// Integers only, so the reduced pair stays exact.
@@ -90,7 +100,7 @@ enum CalcPercent {
         let divisor = greatestCommonDivisor(abs(a), abs(b))
         guard divisor > 0 else { return nil }
         let text = "\(CalcFormatter.display(a / divisor)) : \(CalcFormatter.display(b / divisor))"
-        return card(query, text, text)
+        return card(query, text, text, target: "Ratio")
     }
 
     private static func greatestCommonDivisor(_ a: Double, _ b: Double) -> Double {
@@ -101,11 +111,14 @@ enum CalcPercent {
 
     private static func parseAggregate(_ tokens: [CalcToken], query: String) -> CalcResult? {
         guard tokens.count >= 3, case .ident(let name) = tokens[0],
-            let reduce = aggregates[name], tokens[1] == .ident("of")
+            let aggregate = aggregates[name], tokens[1] == .ident("of")
         else { return nil }
         let values = splitList(Array(tokens[2...]))
-        guard values.count >= 2, let result = reduce(values), result.isFinite else { return nil }
-        return card(query, CalcFormatter.display(result), CalcFormatter.copyText(result))
+        guard values.count >= 2, let result = aggregate.reduce(values), result.isFinite
+        else { return nil }
+        return card(
+            query, CalcFormatter.display(result), CalcFormatter.copyText(result),
+            target: aggregate.name)
     }
 
     /// Snaps to a step, not to a digit count, so `nearest 5` means multiples of 5.
@@ -117,16 +130,24 @@ enum CalcPercent {
         else { return nil }
         let result = (value / step).rounded() * step
         guard result.isFinite else { return nil }
-        return card(query, CalcFormatter.display(result), CalcFormatter.copyText(result))
+        return card(
+            query, CalcFormatter.display(result), CalcFormatter.copyText(result), target: "Rounded")
     }
 
-    private static let aggregates: [String: @Sendable ([Double]) -> Double?] = [
-        "average": { $0.reduce(0, +) / Double($0.count) },
-        "avg": { $0.reduce(0, +) / Double($0.count) },
-        "mean": { $0.reduce(0, +) / Double($0.count) },
-        "sum": { $0.reduce(0, +) },
-        "total": { $0.reduce(0, +) },
-        "min": { $0.min() }, "max": { $0.max() }
+    /// The badge names which reduction ran, so `min` and `max` are told apart on the card.
+    private struct Aggregate {
+        let name: String
+        let reduce: @Sendable ([Double]) -> Double?
+    }
+
+    private static let aggregates: [String: Aggregate] = [
+        "average": Aggregate(name: "Average") { $0.reduce(0, +) / Double($0.count) },
+        "avg": Aggregate(name: "Average") { $0.reduce(0, +) / Double($0.count) },
+        "mean": Aggregate(name: "Average") { $0.reduce(0, +) / Double($0.count) },
+        "sum": Aggregate(name: "Sum") { $0.reduce(0, +) },
+        "total": Aggregate(name: "Sum") { $0.reduce(0, +) },
+        "min": Aggregate(name: "Minimum") { $0.min() },
+        "max": Aggregate(name: "Maximum") { $0.max() }
     ]
 
     /// Each run is evaluated whole, so `sum of 2*3, 4` stays two operands.

--- a/Tinycast/Features/Calculator/Model/CalcPercent.swift
+++ b/Tinycast/Features/Calculator/Model/CalcPercent.swift
@@ -50,7 +50,7 @@ enum CalcPercent {
     /// The tip alone, not the total: it is the number the phrase asks for.
     private static func parseTip(_ tokens: [CalcToken], query: String) -> CalcResult? {
         guard let tip = tokens.firstIndex(of: .ident("tip")), tip >= 2,
-            tokens[tip - 1] == .op("%"), tip + 1 < tokens.count,
+            tip + 2 < tokens.count, tokens[tip - 1] == .op("%"),
             tokens[tip + 1] == .ident("on") || tokens[tip + 1] == .ident("of"),
             let pct = CalcParser.evaluate(Array(tokens[0..<(tip - 1)])),
             let bill = CalcParser.evaluate(Array(tokens[(tip + 2)...]))
@@ -62,7 +62,8 @@ enum CalcPercent {
     }
 
     private static func parseWhatPercentOf(_ tokens: [CalcToken], query: String) -> CalcResult? {
-        guard let isIdx = tokens.firstIndex(of: .ident("is")), isIdx + 3 < tokens.count,
+        guard let isIdx = tokens.firstIndex(of: .ident("is")), isIdx + 4 <= tokens.count,
+            isIdx + 3 < tokens.count,
             tokens[isIdx + 1] == .ident("what"), tokens[isIdx + 2] == .op("%"),
             tokens[isIdx + 3] == .ident("of"),
             let x = CalcParser.evaluate(Array(tokens[0..<isIdx])),
@@ -124,7 +125,8 @@ enum CalcPercent {
     /// Snaps to a step, not to a digit count, so `nearest 5` means multiples of 5.
     private static func parseRoundToNearest(_ tokens: [CalcToken], query: String) -> CalcResult? {
         guard tokens.count >= 5, tokens[0] == .ident("round"),
-            let toIdx = tokens.firstIndex(of: .ident("to")), tokens[toIdx + 1] == .ident("nearest"),
+            let toIdx = tokens.firstIndex(of: .ident("to")), toIdx + 2 < tokens.count,
+            tokens[toIdx + 1] == .ident("nearest"),
             let value = CalcParser.evaluate(Array(tokens[1..<toIdx])),
             let step = CalcParser.evaluate(Array(tokens[(toIdx + 2)...])), step != 0
         else { return nil }

--- a/Tinycast/Features/Calculator/Model/CalcQuantity.swift
+++ b/Tinycast/Features/Calculator/Model/CalcQuantity.swift
@@ -78,12 +78,14 @@ enum CalcQuantity {
         }
     }
 
-    /// Nil where converting says nothing: no region, an unknown one, or the currency already typed.
+    /// The Mac's own currency, except where that is the one written: converting is the only reason
+    /// to type a lone amount, so it pairs with the dollar there — the euro when the dollar is typed.
+    /// A region that resolves to nothing still names no target, which keeps the amount as written.
     private static func regionTarget(_ region: String?, from: CurrencyDef) -> CurrencyDef? {
-        guard let target = region.flatMap({ CalcCurrency.byName[$0.lowercased()] }),
-            target.code != from.code
+        guard let regional = region.flatMap({ CalcCurrency.byName[$0.lowercased()] })
         else { return nil }
-        return target
+        guard regional.code == from.code else { return regional }
+        return CalcCurrency.byName[from.code == "USD" ? "eur" : "usd"]
     }
 
     private static func convertedResult(

--- a/Tinycast/Features/Calculator/Model/CalcQuantity.swift
+++ b/Tinycast/Features/Calculator/Model/CalcQuantity.swift
@@ -214,6 +214,8 @@ enum CalcQuantity {
                 if op == "-" || op == "+" { attachNext = isSign(at: index, tokens) }
             case .arrow:
                 add("→")
+            case .comma:
+                add(",", attached: true)
             }
             index += 1
         }
@@ -280,6 +282,12 @@ private struct QuantityParser {
 
     private mutating func parseExpression(minBindingPower: Int) -> QuantityValue? {
         guard var left = parseOperand() else { return nil }
+        if let target = peekAdditiveConversion() {
+            position += 2
+            operationCount += 1
+            guard let converted = converted(left, to: target) else { return nil }
+            left = converted
+        }
         while let binary = peekBinary(left: left), binary.bindingPower >= minBindingPower {
             if binary.consumesToken { position += 1 }
             operationCount += 1
@@ -291,6 +299,16 @@ private struct QuantityParser {
             left = combined
         }
         return left
+    }
+
+    /// A mid-expression `to` only when `+`/`-` follows it: `to usd * 30` stays genuinely ambiguous.
+    private func peekAdditiveConversion() -> String? {
+        guard position + 2 < tokens.count, CalcUnits.isConnector(tokens[position]),
+            case .ident(let name) = tokens[position + 1],
+            CalcUnits.byName[name] != nil || CalcCurrency.byName[name] != nil,
+            case .op(let next) = tokens[position + 2], next == "+" || next == "-"
+        else { return nil }
+        return name
     }
 
     /// An operator, its binding power, its right operand's minimum, and whether it consumes.

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -6,6 +6,8 @@ enum CalcTimeZone {
         let query = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty, query.count <= 128 else { return nil }
 
+        if let difference = offsetBetween(query, now: now, calendar: calendar) { return difference }
+
         // A trailing `± <n> <unit>` shifts the answer, so `5pm ldn in sf + 2h` is still one query.
         let (zoneQuery, offset) = splitOffset(query)
         let words = zoneQuery.split(whereSeparator: \.isWhitespace).map(String.init)
@@ -15,10 +17,27 @@ enum CalcTimeZone {
         guard let connector = words.lastIndex(where: { $0 == "in" || $0 == "to" || $0 == "at" })
         else { return nil }
         let targetWords = Array(words[(connector + 1)...])
-        guard !targetWords.isEmpty, let target = zone(named: targetWords) else { return nil }
+        guard !targetWords.isEmpty else { return nil }
+
+        // `time in 4 hours` names a duration where a zone would go, so the home zone answers.
+        let target: TimeZone
+        var ahead: (count: Int, component: Calendar.Component)?
+        if let zone = zone(named: targetWords) {
+            target = zone
+        } else if let duration = parseDuration(targetWords.joined(separator: " ")) {
+            target = calendar.timeZone
+            ahead = duration
+        } else {
+            return nil
+        }
 
         let leading = Array(words[0..<connector])
         guard var source = sourceMoment(leading, now: now, calendar: calendar) else { return nil }
+        if let ahead {
+            guard let shifted = calendar.date(byAdding: ahead.component, value: ahead.count, to: source.date)
+            else { return nil }
+            source = SourceMoment(date: shifted, zone: source.zone)
+        }
         if let offset {
             guard let shifted = calendar.date(byAdding: offset.component, value: offset.count, to: source.date)
             else { return nil }
@@ -72,10 +91,48 @@ enum CalcTimeZone {
         let zone: TimeZone
     }
 
+    /// `diff paris`, `time diff paris` — how far a zone runs from the Mac's own.
+    private static func offsetBetween(
+        _ query: String, now: Date, calendar: Calendar
+    ) -> CalcResult? {
+        var words = query.split(whereSeparator: \.isWhitespace).map(String.init)
+        if words.first == "time" { words.removeFirst() }
+        guard words.count >= 2, words[0] == "diff" || words[0] == "difference",
+            let target = zone(named: Array(words.dropFirst()))
+        else { return nil }
+
+        let home = calendar.timeZone
+        let minutes =
+            (target.secondsFromGMT(for: now) - home.secondsFromGMT(for: now)) / 60
+        let sign = minutes < 0 ? "-" : "+"
+        let whole = abs(minutes) / 60
+        let part = abs(minutes) % 60
+        let text = part == 0 ? "\(sign)\(whole)h" : "\(sign)\(whole)h \(part)m"
+
+        return CalcResult(
+            expression: clockString(now, zone: home, calendar: calendar),
+            sourceBadge: label(for: home),
+            targetBadge: label(for: target),
+            payload: .value(
+                display: "\(clockString(now, zone: target, calendar: calendar)) (\(text))",
+                copyText: text))
+    }
+
     private static func sourceMoment(
         _ words: [String], now: Date, calendar: Calendar
     ) -> SourceMoment? {
-        let words = words.filter { !["what", "whats", "the", "is", "it", "current"].contains($0) }
+        var words = words.filter { !["what", "whats", "the", "is", "it", "current"].contains($0) }
+
+        // `time in 4 hours in sf`: the leading half carries its own `in <duration>`.
+        var ahead: (count: Int, component: Calendar.Component)?
+        if let connector = words.lastIndex(where: { $0 == "in" || $0 == "at" }),
+            connector + 1 < words.count,
+            let duration = parseDuration(words[(connector + 1)...].joined(separator: " "))
+        {
+            ahead = duration
+            words = Array(words[0..<connector])
+        }
+
         guard let head = words.first else { return nil }
         guard head == "time" || head == "now" || head == "clock" || parseClock(head) != nil else {
             return nil
@@ -85,7 +142,10 @@ enum CalcTimeZone {
         let zone = rest.isEmpty ? calendar.timeZone : (self.zone(named: rest) ?? calendar.timeZone)
         if head == "time" || head == "now" || head == "clock" {
             guard rest.isEmpty || self.zone(named: rest) != nil else { return nil }
-            return SourceMoment(date: now, zone: zone)
+            guard let ahead else { return SourceMoment(date: now, zone: zone) }
+            guard let shifted = calendar.date(byAdding: ahead.component, value: ahead.count, to: now)
+            else { return nil }
+            return SourceMoment(date: shifted, zone: zone)
         }
 
         guard let clock = parseClock(head) else { return nil }
@@ -100,7 +160,10 @@ enum CalcTimeZone {
         components.minute = clock.minute
         components.timeZone = zone
         guard let date = source.date(from: components) else { return nil }
-        return SourceMoment(date: date, zone: zone)
+        guard let ahead else { return SourceMoment(date: date, zone: zone) }
+        guard let shifted = source.date(byAdding: ahead.component, value: ahead.count, to: date)
+        else { return nil }
+        return SourceMoment(date: shifted, zone: zone)
     }
 
     private static func parseClock(_ word: String) -> (hour: Int, minute: Int)? {
@@ -127,7 +190,9 @@ enum CalcTimeZone {
     }
 
     private static func zone(named words: [String]) -> TimeZone? {
+        // `são paulo` and `zürich` are how the cities are spelled; the identifiers are not.
         let phrase = words.joined(separator: " ")
+            .folding(options: [.diacriticInsensitive], locale: nil)
         if let identifier = aliases[phrase] { return TimeZone(identifier: identifier) }
         guard let identifier = cities[phrase] else { return nil }
         return TimeZone(identifier: identifier)

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -3,8 +3,10 @@ import Foundation
 /// Clock time in another city. See docs/features/calculator.md.
 enum CalcTimeZone {
     static func evaluate(_ raw: String, now: Date, calendar: Calendar) -> CalcResult? {
+        // Every grammar is at least two words, so a one-word app search stops before allocating.
+        guard raw.count <= 128, raw.contains(" ") else { return nil }
         let query = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty, query.count <= 128 else { return nil }
+        guard !query.isEmpty else { return nil }
 
         if let difference = offsetBetween(query, now: now, calendar: calendar) { return difference }
 
@@ -286,12 +288,7 @@ enum CalcTimeZone {
     }
 
     private static func clockString(_ date: Date, zone: TimeZone, calendar: Calendar) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.timeZone = zone
-        formatter.locale = calendar.locale ?? Locale(identifier: "en_US")
-        formatter.dateFormat = "h:mm a"
-        return formatter.string(from: date)
+        CalcDateFormatters.string(from: date, calendar: calendar, zone: zone, pattern: "h:mm a")
     }
 
     private static func dayOffsetWord(

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -3,8 +3,11 @@ import Foundation
 /// Clock time in another city. See docs/features/calculator.md.
 enum CalcTimeZone {
     static func evaluate(_ raw: String, now: Date, calendar: Calendar) -> CalcResult? {
-        // Every grammar is at least two words, so a one-word app search stops before allocating.
-        guard raw.count <= 128, raw.contains(" ") else { return nil }
+        // Every grammar carries a connector or `diff`, so an app search stops before allocating.
+        // Any whitespace, not just a space: a pasted NBSP still separates the words downstream.
+        guard raw.count <= 128, raw.contains(where: \.isWhitespace), hasConnector(raw) else {
+            return nil
+        }
         let query = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return nil }
 
@@ -96,6 +99,22 @@ enum CalcTimeZone {
         let date: Date
         let zone: TimeZone
     }
+
+    /// Scans for a whole-word connector without lowercasing or splitting the whole query first.
+    private static func hasConnector(_ raw: String) -> Bool {
+        var word = ""
+        for character in raw {
+            if character.isWhitespace {
+                if Self.connectors.contains(word.lowercased()) { return true }
+                word = ""
+            } else {
+                word.append(character)
+            }
+        }
+        return Self.connectors.contains(word.lowercased())
+    }
+
+    private static let connectors: Set<String> = ["in", "to", "at", "diff", "difference"]
 
     /// `diff paris`, `time diff paris` — how far a zone runs from the Mac's own.
     private static func offsetBetween(

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -66,7 +66,7 @@ enum CalcTimeZone {
         for separator in [" + ", " - "] {
             guard let range = query.range(of: separator, options: .backwards) else { continue }
             let tail = String(query[range.upperBound...])
-            guard let duration = parseDuration(tail) else { continue }
+            guard let duration = parseDuration(tail, impliesHours: true) else { continue }
             let sign = separator == " - " ? -1 : 1
             return (String(query[..<range.lowerBound]), (duration.count * sign, duration.component))
         }
@@ -74,7 +74,9 @@ enum CalcTimeZone {
     }
 
     /// `2h`, `90 min`, `2 hours` — sub-day only, since a zone answer is a clock time.
-    private static func parseDuration(_ text: String) -> (count: Int, component: Calendar.Component)? {
+    private static func parseDuration(
+        _ text: String, impliesHours: Bool = false
+    ) -> (count: Int, component: Calendar.Component)? {
         let compact = text.replacingOccurrences(of: " ", with: "")
         let digits = compact.prefix { $0.isNumber }
         guard let count = Int(digits), count < 100_000 else { return nil }
@@ -82,6 +84,8 @@ enum CalcTimeZone {
         case "h", "hr", "hrs", "hour", "hours": return (count, .hour)
         case "m", "min", "mins", "minute", "minutes": return (count, .minute)
         case "s", "sec", "secs", "second", "seconds": return (count, .second)
+        // A clock answer makes hours the only sensible unit for a bare `+ 5`.
+        case "" where impliesHours: return (count, .hour)
         default: return nil
         }
     }

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -48,7 +48,8 @@ enum CalcTimeZone {
             source = SourceMoment(date: shifted, zone: source.zone)
         }
         if let offset {
-            guard let shifted = calendar.date(byAdding: offset.component, value: offset.count, to: source.date)
+            guard
+                let shifted = calendar.date(byAdding: offset.component, value: offset.count, to: source.date)
             else { return nil }
             source = SourceMoment(date: shifted, zone: source.zone)
         }

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -182,7 +182,8 @@ enum CalcTimeZone {
         guard !text.isEmpty else { return nil }
 
         let parts = text.split(separator: ":", maxSplits: 1).map(String.init)
-        guard let hour = Int(parts[0]) else { return nil }
+        // A lone ":" splits to nothing, so the first part is not guaranteed to exist.
+        guard let first = parts.first, let hour = Int(first) else { return nil }
         let minute = parts.count > 1 ? Int(parts[1]) : 0
         guard let minute, (0...59).contains(minute) else { return nil }
 

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -8,6 +8,10 @@ enum CalcTimeZone {
         guard raw.count <= 128, raw.contains(where: \.isWhitespace), hasConnector(raw) else {
             return nil
         }
+        // `10 km to mi` also carries a connector, so the last word decides before anything else:
+        // a zone name or a duration is the only thing this grammar can end in.
+        guard endsInZoneOrDuration(raw) else { return nil }
+
         let query = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return nil }
 
@@ -99,6 +103,46 @@ enum CalcTimeZone {
         let date: Date
         let zone: TimeZone
     }
+
+    /// The tail names a zone or a duration, checked before the query is trimmed, lowercased and
+    /// split — which is what keeps a unit conversion like `10 km to mi` out of the zone path.
+    private static func endsInZoneOrDuration(_ raw: String) -> Bool {
+        var tail = ""
+        for character in raw.reversed() {
+            if character.isWhitespace {
+                if !tail.isEmpty { break }
+                continue
+            }
+            tail.insert(Character(character.lowercased()), at: tail.startIndex)
+        }
+        guard !tail.isEmpty else { return false }
+        // Folded, because the identifiers carry no accents while `zürich` and `são paulo` do.
+        let folded = tail.folding(options: [.diacriticInsensitive], locale: nil)
+        if cities[folded] != nil || aliases[folded] != nil { return true }
+        // `time in 4 hours` ends in the unit alone, so a bare unit word counts as a duration tail.
+        if durationUnits.contains(folded) || parseDuration(folded, impliesHours: true) != nil {
+            return true
+        }
+        // A multi-word city ("new york") only shows its last word here, so allow a known suffix.
+        return citySuffixes.contains(folded)
+    }
+
+    private static let durationUnits: Set<String> = [
+        "h", "hr", "hrs", "hour", "hours", "m", "min", "mins", "minute", "minutes",
+        "s", "sec", "secs", "second", "seconds"
+    ]
+
+    /// The final word of every multi-word name in either table, so `in new york` still reaches it.
+    private static let citySuffixes: Set<String> = {
+        var tails: Set<String> = []
+        for name in cities.keys where name.contains(" ") {
+            if let last = name.split(separator: " ").last { tails.insert(String(last)) }
+        }
+        for name in aliases.keys where name.contains(" ") {
+            if let last = name.split(separator: " ").last { tails.insert(String(last)) }
+        }
+        return tails
+    }()
 
     /// Scans for a whole-word connector without lowercasing or splitting the whole query first.
     private static func hasConnector(_ raw: String) -> Bool {

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -6,7 +6,9 @@ enum CalcTimeZone {
         let query = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty, query.count <= 128 else { return nil }
 
-        let words = query.split(whereSeparator: \.isWhitespace).map(String.init)
+        // A trailing `± <n> <unit>` shifts the answer, so `5pm ldn in sf + 2h` is still one query.
+        let (zoneQuery, offset) = splitOffset(query)
+        let words = zoneQuery.split(whereSeparator: \.isWhitespace).map(String.init)
         guard words.count >= 2 else { return nil }
 
         // Every grammar needs a connector, so an app search never touches the zone table.
@@ -16,7 +18,12 @@ enum CalcTimeZone {
         guard !targetWords.isEmpty, let target = zone(named: targetWords) else { return nil }
 
         let leading = Array(words[0..<connector])
-        guard let source = sourceMoment(leading, now: now, calendar: calendar) else { return nil }
+        guard var source = sourceMoment(leading, now: now, calendar: calendar) else { return nil }
+        if let offset {
+            guard let shifted = calendar.date(byAdding: offset.component, value: offset.count, to: source.date)
+            else { return nil }
+            source = SourceMoment(date: shifted, zone: source.zone)
+        }
 
         var display = calendar
         display.timeZone = target
@@ -31,6 +38,33 @@ enum CalcTimeZone {
             sourceBadge: label(for: source.zone),
             targetBadge: label(for: target),
             payload: .value(display: time + dayNote, copyText: time))
+    }
+
+    /// Splits a trailing `+ 2h` / `- 30 min` off the zone phrase it shifts.
+    private static func splitOffset(
+        _ query: String
+    ) -> (String, (count: Int, component: Calendar.Component)?) {
+        for separator in [" + ", " - "] {
+            guard let range = query.range(of: separator, options: .backwards) else { continue }
+            let tail = String(query[range.upperBound...])
+            guard let duration = parseDuration(tail) else { continue }
+            let sign = separator == " - " ? -1 : 1
+            return (String(query[..<range.lowerBound]), (duration.count * sign, duration.component))
+        }
+        return (query, nil)
+    }
+
+    /// `2h`, `90 min`, `2 hours` — sub-day only, since a zone answer is a clock time.
+    private static func parseDuration(_ text: String) -> (count: Int, component: Calendar.Component)? {
+        let compact = text.replacingOccurrences(of: " ", with: "")
+        let digits = compact.prefix { $0.isNumber }
+        guard let count = Int(digits), count < 100_000 else { return nil }
+        switch String(compact.dropFirst(digits.count)) {
+        case "h", "hr", "hrs", "hour", "hours": return (count, .hour)
+        case "m", "min", "mins", "minute", "minutes": return (count, .minute)
+        case "s", "sec", "secs", "second", "seconds": return (count, .second)
+        default: return nil
+        }
     }
 
     private struct SourceMoment {

--- a/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
+++ b/Tinycast/Features/Calculator/Model/CalcTimeZone.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// Clock time in another city. See docs/features/calculator.md.
+enum CalcTimeZone {
+    static func evaluate(_ raw: String, now: Date, calendar: Calendar) -> CalcResult? {
+        let query = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty, query.count <= 128 else { return nil }
+
+        let words = query.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard words.count >= 2 else { return nil }
+
+        // Every grammar needs a connector, so an app search never touches the zone table.
+        guard let connector = words.lastIndex(where: { $0 == "in" || $0 == "to" || $0 == "at" })
+        else { return nil }
+        let targetWords = Array(words[(connector + 1)...])
+        guard !targetWords.isEmpty, let target = zone(named: targetWords) else { return nil }
+
+        let leading = Array(words[0..<connector])
+        guard let source = sourceMoment(leading, now: now, calendar: calendar) else { return nil }
+
+        var display = calendar
+        display.timeZone = target
+        let sameDay =
+            calendar.dateComponents(in: source.zone, from: source.date).day
+            == display.dateComponents(in: target, from: source.date).day
+        let time = clockString(source.date, zone: target, calendar: calendar)
+        let dayNote = sameDay ? "" : " (\(dayOffsetWord(source, target: target, calendar: calendar)))"
+
+        return CalcResult(
+            expression: clockString(source.date, zone: source.zone, calendar: calendar),
+            sourceBadge: label(for: source.zone),
+            targetBadge: label(for: target),
+            payload: .value(display: time + dayNote, copyText: time))
+    }
+
+    private struct SourceMoment {
+        let date: Date
+        let zone: TimeZone
+    }
+
+    private static func sourceMoment(
+        _ words: [String], now: Date, calendar: Calendar
+    ) -> SourceMoment? {
+        let words = words.filter { !["what", "whats", "the", "is", "it", "current"].contains($0) }
+        guard let head = words.first else { return nil }
+        guard head == "time" || head == "now" || head == "clock" || parseClock(head) != nil else {
+            return nil
+        }
+
+        let rest = Array(words.dropFirst())
+        let zone = rest.isEmpty ? calendar.timeZone : (self.zone(named: rest) ?? calendar.timeZone)
+        if head == "time" || head == "now" || head == "clock" {
+            guard rest.isEmpty || self.zone(named: rest) != nil else { return nil }
+            return SourceMoment(date: now, zone: zone)
+        }
+
+        guard let clock = parseClock(head) else { return nil }
+        var source = calendar
+        source.timeZone = zone
+        let day = source.dateComponents([.year, .month, .day], from: now)
+        var components = DateComponents()
+        components.year = day.year
+        components.month = day.month
+        components.day = day.day
+        components.hour = clock.hour
+        components.minute = clock.minute
+        components.timeZone = zone
+        guard let date = source.date(from: components) else { return nil }
+        return SourceMoment(date: date, zone: zone)
+    }
+
+    private static func parseClock(_ word: String) -> (hour: Int, minute: Int)? {
+        var text = word
+        var meridiem: String?
+        for suffix in ["am", "pm"] where text.hasSuffix(suffix) {
+            meridiem = suffix
+            text.removeLast(2)
+        }
+        guard !text.isEmpty else { return nil }
+
+        let parts = text.split(separator: ":", maxSplits: 1).map(String.init)
+        guard let hour = Int(parts[0]) else { return nil }
+        let minute = parts.count > 1 ? Int(parts[1]) : 0
+        guard let minute, (0...59).contains(minute) else { return nil }
+
+        guard let meridiem else {
+            // A bare number is a search ("time in 5"), so only a written clock qualifies.
+            guard text.contains(":"), (0...23).contains(hour) else { return nil }
+            return (hour, minute)
+        }
+        guard (1...12).contains(hour) else { return nil }
+        return (meridiem == "pm" ? (hour % 12) + 12 : hour % 12, minute)
+    }
+
+    private static func zone(named words: [String]) -> TimeZone? {
+        let phrase = words.joined(separator: " ")
+        if let identifier = aliases[phrase] { return TimeZone(identifier: identifier) }
+        guard let identifier = cities[phrase] else { return nil }
+        return TimeZone(identifier: identifier)
+    }
+
+    /// Foundation already carries the IANA database, so nothing here is generated.
+    private static let cities: [String: String] = {
+        var table: [String: String] = [:]
+        for identifier in TimeZone.knownTimeZoneIdentifiers {
+            guard let city = identifier.split(separator: "/").last else { continue }
+            table[city.replacingOccurrences(of: "_", with: " ").lowercased()] = identifier
+        }
+        return table
+    }()
+
+    /// `TimeZone.abbreviationDictionary` is unusable here: its `BDT` is the Bangladeshi taka.
+    /// IATA codes are Foundation-less by nature, so the airport half is a curated product choice.
+    private static let aliases: [String: String] = [
+        "utc": "UTC", "gmt": "GMT", "zulu": "UTC",
+        "est": "America/New_York", "edt": "America/New_York", "et": "America/New_York",
+        "cst": "America/Chicago", "cdt": "America/Chicago", "ct": "America/Chicago",
+        "mst": "America/Denver", "mdt": "America/Denver", "mt": "America/Denver",
+        "pst": "America/Los_Angeles", "pdt": "America/Los_Angeles", "pt": "America/Los_Angeles",
+        "cet": "Europe/Paris", "cest": "Europe/Paris", "bst": "Europe/London",
+        "ist": "Asia/Kolkata", "jst": "Asia/Tokyo", "kst": "Asia/Seoul",
+        "aest": "Australia/Sydney", "aedt": "Australia/Sydney",
+        "nyc": "America/New_York", "new york city": "America/New_York",
+        "la": "America/Los_Angeles", "sf": "America/Los_Angeles",
+        "san francisco": "America/Los_Angeles", "silicon valley": "America/Los_Angeles",
+        "seattle": "America/Los_Angeles", "boston": "America/New_York",
+        "washington": "America/New_York", "dc": "America/New_York",
+        "austin": "America/Chicago", "dallas": "America/Chicago", "houston": "America/Chicago",
+        "miami": "America/New_York", "atlanta": "America/New_York",
+        "philadelphia": "America/New_York", "las vegas": "America/Los_Angeles",
+        "ldn": "Europe/London", "sfo": "America/Los_Angeles", "lax": "America/Los_Angeles",
+        "jfk": "America/New_York", "sgp": "Asia/Singapore",
+        "kolkata": "Asia/Kolkata", "bengaluru": "Asia/Kolkata",
+        "bangalore": "Asia/Kolkata", "mumbai": "Asia/Kolkata", "delhi": "Asia/Kolkata",
+        "new delhi": "Asia/Kolkata", "chennai": "Asia/Kolkata", "hyderabad": "Asia/Kolkata",
+        "saigon": "Asia/Ho_Chi_Minh", "hcmc": "Asia/Ho_Chi_Minh",
+        "munich": "Europe/Berlin", "frankfurt": "Europe/Berlin", "hamburg": "Europe/Berlin",
+        "cologne": "Europe/Berlin", "milan": "Europe/Rome", "barcelona": "Europe/Madrid",
+        "geneva": "Europe/Zurich", "st petersburg": "Europe/Moscow",
+        "kyiv": "Europe/Kyiv", "tel aviv": "Asia/Tel_Aviv", "osaka": "Asia/Tokyo",
+        "kyoto": "Asia/Tokyo", "shenzhen": "Asia/Shanghai", "beijing": "Asia/Shanghai",
+        "guangzhou": "Asia/Shanghai", "melbourne": "Australia/Melbourne",
+        "brisbane": "Australia/Brisbane", "perth": "Australia/Perth",
+        "rio": "America/Sao_Paulo", "rio de janeiro": "America/Sao_Paulo",
+        "cdmx": "America/Mexico_City", "mexico city": "America/Mexico_City",
+        // IATA airport codes. `MAD` is omitted: it is the Moroccan dirham, and money wins.
+        "vie": "Europe/Vienna", "lhr": "Europe/London", "lgw": "Europe/London",
+        "cdg": "Europe/Paris", "ory": "Europe/Paris", "fra": "Europe/Berlin",
+        "muc": "Europe/Berlin", "txl": "Europe/Berlin", "ber": "Europe/Berlin",
+        "ams": "Europe/Amsterdam", "bcn": "Europe/Madrid", "zrh": "Europe/Zurich",
+        "gva": "Europe/Zurich", "cph": "Europe/Copenhagen", "osl": "Europe/Oslo",
+        "arn": "Europe/Stockholm", "hel": "Europe/Helsinki", "dub": "Europe/Dublin",
+        "lis": "Europe/Lisbon", "ath": "Europe/Athens", "prg": "Europe/Prague",
+        "waw": "Europe/Warsaw", "bud": "Europe/Budapest",
+        "svo": "Europe/Moscow", "led": "Europe/Moscow", "fco": "Europe/Rome",
+        "mxp": "Europe/Rome", "bru": "Europe/Brussels",
+        "dxb": "Asia/Dubai", "auh": "Asia/Dubai", "doh": "Asia/Qatar",
+        "bom": "Asia/Kolkata", "del": "Asia/Kolkata", "blr": "Asia/Kolkata",
+        "hkg": "Asia/Hong_Kong", "pvg": "Asia/Shanghai", "pek": "Asia/Shanghai",
+        "icn": "Asia/Seoul", "nrt": "Asia/Tokyo", "hnd": "Asia/Tokyo",
+        "kix": "Asia/Tokyo", "sin": "Asia/Singapore", "bkk": "Asia/Bangkok",
+        "kul": "Asia/Kuala_Lumpur", "cgk": "Asia/Jakarta", "mnl": "Asia/Manila",
+        "tlv": "Asia/Tel_Aviv",
+        "syd": "Australia/Sydney", "mel": "Australia/Melbourne",
+        "bne": "Australia/Brisbane", "per": "Australia/Perth", "akl": "Pacific/Auckland",
+        "yyz": "America/Toronto", "yvr": "America/Vancouver", "yul": "America/Toronto",
+        "ord": "America/Chicago", "dfw": "America/Chicago", "iah": "America/Chicago",
+        "atl": "America/New_York", "sea": "America/Los_Angeles", "den": "America/Denver",
+        "bos": "America/New_York", "mia": "America/New_York", "phx": "America/Phoenix",
+        "ewr": "America/New_York", "iad": "America/New_York",
+        "gru": "America/Sao_Paulo", "eze": "America/Argentina/Buenos_Aires",
+        "scl": "America/Santiago", "bog": "America/Bogota", "lim": "America/Lima",
+        "mex": "America/Mexico_City",
+        "jnb": "Africa/Johannesburg", "cpt": "Africa/Johannesburg", "cai": "Africa/Cairo",
+        "nbo": "Africa/Nairobi", "los": "Africa/Lagos", "cmn": "Africa/Casablanca"
+    ]
+
+    /// Not `localizedName`, which needs a `Locale` — banned in `Model/`.
+    private static func label(for zone: TimeZone) -> String {
+        if zone.identifier == "GMT" || zone.identifier == "UTC" { return "UTC" }
+        guard let city = zone.identifier.split(separator: "/").last else { return zone.identifier }
+        return city.replacingOccurrences(of: "_", with: " ")
+    }
+
+    private static func clockString(_ date: Date, zone: TimeZone, calendar: Calendar) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = zone
+        formatter.locale = calendar.locale ?? Locale(identifier: "en_US")
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: date)
+    }
+
+    private static func dayOffsetWord(
+        _ source: SourceMoment, target: TimeZone, calendar: Calendar
+    ) -> String {
+        var here = calendar
+        here.timeZone = source.zone
+        var there = calendar
+        there.timeZone = target
+        let from = here.startOfDay(for: source.date)
+        let to = there.startOfDay(for: source.date)
+        return to < from ? "yesterday" : "tomorrow"
+    }
+}

--- a/Tinycast/Features/Calculator/Model/CalcUnits.swift
+++ b/Tinycast/Features/Calculator/Model/CalcUnits.swift
@@ -128,6 +128,7 @@ enum CalcUnits {
         // Time
         "ms": ("s", false), "s": ("ms", false), "min": ("s", false), "hr": ("min", false),
         "day": ("hr", false), "week": ("day", false),
+        "workdays": ("hr", false),
         // Area
         "mm²": ("in2", false), "cm²": ("in2", false), "m²": ("ft2", false), "km²": ("mi2", false),
         "in²": ("cm2", false), "ft²": ("m2", false), "yd²": ("m2", false), "mi²": ("km2", false),
@@ -203,6 +204,10 @@ enum CalcUnits {
         add(UnitDef("hr", "Hours", .time, 3600), ["h", "hr", "hrs", "hour", "hours"])
         add(UnitDef("day", "Days", .time, 86400), ["d", "day", "days"])
         add(UnitDef("week", "Weeks", .time, 604800), ["wk", "week", "weeks"])
+        // 8 hours; weekends and holidays would need a calendar, and a calculator must not ask.
+        add(
+            UnitDef("workdays", "Workdays", .time, 28800),
+            ["workday", "workdays", "businessday", "businessdays"])
 
         // Area (base: square meter). The tokenizer folds "²" to "2", so mm²/mm2 are one name.
         add(UnitDef("mm²", "Square Millimeters", .area, 1e-6), ["mm2", "sqmm"])
@@ -260,12 +265,15 @@ enum CalcUnits {
         add(UnitDef("arcsec", "Arcseconds", .angle, .pi / 648000), ["arcsec", "arcsecond", "arcseconds"])
         add(UnitDef("turn", "Turns", .angle, 2 * .pi), ["turn", "turns", "rev", "revolution", "revolutions"])
 
-        // Speed (base: meter/second) — slash-free aliases; symbols keep the pretty "/".
-        add(UnitDef("m/s", "Meters per Second", .speed, 1), ["mps"])
-        add(UnitDef("km/h", "Kilometers per Hour", .speed, 1000.0 / 3600), ["kmh", "kph"])
-        add(UnitDef("mph", "Miles per Hour", .speed, 1609.344 / 3600), ["mph"])
-        add(UnitDef("ft/s", "Feet per Second", .speed, 0.3048), ["fps"])
+        // Speed (base: meter/second) — the tokenizer keeps a slashed spelling whole, so it's a name.
+        add(UnitDef("m/s", "Meters per Second", .speed, 1), ["mps", "m/s", "m/sec"])
+        add(
+            UnitDef("km/h", "Kilometers per Hour", .speed, 1000.0 / 3600),
+            ["kmh", "kph", "km/h", "km/hr", "kmph"])
+        add(UnitDef("mph", "Miles per Hour", .speed, 1609.344 / 3600), ["mph", "mi/h", "mi/hr"])
+        add(UnitDef("ft/s", "Feet per Second", .speed, 0.3048), ["fps", "ft/s", "ft/sec"])
         add(UnitDef("kn", "Knots", .speed, 1852.0 / 3600), ["kn", "knot", "knots"])
+        add(UnitDef("km/s", "Kilometers per Second", .speed, 1000), ["km/s", "km/sec"])
 
         // Pressure (base: pascal)
         add(UnitDef("Pa", "Pascals", .pressure, 1), ["pa", "pascal", "pascals"])
@@ -280,10 +288,10 @@ enum CalcUnits {
 
         // Data transfer rate (base: bit/second) — SI (1000ⁿ) bit rates.
         add(UnitDef("bps", "Bits per Second", .dataRate, 1), ["bps"])
-        add(UnitDef("Kbps", "Kilobits per Second", .dataRate, 1e3), ["kbps"])
-        add(UnitDef("Mbps", "Megabits per Second", .dataRate, 1e6), ["mbps"])
-        add(UnitDef("Gbps", "Gigabits per Second", .dataRate, 1e9), ["gbps"])
-        add(UnitDef("Tbps", "Terabits per Second", .dataRate, 1e12), ["tbps"])
+        add(UnitDef("Kbps", "Kilobits per Second", .dataRate, 1e3), ["kbps", "kbit/s", "kb/s"])
+        add(UnitDef("Mbps", "Megabits per Second", .dataRate, 1e6), ["mbps", "mbit/s", "mb/s"])
+        add(UnitDef("Gbps", "Gigabits per Second", .dataRate, 1e9), ["gbps", "gbit/s", "gb/s"])
+        add(UnitDef("Tbps", "Terabits per Second", .dataRate, 1e12), ["tbps", "tbit/s", "tb/s"])
 
         return table
     }()

--- a/Tinycast/Features/Calculator/UI/CalculatorCardView.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorCardView.swift
@@ -149,6 +149,11 @@ enum CalcActionsMenu {
             items: [
                 PopoverMenuItem(title: "Copy Answer", systemImage: "doc.on.doc", shortcut: "↵") {
                     core.calculatorCoordinator.copyCalculatorResult(result)
+                },
+                PopoverMenuItem(
+                    title: "Copy Calculation", systemImage: "doc.on.doc.fill", shortcut: "⇧⌘↵"
+                ) {
+                    core.calculatorCoordinator.copyCalculationWithExpression(result)
                 }
             ]
         )

--- a/Tinycast/Features/Calculator/UI/CalculatorCardView.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorCardView.swift
@@ -81,7 +81,7 @@ private struct CalcColumn: View {
 
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
-            Text(text)
+            Text(CalcSyntax.highlighted(text))
                 .font(Theme.Typography.calcResult.weight(weight))
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
@@ -102,6 +102,42 @@ private struct CalcColumn: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal, Theme.Spacing.md)
     }
+}
+
+/// Dims the words that join an expression, so the values they join read first.
+private enum CalcSyntax {
+    static func highlighted(_ text: String) -> AttributedString {
+        var attributed = AttributedString()
+        let words = text.split(separator: " ", omittingEmptySubsequences: false)
+        // Rebuilt word by word, so a connector is only ever matched whole — `min` is not `in`.
+        for (index, word) in words.enumerated() {
+            if index > 0 { attributed.append(AttributedString(" ")) }
+            var piece = AttributedString(String(word))
+            if isConnector(word, at: index, of: words) {
+                piece.foregroundColor = Theme.Colors.textTertiary
+            }
+            attributed.append(piece)
+        }
+        return attributed
+    }
+
+    /// `in` joins two units and follows one, which is what separates it from the inch it spells.
+    /// In `10 in in cm` only the second joins, so the first stays a unit.
+    private static func isConnector(
+        _ word: Substring, at index: Int, of words: [Substring]
+    ) -> Bool {
+        let lowered = word.lowercased()
+        if connectors.contains(lowered) { return true }
+        guard lowered == "in", index > 0, index + 1 < words.count else { return false }
+        return words[index + 1].lowercased() != "in"
+    }
+
+    /// Words only, never a unit: `min` and `in` are also units, so they are matched by position.
+    private static let connectors: Set<String> = [
+        "to", "of", "off", "on", "as", "from", "ago", "at", "tip", "ratio", "average", "avg",
+        "mean", "sum", "total", "round", "nearest", "and", "is", "what", "the", "next", "last",
+        "+", "-", "×", "÷", "^", "→", "->", "mod"
+    ]
 }
 
 /// Actions menu for the card; only answers copy, so an error card is never passed one.

--- a/Tinycast/Features/Calculator/UI/CalculatorCoordinator.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorCoordinator.swift
@@ -35,6 +35,14 @@ final class CalculatorCoordinator {
         Paster.copyPlainText(copyText)
     }
 
+    /// `⇧⌘↵` on the card: the whole calculation, for pasting into a note or a message.
+    func copyCalculationWithExpression(_ result: CalcResult) {
+        guard case .value(let display, let copyText) = result.payload else { return }
+        calcHistory.record(expression: result.expression, result: display)
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        Paster.copyPlainText("\(result.expression) = \(copyText)")
+    }
+
     /// Enter on a Calculator History row: re-copy the stored answer (no re-record).
     func copyHistoryEntry(_ entry: CalcHistoryEntry) {
         paletteCoordinator.hidePalette(restoreFocus: false)

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -81,6 +81,11 @@ operand contains a letter, because two letter-free operands (`5/2 - 1/2`) are eq
 arithmetic and are left to the calculator rather than silently read as dates. Two-digit years expand
 the way date pickers do — 00–68 to the 2000s, 69–99 to the 1900s.
 
+A **dotted** date is day-first (`19.2.27` is 19 February 2027), matching the convention that writes
+it, where the slashed form stays month-first. It needs three parts and a two- or four-digit year,
+which is what separates a date from a decimal and from a version number: `1.5 + 3` is 4.5 and
+`1.2.3 + 1` earns no card.
+
 Grammar G needs the qualifier. A lone `tomorrow` is an app search, so only `at <time>` or a
 leading `next` / `last` earns a card — the same rule that keeps `today` and `july` silent.
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -86,6 +86,12 @@ it, where the slashed form stays month-first. It needs three parts and a two- or
 which is what separates a date from a decimal and from a version number: `1.5 + 3` is 4.5 and
 `1.2.3 + 1` earns no card.
 
+The version-number overlap is only **partly** closed, and irreducibly so: `1.2.24` is both a
+plausible semver and a valid 1 February 2024, with nothing in the text to tell them apart. A
+one-digit or three-digit tail is rejected (`1.2.3`, `10.15.7`), which covers the common shapes, but
+a two-digit patch reads as a date. Requiring a four-digit year would close it and cost `19.2.27`,
+which is the more common thing to type.
+
 The same convention writes an **ordinal dot** after the day, so `28. aug + 3` reads as 28 August.
 Only a trailing dot is dropped, which is why `28.5 aug` stays silent rather than becoming a date.
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -86,6 +86,9 @@ it, where the slashed form stays month-first. It needs three parts and a two- or
 which is what separates a date from a decimal and from a version number: `1.5 + 3` is 4.5 and
 `1.2.3 + 1` earns no card.
 
+The same convention writes an **ordinal dot** after the day, so `28. aug + 3` reads as 28 August.
+Only a trailing dot is dropped, which is why `28.5 aug` stays silent rather than becoming a date.
+
 Grammar G needs the qualifier. A lone `tomorrow` is an app search, so only `at <time>` or a
 leading `next` / `last` earns a card — the same rule that keeps `today` and `july` silent.
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -63,7 +63,8 @@ against a fixed clock.
 
 - **A** — duration until a moment: `hrs till 9am`, `days till 9april`
 - **B** — duration since a past moment: `days since 9jul`, `hrs since noon`
-- **C** — a moment ± a duration: `today + 3 weeks`, `now + 90 min`
+- **C** — a moment ± durations: `today + 3 weeks`, `now + 90 min`,
+  `17.2.26 + 100 weekdays - 4 + 2`
 - **D** — difference between two moments: `jul 4 - today`
 - **E** — a leading duration: `5 weekdays from now`, `3 days from today`, `2 weeks ago`
 - **F** — a weekday inside a future week: `monday in 3 weeks`, `friday in 2 weeks`
@@ -109,6 +110,11 @@ where the documented forward bias still decides: `jul 4 - today` keeps looking a
 A bare number after a moment takes the unit that moment implies: hours off a clock time
 (`3:45pm + 5` → 8:45 PM), days off a date (`august 5 + 5` → 10 August). It is checked before the
 spelled durations, since `5` names no unit of its own.
+
+Grammar C **chains**: every `± <term>` after the first is applied in written order, so
+`17.2.26 + 100 weekdays - 4 + 2` shifts three times. All of them must be durations — one term that
+is not (`today + 3 weeks - kg`) drops the whole card rather than answering from a prefix, which is
+what leaves a trailing moment to grammar D and keeps `jul 4 - today` a difference.
 
 Grammar F resolves the weekday **inside the landing week** rather than counting forward from the
 landing day, so `monday in 3 weeks` is that week's Monday whichever day you ask on. The week is

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -67,6 +67,12 @@ against a fixed clock.
 - **D** — difference between two moments: `jul 4 - today`
 - **E** — a leading duration: `5 weekdays from now`, `3 days from today`, `2 weeks ago`
 
+**An answered moment badges its weekday.** Grammars C and E resolve to a date, and the day of the
+week is the thing a date does not say out loud — so `5 weekdays from now` reads `4 September` under
+a `Friday` pill rather than repeating the weekday inside the date and badging it `Result`.
+`answerString` is `momentString` without the leading `EEEE` for exactly that reason; the source
+badge keeps its own weekday, since nothing else on the card carries it.
+
 A bare, recurring date or time resolves by _bias_: `till` takes the upcoming occurrence, `since` the
 most recent past one; an absolute date ignores the bias. Grammar D only engages when at least one
 operand contains a letter, because two letter-free operands (`5/2 - 1/2`) are equally valid as
@@ -221,6 +227,10 @@ and currency paths so a spelled-out word never outranks a measurement:
 The list forms are the reason `CalcToken` carries a `comma` case. It is meaningful only here — every
 other path rejects it — and a comma **between digits** is still the grouping separator it always was,
 so `1,000 + 234` is unchanged and a bare `10,5` stays silent.
+
+Each of these badges what its number **is** — `Tip`, `Discounted`, `Percentage`, `Total`, `Ratio`,
+`Average`, `Sum`, `Minimum`, `Maximum`, `Rounded` — rather than the bare `Result` that says nothing
+the card doesn't already show. `min` and `max` are only told apart by it.
 
 ## Modulo
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -15,6 +15,17 @@ in (see Currency below).
 - **`CalcEngine.evaluate` never fetches** — it takes a finished `CurrencyRates?`, nil meaning no
   snapshot has landed yet. `CurrencyRateStore` owns the fetch and the cacheless `.ephemeral` session,
   and `CurrencyFeed` — pure, so the harness covers it — turns the payloads into that snapshot.
+- **The time-zone table is Foundation's, never generated and never hand-listed.**
+  `TimeZone.knownTimeZoneIdentifiers` already carries the whole IANA database, so `CalcTimeZone`
+  builds its city index from that on first use rather than shipping a copy that would rot every time
+  IANA moves a zone. `TimeZone.abbreviationDictionary` stays deliberately unused — it holds 51
+  entries and its `BDT` is the Bangladeshi taka. The home zone is read off the **injected calendar**,
+  never `TimeZone.current`, which is what keeps the path pure and the harness deterministic.
+  `localizedName` needs a `Locale`, so a badge is the identifier's own city component instead.
+- **A workday is 8 hours, and nothing consults a calendar.** Weekends and public holidays would make
+  the same query answer differently on two Macs, and the only supported source for them is EventKit,
+  whose Full Calendar Access grant a calculator must never provoke mid-keystroke. `workdays` is
+  therefore an ordinary time unit, and `calendarEnabled` stays the Calendar feature's own consent.
 - **`CurrencyData.generated.swift` is emitted by `node Scripts/gen-currencies.js`** and never hand-edited.
   Three currency tables are hand-maintained, all in `CalcCurrency`: `contested`, the nouns several
   currencies share (`dollars`, `pounds`); `isoNames`, the standard's own names where CLDR substitutes
@@ -27,18 +38,22 @@ in (see Currency below).
 
 1. Natural-language date/time (`CalcDateTime`, e.g. `hrs till 9am`, `days till 9april`,
    `today + 3 weeks`)
-2. Numeric reject
-3. Tokenize
-4. Complete-prefix evaluation for a trailing binary operator (`10kg +` → `10 kg`)
-5. Base conversion
-6. Explicit unit conversion (`10km to mi`)
-7. **Typed quantity arithmetic** (`10kg + 500g`, `$10 + €5`, `(1hr + 30min) to s`,
+2. **Time zones** (`CalcTimeZone`, e.g. `time in Tokyo`, `5pm ldn in sf`) — before tokenizing,
+   because a zone phrase is words rather than calculator input
+3. Numeric reject
+4. Tokenize
+5. Complete-prefix evaluation for a trailing binary operator (`10kg +` → `10 kg`)
+6. Base conversion
+7. **Timespan** (`145 mins to timespan` → `2 hr 25 min`)
+8. Explicit unit conversion (`10km to mi`)
+9. **Typed quantity arithmetic** (`10kg + 500g`, `$10 + €5`, `(1hr + 30min) to s`,
    `(20 sgd to usd) * 30`), which also answers a bare amount (`1 usd`, `1 btc`) in the Mac's own
    currency
-8. **Currency conversion** (`1 euro to dollars`, `€20 to GBP`, `1 btc to eur`)
-9. **Bare-unit auto-conversion** (`1m` → feet + inches, `1hr` → 60 min, via
+10. **Currency conversion** (`1 euro to dollars`, `€20 to GBP`, `1 btc to eur`)
+11. **Bare-unit auto-conversion** (`1m` → feet + inches, `1hr` → 60 min, via
    `CalcUnits.parseBareConversion` + the `autoTargets` map)
-10. Plain arithmetic
+12. Natural-language percent, ratio and list forms (`CalcPercent`)
+13. Plain arithmetic
 
 Date/time depends on the clock, so it takes an injected `now` / `calendar` — the public `evaluate(_:)`
 uses the live clock, and `evaluate(_:now:calendar:)` lets `calc-test.swift` assert exact strings
@@ -63,6 +78,14 @@ trailing `to` / `in` converts the complete expression. A conversion inside paren
 quantity, so `(20 sgd to usd) * 30` converts then multiplies. Percentages keep relative semantics
 for addition (`10kg + 20%` → `12 kg`) and act as fractional scalars for multiplication and division
 (`10kg * 3%` → `0.3 kg`, `10kg / 25%` → `40 kg`).
+
+A conversion may also appear **mid-expression, but only where `+` or `-` follows it**:
+`10kg to lb + 3lb` converts and then adds, without needing the parentheses it used to. The
+restriction is the whole point. `20 eur to usd * 30` has two honest readings — convert then scale,
+or convert into a scaled unit — so it stays silent and keeps asking for `(20 eur to usd) * 30`,
+while `+` and `-` carry no such ambiguity because a conversion target is never an addend.
+A **trailing** `to` is untouched by this and still converts the whole expression, so
+`10kg + 500g to lb` remains the sum in pounds rather than `10kg + (500g to lb)`.
 
 **The last unit typed decides the answer's unit.** `+` / `-` convert the _left_ side into the right
 operand's unit, so `5feet + 1m` is `2.524 m` and `10kg + 500g` is `10,500 g` — the unit you finished
@@ -94,11 +117,70 @@ An attached `k` is a thousands suffix (`10k` → `10,000`), while whitespace kee
 (`10 k to c`); the established attached Kelvin conversion form remains valid when the temperature
 target makes the intent unambiguous (`273.15K to C`).
 
+A **slashed rate** (`km/h`, `m/s`, `mbit/s`) is one unit rather than a division, but only when the
+table knows the whole spelling: the tokenizer looks ahead from a letter run across a `/` to the next
+one and keeps them together only if `CalcUnits.byName` resolves the result. That is the same
+table-consulting lookahead the `USD1K` prefix split already uses, and it is why `6/2(1+2)` and
+`10 m / 2` still divide while `1 km/x` stays silent.
+
+Beyond the core four, `CalcParser.functions` carries the reciprocal trig (`cot`, `sec`, `csc`),
+the inverses (`asin`/`arcsin` through `atan`), the hyperbolics (`sinh`, `acosh`, …) and
+`cbrt`/`exp`/`log2`/`sign`/`trunc`, alongside the `tau` and `phi` constants. `sec` is also the
+abbreviation for seconds, which costs nothing: a unit position resolves through `CalcUnits` long
+before a bare name reaches the function table, so `10 sec to min` stays a duration.
+
 Scientific notation (`1e5` → `100,000`, `5e-3km`, `3e+2`) is read only while the exponent hugs the
 mantissa, which is what keeps `2 e` and `2e` reading as 2 × Euler's _e_ — an exponent needs digits
 after the `e`. Like `10k`, it tokenizes as a shorthand rather than a plain literal, so a lone `1e5`
 still earns a card where a lone `100000` deliberately doesn't. A literal that overflows to infinity
 (`1e400`) is treated as non-calculator input, not as a card.
+
+## Time zones
+
+`CalcTimeZone` answers `time in Tokyo`, `what time is it in London`, `5pm ldn in sf` and
+`9:30am in nyc`. It runs **before the tokenizer** — a zone phrase is words, and `5pm ldn in sf`
+is not calculator input — but its grammar always needs an `in` / `to` / `at` connector, so an
+ordinary app search never reaches the zone table at all.
+
+The source is the Mac's own zone unless the query names one, which is what makes `5pm london in sf`
+work without either side being local. That zone comes from the **injected calendar**, so `Model/`
+performs no environment read and `calc-test` pins UTC exactly as it pins the clock. A result that
+lands on another date is suffixed `(tomorrow)` / `(yesterday)` rather than silently reading as the
+same day — the copyable text stays the bare time.
+
+Two tables back it. `cities` is derived from `TimeZone.knownTimeZoneIdentifiers` on first use: 443
+identifiers keyed by their city component, ~0.8 ms to build and ~18 ns to query, so nothing is
+generated and no copy of tzdata is committed. `aliases` is the hand-written half, and the only place
+judgement lives — the abbreviations (`pst`, `cet`, `jst`), the nicknames a zone name doesn't carry
+(`sf`, `nyc`, `ldn`), and the renamed zones Foundation still resolves but no longer lists
+(`kolkata`, `saigon`). It is deliberately small and deliberately not slang, for the same reason
+`CalcCurrency` refuses `quid`.
+
+`aliases` also carries the **IATA airport codes** (`vie`, `lhr`, `nrt`, `sfo`), which no Foundation
+surface knows: `TimeZone(abbreviation:)` and `TimeZone(identifier:)` both return nil for every one,
+and the whole `abbreviationDictionary` is 51 zone abbreviations rather than airports. They are a
+curated product choice, so the list is the busiest airports rather than an attempt at all ~9,000.
+Two are deliberately absent: `MAD` is the Moroccan dirham, and `IST` is India Standard Time — a
+currency and a zone abbreviation both outrank an airport, the same ordering the rest of the file
+follows. The compiler enforces the rest: a duplicate key in the literal is a warning, which is what
+caught `syd` and `hkg` already being nicknames.
+
+Order settles the collisions. Time zones run **last** among the named paths, after units and
+currency, so `10 cordoba to usd` stays money and `1 cup to ml` stays volume. `cordoba` is the one
+word the zone and currency tables both claim.
+
+## Timespans
+
+`145 mins to timespan` breaks a duration into the units that fit it (`2 hr 25 min`), with zero
+parts dropped. Weeks are the largest step on purpose: a month is not a fixed number of seconds, so
+carrying one would make the answer depend on which month you meant. Only a time unit converts, so
+`10 km to timespan` stays silent.
+
+## Workdays
+
+`workdays` is a time unit of 8 hours, which answers `55h in workdays` and `3 workdays in hours`
+with no calendar involved. Weekends and public holidays are deliberately not modelled — see the
+invariant above.
 
 ## Implicit multiplication
 
@@ -112,6 +194,23 @@ starts an implicit product. Adjacent _numbers_ never do — `5 3` stays an app s
 currency name is a constant or function, so `10km` keeps its own path. `QuantityParser.peekBinary`
 carries the same `(` rule so the typed side agrees (`$5(2)` → `10.00 USD`, `2(3)kg` → `6 kg`, matching
 `2*(3)kg`); adjacency there still means the composite-quantity `+` described above, never a product.
+
+## Natural-language forms
+
+`CalcPercent` owns the phrasings the arithmetic parser can't see, all of which run after the unit
+and currency paths so a spelled-out word never outranks a measurement:
+
+- `20% off 500` → 400, and `50 as % of 200` → 25%
+- `15% tip on 42` → 6.3 — the tip alone, which is what the phrase asks for
+- `50 is what % of 200` → 25%, the spoken form of `as % of`
+- `30 is 20% of what` → 150, solving for the whole instead of the share
+- `ratio of 1920 to 1080` → `16 : 9`, reduced by GCD; integers only
+- `average|sum|min|max of 10, 20, 30`, separated by `,` or `and`
+- `round 47 to nearest 5` → 45, snapping to a step rather than a digit count
+
+The list forms are the reason `CalcToken` carries a `comma` case. It is meaningful only here — every
+other path rejects it — and a comma **between digits** is still the grouping separator it always was,
+so `1,000 + 234` is unchanged and a bare `10,5` stays silent.
 
 ## Modulo
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -368,12 +368,17 @@ reads `122.84 BDT`, badged `US Dollar → Bangladeshi Taka`, and `1 btc` follows
 region comes from `RegionCurrency`, one `Locale.current.currency` read — a preference, so nothing
 ever asks for location, and a `Model/` file never performs it.
 
+Where the region names the currency already written, the amount pairs with the **dollar** instead —
+the **euro** where the dollar is the one that was typed. Converting is the only reason to write a
+lone amount, so `25 eur` on a European Mac answering `25.00 EUR` said nothing at all; it now reads
+`28.95 USD`, which is what Raycast answers for the same query.
+
 The target only applies where there is genuinely nothing else to say. An operator keeps the currency
 written (`$10 + €5` stays euros), an explicit target overrides everything, a trailing operator holds
 the typed currency while the expression is still being written (`$10 +`), and a lone code with no
 amount is still an app search. Where the region names no currency, names one the table doesn't carry,
-names the currency already written, or names one the snapshot doesn't quote, the amount answers in
-the currency written rather than erroring about a code the user never typed.
+or names one the snapshot doesn't quote, the amount answers in the currency written rather than
+erroring about a code the user never typed — an unresolvable region still names no target.
 
 ### Exchange rates
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -174,6 +174,11 @@ A trailing `+ 2h` / `- 30 min` shifts the answer before it is converted, so `5pm
 stays one query rather than needing two. Only sub-day units qualify, since a zone answer is a clock
 time, and `5pm london in sf + 2 kg` is silent rather than wrong.
 
+The offset's unit may be left out — `time in sao paulo + 5` is five hours — because a clock answer
+admits no other reading. The implication is the **offset's alone**: `time in 4` still names no zone
+and stays silent, and a bare `5 + 3` is arithmetic exactly as it was. It mirrors the bare number a
+moment already takes in grammar C.
+
 `diff paris` answers how far a zone runs from the Mac's own, and a duration may stand where a zone
 would (`time in 4 hours`, `time in 4 hours in san francisco`) — the zone table is tried first, so a
 city always outranks a duration. City names are matched **diacritic-folded**, because the identifiers

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -66,6 +66,7 @@ against a fixed clock.
 - **C** — a moment ± a duration: `today + 3 weeks`, `now + 90 min`
 - **D** — difference between two moments: `jul 4 - today`
 - **E** — a leading duration: `5 weekdays from now`, `3 days from today`, `2 weeks ago`
+- **F** — a weekday inside a future week: `monday in 3 weeks`, `friday in 2 weeks`
 
 **An answered moment badges its weekday.** Grammars C and E resolve to a date, and the day of the
 week is the thing a date does not say out loud — so `5 weekdays from now` reads `4 September` under
@@ -78,6 +79,12 @@ most recent past one; an absolute date ignores the bias. Grammar D only engages 
 operand contains a letter, because two letter-free operands (`5/2 - 1/2`) are equally valid as
 arithmetic and are left to the calculator rather than silently read as dates. Two-digit years expand
 the way date pickers do — 00–68 to the 2000s, 69–99 to the 1900s.
+
+Grammar F resolves the weekday **inside the landing week** rather than counting forward from the
+landing day, so `monday in 3 weeks` is that week's Monday whichever day you ask on. The week is
+`Calendar`'s own, so it follows the user's first-weekday preference — on a Monday-first calendar
+`sunday in 1 week` lands at the end of that week rather than its start. It runs after every other
+grammar because `in` is also the unit connector, which is what keeps `10 in in cm` a conversion.
 
 `CalcQuantity` is a separate typed precedence parser rather than a mode added to the scalar
 `CalcParser`. Scalar `*` / `/` preserve the unit, compatible quantity division returns a scalar, and a

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -65,6 +65,7 @@ against a fixed clock.
 - **B** — duration since a past moment: `days since 9jul`, `hrs since noon`
 - **C** — a moment ± a duration: `today + 3 weeks`, `now + 90 min`
 - **D** — difference between two moments: `jul 4 - today`
+- **E** — a leading duration: `5 weekdays from now`, `3 days from today`, `2 weeks ago`
 
 A bare, recurring date or time resolves by _bias_: `till` takes the upcoming occurrence, `since` the
 most recent past one; an absolute date ignores the bias. Grammar D only engages when at least one
@@ -178,9 +179,18 @@ carrying one would make the answer depend on which month you meant. Only a time 
 
 ## Workdays
 
-`workdays` is a time unit of 8 hours, which answers `55h in workdays` and `3 workdays in hours`
-with no calendar involved. Weekends and public holidays are deliberately not modelled — see the
-invariant above.
+`workdays` is two separate things, and both avoid a calendar.
+
+As a **unit** it is 8 hours, which answers `55h in workdays` and `3 workdays in hours`.
+
+As a **duration in date arithmetic** it counts days and skips weekends: `today + 5 business days`,
+`tomorrow + 10 work days`, `5 weekdays from now`, `august 26 2026 + 15 workdays`. `business day`,
+`work day`, `working day` and `weekday` are all the same phrase, written as one word or two.
+`addBusinessDays` steps a day at a time rather than doing arithmetic on weeks, which is what keeps a
+Saturday anchor honest — `saturday + 1 business day` is Monday, not Sunday.
+
+Public holidays are deliberately not modelled in either. The only supported source is EventKit, and a
+calculator must never provoke its Full Calendar Access grant mid-keystroke — see the invariant above.
 
 ## Implicit multiplication
 

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -89,8 +89,16 @@ which is what separates a date from a decimal and from a version number: `1.5 + 
 The same convention writes an **ordinal dot** after the day, so `28. aug + 3` reads as 28 August.
 Only a trailing dot is dropped, which is why `28.5 aug` stays silent rather than becoming a date.
 
-Grammar G needs the qualifier. A lone `tomorrow` is an app search, so only `at <time>` or a
-leading `next` / `last` earns a card — the same rule that keeps `today` and `july` silent.
+Grammar G needs the qualifier. A lone `tomorrow` is an app search, so `at <time>` or a leading
+`next` / `last` earns a card — the same rule that keeps `today` and `july` silent. **A written day
+is qualifier enough**: `25. aug`, `aug 25` and `25.8.27` all answer, badged with their weekday,
+because nobody types a day-and-month pair looking for an app. A month alone still names no day, so
+`july` stays a search.
+
+A bare date takes the year it is **nearest**, not the next one — three days behind is likelier the
+date meant than the same day twelve months out. Grammar C shifts a moment, so it reads the year the
+same way and `25. aug` and `25. aug + 3` can never disagree. Grammar D measures _to_ a moment,
+where the documented forward bias still decides: `jul 4 - today` keeps looking ahead.
 
 A bare number after a moment takes the unit that moment implies: hours off a clock time
 (`3:45pm + 5` → 8:45 PM), days off a date (`august 5 + 5` → 10 August). It is checked before the

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -67,6 +67,7 @@ against a fixed clock.
 - **D** — difference between two moments: `jul 4 - today`
 - **E** — a leading duration: `5 weekdays from now`, `3 days from today`, `2 weeks ago`
 - **F** — a weekday inside a future week: `monday in 3 weeks`, `friday in 2 weeks`
+- **G** — a named moment, once qualified: `tomorrow at 9am`, `next monday`, `last friday`
 
 **An answered moment badges its weekday.** Grammars C and E resolve to a date, and the day of the
 week is the thing a date does not say out loud — so `5 weekdays from now` reads `4 September` under
@@ -79,6 +80,13 @@ most recent past one; an absolute date ignores the bias. Grammar D only engages 
 operand contains a letter, because two letter-free operands (`5/2 - 1/2`) are equally valid as
 arithmetic and are left to the calculator rather than silently read as dates. Two-digit years expand
 the way date pickers do — 00–68 to the 2000s, 69–99 to the 1900s.
+
+Grammar G needs the qualifier. A lone `tomorrow` is an app search, so only `at <time>` or a
+leading `next` / `last` earns a card — the same rule that keeps `today` and `july` silent.
+
+A bare number after a moment takes the unit that moment implies: hours off a clock time
+(`3:45pm + 5` → 8:45 PM), days off a date (`august 5 + 5` → 10 August). It is checked before the
+spelled durations, since `5` names no unit of its own.
 
 Grammar F resolves the weekday **inside the landing week** rather than counting forward from the
 landing day, so `monday in 3 weeks` is that week's Monday whichever day you ask on. The week is
@@ -161,6 +169,16 @@ work without either side being local. That zone comes from the **injected calend
 performs no environment read and `calc-test` pins UTC exactly as it pins the clock. A result that
 lands on another date is suffixed `(tomorrow)` / `(yesterday)` rather than silently reading as the
 same day — the copyable text stays the bare time.
+
+A trailing `+ 2h` / `- 30 min` shifts the answer before it is converted, so `5pm ldn in sf + 2h`
+stays one query rather than needing two. Only sub-day units qualify, since a zone answer is a clock
+time, and `5pm london in sf + 2 kg` is silent rather than wrong.
+
+`diff paris` answers how far a zone runs from the Mac's own, and a duration may stand where a zone
+would (`time in 4 hours`, `time in 4 hours in san francisco`) — the zone table is tried first, so a
+city always outranks a duration. City names are matched **diacritic-folded**, because the identifiers
+carry no accents while the cities do: `são paulo` and `zürich` resolve alongside their bare
+spellings, the same folding `CalcCurrency` already applies to its nouns.
 
 Two tables back it. `cities` is derived from `TimeZone.knownTimeZoneIdentifiers` on first use: 443
 identifiers keyed by their city component, ~0.8 ms to build and ~18 ns to query, so nothing is


### PR DESCRIPTION
## Related issue

Addresses **#353**, closed as invalid on the grounds that business days depend on the Calendar feature and would break when it's switched off. That isn't the case here.

## What changed

**Time zones.** `CalcTimeZone` answers `time in Tokyo`, `5pm ldn in sf` and `diff paris`, built on **Apple's Foundation**: `TimeZone.knownTimeZoneIdentifiers` already carries the whole IANA database, so nothing is generated and no copy of tzdata is committed — the table updates with macOS. The city index is a **lazy `static let`**, built on the first zone query and never rebuilt (443 identifiers, ~18 ns a lookup); a query that names no zone never touches it. `aliases` is the hand-written half: abbreviations, nicknames (`sf`, `nyc`, `ldn`) and IATA codes. The home zone comes off the **injected `Calendar`**, so `Model/` performs no environment read.

**Dates.** Business days skip weekends, plus dotted and ordinal spellings (`19.2.27`, `28. aug`), bare dates, and `monday in 3 weeks`. A date answer now badges its weekday instead of `Result`.

**Everything else.** Slashed rates, timespans, the rest of the trig set, `square root of`, `power`, tip/ratio/aggregate phrasings, and a mid-expression `to` so `100 km/h to mph + 3mph` no longer needs parentheses.

## No dependencies, no permissions, no calendar events

Two unrelated things share the word: `Foundation.Calendar` is pure date math compiled into the system, EventKit is your events and the thing that's TCC-gated. Only the first is used — a grep for `EventKit`, `EKEventStore` or `calendarEnabled` across `Features/Calculator/` returns nothing, so business days work with the Calendar feature **off** and nothing ever prompts. Public holidays are deliberately not modelled, since EventKit is their only source and the answer would then differ between two Macs. The one import across the whole diff is `Foundation`.

## Examples

| Query | Answer |
| --- | --- |
| `today + 5 business days` | 4 September · Friday |
| `5 weekdays from now` | 4 September · Friday |
| `august 26 2026 + 15 workdays` | 16 September · Wednesday |
| `28. aug + 3` | 31 August · Monday |
| `time in vie` | 2:00 PM · UTC → Vienna |
| `5pm ldn in sf + 2h` | 11:00 AM |
| `100 km/h to mph + 3mph` | 65.13711922 mph |
| `ratio of 1920 to 1080` | 16 : 9 |

## Drawbacks

`1.2.24` is both a plausible semver and a valid 1 February 2024, and nothing separates them — a one- or three-digit tail is rejected, but a two-digit patch reads as a date. Requiring a four-digit year would close it and cost `19.2.27`.

`20 eur to usd * 30` still wants parentheses: it has two honest readings where `+` and `-` have one.

## Tests & validation

- `calc-test` gains ~170 assertions: every grammar above, the ambiguity guards (`10 in in cm` stays a conversion, `mad` stays the dirham), weekend boundaries from Friday, Monday and Saturday anchors, and the malformed inputs that used to trap.
- All 49 harnesses pass, Debug builds with no new warnings, `lint.sh` clean, `Model/` stays Foundation-only.
- Hot path measured against `main` over 146 app-name prefixes: **2.04 µs → 2.08 µs per keystroke**, so a search that isn't a calculation costs the same. Release bundle 9296 KB → 9396 KB.

