### PR TITLE
Resolve palette shortcuts through the ASCII-capable keyboard layout

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -141,6 +141,7 @@ run palette-tab-test       Tinycast/Palette/PaletteMode.swift \
 run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swift \
                            Tinycast/Features/HotKeys/Model/DoubleTapDetector.swift \
                            Tinycast/Features/HotKeys/Model/HyperKey.swift \
+                           Tinycast/Platform/ASCIIKeyboardLayout.swift \
                            Tinycast/Features/HotKeys/Service/KeyShortcut.swift \
                            Tinycast/Features/HotKeys/Model/HotKeyAction.swift \
                            Tinycast/Features/QuickActions/Model/QuickAction.swift \

--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -87,11 +87,19 @@ struct DoubleTapDetectorTests {
     }
 
     static func layoutCharacters() {
-        let character = ASCIIKeyboardLayout.character(for: kVK_ANSI_K)
-        expect(character?.isEmpty == false, "the ASCII-capable layout translates an ANSI letter key")
+        let keyCodes = [kVK_ANSI_K, kVK_ANSI_X, kVK_ANSI_Q, kVK_ANSI_Comma, kVK_ANSI_Period]
+        let characters = keyCodes.compactMap { ASCIIKeyboardLayout.character(for: $0) }
         expect(
-            character?.unicodeScalars.allSatisfy(\.isASCII) == true,
+            characters.count == keyCodes.count,
+            "the ASCII-capable layout translates every ANSI key a palette chord uses")
+        expect(
+            characters.allSatisfy { $0.unicodeScalars.allSatisfy(\.isASCII) },
             "the shortcut character stays ASCII while a non-ASCII input source is active")
+        expect(
+            keyCodes.allSatisfy {
+                ASCIIKeyboardLayout.character(for: $0, modifiers: UInt32(cmdKey >> 8)) != nil
+            },
+            "a layout's Command table resolves the same keys, so ⌘ chords never lose their letter")
     }
 
     // MARK: - Built-in command mappings

--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -56,6 +56,7 @@ struct DoubleTapDetectorTests {
     static func main() {
         modifierGlyphs()
         commandActions()
+        layoutCharacters()
         hyperChord()
         hyperRetargeting()
         firing()
@@ -83,6 +84,14 @@ struct DoubleTapDetectorTests {
             DoubleTapModifier.allCases.map(\.rawValue)
                 == ["control", "option", "shift", "command"],
             "raw values are the persisted spelling and stay in canonical ⌃⌥⇧⌘ order")
+    }
+
+    static func layoutCharacters() {
+        let character = ASCIIKeyboardLayout.character(for: kVK_ANSI_K)
+        expect(character?.isEmpty == false, "the ASCII-capable layout translates an ANSI letter key")
+        expect(
+            character?.unicodeScalars.allSatisfy(\.isASCII) == true,
+            "the shortcut character stays ASCII while a non-ASCII input source is active")
     }
 
     // MARK: - Built-in command mappings

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		F03DB7A7898F0388E821FDBB /* AppleIntelligenceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B5C0B83C3645AC90639B85 /* AppleIntelligenceProvider.swift */; };
 		F3E0C5D483CC854D63448A4B /* UpdateReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76460C2D60828CC79F0CE972 /* UpdateReadiness.swift */; };
 		F44DA0C81285A90138E13A7B /* ChatGPTSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */; };
+		F4A75F90028F57D6DC1EF7DB /* ASCIIKeyboardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D1CA733FFAEF665D867A45 /* ASCIIKeyboardLayout.swift */; };
 		F51785CF5A6EC0B87D6802C9 /* ExtensionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCBDD92DEAD780A1DC423CA /* ExtensionScreen.swift */; };
 		F71FC7195AC8D6626BEE8931 /* NotesPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91151402A1A4586B2496BF35 /* NotesPanel.swift */; };
 		F801D00F877421DC7045C5F3 /* RedactedPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131B15F5EF86A067FA6C36D7 /* RedactedPlaceholder.swift */; };
