### PR TITLE
Keep the clipboard history and learned data out of ~/Library/Caches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ system-wide chord, and HIToolbox's TIS APIs remain the public input-source mecha
 | `Tinycast/Palette/` | the palette shell: panel, window controller, `RootPaletteView`, `PaletteScreen` |
 | `Tinycast/Windows/` | the non-palette AppKit surfaces: `Dialog/`, `HUD/`, `About/`, `AppWindowController` |
 | `Tinycast/Features/` | one folder per feature; larger ones split `Model/` `Service/` `UI/` `Settings/` |
+| `Tinycast/Migration/` | one-time data moves, each with a delete-by date — **this folder goes on 2026-09-05** |
 | `Tests/` | the standalone harnesses — one Swift file each, no XCTest target |
 | `Scripts/` | every executable script: test runner, data generators, packaging, linting, editor setup |
 

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -103,6 +103,11 @@ run calc-test              Tinycast/Features/Calculator/Model/*.swift
 run calendar-test          Tinycast/Features/Calendar/Model/*.swift
 run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
+# Expires 2026-09-05, and fails this suite once it has: see Tinycast/Migration/.
+run storage-relocation-test Tinycast/Platform/AppPaths.swift \
+                            Tinycast/Migration/StorageRelocation.swift \
+                            Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
 run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift \
                            Tinycast/Features/Emoji/Model/EmojiData.generated.swift

--- a/Tests/custom-command-test.swift
+++ b/Tests/custom-command-test.swift
@@ -137,7 +137,8 @@ struct CustomCommandTests {
             // thing under test.
             return (
                 log.replacingOccurrences(of: "\r", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines), result)
+                    .trimmingCharacters(in: .whitespacesAndNewlines), result
+            )
         }
 
         let simple = await collect(ShellCommandRunner.stream("echo captured"))
@@ -249,7 +250,8 @@ struct CustomCommandTests {
         check(
             "a blank folder means home rather than an empty path",
             store.commands.first?.workingDirectory == nil)
-        check("a command with no icon falls back to the shared glyph",
+        check(
+            "a command with no icon falls back to the shared glyph",
             store.commands.first?.symbol == CustomCommand.sfSymbol)
 
         // MARK: Arguments

--- a/Tests/storage-relocation-test.swift
+++ b/Tests/storage-relocation-test.swift
@@ -1,0 +1,250 @@
+// Standalone test for the one-time move out of Caches, and the tripwire that retires it.
+// It drives the real `ClipboardStore` on both sides of the move: a hand-copied schema would drift.
+import Foundation
+
+@main
+@MainActor
+struct StorageRelocationTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func main() {
+        theRelocationWindowIsStillOpen()
+        movesTheDurableStoresAndLeavesTheCaches()
+        theWriteAheadLogTravelsWithTheDatabase()
+        rewritesOwnedImagePathsAndLeavesExternalOnes()
+        resumesAfterAPartialRun()
+        aSecondRunChangesNothing()
+        aCacheOnlyDirectoryIsLeftAlone()
+        mergesImagesWhenTheDestinationAlreadyExists()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Cases
+
+    /// The point of `Tinycast/Migration/`: it fails the suite rather than outliving its purpose.
+    static func theRelocationWindowIsStillOpen() {
+        expect(
+            Date() < StorageRelocation.removeAfter,
+            """
+            the relocation window has closed — delete it now:
+              rm -rf Tinycast/Migration Tests/storage-relocation-test.swift
+              drop the `run storage-relocation-test` line from Scripts/run-tests.sh
+              drop the `StorageRelocation.run()` call from Tinycast/App/TinycastApp.swift
+              drop the `Tinycast/Migration/` row from AGENTS.md, then `xcodegen generate`
+            """)
+    }
+
+    static func movesTheDurableStoresAndLeavesTheCaches() {
+        withDirectories { caches, support in
+            seed(caches, rows: [ClipboardItem(text: "hello", sourceBundleID: nil)])
+            write("png", to: caches.appendingPathComponent("images"), "a.png")
+            for name in [
+                "calculator-history.json", "launcher-ranking.json", "emoji-frequency.json",
+                "currency-rates.json"
+            ] {
+                write("[]", to: caches, name)
+            }
+
+            StorageRelocation.run(caches: caches, support: support)
+
+            for name in [
+                "clipboard.sqlite3", "calculator-history.json", "launcher-ranking.json",
+                "emoji-frequency.json"
+            ] {
+                expect(exists(support, name), "\(name) moved to Application Support")
+                expect(!exists(caches, name), "\(name) no longer sits in Caches")
+            }
+            expect(
+                exists(support.appendingPathComponent("images"), "a.png"),
+                "image blobs move with the database")
+            expect(
+                exists(caches, "currency-rates.json") && !exists(support, "currency-rates.json"),
+                "a refetchable cache is not durable data, and stays put")
+            expect(texts(in: support) == ["hello"], "and the history reopens where it landed")
+        }
+    }
+
+    /// A force-quit leaves a hot `-wal` behind; stranding it in Caches loses the writes it holds.
+    static func theWriteAheadLogTravelsWithTheDatabase() {
+        withDirectories { caches, support in
+            seed(caches, rows: [])
+            for suffix in ["-wal", "-shm"] { write("x", to: caches, "clipboard.sqlite3" + suffix) }
+
+            StorageRelocation.run(caches: caches, support: support)
+
+            for suffix in ["-wal", "-shm"] {
+                let name = "clipboard.sqlite3" + suffix
+                expect(exists(support, name), "\(name) travels with the database")
+                expect(!exists(caches, name), "and nothing of it is left behind")
+            }
+        }
+    }
+
+    static func rewritesOwnedImagePathsAndLeavesExternalOnes() {
+        withDirectories { caches, support in
+            let owned = caches.appendingPathComponent("images/kept.png").path
+            // Imported from another app: real, outside our images directory, not ours to move.
+            let outside = caches.deletingLastPathComponent()
+            let external = outside.appendingPathComponent("elsewhere.png").path
+            seed(
+                caches,
+                rows: [
+                    ClipboardItem(text: "hello", sourceBundleID: nil),
+                    ClipboardItem(imagePath: owned, sourceBundleID: nil),
+                    ClipboardItem(imagePath: external, sourceBundleID: nil)
+                ])
+            write("png", to: caches.appendingPathComponent("images"), "kept.png")
+            write("png", to: outside, "elsewhere.png")
+
+            StorageRelocation.run(caches: caches, support: support)
+
+            let paths = imagePaths(in: support)
+            expect(
+                paths.contains(support.appendingPathComponent("images/kept.png").path),
+                "an owned blob's row follows it to Application Support")
+            expect(paths.contains(external), "a reference we never owned is left byte-for-byte")
+            expect(paths.count == 2, "and a text row keeps its null path")
+            expect(
+                resolvesEveryImage(in: support),
+                "every image row resolves to a file that is actually there")
+        }
+    }
+
+    /// The crash window: the database landed, the blobs did not. The next launch finishes it.
+    static func resumesAfterAPartialRun() {
+        withDirectories { caches, support in
+            let owned = caches.appendingPathComponent("images/kept.png").path
+            seed(caches, rows: [ClipboardItem(imagePath: owned, sourceBundleID: nil)])
+            write("png", to: caches.appendingPathComponent("images"), "kept.png")
+            for suffix in ["", "-wal", "-shm"] {
+                try? FileManager.default.moveItem(
+                    at: caches.appendingPathComponent("clipboard.sqlite3" + suffix),
+                    to: support.appendingPathComponent("clipboard.sqlite3" + suffix))
+            }
+
+            StorageRelocation.run(caches: caches, support: support)
+
+            expect(
+                imagePaths(in: support)
+                    == [support.appendingPathComponent("images/kept.png").path],
+                "the blobs catch up with the database, and the rows follow them")
+        }
+    }
+
+    static func aSecondRunChangesNothing() {
+        withDirectories { caches, support in
+            let owned = caches.appendingPathComponent("images/kept.png").path
+            seed(caches, rows: [ClipboardItem(imagePath: owned, sourceBundleID: nil)])
+            write("png", to: caches.appendingPathComponent("images"), "kept.png")
+
+            StorageRelocation.run(caches: caches, support: support)
+            let after = imagePaths(in: support)
+            StorageRelocation.run(caches: caches, support: support)
+
+            expect(
+                imagePaths(in: support) == after,
+                "re-running over a migrated layout rewrites nothing a second time")
+            expect(resolvesEveryImage(in: support), "and leaves the blobs where the first run put them")
+        }
+    }
+
+    static func aCacheOnlyDirectoryIsLeftAlone() {
+        withDirectories { caches, support in
+            write("{}", to: caches, "currency-rates.json")
+
+            StorageRelocation.run(caches: caches, support: support)
+
+            expect(
+                (try? FileManager.default.contentsOfDirectory(atPath: support.path))?.isEmpty
+                    == true,
+                "nothing to move means nothing is created")
+        }
+    }
+
+    static func mergesImagesWhenTheDestinationAlreadyExists() {
+        withDirectories { caches, support in
+            seed(caches, rows: [])
+            write("old", to: caches.appendingPathComponent("images"), "old.png")
+            write("new", to: support.appendingPathComponent("images"), "new.png")
+
+            StorageRelocation.run(caches: caches, support: support)
+
+            let images = support.appendingPathComponent("images")
+            expect(
+                exists(images, "old.png") && exists(images, "new.png"),
+                "a rename that cannot merge falls back to moving the blobs one by one")
+            expect(
+                !FileManager.default.fileExists(
+                    atPath: caches.appendingPathComponent("images").path),
+                "and the emptied directory goes")
+        }
+    }
+
+    // MARK: - Harness
+
+    /// Runs `body` against a fresh Caches/Application Support pair, torn down afterwards.
+    static func withDirectories(_ body: (URL, URL) -> Void) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-relocation-test-\(UUID().uuidString)")
+        let caches = root.appendingPathComponent("Caches")
+        let support = root.appendingPathComponent("Application Support")
+        for url in [caches, support] {
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        defer { try? FileManager.default.removeItem(at: root) }
+        body(caches, support)
+    }
+
+    /// The store closes with the scope, so the relocation never moves a database out from under it.
+    static func seed(_ directory: URL, rows: [ClipboardItem]) {
+        let store = ClipboardStore(directory: directory)
+        if !rows.isEmpty { expect(store.importEntries(rows) == rows.count, "seeded \(rows.count)") }
+    }
+
+    static func texts(in directory: URL) -> [String] {
+        reopened(directory).items.compactMap(\.text)
+    }
+
+    static func imagePaths(in directory: URL) -> [String] {
+        reopened(directory).items.compactMap(\.imagePath).sorted()
+    }
+
+    static func resolvesEveryImage(in directory: URL) -> Bool {
+        let store = reopened(directory)
+        return store.items.filter { $0.kind == .image }
+            .compactMap { store.imageURL(for: $0) }
+            .allSatisfy { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    static func reopened(_ directory: URL) -> ClipboardStore {
+        let store = ClipboardStore(directory: directory)
+        store.load()
+        return store
+    }
+
+    static func write(_ contents: String, to directory: URL, _ name: String) {
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? contents.write(
+            to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
+    static func exists(_ directory: URL, _ name: String) -> Bool {
+        FileManager.default.fileExists(atPath: directory.appendingPathComponent(name).path)
+    }
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition {
+            passes += 1
+        } else {
+            fail(label)
+        }
+    }
+
+    static func fail(_ label: String) {
+        print("FAIL: \(label)")
+        failures += 1
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		903FFCACE52FFA25958AD832 /* SnippetArgumentsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80495AE6BF7CE22BD6B20EE /* SnippetArgumentsPrompt.swift */; };
 		906C261B36E9E0B597198E3D /* UninstallRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7DAF3FFEE6CAB656B0FA8A /* UninstallRules.swift */; };
 		914402CB38C5D09C611AA8F4 /* AIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106F9FEF3F0C36E0C5686DA7 /* AIRequest.swift */; };
