### PR TITLE
Eject the external disks that report themselves as fixed

### DIFF
--- a/Tinycast/Features/SystemActions/Service/SystemActionRunner.swift
+++ b/Tinycast/Features/SystemActions/Service/SystemActionRunner.swift
@@ -376,16 +376,20 @@ enum SystemActionRunner {
     @discardableResult
     private static func ejectAllDisks() throws -> Int {
         let keys: Set<URLResourceKey> = [
-            .volumeIsEjectableKey, .volumeIsInternalKey, .volumeIsLocalKey
+            .volumeIsEjectableKey, .volumeIsInternalKey, .volumeIsLocalKey,
+            .volumeIsRootFileSystemKey
         ]
         let urls =
             FileManager.default.mountedVolumeURLs(
                 includingResourceValuesForKeys: Array(keys), options: [.skipHiddenVolumes]) ?? []
         let ejectable = urls.filter { url in
             guard let values = try? url.resourceValues(forKeys: keys) else { return false }
-            return values.volumeIsEjectable == true
-                && values.volumeIsInternal != true
-                && values.volumeIsLocal != false
+            guard values.volumeIsLocal != false,
+                values.volumeIsInternal != true,
+                values.volumeIsRootFileSystem != true
+            else { return false }
+            // A dock's fixed-media HDD is external but not ejectable, so external alone qualifies.
+            return values.volumeIsEjectable == true || values.volumeIsInternal == false
         }
         var failures: [String] = []
         var ejected = 0
@@ -396,7 +400,11 @@ enum SystemActionRunner {
                 try NSWorkspace.shared.unmountAndEjectDevice(at: url)
                 ejected += 1
             } catch {
-                guard mountedVolumeExists(url) else { continue }
+                // An eject that errors yet leaves no mount behind still took the volume offline.
+                guard mountedVolumeExists(url) else {
+                    ejected += 1
+                    continue
+                }
                 failures.append("\(url.lastPathComponent): \(error.localizedDescription)")
             }
         }

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -239,8 +239,11 @@ is TCC-protected, so an unprivileged read fails in a way indistinguishable from 
 silently skip a real empty. Eject All Disks, Dismiss Notifications and Unhide All Apps report the same
 way when there is nothing to act on. Volume and mute fall back to the output's preferred stereo channels when the device exposes
 no master element (common on HDMI), and Toggle Mute parks the level at zero when there is no mute
-control at all. Multi-disk ejection excludes internal and network volumes, treats a sibling volume
-that the same physical eject already unmounted as done, and reports remaining failures together.
+control at all. Multi-disk ejection takes every external or ejectable volume — a dock's fixed-media
+HDD reports as neither ejectable nor removable, so external alone qualifies — while excluding
+internal, network and root volumes, treats a sibling volume that the same physical eject already
+unmounted as done, counts a volume whose eject errored but whose mount is gone as ejected, and
+reports remaining failures together.
 Preference-backed toggles refuse to write when the current value can't be read, and notification
 dismissal matches Accessibility subroles rather than English labels.
 


### PR DESCRIPTION
## Related issue

Closes #350

## What changed

`ejectAllDisks` filtered on `volumeIsEjectable`, which a hard drive in a USB dock reports as `false` — external and physical, but `Removable Media: Fixed` — so the dock's disks were skipped and a dock on its own answered `No Disks to Eject`. The filter now takes a volume that is **ejectable or explicitly external** (`volumeIsInternal == false`), and gained a `volumeIsRootFileSystem` exclusion so a Mac booted from an external disk cannot eject the one it is running from.

Second, a volume whose eject threw yet left no mount behind now counts as ejected instead of being passed over — a disk that unmounts but refuses the eject call can no longer land on `No Disks to Eject`. The pre-attempt check that treats a sibling the same physical eject already took as done is unchanged.

## Memory footprint

Not measured: no allocation, retained object or lifetime changed — the diff is one filter predicate and one counter branch inside an existing action.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | n/a    |
| Palette open            | n/a    |
| Feature in use (peak)   | n/a    |
| Palette closed, settled | n/a    |

Leak-tested: n/a

## Drawbacks

The reporter's hardware — a multi-bay USB dock with fixed-media HDDs — was not available to test against, so the new predicate is verified by the resource values macOS reports rather than by an actual dock eject. A read-only probe over the mounted volumes confirms the boot volume is still excluded.

## Tests & validation

`./Scripts/run-tests.sh` (all 50 harnesses), Debug build with no new warnings, `./Scripts/lint.sh` clean. No harness covers this: the selection reads live `URLResourceKey` values from mounted volumes, which the Model-layer harnesses cannot fake.