### PR TITLE
Let a quicklink answer to an alias

### DIFF
--- a/Tinycast/DesignSystem/SettingsComponents.swift
+++ b/Tinycast/DesignSystem/SettingsComponents.swift
@@ -105,7 +105,9 @@ struct SettingsFilterField: View {
 
 /// Dressed like `ShortcutRecorder`; a persistent `TextField` — swapping views broke repeat focus.
 struct AliasField: View {
-    let entry: AppEntry
+    /// The owner's `preferenceKey`, taken raw so a row without an `AppEntry` can carry one too.
+    let key: String
+    let name: String
     @Environment(AliasStore.self) private var aliases
     @State private var draft = ""
     @FocusState private var focused: Bool
@@ -134,13 +136,13 @@ struct AliasField: View {
                         .foregroundStyle(.tertiary)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Clear alias for \(entry.name)")
+                .accessibilityLabel("Clear alias for \(name)")
             }
         }
-        .onAppear { draft = aliases.alias(for: entry.preferenceKey) ?? "" }
+        .onAppear { draft = aliases.alias(for: key) ?? "" }
         // A backup import replaces the table out from under an unfocused row.
         .onChange(of: aliases.revision) { _, _ in
-            if !focused { draft = aliases.alias(for: entry.preferenceKey) ?? "" }
+            if !focused { draft = aliases.alias(for: key) ?? "" }
         }
         .padding(.horizontal, Theme.Spacing.sm)
         .frame(width: Theme.Size.shortcutRecorder, height: 24)
@@ -150,22 +152,28 @@ struct AliasField: View {
                 focused ? Color.accentColor : Theme.Colors.cardStroke, lineWidth: 1)
         )
         .clipShape(shape)
-        .accessibilityLabel("Alias for \(entry.name)")
+        .accessibilityLabel("Alias for \(name)")
     }
 
     /// The one commit path — ↵ or focus landing elsewhere; a blank draft removes the alias.
     private func commit() {
-        aliases.setAlias(draft, for: entry.preferenceKey)
-        draft = aliases.alias(for: entry.preferenceKey) ?? ""
+        aliases.setAlias(draft, for: key)
+        draft = aliases.alias(for: key) ?? ""
     }
 
     private func revert() {
-        draft = aliases.alias(for: entry.preferenceKey) ?? ""
+        draft = aliases.alias(for: key) ?? ""
         focused = false
     }
 
     private func clear() {
         draft = ""
         commit()
+    }
+}
+
+extension AliasField {
+    init(entry: AppEntry) {
+        self.init(key: entry.preferenceKey, name: entry.name)
     }
 }

