### PR TITLE
Add custom Quick Action instructions

### DIFF
--- a/Tests/quick-action-test.swift
+++ b/Tests/quick-action-test.swift
@@ -78,6 +78,7 @@ struct QuickActionTests {
 
         store.settings.setPreviewsResult(true, for: .fixGrammar)
         store.settings.targetLanguage = "de"
+        store.settings.setInstructionOverride("Use British English.", for: .fixGrammar)
 
         let reopened = QuickActionSettingsStore(defaults: defaults)
         expect(
@@ -85,6 +86,9 @@ struct QuickActionTests {
             "the route survives a relaunch")
         expect(reopened.settings.previewsResult(.fixGrammar), "a preview choice survives a relaunch")
         expect(reopened.settings.targetLanguage == "de", "the target language survives a relaunch")
+        expect(
+            reopened.settings.instructionOverride(for: .fixGrammar) == "Use British English.",
+            "an action's instructions survive a relaunch")
 
         // A removed connection must not leave this pointing at a route that cannot answer.
         reopened.repairModel(against: [], fallback: .appleIntelligence)
@@ -158,6 +162,31 @@ struct QuickActionTests {
         expect(
             QuickActionPrompt.message(for: .rewrite, selection: "hi").hasPrefix("Text:"),
             "an action whose instructions already say what to do adds no second request")
+
+        expect(
+            QuickActionPrompt.instructions(for: .rewrite, override: "My instructions")
+                == "My instructions",
+            "an override replaces the complete built-in prompt")
+        expect(
+            QuickActionPrompt.instructions(for: .rewrite, override: "").isEmpty,
+            "an empty override deliberately sends no instructions")
+        expect(
+            QuickActionPrompt.instructions(for: .translate, override: "My instructions")
+                == QuickActionPrompt.instructions(for: .translate),
+            "Translate never accepts model instructions")
+
+        var settings = QuickActionSettings()
+        settings.setInstructionOverride("Custom", for: .rewrite)
+        settings.setInstructionOverride("Ignored", for: .translate)
+        expect(
+            settings.instructionOverride(for: .rewrite) == "Custom",
+            "each model-backed action keeps its own instructions")
+        expect(
+            settings.instructionOverride(for: .fixGrammar) == nil,
+            "customizing one action leaves the others on their defaults")
+        expect(
+            settings.instructionOverride(for: .translate) == nil,
+            "Translate cannot persist model instructions")
     }
 
     static func previewChoicesRememberOnlyWhatWasChosen() {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -106,6 +106,8 @@ enum SettingsBackupCoverage {
         AppSettingsKey.quickActionPreviews.rawValue:
             "Says which actions may rewrite a document without showing the result first, which is a "
             + "decision each Mac makes about its own text.",
+        AppSettingsKey.quickActionInstructions.rawValue:
+            "Custom model instructions change transformed results and must not move unseen.",
         AppSettingsKey.quickActionLanguage.rawValue:
             "Follows the language the person at this Mac reads, not the one who wrote the backup."
     ]

--- a/Tinycast/Features/QuickActions/Model/QuickActionPrompt.swift
+++ b/Tinycast/Features/QuickActions/Model/QuickActionPrompt.swift
@@ -2,10 +2,11 @@ import Foundation
 
 /// Chat's `AIPreamble` is not sent here: it describes a launcher nobody is asking the model about.
 enum QuickActionPrompt {
-    static func instructions(for action: QuickAction) -> String {
-        switch action {
+    static func instructions(for action: QuickAction, override: String? = nil) -> String {
+        if !action.usesTranslationFramework, let override { return override }
+        return switch action {
         case .fixGrammar:
-            return boundary + """
+            boundary + """
 
 
                 Correct spelling, grammar and punctuation in the text. Preserve the writer's \
@@ -13,7 +14,7 @@ enum QuickActionPrompt {
                 is wrong, return the text unchanged.
                 """
         case .rewrite:
-            return boundary + """
+            boundary + """
 
 
                 Rewrite the text so it reads more clearly. Keep the writer's meaning, register and \
@@ -21,7 +22,7 @@ enum QuickActionPrompt {
                 there.
                 """
         case .summarize:
-            return """
+            """
                 You summarize text for a reader who has already seen it.
 
                 Write a short summary of the text that follows. Lead with the single most important \
@@ -32,7 +33,7 @@ enum QuickActionPrompt {
                 """
         case .translate:
             // Apple's translator does this one; exhaustive so a new action cannot forget a prompt.
-            return boundary
+            boundary
         }
     }
 

--- a/Tinycast/Features/QuickActions/Model/QuickActionSettings.swift
+++ b/Tinycast/Features/QuickActions/Model/QuickActionSettings.swift
@@ -6,6 +6,7 @@ struct QuickActionSettings: Equatable, Sendable {
 
     /// BCP-47, e.g. `es-419`. Empty means the Mac's own language.
     var targetLanguage: String = ""
+    private(set) var instructionOverrides: [QuickAction: String] = [:]
 
     func previewsResult(_ action: QuickAction) -> Bool {
         if action.alwaysPreviews { return true }
@@ -17,6 +18,15 @@ struct QuickActionSettings: Equatable, Sendable {
         previewChoices[action] = previews
     }
 
+    func instructionOverride(for action: QuickAction) -> String? {
+        instructionOverrides[action]
+    }
+
+    mutating func setInstructionOverride(_ instructions: String?, for action: QuickAction) {
+        guard !action.usesTranslationFramework else { return }
+        instructionOverrides[action] = instructions
+    }
+
     /// Round-trips through `UserDefaults`; an unknown key is an action that no longer exists.
     var storedPreviewChoices: [String: Bool] {
         get { Dictionary(uniqueKeysWithValues: previewChoices.map { ($0.rawValue, $1) }) }
@@ -24,6 +34,18 @@ struct QuickActionSettings: Equatable, Sendable {
             previewChoices = Dictionary(
                 uniqueKeysWithValues: newValue.compactMap { key, value in
                     QuickAction(rawValue: key).map { ($0, value) }
+                })
+        }
+    }
+
+    var storedInstructionOverrides: [String: String] {
+        get { Dictionary(uniqueKeysWithValues: instructionOverrides.map { ($0.rawValue, $1) }) }
+        set {
+            instructionOverrides = Dictionary(
+                uniqueKeysWithValues: newValue.compactMap { key, value in
+                    guard let action = QuickAction(rawValue: key), !action.usesTranslationFramework
+                    else { return nil }
+                    return (action, value)
                 })
         }
     }

--- a/Tinycast/Features/QuickActions/Service/QuickActionRunner.swift
+++ b/Tinycast/Features/QuickActions/Service/QuickActionRunner.swift
@@ -38,10 +38,12 @@ final class QuickActionRunner {
     /// No transcript to grow, so a caller showing progress reads `onDelta` and the rest just await.
     static func run(
         _ action: QuickAction, selection: String, using provider: any AIProvider,
+        instructionOverride: String?,
         onDelta: @MainActor (String) -> Void = { _ in }
     ) async throws -> String {
         let request = AIRequest(
-            instructions: QuickActionPrompt.instructions(for: action),
+            instructions: QuickActionPrompt.instructions(
+                for: action, override: instructionOverride),
             messages: [
                 AIMessage(
                     role: .user,

--- a/Tinycast/Features/QuickActions/Settings/QuickActionSettingsStore.swift
+++ b/Tinycast/Features/QuickActions/Settings/QuickActionSettingsStore.swift
@@ -23,6 +23,9 @@ final class QuickActionSettingsStore {
             as? [String: Bool] ?? [:]
         loaded.targetLanguage =
             defaults.string(forKey: AppSettingsKey.quickActionLanguage.rawValue) ?? ""
+        loaded.storedInstructionOverrides =
+            defaults.dictionary(forKey: AppSettingsKey.quickActionInstructions.rawValue)
+            as? [String: String] ?? [:]
         settings = loaded
         model = Self.decodeModel(
             defaults.data(forKey: AppSettingsKey.quickActionModel.rawValue))
@@ -50,6 +53,9 @@ final class QuickActionSettingsStore {
         defaults.set(
             settings.storedPreviewChoices, forKey: AppSettingsKey.quickActionPreviews.rawValue)
         defaults.set(settings.targetLanguage, forKey: AppSettingsKey.quickActionLanguage.rawValue)
+        defaults.set(
+            settings.storedInstructionOverrides,
+            forKey: AppSettingsKey.quickActionInstructions.rawValue)
     }
 
     private func persistModel() {

--- a/Tinycast/Features/QuickActions/Settings/QuickActionsSettingsView.swift
+++ b/Tinycast/Features/QuickActions/Settings/QuickActionsSettingsView.swift
@@ -11,6 +11,7 @@ struct QuickActionsSettingsView: View {
 
     /// Polled like the Permissions pane: the grant lands in System Settings, which sends nothing.
     @State private var isTrusted = Permissions.isAccessibilityTrusted()
+    @State private var editingAction: QuickAction?
     private let refreshTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -48,6 +49,14 @@ struct QuickActionsSettingsView: View {
         }
         .formStyle(.grouped)
         .onReceive(refreshTimer) { _ in isTrusted = Permissions.isAccessibilityTrusted() }
+        .sheet(item: $editingAction) { action in
+            InstructionsEditorSheet(
+                action: action,
+                instructionOverride: store.settings.instructionOverride(for: action)
+            ) { instructionOverride in
+                store.settings.setInstructionOverride(instructionOverride, for: action)
+            }
+        }
         .onAppear {
             core.quickActionCoordinator.loadLanguages()
             store.resolveModel(
@@ -63,6 +72,15 @@ struct QuickActionsSettingsView: View {
                     Image(systemName: action.symbol)
                         .frame(width: Theme.Size.settingsRowIcon)
                 } trailing: {
+                    if !action.usesTranslationFramework {
+                        Button { editingAction = action } label: {
+                            SymbolImage(
+                                name: "pencil", size: Theme.Size.quickActionHeaderIcon)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Edit \(action.title) instructions")
+                        .accessibilityLabel("Edit \(action.title) instructions")
+                    }
                     ShortcutRecorder(action: .quickAction(action), isQuiet: true)
                     Picker("", selection: previewBinding(action)) {
                         Text("Replace").tag(false)
@@ -181,5 +199,64 @@ struct QuickActionsSettingsView: View {
             appleIntelligence: aiSettings.isAppleIntelligenceAvailable(),
             chatGPT: core.chatGPTSubscription.models,
             connections: aiSettings.connections)
+    }
+
+    private struct InstructionsEditorSheet: View {
+        @Environment(\.dismiss) private var dismiss
+        @State private var instructions: String
+
+        let action: QuickAction
+        let builtIn: String
+        let onSave: (String?) -> Void
+
+        init(
+            action: QuickAction, instructionOverride: String?,
+            onSave: @escaping (String?) -> Void
+        ) {
+            self.action = action
+            let builtIn = QuickActionPrompt.instructions(for: action)
+            _instructions = State(initialValue: instructionOverride ?? builtIn)
+            self.builtIn = builtIn
+            self.onSave = onSave
+        }
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+                Text("Customize \(action.title)")
+                    .font(.title2.weight(.bold))
+
+                Text("Tell Tinycast how you want \(action.title) to handle your selected text.")
+                    .foregroundStyle(.secondary)
+
+                TextEditor(text: $instructions)
+                    .font(.body)
+                    .scrollContentBackground(.hidden)
+                    .padding(Theme.Spacing.sm)
+                    .frame(height: Theme.Size.editorTextHeight * 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                            .fill(Theme.Colors.cardFill)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                            .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
+                    )
+
+                HStack {
+                    Button("Use Default") { instructions = builtIn }
+                        .disabled(instructions == builtIn)
+                    Spacer()
+                    Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
+                    Button("Save") {
+                        onSave(instructions == builtIn ? nil : instructions)
+                        dismiss()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+            .padding(Theme.Spacing.xxl)
+            .frame(width: Theme.Size.editorSheetWidth)
+        }
     }
 }

--- a/Tinycast/Features/QuickActions/UI/QuickActionCoordinator.swift
+++ b/Tinycast/Features/QuickActions/UI/QuickActionCoordinator.swift
@@ -173,6 +173,7 @@ final class QuickActionCoordinator {
         let provider = try core.quickActionProvider()
         return try await QuickActionRunner.run(
             state.action, selection: state.original, using: provider,
+            instructionOverride: store.settings.instructionOverride(for: state.action),
             onDelta: { delta in
                 guard streaming else { return }
                 state.append(delta)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -62,6 +62,7 @@ enum AppSettingsKey: String, CaseIterable {
     case quickActionsEnabled = "quickActionsEnabled"
     case quickActionModel = "quickActionModel"
     case quickActionPreviews = "quickActionPreviews"
+    case quickActionInstructions = "quickActionInstructions"
     case quickActionLanguage = "quickActionLanguage"
     case supportReminders = "supportReminders"
 }

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -43,9 +43,13 @@ provider protocol and the connections behind it.
   `SystemLanguageModel.Guardrails.permissiveContentTransformations`. The default filter is tuned for
   a model writing fresh prose and refuses to transform text somebody already wrote, which is the
   whole feature.
-- **The selection is untrusted input.** `QuickActionPrompt` tells every model that the text is
-  material to work on and never instructions to follow, and that only the transformed text may come
-  back — no preamble, no fences. The output is pasted into somebody's document.
+- **Built-in instructions treat the selection as untrusted input.** `QuickActionPrompt` tells the
+  model that the text is material to work on and never instructions to follow, and that only the
+  transformed text may come back — no preamble, no fences. Custom instructions replace these rules
+  too. The output is pasted into somebody's document.
+- **Each model action owns its instructions.** The pencil on Fix Grammar, Rewrite and Summarize opens
+  a sheet prefilled with the exact built-in prompt. Saving replaces that prompt for only that action;
+  Use Default restores it. Translate has no editor because no model handles translation.
 
 ## The actions
 
@@ -61,6 +65,9 @@ a fifth cannot compile without a launcher command of its own.
 | Rewrite | provider | panel | yes |
 | Translate | Apple Translation | panel | no |
 | Summarize | provider | panel, always | no |
+
+Custom instructions stay on this Mac and are excluded from settings backups, like chat's system
+prompt, because importing them would change results without the reader seeing them first.
 
 Only Fix Grammar applies unseen: it changes what was wrong, where a rewrite changes the voice.
 Summarize can never be told to replace text unseen — it answers a question *about* the text, so
@@ -178,6 +185,8 @@ behaviour rather than something Tinycast asserts, so it is the part worth checki
 - Press one in a password field: refused.
 - Summarize a long selection: the panel streams, grows without the title drifting, and scrolls past
   `quickActionPanelBody`.
+- Replace Rewrite's instructions, confirm only Rewrite follows them after relaunch, then use the
+  modal's default and confirm the shipped behaviour returns.
 - Translate into a language that has not been downloaded: the panel offers the download, then
   translates.
 - Revoke Accessibility while enabled: a HUD explains instead of failing silently.


### PR DESCRIPTION
## Related issue

Closes #384

## What changed

Fix Grammar, Rewrite, and Summarize now have a pencil button in Quick Actions settings. It opens a modal with that action's current instructions, which the user can replace or reset with Use Default.

Each override is stored separately on this Mac and replaces the complete built-in prompt. The four actions, their result behavior, and Translate's Apple Translation path stay unchanged.

## Memory footprint

No new service, timer, background task, or resource-owning path was added. The retained state is limited to up to three instruction strings in the existing Quick Action settings store. The modal state exists only while its sheet is open. Memory was not separately measured.

Leak-tested: Not separately measured; the change adds no resource-owning path.

## Demo

https://github.com/user-attachments/assets/3f4ba25e-d6c7-41c6-8e0c-91f304874758

## Drawbacks

A custom prompt replaces the built-in output and prompt-injection rules too. This is intentional so the editor controls the complete instruction sent to the model. Custom instructions stay on the current Mac and are excluded from settings backups.

## Tests & validation

- `./Scripts/run-tests.sh` passed, all 50 harnesses.
- `./Scripts/lint.sh` passed with existing repository warnings.
- Debug build passed.
- Release build passed.
- `git diff --check` passed.
- Opened the editors in Tinycast Dev, confirmed the built-in prompt, saved custom text with leading and trailing spaces, and verified the stored value was unchanged.