### PR TITLE
Send Quick Press keys unmodified, so Escape is Escape

### DIFF
--- a/Tinycast/Features/HotKeys/Service/HyperKeyTap.swift
+++ b/Tinycast/Features/HotKeys/Service/HyperKeyTap.swift
@@ -418,6 +418,8 @@ final class HyperKeyTap: HealthCheckable {
         let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
         let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
         for event in [down, up] {
+            // The session source still carries the chord we injected, and a modified Escape is eaten.
+            event?.flags = []
             event?.setIntegerValueField(.eventSourceUserData, value: Self.syntheticTag)
             event?.post(tap: .cghidEventTap)
         }

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -152,6 +152,12 @@ Caps Lock's alpha-shift bit, or — for a key modifier outside the Hyper set —
 device bits. Events the tap posts carry a `"TYCT"` marker in `.eventSourceUserData`, the same FourCC
 `HotKeyCenter` uses, so the tap never reacts to its own synthetics.
 
+A Quick Press key is posted with **`flags` cleared explicitly**, like every other synthetic in the app.
+A keyboard event built from `.combinedSessionState` inherits the source's modifiers, and the release
+that ended the hold is still in flight a runloop turn later — so the Escape went out as ⌃⌥⇧⌘Escape.
+Terminals read the raw `0x1B` and did not care; a focused field editor and any exact-match keymap
+swallowed it, which is why Quick Press worked in Ghostty but never in Zed or the palette itself.
+
 ### ✦ is the notation, not a preference
 
 Any combo whose modifiers are a superset of the chord renders with the Hyper set replaced by a single


### PR DESCRIPTION
## Related issue

Closes #123

## What changed

`HyperKeyTap.postKey` now clears `flags` on the events it posts.

It was the only synthetic-key site in the app that never assigned them — `Paster.postCommand` sets
`.maskCommand`, `TextInjector.makeKeyEvents` sets its `flags` parameter. A keyboard event built from
`CGEventSource(stateID: .combinedSessionState)` inherits the source's modifier state, and the release
that ended the Hyper hold is still travelling a runloop turn later, so the Quick Press Escape went out
carrying the ⌃⌥⇧⌘ chord.

That is why the bug looked application-specific rather than like a mistuned threshold: Ghostty reads
the raw `0x1B` and ignores modifiers, so it always worked. Zed matches keystrokes exactly, and
`ctrl-alt-shift-cmd-escape` binds to nothing. The palette's own search field is worse still — with a
field editor focused, AppKit swallows a modified Escape before SwiftUI's `.onKeyPress(.escape)` ever
sees it.

Measured against a focused `TextField`, matching the palette's state:

| Modifiers on Escape | Reaches `.onKeyPress(.escape)` |
| ------------------- | ------------------------------ |
| none                | ✅                             |
| ⇧, ⌥                | ✅                             |
| ⌃                   | ❌                             |
| ⌘                   | ❌                             |
| ⌃⌥⌘ / ⌃⌥⇧⌘          | ❌                             |

Clearing is unconditionally correct here: Quick Press is only offered for keys with an original
function, which is Caps Lock alone, so no physical modifier is genuinely held at that point.

Note for triage: #362 was previously pointed at as the tracking issue for this. It is unrelated — an
Apple-side hang in the Caps Lock caret indicator — and is now closed.

## Memory footprint

No allocation change: two property writes on events the tap already created.

| Step                    | Memory      |
| ----------------------- | ----------- |
| Idle after launch       | unchanged   |
| Palette open            | unchanged   |
| Feature in use (peak)   | unchanged   |
| Palette closed, settled | unchanged   |

Leak-tested: n/a — no ownership, lifetime or retain change in the diff.

## Drawbacks

None. It brings the one outlier in line with how every other synthetic key in the app is posted.

The residue is cleared at creation rather than by waiting for the release to land, so this relies on
the WindowServer not re-stamping live modifiers onto a posted event — the same assumption
`Paster.postCommand`'s ⌘V has depended on for a long time.

## Tests & validation

`./Scripts/run-tests.sh` — all 50 harnesses pass. Debug build succeeds with no new warnings;
`./Scripts/lint.sh` clean.

No harness covers this: `postKey` is a `CGEvent` call in `Service/`, which the Model-only harnesses
deliberately cannot reach.

Validated instead by probing the receiving side directly — a throwaway SwiftUI app with a focused
`TextField` and the palette's `onKeyPress` stack, fed synthesized Escapes across every modifier
combination. That produced the table above and identifies which modifiers get an Escape swallowed.

Still wants a hand check on device: Caps Lock as Hyper with Quick Press set to Escape should now
dismiss the palette, and should register in Zed.