--- a/Tinycast/Features/Quicklinks/Settings/QuicklinksSettingsView.swift
+++ b/Tinycast/Features/Quicklinks/Settings/QuicklinksSettingsView.swift
@@ -83,7 +83,7 @@ struct QuicklinksSettingsView: View {
             }
             Button("Add Quicklink…") { core.quicklinkCoordinator.editQuicklink(nil) }
         } footer: {
-            Text("Name it, paste a link, then give it a shortcut if you want one.")
+            Text("Name it, paste a link, then add an alias or a shortcut if you want one.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -165,6 +165,10 @@ private struct QuicklinkSettingsRow: View {
                     .foregroundStyle(.secondary)
                     .help("Hidden from root search")
             }
+
+            // An alias only reaches the ranker through the root-search slice, so it dims with it.
+            AliasField(key: quicklink.entryID, name: quicklink.name)
+                .settingsEnabled(quicklink.showsInRootSearch)
 
             ShortcutRecorder(action: .quicklink(id: quicklink.id))
 

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -151,7 +151,9 @@ visibility checkbox, not a per-invocation action, so the ⌘K menu stays out of 
 on `LauncherItemsSection` puts an `AliasField` on each row, dressed like the `ShortcutRecorder`
 beside it; edits store as typed and trim when the field loses focus, and a blank means none. That
 list filters by **membership only**, keeping the index's name order — re-ranking it per keystroke
-would move the row being edited out from under its own field editor.
+would move the row being edited out from under its own field editor. A pane with a hand-written row
+hands `AliasField` the key itself: Settings ▸ Quicklinks passes `Quicklink.entryID`, and dims the
+field on a quicklink hidden from root search, whose entry the ranker never sees.
 
 Aliases ride along in a settings backup (`launcherAliases`), and deleting what an alias points at —
 uninstalling an app, deleting a quicklink or custom command, uninstalling an extension — removes it

--- a/docs/features/quicklinks.md
+++ b/docs/features/quicklinks.md
@@ -122,7 +122,9 @@ Tinycast's own dialog and leaves no partial state.
 
 Quicklinks are their own `AppEntry.Kind`, their own `AppIndex` slice and their own launcher section,
 between System Settings and Snippets. Only the **name** is indexed; the destination is not searchable
-(a URL is a subsequence of almost any query). Per-quicklink "Show in root search" filters the slice;
+(a URL is a subsequence of almost any query) — beside the name, a quicklink answers to whatever
+[user alias](launcher.md#user-aliases) its Settings row carries, which is why a hidden one dims the
+field. Per-quicklink "Show in root search" filters the slice;
 the pane's "Show in launcher" takes the section and the four Quicklink commands out of the
 launcher together, leaving shortcuts and the pane itself working.
 


### PR DESCRIPTION
## Related issue

Closes #383

## What changed

Every row in **Settings ▸ Quicklinks** now carries an **Add Alias** field beside its shortcut
recorder, so a quicklink can be reached by a short alias instead of its full name or a hotkey.

Almost all of this already existed. `AliasStore` is keyed by `AppEntry.preferenceKey`, `AppIndex.rank`
folds `userAlias` in for every entry kind, the launcher row already draws the alias chip, aliases ride
along in a settings backup, and deleting a quicklink already clears its alias key. The only gap was the
editing surface: the Quicklinks pane writes its own row instead of using `LauncherItemsSection`, which
is what puts an `AliasField` on Applications, System Settings, Commands, System Actions and Calendar.

So the change is two small things:

- `AliasField` now takes the preference key and the display name directly, with an `init(entry:)`
  keeping the `AppEntry`-backed call sites unchanged.
- `QuicklinkSettingsRow` adds one, keyed by `Quicklink.entryID`, dimmed on a quicklink hidden from
  root search — its entry is filtered out of the index, so an alias there would be inert.

The pane's footer now mentions the alias, and `docs/features/launcher.md` + `quicklinks.md` record the
hand-written-row case.

## Memory footprint

Not measured: no runtime path changed. This adds one `AliasField` per already-realized settings row,
reading the same `AliasStore` the other panes read, and touches nothing that runs while the palette is
open.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — no new object graph, observer, timer or task.

## Demo

No before/after video captured. The visual change is one field appearing in the Quicklinks rows; the
row was rendered offscreen at the settings detail column's real width (645pt — the window's
`contentMinSize` of 860 means it is never narrower) to confirm the extra 120pt field does not crowd
the name or the link.

## Drawbacks

- The quicklinks row trailing stack is now two status glyphs, an alias field, a recorder and two
  buttons. It reads fine at the window's minimum width, but it is the busiest row in Settings.
- An alias lives in `launcherAliases`, not in the quicklinks JSON export, so exporting a quicklink does
  not carry its alias. That matches how application aliases behave, so it is left alone.

## Tests & validation

`./Scripts/run-tests.sh` — all 50 harnesses pass. Debug build compiles with no new warnings,
`./Scripts/lint.sh` is clean, and `Features/*/Model/` still imports no UI framework. No harness case
added: the ranking behaviour is unchanged and already covered by `Tests/ranking-test.swift`; what is
new is a settings row.