@@ -804,6 +805,7 @@
 		E01488803F8025B0523D44BA /* RelaunchRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaunchRunner.swift; sourceTree = "<group>"; };
 		E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		E27FB790A72ACD75DFCDFDDF /* VolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSlider.swift; sourceTree = "<group>"; };
+		E2D1CA733FFAEF665D867A45 /* ASCIIKeyboardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCIIKeyboardLayout.swift; sourceTree = "<group>"; };
 		E44875ABECB1F1B648EC90F4 /* SupportWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportWindowView.swift; sourceTree = "<group>"; };
 		E475F373557FD3524086CE19 /* MeetingCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCalendar.swift; sourceTree = "<group>"; };
 		E54932083F6BC197453EA0C8 /* UninstallSearchRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSearchRoot.swift; sourceTree = "<group>"; };
@@ -878,6 +880,7 @@
 				5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */,
 				8E5F9675F2090C3AA9EEBF65 /* Appearance.swift */,
 				B6A96350EBE68EC79497FA2D /* AppPaths.swift */,
+				E2D1CA733FFAEF665D867A45 /* ASCIIKeyboardLayout.swift */,
 				D3F82845FDA307DF71676352 /* CalendarAccess.swift */,
 				5DD86B3ABBB71BC6EA116D85 /* CameraAccess.swift */,
 				BFB023D167225228757CC4B2 /* HealthTicker.swift */,
@@ -2259,6 +2262,7 @@
 				76056E33DD554E1153BB3DD0 /* AISettingsView.swift in Sources */,
 				4D8C05DD67FAB9F2DA1F31FB /* AIStreamDecoder.swift in Sources */,
 				6DF29BAB73F545DA2DE63F9B /* APIKeyStore.swift in Sources */,
+				F4A75F90028F57D6DC1EF7DB /* ASCIIKeyboardLayout.swift in Sources */,
 				540F1433DC46BC97C9F80E06 /* AboutView.swift in Sources */,
 				CD04C9CA00C002C0EC82756A /* AccessibilityText.swift in Sources */,
 				16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */,

--- a/Tinycast/Features/Extensions/UI/ExtensionPaletteModifiers.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionPaletteModifiers.swift
@@ -9,7 +9,9 @@ struct ExtensionShortcutKeys: ViewModifier {
         content.onKeyPress(phases: .down) { press in
             guard let screen, !press.modifiers.isEmpty else { return .ignored }
             return screen.dispatchShortcut(
-                key: press.key, modifiers: press.modifiers, at: selection) ? .handled : .ignored
+                key: ASCIIKeyboardLayout.keyEquivalent(fallingBackTo: press.key),
+                modifiers: press.modifiers,
+                at: selection) ? .handled : .ignored
         }
     }
 }