+		9151075EDA8266D7F767D2D8 /* StorageRelocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255C39B045A1E21AB9A5BF9E /* StorageRelocation.swift */; };
 		92EDFE4591BE41718ECE1C82 /* ChatGPTSubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943495E91C0D09B633746515 /* ChatGPTSubscriptionManager.swift */; };
 		935F7433BB0C0ECDE6FA3BF3 /* ClipboardScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */; };
 		939F3944AE8D36A8C337D46F /* Signposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9044F107ADD5896746DBC35 /* Signposts.swift */; };
@@ -483,6 +484,7 @@
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		2384FC4A96FDAD19D0737312 /* CameraPreviewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewSession.swift; sourceTree = "<group>"; };
 		23F7C8CBD0AA75D016DBFC06 /* SettingsPaneScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScanner.swift; sourceTree = "<group>"; };
+		255C39B045A1E21AB9A5BF9E /* StorageRelocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRelocation.swift; sourceTree = "<group>"; };
 		2575583134BE03EA9FA719CD /* ActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicy.swift; sourceTree = "<group>"; };
 		26AD346C8FD5F2D4F00FF2B6 /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		27021D72339800AA6DA3D3FF /* AIScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIScreen.swift; sourceTree = "<group>"; };
@@ -1804,6 +1806,7 @@
 				BCD69CF996AA28C1A52C0D05 /* App */,
 				1FC9BDBE6549F7189CB995AB /* DesignSystem */,
 				95CA98985928A88B33F82556 /* Features */,