--- a/Tinycast/Features/HotKeys/Service/KeyShortcut.swift
+++ b/Tinycast/Features/HotKeys/Service/KeyShortcut.swift
@@ -98,7 +98,7 @@ struct KeyShortcut: Hashable, Sendable {
     @MainActor private var keyGlyph: String {
         if let special = Self.specialKeyGlyphs[carbonKeyCode] { return special }
         if let name = Self.functionKeyNames[carbonKeyCode] { return name }
-        return Self.layoutCharacter(for: carbonKeyCode)?.uppercased() ?? "?"
+        return ASCIIKeyboardLayout.character(for: carbonKeyCode)?.uppercased() ?? "?"
     }
 
     private static let specialKeyGlyphs: [Int: String] = [
@@ -115,37 +115,6 @@ struct KeyShortcut: Hashable, Sendable {
         kVK_F16: "F16", kVK_F17: "F17", kVK_F18: "F18", kVK_F19: "F19", kVK_F20: "F20"
     ]
 
-    // `TISGetInputSourceProperty` is only safe on the main thread.
-    @MainActor private static func layoutCharacter(for keyCode: Int) -> String? {
-        guard
-            let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?
-                .takeRetainedValue(),
-            let layoutDataPointer = TISGetInputSourceProperty(
-                source, kTISPropertyUnicodeKeyLayoutData)
-        else { return nil }
-
-        let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
-        let keyLayout = unsafeBitCast(
-            CFDataGetBytePtr(layoutData), to: UnsafePointer<UCKeyboardLayout>.self)
-        var deadKeyState: UInt32 = 0
-        var length = 0
-        var characters = [UniChar](repeating: 0, count: 4)
-
-        let error = UCKeyTranslate(
-            keyLayout,
-            UInt16(keyCode),
-            UInt16(kUCKeyActionDisplay),
-            0,  // no modifiers: the glyph is the key's base character
-            UInt32(LMGetKbdType()),
-            OptionBits(kUCKeyTranslateNoDeadKeysBit),
-            &deadKeyState,
-            characters.count,
-            &length,
-            &characters
-        )
-        guard error == noErr, length > 0 else { return nil }
-        return String(utf16CodeUnits: characters, count: length)
-    }
 }
 
 // Decoding routes through the masking initializer. See docs/features/hotkeys.md#persistence.

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -64,7 +64,9 @@ final class PalettePanel: NSPanel {
         else { return nil }
         let arrow: (key: KeyEquivalent, code: Int)
         // Character chords, not key codes: Dvorak transposes the two.
-        switch event.charactersIgnoringModifiers?.lowercased() {
+        switch ASCIIKeyboardLayout.character(for: Int(event.keyCode))?.lowercased()
+            ?? event.charactersIgnoringModifiers?.lowercased()
+        {
         case "n": arrow = (.downArrow, kVK_DownArrow)
         case "p": arrow = (.upArrow, kVK_UpArrow)
         case "f": arrow = (.rightArrow, kVK_RightArrow)

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -63,8 +63,8 @@ final class PalettePanel: NSPanel {
         guard event.modifierFlags.intersection([.command, .option, .control, .shift]) == .control
         else { return nil }
         let arrow: (key: KeyEquivalent, code: Int)
-        // Character chords, not key codes: Dvorak transposes the two.
-        switch ASCIIKeyboardLayout.character(for: Int(event.keyCode))?.lowercased()
+        // Through the ASCII-capable layout: an IME must not move ⌃N off its physical key.
+        switch ASCIIKeyboardLayout.character(for: event)?.lowercased()
             ?? event.charactersIgnoringModifiers?.lowercased()
         {
         case "n": arrow = (.downArrow, kVK_DownArrow)

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -266,9 +266,10 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 self.core.palette.prepare(mode: .launcher)
                 return true
             }
-            // Character chords, not key codes: Dvorak transposes the two.
-            guard let character = ASCIIKeyboardLayout.character(for: Int(event.keyCode))?
-                .lowercased() ?? event.charactersIgnoringModifiers?.lowercased()
+            // Through the ASCII-capable layout: an IME must not move ⌘W off its physical key.
+            guard
+                let character = ASCIIKeyboardLayout.character(for: event)?.lowercased()
+                    ?? event.charactersIgnoringModifiers?.lowercased()
             else { return false }
             switch character {
             case ",":

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -267,7 +267,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 return true
             }
             // Character chords, not key codes: Dvorak transposes the two.
-            guard let character = event.charactersIgnoringModifiers?.lowercased() else { return false }
+            guard let character = ASCIIKeyboardLayout.character(for: Int(event.keyCode))?
+                .lowercased() ?? event.charactersIgnoringModifiers?.lowercased()
+            else { return false }
             switch character {
             case ",":
                 self.core.settingsCoordinator.showSettings()

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -361,8 +361,10 @@ struct RootPaletteView: View {
                 screen: menuOpen ? nil : screen as? ExtensionCommandScreen, selection: sel)
         )
         // ⌘K toggles the actions panel for the current selection.
-        .onKeyPress(keys: ["k"], phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
+        .onKeyPress(phases: .down) { press in
+            guard press.modifiers.contains(.command),
+                ASCIIKeyboardLayout.matches(press.key, character: "k")
+            else { return .ignored }
             // The Actions menu has no anchor in the compact bar, so swallow ⌘K there.
             guard !isCollapsed else { return .handled }
             let screen = screen
@@ -396,8 +398,10 @@ struct RootPaletteView: View {
             return .ignored
         }
         // ⌃X / ⌃⇧X mirror the delete rows — both cases, Shift uppercasing — and close an open menu.
-        .onKeyPress(keys: ["x", "X"], phases: .down) { press in
-            guard press.modifiers.contains(.control) else { return .ignored }
+        .onKeyPress(phases: .down) { press in
+            guard press.modifiers.contains(.control),
+                ASCIIKeyboardLayout.matches(press.key, character: "x")
+            else { return .ignored }
             let screen = screen
             let selection = selection(in: screen)
             let all = press.modifiers.contains(.shift)
@@ -415,15 +419,18 @@ struct RootPaletteView: View {
             return .handled
         }
         // Never gated on the rows: an over-narrow filter empties them, and this is the way out.
-        .onKeyPress(keys: ["p"], phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
+        .onKeyPress(phases: .down) { press in
+            guard press.modifiers.contains(.command),
+                ASCIIKeyboardLayout.matches(press.key, character: "p")
+            else { return .ignored }
             guard !isCollapsed, vm.mode == .clipboard else { return .ignored }
             toggleClipboardFilter()
             return .handled
         }
         // ⇧⌘F mirrors the Add/Remove Favorites row, closing an open menu the way that row does.
-        .onKeyPress(keys: ["f", "F"], phases: .down) { press in
+        .onKeyPress(phases: .down) { press in
             guard press.modifiers.contains(.command), press.modifiers.contains(.shift),
+                ASCIIKeyboardLayout.matches(press.key, character: "f"),
                 !isCollapsed, let launcher = screen as? LauncherScreen
             else { return .ignored }
             guard launcher.toggleFavorite(at: selection(in: launcher)) else { return .ignored }
@@ -431,15 +438,17 @@ struct RootPaletteView: View {
             return .handled
         }
         // Both cases, Shift uppercasing the key; the compact bar shows no target.
-        .onKeyPress(keys: ["q", "Q"], phases: .down) { press in
+        .onKeyPress(phases: .down) { press in
             guard press.modifiers.contains(.control), press.modifiers.contains(.shift),
+                ASCIIKeyboardLayout.matches(press.key, character: "q"),
                 !isCollapsed, let launcher = screen as? LauncherScreen
             else { return .ignored }
             return launcher.quit(at: selection(in: launcher)) ? .handled : .ignored
         }
         // ⌘R mirrors the Restart Application row, on the same guard and the same compact-bar skip.
-        .onKeyPress(keys: ["r"], phases: .down) { press in
-            guard press.modifiers.contains(.command), !isCollapsed,
+        .onKeyPress(phases: .down) { press in
+            guard press.modifiers.contains(.command),
+                ASCIIKeyboardLayout.matches(press.key, character: "r"), !isCollapsed,
                 let launcher = screen as? LauncherScreen
             else { return .ignored }
             return launcher.restart(at: selection(in: launcher)) ? .handled : .ignored

--- a/Tinycast/Platform/ASCIIKeyboardLayout.swift
+++ b/Tinycast/Platform/ASCIIKeyboardLayout.swift
@@ -3,7 +3,8 @@ import Carbon.HIToolbox
 import SwiftUI
 
 enum ASCIIKeyboardLayout {
-    @MainActor static func character(for keyCode: Int) -> String? {
+    /// No modifiers by default: the key's base character, which is what a shortcut glyph shows.
+    @MainActor static func character(for keyCode: Int, modifiers: UInt32 = 0) -> String? {
         guard
             let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?
                 .takeRetainedValue(),
@@ -22,7 +23,7 @@ enum ASCIIKeyboardLayout {
             keyLayout,
             UInt16(keyCode),
             UInt16(kUCKeyActionDisplay),
-            0,
+            modifiers,
             UInt32(LMGetKbdType()),
             OptionBits(kUCKeyTranslateNoDeadKeysBit),
             &deadKeyState,
@@ -34,14 +35,26 @@ enum ASCIIKeyboardLayout {
         return String(utf16CodeUnits: characters, count: length)
     }
 
+    /// A layout owns its Command table: "Dvorak – QWERTY ⌘" only restores ⌘K to QWERTY through it.
+    @MainActor static func character(for event: NSEvent) -> String? {
+        character(
+            for: Int(event.keyCode),
+            modifiers: event.modifierFlags.contains(.command) ? UInt32(cmdKey >> 8) : 0)
+    }
+
     /// SwiftUI exposes the input-source character; recover the logical ASCII key from AppKit.
     @MainActor static func keyEquivalent(fallingBackTo key: KeyEquivalent) -> KeyEquivalent {
         guard let event = NSApp.currentEvent,
             !event.modifierFlags.isDisjoint(with: [.command, .control]),
-            let character = character(for: Int(event.keyCode))?.lowercased().first,
+            let character = character(for: event)?.lowercased().first,
             character.unicodeScalars.allSatisfy(\.isASCII)
-        else { return key }
+        else { return lowercased(key) }
         return KeyEquivalent(character)
+    }
+
+    /// Shift uppercases SwiftUI's key, but every chord spells its letter in lower case.
+    private static func lowercased(_ key: KeyEquivalent) -> KeyEquivalent {
+        key.character.lowercased().first.map { KeyEquivalent($0) } ?? key
     }
 
     @MainActor static func matches(_ key: KeyEquivalent, character: Character) -> Bool {

--- a/Tinycast/Platform/ASCIIKeyboardLayout.swift
+++ b/Tinycast/Platform/ASCIIKeyboardLayout.swift
@@ -1,0 +1,50 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+enum ASCIIKeyboardLayout {
+    @MainActor static func character(for keyCode: Int) -> String? {
+        guard
+            let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?
+                .takeRetainedValue(),
+            let layoutDataPointer = TISGetInputSourceProperty(
+                source, kTISPropertyUnicodeKeyLayoutData)
+        else { return nil }
+
+        let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
+        let keyLayout = unsafeBitCast(
+            CFDataGetBytePtr(layoutData), to: UnsafePointer<UCKeyboardLayout>.self)
+        var deadKeyState: UInt32 = 0
+        var length = 0
+        var characters = [UniChar](repeating: 0, count: 4)
+
+        let error = UCKeyTranslate(
+            keyLayout,
+            UInt16(keyCode),
+            UInt16(kUCKeyActionDisplay),
+            0,
+            UInt32(LMGetKbdType()),
+            OptionBits(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            characters.count,
+            &length,
+            &characters
+        )
+        guard error == noErr, length > 0 else { return nil }
+        return String(utf16CodeUnits: characters, count: length)
+    }
+
+    /// SwiftUI exposes the input-source character; recover the logical ASCII key from AppKit.
+    @MainActor static func keyEquivalent(fallingBackTo key: KeyEquivalent) -> KeyEquivalent {
+        guard let event = NSApp.currentEvent,
+            !event.modifierFlags.isDisjoint(with: [.command, .control]),
+            let character = character(for: Int(event.keyCode))?.lowercased().first,
+            character.unicodeScalars.allSatisfy(\.isASCII)
+        else { return key }
+        return KeyEquivalent(character)
+    }
+
+    @MainActor static func matches(_ key: KeyEquivalent, character: Character) -> Bool {
+        keyEquivalent(fallingBackTo: key) == KeyEquivalent(character)
+    }
+}

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -361,7 +361,9 @@ exactly as the chord natively would. A chord carrying any modifier beyond ⌃ �
 Character shortcut handlers accept every key so SwiftUI still calls them when the active input
 source produces a non-ASCII character. Inside the callback, `ASCIIKeyboardLayout` resolves
 `NSApp.currentEvent.keyCode` through the current ASCII-capable layout before comparing the shortcut.
-Panel-owned chords use the same translation directly. A non-ASCII input source or IME therefore
+Panel-owned chords use the same translation directly. A ⌘ chord translates through the layout's own
+Command table, so "Dvorak – QWERTY ⌘" keeps giving QWERTY positions while Command is held; a ⌃ chord
+translates without it, since only Command is remapped. A non-ASCII input source or IME therefore
 cannot turn ⌘K into a different logical key, while Dvorak and other ASCII layouts keep their own
 letter positions. No replacement event is synthesized, and unmodified typing stays on the active
 input source and follows the normal composition path.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -358,6 +358,14 @@ movement and the scroll-into-view intent all follow for free. The caret keeps �
 because `moveHorizontally` leaves →/← `.ignored` there, and the field editor then moves by a character
 exactly as the chord natively would. A chord carrying any modifier beyond ⌃ — ⌃⇧Q, say — is left alone.
 
+Character shortcut handlers accept every key so SwiftUI still calls them when the active input
+source produces a non-ASCII character. Inside the callback, `ASCIIKeyboardLayout` resolves
+`NSApp.currentEvent.keyCode` through the current ASCII-capable layout before comparing the shortcut.
+Panel-owned chords use the same translation directly. A non-ASCII input source or IME therefore
+cannot turn ⌘K into a different logical key, while Dvorak and other ASCII layouts keep their own
+letter positions. No replacement event is synthesized, and unmodified typing stays on the active
+input source and follows the normal composition path.
+
 ## Focus restoration (load-bearing)
 
 `PaletteWindowController` records `previousApp` (the frontmost app) on show. Paste then targets that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -229,7 +229,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - With a calculation typed, the calculator card is first and is selected first
 - Section headers appear in order: Favorites, Applications, System Settings, Quicklinks, Snippets,
   System Actions, Window Management, Custom Commands, Commands
-- ⌘K opens the Actions menu; ↑/↓ move it, ↵ activates, Escape closes the menu rather than the palette
+- With a non-ASCII input source active, ⌘K opens Actions; ↑/↓ move it, ↵ activates, Escape closes it
 - While a menu is open, typing does **not** change the query and the caret is hidden
 - Tab toggles launcher ↔ clipboard; bare Backspace on an empty query backs out of a sub-screen
 - Launching an app focuses it; escaping the palette returns focus to the app you came from


### PR DESCRIPTION
## Related issue

N/A — no directly matching issue was found.

## What changed

### Problem

Palette-internal shortcuts were matched against the character produced by the active input source.

For example, with a non-ASCII input source or IME active, opening the palette and pressing
Command-K did not open Actions. Switching to an English input source made the same physical shortcut
work. Global shortcuts were unaffected because Carbon registers them with hardware key codes and
modifier masks. Internal shortcuts instead passed through the focused field editor and SwiftUI
`KeyEquivalent` matching, so the input source could change the character before a filtered
`.onKeyPress(keys: ["k"])` handler saw it.

### Resolution

Added `ASCIIKeyboardLayout`, which resolves a hardware key code through macOS's current
ASCII-capable keyboard layout.

Character shortcut handlers now accept every key press and compare the logical ASCII key inside the
callback, using `NSApp.currentEvent.keyCode`. Panel-owned chords and extension action shortcuts use
the same translation. This keeps Command-K and the other Command/Control palette shortcuts working
while a non-ASCII input source or IME is active.

The translation:

- Applies only to Command and Control chords, leaving ordinary typing, Option-only input, dead keys,
  and IME composition unchanged.
- Falls back to SwiftUI's original `KeyEquivalent` when an ASCII translation is unavailable.
- Uses the current ASCII-capable layout, so Dvorak, Colemak, and similar layouts retain their logical
  letter positions.
- Does not synthesize or redispatch replacement `NSEvent` instances.

`KeyShortcut` also uses the shared translator when rendering shortcut glyphs, keeping the displayed
shortcut and the key used for matching consistent. The hotkey harness and manual regression
documentation now cover this behavior.

## Memory footprint

Measured with `/usr/bin/footprint` on the ad-hoc-signed Debug build on macOS 26.5.2.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 42 MB  |
| Palette open            | 41 MB  |
| Feature in use (peak)   | 45 MB  |
| Palette closed, settled | 44 MB  |

Leak-tested: Repeated Command-K / Backspace 11 times and then closed the palette. Peak footprint
stayed below 53 MB. `leaks` reported no retained synthetic `NSEvent` and no Tinycast-owned allocation
chain; its remaining 15.2 KB was in macOS AppIntents XPC objects also present in the baseline process.

## Drawbacks

- Modified character handlers receive every key press and immediately ignore non-matching keys.
- Resolving a Command or Control chord queries the current ASCII-capable layout on the main actor.
  This avoids caching a layout that can change while Tinycast is running.
- Matching uses `NSApp.currentEvent` while SwiftUI invokes the key-press callback. If that event is
  unavailable or cannot be translated, matching falls back to SwiftUI's original key.

## Tests & validation

- All 50 test harnesses passed.
- Extended `Tests/hotkey-test.swift` to cover ASCII-capable keyboard layout translation.
- SwiftLint passed with only existing repository warnings.
- Pure-layer import validation passed.
- Debug configuration built successfully.
- Manually verified Command-K with a non-ASCII input source active.
- Verified ordinary IME text entry remains unchanged.
- Verified global shortcuts continue to work.
- Repeated Command-K 11 times and confirmed that replacement `NSEvent` objects do not accumulate.