+				E9C501C77B2363BC7AD75457 /* Migration */,
 				BCE065D58E699AFB41A13CD3 /* Palette */,
 				02ADF9B2610482EE749E5C66 /* Platform */,
 				AAC55CF3217A6A536330E9CF /* Resources */,
@@ -2045,6 +2048,14 @@
 				096F955B26BAEE5AED65B559 /* HTTPAIProvider.swift */,
 			);
 			path = Service;
+			sourceTree = "<group>";
+		};
+		E9C501C77B2363BC7AD75457 /* Migration */ = {
+			isa = PBXGroup;
+			children = (
+				255C39B045A1E21AB9A5BF9E /* StorageRelocation.swift */,
+			);
+			path = Migration;
 			sourceTree = "<group>";
 		};
 		EAE6420AAFDAF2495E748FD5 /* Model */ = {
@@ -2581,6 +2592,7 @@
 				2F1161E2706CD883E9599000 /* SpaceGesture.swift in Sources */,
 				68DE5268907FD4F96C1A346E /* SpaceSwitcher.swift in Sources */,
 				089C174783A60216FCC952B3 /* SpotlightNames.swift in Sources */,
+				9151075EDA8266D7F767D2D8 /* StorageRelocation.swift in Sources */,
 				E29056264B57A3F0EC5F5698 /* SupportCoordinator.swift in Sources */,
 				B589C3ECFF03C790102361D4 /* SupportReminderSchedule.swift in Sources */,
 				E29CF7293742DDCAE030682C /* SupportReminderStore.swift in Sources */,

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -9,6 +9,11 @@ struct TinycastApp: App {
     // Channel-aware: "Tinycast", "Tinycast Dev", or "Tinycast Beta".
     private let appName = Bundle.main.appDisplayName
 
+    /// Before `body`, and so before the first `AppCore.shared`: no store may open at the old path.
+    init() {
+        StorageRelocation.run()
+    }
+
     var body: some Scene {
         MenuBarExtra(isInserted: $showInMenuBar) {
             if let meeting = AppCore.shared.calendarCoordinator.menuBarEvent {

--- a/Tinycast/Features/Calculator/Service/CalculatorHistoryStore.swift
+++ b/Tinycast/Features/Calculator/Service/CalculatorHistoryStore.swift
@@ -8,7 +8,7 @@ struct CalcHistoryEntry: Identifiable, Codable, Hashable, Sendable {
     let createdAt: Date
 }
 
-/// A capped JSON file in Caches, beside `ClipboardStore` so `brew uninstall --zap` gets it too.
+/// A capped JSON file beside `ClipboardStore` so `brew uninstall --zap` gets it too.
 @MainActor
 @Observable
 final class CalculatorHistoryStore {
@@ -29,7 +29,7 @@ final class CalculatorHistoryStore {
     private var revision = 0
 
     init() {
-        fileURL = AppPaths.caches().appendingPathComponent("calculator-history.json")
+        fileURL = AppPaths.applicationSupport().appendingPathComponent("calculator-history.json")
 
         if let data = try? Data(contentsOf: fileURL),
             let decoded = try? JSONDecoder().decode([CalcHistoryEntry].self, from: data)

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -144,14 +144,14 @@ final class ClipboardStore {
     @ObservationIgnored private var staleImagesStmt: OpaquePointer?
     @ObservationIgnored private var deleteStaleStmt: OpaquePointer?
 
-    /// `directory` defaults to the per-channel cache; the harness passes a throwaway one.
+    /// `directory` defaults to the per-channel store; the harness passes a throwaway one.
     init(directory: URL? = nil) {
         let base = directory ?? Self.defaultDirectory
         imagesDir = base.appendingPathComponent("images", isDirectory: true)
         dbURL = base.appendingPathComponent("clipboard.sqlite3")
         try? FileManager.default.createDirectory(at: imagesDir, withIntermediateDirectories: true)
         if !openDatabase() {
-            // A regenerable cache: discard a corrupt or outdated one and start over.
+            // Captured, not authored: discard a corrupt or outdated database and start over.
             closeDatabase()
             for suffix in ["", "-wal", "-shm"] {
                 try? FileManager.default.removeItem(atPath: dbURL.path + suffix)
@@ -160,11 +160,11 @@ final class ClipboardStore {
         }
     }
 
-    /// Under Caches, history being regenerable; "Clear History" is the durable control.
+    /// Application Support, not Caches: a history the OS may reclaim is not a history.
     private static var defaultDirectory: URL {
         let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
         return FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent(bundleID, isDirectory: true)
     }
 

--- a/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
@@ -126,7 +126,7 @@ struct CustomCommandEditorSheet: View {
         "arrow.up.circle", "arrow.down.circle", "doc.text", "folder", "magnifyingglass",
         "ladybug", "chevron.left.forwardslash.chevron.right", "network", "lock", "key",
         "display", "speaker.wave.2", "moon", "sun.max", "power", "clock", "calendar",
-        "chart.bar", "flame",
+        "chart.bar", "flame"
     ]
 
     private var iconField: some View {

--- a/Tinycast/Features/Emoji/Service/FrequentEmojiStore.swift
+++ b/Tinycast/Features/Emoji/Service/FrequentEmojiStore.swift
@@ -7,7 +7,7 @@ struct FrequentEmoji: Codable, Hashable, Sendable {
     var lastUsed: Date
 }
 
-/// Usage counts as a capped JSON file in Caches, feeding the grid's "Frequently Used".
+/// Usage counts as a capped JSON file, feeding the grid's "Frequently Used".
 @MainActor
 @Observable
 final class FrequentEmojiStore {
@@ -22,7 +22,7 @@ final class FrequentEmojiStore {
     private var revision = 0
 
     init() {
-        fileURL = AppPaths.caches().appendingPathComponent("emoji-frequency.json")
+        fileURL = AppPaths.applicationSupport().appendingPathComponent("emoji-frequency.json")
 
         if let data = try? Data(contentsOf: fileURL),
             let decoded = try? JSONDecoder().decode([FrequentEmoji].self, from: data)

--- a/Tinycast/Features/Launcher/Model/LauncherRankingStore.swift
+++ b/Tinycast/Features/Launcher/Model/LauncherRankingStore.swift
@@ -8,7 +8,7 @@ struct LauncherRankingRecord: Codable, Hashable, Sendable {
     var lastUsed: Date
 }
 
-/// Learns which result a query leads to, as bounded on-device frecency data in Caches.
+/// Learns which result a query leads to, as bounded on-device frecency data.
 @MainActor
 @Observable
 final class LauncherRankingStore {
@@ -155,10 +155,11 @@ final class LauncherRankingStore {
         }
     }
 
+    /// Application Support, not Caches: relearning a ranking takes the user weeks of use.
     private static func defaultFileURL() -> URL {
         let bundleID = Bundle.main.bundleIdentifier ?? "com.tinycast.app"
         let base = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent(bundleID, isDirectory: true)
         try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
         return base.appendingPathComponent("launcher-ranking.json")

--- a/Tinycast/Migration/StorageRelocation.swift
+++ b/Tinycast/Migration/StorageRelocation.swift
@@ -1,0 +1,87 @@
+import Foundation
+import SQLite3
+
+// Spelled as the C macro in sqlite3.h, which isn't imported into Swift.
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+/// Moves the stores that outlive a cache out of `~/Library/Caches`, before anything opens them.
+enum StorageRelocation {
+    /// The tripwire in `Tests/storage-relocation-test.swift` fails the suite once this date passes.
+    static let removeAfter =
+        DateComponents(
+            calendar: Calendar(identifier: .gregorian), timeZone: .gmt,
+            year: 2026, month: 9, day: 5
+        ).date ?? .distantPast
+
+    private static let databaseName = "clipboard.sqlite3"
+    private static let imagesName = "images"
+    private static let databaseFiles = [databaseName, databaseName + "-wal", databaseName + "-shm"]
+    private static let jsonFiles = [
+        "calculator-history.json", "launcher-ranking.json", "emoji-frequency.json"
+    ]
+
+    /// Idempotent and driven by what is on disk: a "done" flag would be the residue this avoids.
+    static func run(
+        caches: URL = AppPaths.caches(), support: URL = AppPaths.applicationSupport()
+    ) {
+        for name in jsonFiles { move(name, from: caches, to: support) }
+        let movedImages = moveImages(from: caches, to: support)
+        // `map` before `contains`: every file has to move, not just up to the first one that did.
+        let movedDatabase = databaseFiles.map { move($0, from: caches, to: support) }.contains(true)
+        guard movedImages || movedDatabase else { return }
+        rewriteImagePaths(
+            in: support.appendingPathComponent(databaseName),
+            from: caches.appendingPathComponent(imagesName).path + "/",
+            to: support.appendingPathComponent(imagesName).path + "/")
+    }
+
+    @discardableResult
+    private static func move(_ name: String, from caches: URL, to support: URL) -> Bool {
+        let source = caches.appendingPathComponent(name)
+        guard FileManager.default.fileExists(atPath: source.path) else { return false }
+        // A destination that already exists is the live copy; the stale source is left alone.
+        return
+            (try? FileManager.default.moveItem(
+                at: source, to: support.appendingPathComponent(name))) != nil
+    }
+
+    /// The one move with a fallback: a rename cannot merge, and giving up orphans every thumbnail.
+    private static func moveImages(from caches: URL, to support: URL) -> Bool {
+        let source = caches.appendingPathComponent(imagesName, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: source.path) else { return false }
+        let destination = support.appendingPathComponent(imagesName, isDirectory: true)
+        if (try? FileManager.default.moveItem(at: source, to: destination)) != nil { return true }
+        try? FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        for name in (try? FileManager.default.contentsOfDirectory(atPath: source.path)) ?? [] {
+            try? FileManager.default.moveItem(
+                at: source.appendingPathComponent(name),
+                to: destination.appendingPathComponent(name))
+        }
+        // Only once it has emptied: a blob that could not move is still the only copy.
+        if (try? FileManager.default.contentsOfDirectory(atPath: source.path))?.isEmpty == true {
+            try? FileManager.default.removeItem(at: source)
+        }
+        return true
+    }
+
+    /// `image_path` is absolute, so the rows follow the blobs; an external reference stays put.
+    private static func rewriteImagePaths(in database: URL, from old: String, to new: String) {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(database.path, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK else {
+            sqlite3_close_v2(db)
+            return
+        }
+        defer { sqlite3_close_v2(db) }
+        var stmt: OpaquePointer?
+        // Prefix-matched with `substr`, not `LIKE`, whose `%` and `_` a home directory may hold.
+        let sql = """
+            UPDATE items SET image_path = ?1 || substr(image_path, length(?2) + 1)
+            WHERE substr(image_path, 1, length(?2)) = ?2
+            """
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, new, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, old, -1, SQLITE_TRANSIENT)
+        sqlite3_step(stmt)
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,10 +43,16 @@ project settings in `project.yml`, run `xcodegen generate` and commit the result
 
 Debug builds are a separate channel: **`Tinycast Dev.app`**, bundle id `com.tinycast.app.dev`. Every
 persisted thing is keyed by bundle id — `~/Library/Preferences/<id>.plist` (settings and hotkey
-bindings), `~/Library/Caches/<id>/` (clipboard history, calculator history, exchange rates, frequent
-emoji), `~/Library/Application Support/<id>/` (the onboarding marker, Notes and snippets), the
-`SMAppService` login item, and the Accessibility / Input Monitoring (TCC) grants — so a local build can
-neither read nor clobber an installed app's state, and both run side by side.
+bindings), `~/Library/Application Support/<id>/` (the onboarding marker, Notes, snippets, quicklinks,
+clipboard history, calculator history, launch ranking and frequent emoji),
+`~/Library/Caches/<id>/` (exchange rates, the update check, staged downloads), the `SMAppService`
+login item, and the Accessibility / Input Monitoring (TCC) grants — so a local build can neither read
+nor clobber an installed app's state, and both run side by side.
+
+**What earns a place in Caches is refetchable, and nothing else.** Anything the user would notice the
+loss of goes in Application Support: `~/Library/Caches` is excluded from Time Machine and the system
+reclaims it under disk pressure without saying so. `Tinycast/Migration/StorageRelocation.swift` moves
+an older layout across on first launch, and is deleted on 2026-09-05.
 
 Consequences worth knowing:
 

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -6,8 +6,10 @@
   If the writer and the poller ever disagree, the app re-captures its own pastes in a loop.
 - **`Model/ClipboardStore.swift` keeps to Foundation plus SQLite3 and no other app source**, so
   `clipboard-test` can compile it standalone. It uses `isolated deinit` for its SQLite teardown.
-- A database that cannot be opened is deleted and recreated. That is only sound because history is
-  regenerable — `QuicklinkStore` deliberately does the opposite.
+- A database that cannot be opened is deleted and recreated. That is sound because a history is
+  captured rather than authored, and there is no UI for an unavailable clipboard — `QuicklinkStore`
+  deliberately does the opposite. It is **not** a licence to treat the file as disposable: it lives in
+  Application Support precisely because nothing else can put it back.
 - **A link or an address is derived from the text, never persisted.** `ClipboardItem.Kind` stays
   `text`/`image` — the two things capture can tell apart — so improving the classifier is a code
   change rather than a database migration plus a backfill.
@@ -21,8 +23,13 @@ pasteboard and the poller skips anything carrying it.
 ## Store
 
 `ClipboardStore` is SQLite-backed: rows plus a trigram FTS5 index in `clipboard.sqlite3`, with image
-blobs as loose PNG files, all under `~/Library/Caches/<bundle-id>/`. The newest 1000 rows are mirrored
-in the observable `items` window; FTS search reaches older rows.
+blobs as loose PNG files, all under `~/Library/Application Support/<bundle-id>/`. The newest 1000 rows
+are mirrored in the observable `items` window; FTS search reaches older rows.
+
+**Application Support, not Caches.** `~/Library/Caches` is excluded from Time Machine and the system
+may reclaim it at any time without telling the app, so a history kept there survives neither a restore
+nor a full disk — while the retention setting offers **Forever** and a pin is an explicit act. The
+store used to live there; `StorageRelocation` moves an existing one across, once.
 
 A database that won't open is deleted and recreated (worst case the store degrades to session-only
 in-memory history).

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -448,7 +448,7 @@ never shares with an installed copy.
 | Command shortcuts | `UserDefaults` → `hotkey.extensionCommand.<entry id>` | yes |
 | Favorites, hidden items | `UserDefaults` → `favoriteApps`, `hiddenItemKeys` | yes |
 | User alias | `UserDefaults` → `launcherAliases` | yes |
-| Launch ranking | `Caches/<bundle id>/launcher-ranking.json` | yes |
+| Launch ranking | `launcher-ranking.json` | yes |
 
 `ExtensionCatalog.safeName` maps an npm-style name onto one path segment, and is the **only** copy of
 that mapping — a second one that drifts orphans every file the first one wrote.

--- a/docs/features/quicklinks.md
+++ b/docs/features/quicklinks.md
@@ -150,16 +150,16 @@ and use the system handler, once, without changing what is saved.
 ~/Library/Application Support/<bundle-id>/quicklinks.sqlite3
 ```
 
-Application Support, not Caches: quicklinks are **authored data, not a regenerable cache**. That one
-fact decides the two ways `QuicklinkStore` differs from `ClipboardStore`, which it otherwise mirrors
-(WAL, `PRAGMA table_info` column sniffing plus `ALTER TABLE` for migrations, prepared statements, an
+Quicklinks are **authored data**, which decides the one way `QuicklinkStore` differs from
+`ClipboardStore` — they are neighbours in Application Support, and otherwise mirror each other (WAL,
+`PRAGMA table_info` column sniffing plus `ALTER TABLE` for migrations, prepared statements, an
 `isolated deinit`):
 
-- The database lives beside the snippets library rather than in the cache.
 - **A database that won't open is never deleted.** `ClipboardStore` discards and recreates a corrupt
-  file because history is regenerable; doing that here would destroy the user's library. The store
-  publishes `isAvailable == false`, every mutation refuses with `QuicklinkError.storageUnavailable`,
-  and the pane says so. `Tests/quicklink-test.swift` asserts the file survives byte-for-byte.
+  file because a history is captured rather than authored; doing that here would destroy the user's
+  library. The store publishes `isAvailable == false`, every mutation refuses with
+  `QuicklinkError.storageUnavailable`, and the pane says so. `Tests/quicklink-test.swift` asserts the
+  file survives byte-for-byte.
 
 Editing preserves the UUID, and with it the quicklink's shortcut, favorite slot, visibility and
 learned ranking. Deleting goes through `AppCore`, which unwinds all four before removing the row.


### PR DESCRIPTION
## Related issue

Closes #377 

## What changed

Four stores move from `~/Library/Caches/<bundle id>/` to `~/Library/Application Support/<bundle id>/`:

| File | Why it moves |
| --- | --- |
| `clipboard.sqlite3` (+`-wal`/`-shm`), `images/` | captured content; retention offers **Forever** and a pin is an explicit act |
| `calculator-history.json` | a record of what the user typed and copied — nothing can rebuild it |
| `launcher-ranking.json` | relearning a ranking takes weeks of use |
| `emoji-frequency.json` | same shape as the ranking |

`~/Library/Caches` is excluded from Time Machine and the system reclaims it under disk pressure without
telling the app, so none of these survived a restore or a full disk. What is left behind is only what a
network call can fetch again: `currency-rates.json`, `update-check.json` and the `Updates/` staging
directory.

`ClipboardStore` and `LauncherRankingStore` keep their inlined path computation rather than reaching for
`AppPaths` — that is what lets `clipboard-test` and `ranking-test` compile them standalone.

### The relocation

`Tinycast/Migration/StorageRelocation.swift` moves an existing layout across, once. Two things in it are
worth a look in review:

- **Image rows hold absolute paths.** Moving `images/` without rewriting the rows orphans every
  thumbnail. The rewrite is a `substr` prefix match rather than `LIKE`, whose `%` and `_` a home
  directory may legitimately contain — and the prefix test is also what leaves an *externally*
  referenced image (one imported from another app) untouched, matching `ClipboardStore.owns`.
- **It is idempotent and driven by what is on disk**, not by a `UserDefaults` flag — a flag would be
  exactly the residue this folder exists to avoid. A run interrupted between the two renames is finished
  by the next launch.

It is called from `TinycastApp.init()`. That placement is load-bearing rather than incidental: SwiftUI
evaluates the `MenuBarExtra` scene body — which touches `AppCore.shared` — **before**
`applicationWillFinishLaunching`, so a call from the delegate runs after `ClipboardStore` has already
created an empty database at the destination. Measured order with the call in the delegate:

```
1  TinycastApp.init
2  ClipboardStore.init            ← store opens, creates an empty DB at the destination
3  applicationWillFinishLaunching
4  StorageRelocation.run          ← too late
```

`App.init()` runs before `body`, which is the only path to `AppCore.shared`.

### Its expiry

The migration is temporary, and retires itself on a schedule rather than on memory.
`storage-relocation-test` asserts `Date() < StorageRelocation.removeAfter`, so from **2026-09-05**
`./Scripts/run-tests.sh` fails and prints the checklist of what to delete. The tripwire lives inside the
code it guards, so it cannot outlive it. `AGENTS.md` carries a `Tinycast/Migration/` row with the same
date, and removing it is on that checklist.

## Memory footprint

Not measured, and not meaningful for this change: it moves file paths and adds a launch-time function
that stats five paths and, once per install, performs a handful of renames. No new long-lived state, no
new allocations on any palette path, nothing retained. Numbers invented for the table below would be
noise rather than evidence, so I have left it empty rather than fill it dishonestly.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — nothing here outlives the call.

## Drawbacks

- **`~/Library/Application Support` grows by whatever the history weighs**, which is unbounded under
  *Forever* and dominated by image blobs. That is the point of the change, but it is real: this data now
  counts against Time Machine and iCloud-managed disk space where before it did not.
- **A corrupt database is still deleted and recreated.** Durable storage arguably calls for the
  `QuicklinkStore` posture (`isAvailable == false`, refuse mutations, say so in the pane), but that is a
  second feature — new state, new UI copy, new tests — and this PR is about placement. The invariant in
  `docs/features/clipboard.md` is reworded to rest on *a history is captured rather than authored* rather
  than on the word "regenerable".
- **A relocation that half-fails leaves the stale source in Caches.** `move` refuses to overwrite an
  existing destination, on the grounds that the destination is the live copy. Given the ordering above
  the destination cannot exist before the move, so this only bites if a rename fails for an external
  reason such as permissions.
- The `Tinycast/Migration/` folder is a new top level not in the `AGENTS.md` layout. Deliberate: a whole
  folder disappearing is a cleaner deletion signal than a file inside a feature.

## Tests & validation

`./Scripts/run-tests.sh` — all 50 harnesses pass. `./Scripts/lint.sh` clean. Debug build with no new
warnings. The `Features/*/Model/` purity grep is empty.

**New harness `storage-relocation-test` (30 assertions).** It compiles the real `ClipboardStore` on both
sides of the move rather than hand-copying the schema, which would drift. Cases: every file lands and
`currency-rates.json` stays put; a hot `-wal`/`-shm` from a force-quit travels with its database; owned
image rows are rewritten while an external reference stays byte-for-byte; a run interrupted between the
two renames is completed by the next launch; a second run is a no-op; a Caches directory with nothing of
ours is untouched; and the images merge fallback when the destination directory already exists.

I mutation-tested the harness rather than trusting it green — dropping the path rewrite, dropping the
images move, and dropping the `-wal`/`-shm` from the file list each make it fail.

**End-to-end against the real app**, on a throwaway `com.tinycast.app.migtest` channel so no real data
was involved. Built the pre-change app from a clean worktree at `HEAD`; it wrote `clipboard.sqlite3` and
`images/` into Caches and captured two texts and two images. Quit it, built this branch on the same
channel, relaunched:

```
rows the clipboard screen would render: 4
  1. [image] 200×200  ← 87719465-…png
  2. [text ] MIGRATION TEST TWO — also before the change
  3. [image] 320×240  ← 99A2AAE2-…png
  4. [text ] MIGRATION TEST ONE — copied before the change

every image row decodes to a real picture: true
```

Caches was left holding only `currency-rates.json`, and both image rows had been rewritten to
Application Support. That listing comes from driving the shipped `ClipboardStore` exactly as
`ClipboardView` does — `search("", filter: .all)` then `imageURL(for:)` — not from reading the database
directly.

Also run against a real 989-row history (597 text, 392 image, 2 pins): all 392 image paths rewritten,
zero missing blobs on disk.

**Not verified:** a screenshot of the palette rendering the migrated rows. `screencapture` has no Screen
Recording grant and `osascript` no assistive access on this machine, so the visual confirmation above
stops at the render path rather than the pixels.
