### PR TITLE
Enable or disable an individual quicklink or custom command

### DIFF
--- a/Tests/custom-command-test.swift
+++ b/Tests/custom-command-test.swift
@@ -59,6 +59,14 @@ struct CustomCommandTests {
             "update clears a flag left out of the draft",
             store.command(id: added.id)?.requiresConfirmation == false)
 
+        check("a new command is enabled", store.command(id: added.id)?.isEnabled == true)
+        store.setEnabled(false, id: added.id)
+        check("disabling is stored", store.command(id: added.id)?.isEnabled == false)
+        check(
+            "disabling keeps every other field intact",
+            store.command(id: added.id)?.command == "/usr/bin/true")
+        store.setEnabled(true, id: added.id)
+
         let expected = store.commands
         check(
             "commands survive a reload with their flags",
@@ -104,6 +112,9 @@ struct CustomCommandTests {
         check(
             "a record written before arguments existed still loads",
             CustomCommandStore(defaults: defaults).commands.first?.name == "Legacy")
+        check(
+            "a record written before the enabled flag loads as enabled",
+            CustomCommandStore(defaults: defaults).commands.first?.isEnabled == true)
 
         // MARK: Runner
 

--- a/Tests/quicklink-test.swift
+++ b/Tests/quicklink-test.swift
@@ -163,12 +163,20 @@ struct QuicklinkTests {
                 store.quicklink(id: github.id)?.showsInRootSearch == false,
                 "hiding from root search is stored")
 
+            expect(github.isEnabled, "a new quicklink is enabled")
+            try? store.setEnabled(false, id: github.id)
+            expect(store.quicklink(id: github.id)?.isEnabled == false, "disabling is stored")
+            expect(
+                store.quicklink(id: github.id)?.link == "https://github.com/issues",
+                "disabling keeps every other field intact")
+
             guard let copy = try? store.duplicate(id: github.id) else {
                 return fail("duplicating a quicklink succeeds")
             }
             expect(copy.id != github.id, "a duplicate is a new identity")
             expect(copy.name == "GitHub Issues Copy", "a duplicate gets a distinct name")
             expect(copy.link == "https://github.com/issues", "a duplicate keeps the destination")
+            expect(!copy.isEnabled, "a duplicate inherits the enabled flag")
 
             try? store.remove(id: copy.id)
             expect(store.quicklinks.map(\.id) == [github.id], "removing drops only that row")
@@ -246,6 +254,7 @@ struct QuicklinkTests {
             draft.openWithBundleID = "com.apple.finder"
             stored = try? store.add(draft).id
             try? store.togglePinned(id: stored!)
+            try? store.setEnabled(false, id: stored!)
         }
 
         let reopened = QuicklinkStore(directory: dir)
@@ -259,9 +268,10 @@ struct QuicklinkTests {
         expect(restored.iconSymbol == "folder", "the icon survives")
         expect(restored.openWithBundleID == "com.apple.finder", "the open-with app survives")
         expect(restored.isPinned, "the pin stamp survives")
+        expect(!restored.isEnabled, "the enabled flag survives")
     }
 
-    /// The column order the store binds must match the order it reads.
+    /// The bound column order must match the read order, and an older table must gain `is_enabled`.
     static func readsADatabaseWrittenElsewhere() {
         let dir = scratchDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -289,6 +299,12 @@ struct QuicklinkTests {
         expect(row.openWithBundleID == nil, "a null open-with reads as none")
         expect(!row.showsInRootSearch, "the root-search flag lines up")
         expect(!row.isPinned, "a null pin stamp reads as unpinned")
+        expect(row.isEnabled, "a table written before is_enabled loads its rows as enabled")
+
+        // A second open must find the column already there rather than adding it twice.
+        let reopened = QuicklinkStore(directory: dir)
+        reopened.load()
+        expect(reopened.quicklinks.count == 1, "the migrated table reopens cleanly")
     }
 
     /// Quicklinks are authored data, so an unreadable database is reported, never recreated.
@@ -317,7 +333,8 @@ struct QuicklinkTests {
         let stamp = Date(timeIntervalSince1970: 500)
         let pinned = Quicklink(
             name: "Pinned", link: "~/Downloads", openWithBundleID: "com.apple.finder",
-            iconSymbol: "folder", showsInRootSearch: false, pinnedAt: stamp, createdAt: stamp)
+            iconSymbol: "folder", isEnabled: false, showsInRootSearch: false, pinnedAt: stamp,
+            createdAt: stamp)
         let plain = Quicklink(name: "GitHub", link: "https://github.com", createdAt: stamp)
         let source = [plain, pinned]
 
@@ -358,6 +375,7 @@ struct QuicklinkTests {
         guard let decoded = try? QuicklinkArchive.decode(handWritten), let first = decoded.first
         else { return fail("a hand-written archive decodes") }
         expect(first.name == "Staging", "the name is read")
+        expect(first.isEnabled, "an omitted enabled flag defaults to on")
         expect(first.showsInRootSearch, "an omitted root-search flag defaults to shown")
         expect(first.pinnedAt == nil, "an omitted pin stamp reads as unpinned")
 

--- a/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+++ b/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
@@ -30,6 +30,8 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     let id: UUID
     var name: String
     var command: String
+    /// Off keeps the command and everything attached to it, but nothing may offer or run it.
+    var isEnabled: Bool
     /// Sources the shell config so aliases resolve; opt-in, a heavy one costing more.
     var loadsShellEnvironment: Bool
     var requiresConfirmation: Bool
@@ -44,7 +46,7 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
     var iconSymbol: String?
 
     init(
-        id: UUID = UUID(), name: String, command: String,
+        id: UUID = UUID(), name: String, command: String, isEnabled: Bool = true,
         loadsShellEnvironment: Bool = false, requiresConfirmation: Bool = false,
         showsConfirmation: Bool = false, arguments: [CustomCommandArgument] = [],
         showsOutput: Bool = false, workingDirectory: String? = nil, iconSymbol: String? = nil
@@ -52,6 +54,7 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
         self.id = id
         self.name = name
         self.command = command
+        self.isEnabled = isEnabled
         self.loadsShellEnvironment = loadsShellEnvironment
         self.requiresConfirmation = requiresConfirmation
         self.showsConfirmation = showsConfirmation
@@ -73,8 +76,8 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
 
     // Hand-written, so an added field keeps stored commands and older backups readable.
     private enum CodingKeys: String, CodingKey {
-        case id, name, command, loadsShellEnvironment, requiresConfirmation, showsConfirmation
-        case arguments, showsOutput, workingDirectory, iconSymbol
+        case id, name, command, isEnabled, loadsShellEnvironment, requiresConfirmation
+        case showsConfirmation, arguments, showsOutput, workingDirectory, iconSymbol
     }
 
     init(from decoder: Decoder) throws {
@@ -82,6 +85,7 @@ struct CustomCommand: Codable, Hashable, Identifiable, Sendable {
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         command = try container.decode(String.self, forKey: .command)
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
         loadsShellEnvironment =
             try container.decodeIfPresent(Bool.self, forKey: .loadsShellEnvironment) ?? false
         requiresConfirmation =
@@ -159,6 +163,15 @@ final class CustomCommandStore {
         let value = try validated(draft)
         var updated = commands
         updated[index] = value
+        commit(updated)
+    }
+
+    func setEnabled(_ enabled: Bool, id: UUID) {
+        guard let index = commands.firstIndex(where: { $0.id == id }),
+            commands[index].isEnabled != enabled
+        else { return }
+        var updated = commands
+        updated[index].isEnabled = enabled
         commit(updated)
     }
 

--- a/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
@@ -33,6 +33,12 @@ struct CommandsSettingsView: View {
                     ForEach(sortedCommands) { command in
                         CustomCommandSettingsRow(
                             command: command,
+                            isEnabled: Binding(
+                                get: { command.isEnabled },
+                                set: {
+                                    core.customCommandCoordinator.setCustomCommandEnabled(
+                                        $0, id: command.id)
+                                }),
                             onEdit: { editor = EditorTarget(command: command) },
                             onDelete: { pendingDeletion = command })
                     }
@@ -75,6 +81,7 @@ private struct EditorTarget: Identifiable {
 
 private struct CustomCommandSettingsRow: View {
     let command: CustomCommand
+    @Binding var isEnabled: Bool
     let onEdit: () -> Void
     let onDelete: () -> Void
 
@@ -82,7 +89,9 @@ private struct CustomCommandSettingsRow: View {
         SettingsRow(title: command.name, subtitle: command.command) {
             Image(systemName: command.symbol)
         } trailing: {
+            // A disabled command's shortcut fires into the funnel's refusal, so it dims too.
             ShortcutRecorder(action: .customCommand(id: command.id))
+                .settingsEnabled(command.isEnabled)
 
             Button(action: onEdit) {
                 Image(systemName: "pencil")
@@ -98,6 +107,12 @@ private struct CustomCommandSettingsRow: View {
             .buttonStyle(.plain)
             .help("Delete Command")
             .accessibilityLabel("Delete \(command.name)")
+
+            Toggle("", isOn: $isEnabled)
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .help("Enabled")
+                .accessibilityLabel("Enable \(command.name)")
         }
     }
 }

--- a/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CustomCommandEditorSheet.swift
@@ -252,6 +252,8 @@ struct CustomCommandEditorSheet: View {
         // Editing keeps the UUID, and with it every reference the command owns.
         let draft = CustomCommand(
             id: command?.id ?? UUID(), name: name, command: shellCommand,
+            // The pane's row owns the checkbox; an edit carries the flag rather than resetting it.
+            isEnabled: command?.isEnabled ?? true,
             loadsShellEnvironment: loadsShellEnvironment,
             requiresConfirmation: requiresConfirmation,
             showsConfirmation: showsConfirmation,

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
@@ -74,6 +74,11 @@ final class CustomCommandCoordinator {
         try store.update(draft)
     }
 
+    /// Keeps the command and its shortcut, but takes it out of every surface that could run it.
+    func setCustomCommandEnabled(_ enabled: Bool, id: UUID) {
+        store.setEnabled(enabled, id: id)
+    }
+
     func deleteCustomCommand(id: UUID) {
         guard let command = store.command(id: id) else { return }
         removeCustomCommandReferences(ids: [id], entryIDs: [command.entryID])
@@ -97,7 +102,7 @@ final class CustomCommandCoordinator {
     func runCustomCommand(id: UUID) {
         // Also the feature switch: with it off a registered hotkey must run nothing.
         guard settings.customCommandsEnabled else { return }
-        guard let command = store.command(id: id) else { return }
+        guard let command = store.command(id: id), command.isEnabled else { return }
         guard command.arguments.isEmpty else {
             argumentSession.begin(command: command)
             // Never a restored mode: this screen is always a fresh prompt, never a resumed one.

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -258,7 +258,7 @@ final class AppIndex {
 
     /// Replaces the command slice without rescanning, so Settings edits land at once.
     func setCustomCommands(_ commands: [CustomCommand]) {
-        let entries = commands.map { command in
+        let entries = commands.filter(\.isEnabled).map { command in
             AppEntry(
                 id: command.entryID, name: command.name,
                 url: URL(string: "tinycast://custom-command/" + command.id.uuidString)!,
@@ -274,7 +274,7 @@ final class AppIndex {
     func setQuicklinks(_ quicklinks: [Quicklink]) {
         let entries =
             quicklinks
-            .filter(\.showsInRootSearch)
+            .filter { $0.isEnabled && $0.showsInRootSearch }
             .sorted(by: Quicklink.precedes)
             .map { quicklink in
                 AppEntry(

--- a/Tinycast/Features/Quicklinks/Model/Quicklink.swift
+++ b/Tinycast/Features/Quicklinks/Model/Quicklink.swift
@@ -14,6 +14,8 @@ struct Quicklink: Codable, Hashable, Identifiable, Sendable {
     var openWithBundleID: String?
     /// SF Symbol override; nil takes the glyph the detected destination suggests.
     var iconSymbol: String?
+    /// Off keeps the row and everything attached to it, but nothing may offer or open it.
+    var isEnabled: Bool
     var showsInRootSearch: Bool
     /// A stamp rather than a flag, so the pinned block is ordered by *when* you pinned.
     var pinnedAt: Date?
@@ -21,14 +23,15 @@ struct Quicklink: Codable, Hashable, Identifiable, Sendable {
 
     init(
         id: UUID = UUID(), name: String, link: String, openWithBundleID: String? = nil,
-        iconSymbol: String? = nil, showsInRootSearch: Bool = true, pinnedAt: Date? = nil,
-        createdAt: Date = Date()
+        iconSymbol: String? = nil, isEnabled: Bool = true, showsInRootSearch: Bool = true,
+        pinnedAt: Date? = nil, createdAt: Date = Date()
     ) {
         self.id = id
         self.name = name
         self.link = link
         self.openWithBundleID = openWithBundleID
         self.iconSymbol = iconSymbol
+        self.isEnabled = isEnabled
         self.showsInRootSearch = showsInRootSearch
         self.pinnedAt = pinnedAt
         self.createdAt = createdAt
@@ -60,7 +63,8 @@ struct Quicklink: Codable, Hashable, Identifiable, Sendable {
 
     // Hand-written, so an added field keeps old exports importable and imports stay minimal.
     private enum CodingKeys: String, CodingKey {
-        case id, name, link, openWithBundleID, iconSymbol, showsInRootSearch, pinnedAt, createdAt
+        case id, name, link, openWithBundleID, iconSymbol, isEnabled, showsInRootSearch, pinnedAt
+        case createdAt
     }
 
     init(from decoder: Decoder) throws {
@@ -70,6 +74,7 @@ struct Quicklink: Codable, Hashable, Identifiable, Sendable {
         link = try container.decode(String.self, forKey: .link)
         openWithBundleID = try container.decodeIfPresent(String.self, forKey: .openWithBundleID)
         iconSymbol = try container.decodeIfPresent(String.self, forKey: .iconSymbol)
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
         showsInRootSearch =
             try container.decodeIfPresent(Bool.self, forKey: .showsInRootSearch) ?? true
         pinnedAt = try container.decodeIfPresent(Date.self, forKey: .pinnedAt)

--- a/Tinycast/Features/Quicklinks/Model/QuicklinkArchive.swift
+++ b/Tinycast/Features/Quicklinks/Model/QuicklinkArchive.swift
@@ -71,6 +71,7 @@ enum QuicklinkArchive {
                     link: candidate.link.trimmingCharacters(in: .whitespacesAndNewlines),
                     openWithBundleID: candidate.openWithBundleID,
                     iconSymbol: candidate.iconSymbol,
+                    isEnabled: candidate.isEnabled,
                     showsInRootSearch: candidate.showsInRootSearch,
                     pinnedAt: candidate.pinnedAt))
         }

--- a/Tinycast/Features/Quicklinks/Model/QuicklinkStore.swift
+++ b/Tinycast/Features/Quicklinks/Model/QuicklinkStore.swift
@@ -23,7 +23,8 @@ final class QuicklinkStore {
           icon TEXT,
           in_root_search INTEGER NOT NULL DEFAULT 1,
           pinned_at REAL,
-          created_at REAL NOT NULL
+          created_at REAL NOT NULL,
+          is_enabled INTEGER NOT NULL DEFAULT 1
         );
         """
 
@@ -103,6 +104,12 @@ final class QuicklinkStore {
         try write(value)
     }
 
+    func setEnabled(_ enabled: Bool, id: UUID) throws(QuicklinkError) {
+        guard var value = quicklink(id: id), value.isEnabled != enabled else { return }
+        value.isEnabled = enabled
+        try write(value)
+    }
+
     func setShowsInRootSearch(_ shows: Bool, id: UUID) throws(QuicklinkError) {
         guard var value = quicklink(id: id), value.showsInRootSearch != shows else { return }
         value.showsInRootSearch = shows
@@ -117,7 +124,8 @@ final class QuicklinkStore {
             Quicklink(
                 name: Self.uniqueName(basedOn: source.name, taken: quicklinks.map(\.name)),
                 link: source.link, openWithBundleID: source.openWithBundleID,
-                iconSymbol: source.iconSymbol, showsInRootSearch: source.showsInRootSearch))
+                iconSymbol: source.iconSymbol, isEnabled: source.isEnabled,
+                showsInRootSearch: source.showsInRootSearch))
     }
 
     /// Adds a batch, skipping anything invalid — the import and backup path. Returns what landed.
@@ -146,13 +154,14 @@ final class QuicklinkStore {
         sqlite3_bind_text(stmt, 3, value.link, -1, SQLITE_TRANSIENT)
         bind(stmt, 4, value.openWithBundleID)
         bind(stmt, 5, value.iconSymbol)
-        sqlite3_bind_int(stmt, 6, value.showsInRootSearch ? 1 : 0)
+        sqlite3_bind_int(stmt, 6, value.isEnabled ? 1 : 0)
+        sqlite3_bind_int(stmt, 7, value.showsInRootSearch ? 1 : 0)
         if let pinnedAt = value.pinnedAt {
-            sqlite3_bind_double(stmt, 7, pinnedAt.timeIntervalSince1970)
+            sqlite3_bind_double(stmt, 8, pinnedAt.timeIntervalSince1970)
         } else {
-            sqlite3_bind_null(stmt, 7)
+            sqlite3_bind_null(stmt, 8)
         }
-        sqlite3_bind_double(stmt, 8, value.createdAt.timeIntervalSince1970)
+        sqlite3_bind_double(stmt, 9, value.createdAt.timeIntervalSince1970)
         let status = sqlite3_step(stmt)
         sqlite3_reset(stmt)
         sqlite3_clear_bindings(stmt)
@@ -234,6 +243,10 @@ final class QuicklinkStore {
                 == SQLITE_OK,
             sqlite3_exec(db, Self.schema, nil, nil, nil) == SQLITE_OK
         else { return false }
+        // `IF NOT EXISTS` leaves an older table as it was, so its new column is added by hand.
+        sqlite3_exec(
+            db, "ALTER TABLE quicklinks ADD COLUMN is_enabled INTEGER NOT NULL DEFAULT 1", nil, nil,
+            nil)
         // After the schema, so a column added later can be indexed the same way.
         sqlite3_exec(
             db,
@@ -241,17 +254,18 @@ final class QuicklinkStore {
             nil, nil, nil)
         upsertStmt = prepare(
             """
-            INSERT INTO quicklinks(id, name, link, open_with, icon, in_root_search, pinned_at, created_at)
-            VALUES(?,?,?,?,?,?,?,?)
+            INSERT INTO quicklinks(id, name, link, open_with, icon, is_enabled, in_root_search, pinned_at, created_at)
+            VALUES(?,?,?,?,?,?,?,?,?)
             ON CONFLICT(id) DO UPDATE SET
               name = excluded.name, link = excluded.link, open_with = excluded.open_with,
-              icon = excluded.icon, in_root_search = excluded.in_root_search,
-              pinned_at = excluded.pinned_at
+              icon = excluded.icon, is_enabled = excluded.is_enabled,
+              in_root_search = excluded.in_root_search, pinned_at = excluded.pinned_at
             """
         )
+        // Both statements name columns in the struct's order, which `is_enabled` was appended after.
         loadStmt = prepare(
             """
-            SELECT id, name, link, open_with, icon, in_root_search, pinned_at, created_at
+            SELECT id, name, link, open_with, icon, is_enabled, in_root_search, pinned_at, created_at
             FROM quicklinks
             """
         )
@@ -281,9 +295,10 @@ final class QuicklinkStore {
         return Quicklink(
             id: id, name: name, link: link, openWithBundleID: columnString(stmt, 3),
             iconSymbol: columnString(stmt, 4),
-            showsInRootSearch: sqlite3_column_int(stmt, 5) != 0,
-            pinnedAt: columnDate(stmt, 6),
-            createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 7)))
+            isEnabled: sqlite3_column_int(stmt, 5) != 0,
+            showsInRootSearch: sqlite3_column_int(stmt, 6) != 0,
+            pinnedAt: columnDate(stmt, 7),
+            createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 8)))
     }
 
     private static func columnDate(_ stmt: OpaquePointer?, _ index: Int32) -> Date? {

--- a/Tinycast/Features/Quicklinks/Settings/QuicklinkEditorSheet.swift
+++ b/Tinycast/Features/Quicklinks/Settings/QuicklinkEditorSheet.swift
@@ -233,6 +233,8 @@ struct QuicklinkEditorSheet: View {
         let draft = Quicklink(
             id: existing?.id ?? UUID(), name: name, link: link,
             openWithBundleID: openWithBundleID, iconSymbol: iconSymbol,
+            // The pane's row owns the checkbox; an edit carries the flag rather than resetting it.
+            isEnabled: existing?.isEnabled ?? true,
             showsInRootSearch: showsInRootSearch,
             // Re-pinning keeps the original stamp, so saving an edit doesn't move the row.
             pinnedAt: isPinned ? (existing?.pinnedAt ?? Date()) : nil,

--- a/Tinycast/Features/Quicklinks/Settings/QuicklinksSettingsView.swift
+++ b/Tinycast/Features/Quicklinks/Settings/QuicklinksSettingsView.swift
@@ -77,6 +77,11 @@ struct QuicklinksSettingsView: View {
                 ForEach(results) { quicklink in
                     QuicklinkSettingsRow(
                         quicklink: quicklink,
+                        isEnabled: Binding(
+                            get: { quicklink.isEnabled },
+                            set: {
+                                core.quicklinkCoordinator.setQuicklinkEnabled($0, id: quicklink.id)
+                            }),
                         onEdit: { core.quicklinkCoordinator.editQuicklink(quicklink) },
                         onDelete: { pendingDeletion = quicklink })
                 }
@@ -148,6 +153,7 @@ struct QuicklinksSettingsView: View {
 
 private struct QuicklinkSettingsRow: View {
     let quicklink: Quicklink
+    @Binding var isEnabled: Bool
     let onEdit: () -> Void
     let onDelete: () -> Void
 
@@ -168,9 +174,11 @@ private struct QuicklinkSettingsRow: View {
 
             // An alias only reaches the ranker through the root-search slice, so it dims with it.
             AliasField(key: quicklink.entryID, name: quicklink.name)
-                .settingsEnabled(quicklink.showsInRootSearch)
+                .settingsEnabled(quicklink.isEnabled && quicklink.showsInRootSearch)
 
+            // A disabled quicklink's shortcut fires into the funnel's refusal, so it dims too.
             ShortcutRecorder(action: .quicklink(id: quicklink.id))
+                .settingsEnabled(quicklink.isEnabled)
 
             Button(action: onEdit) {
                 Image(systemName: "pencil")
@@ -186,6 +194,12 @@ private struct QuicklinkSettingsRow: View {
             .buttonStyle(.plain)
             .help("Delete Quicklink")
             .accessibilityLabel("Delete \(quicklink.name)")
+
+            Toggle("", isOn: $isEnabled)
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .help("Enabled")
+                .accessibilityLabel("Enable \(quicklink.name)")
         }
     }
 

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
@@ -72,9 +72,9 @@ final class QuicklinkCoordinator {
 
     /// The one funnel for every open, so neither the switch nor the prompt can be bypassed.
     func openQuicklink(id: UUID, forcingDefaultApp: Bool = false) {
-        guard settings.quicklinksEnabled, let quicklink = store.quicklink(id: id) else {
-            return
-        }
+        guard settings.quicklinksEnabled, let quicklink = store.quicklink(id: id),
+            quicklink.isEnabled
+        else { return }
         // With the palette closed a shortcut still reads the selection from the frontmost app.
         let target =
             windowController.isVisible
@@ -221,6 +221,11 @@ final class QuicklinkCoordinator {
 
     func setQuicklinkShowsInRootSearch(_ shows: Bool, id: UUID) {
         do { try store.setShowsInRootSearch(shows, id: id) } catch { report(error) }
+    }
+
+    /// Keeps the row and its shortcut, but takes it out of every surface that could open it.
+    func setQuicklinkEnabled(_ enabled: Bool, id: UUID) {
+        do { try store.setEnabled(enabled, id: id) } catch { report(error) }
     }
 
     func duplicateQuicklink(id: UUID) {

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
@@ -7,10 +7,13 @@ struct QuicklinkListScreen: PaletteScreen {
     let vm: PaletteState
     let openActions: () -> Void
 
+    /// A disabled quicklink is offered nowhere, so it is absent here as it is from root search.
+    private var library: [Quicklink] { store.quicklinks.filter(\.isEnabled) }
+
     var rows: [Quicklink] {
         let query = vm.query.trimmingCharacters(in: .whitespaces)
-        guard !query.isEmpty else { return store.quicklinks }
-        return store.quicklinks.filter { $0.name.localizedCaseInsensitiveContains(query) }
+        guard !query.isEmpty else { return library }
+        return library.filter { $0.name.localizedCaseInsensitiveContains(query) }
     }
 
     var primaryActionTitle: String { "Open Quicklink" }
@@ -61,8 +64,7 @@ struct QuicklinkListScreen: PaletteScreen {
     private func content(selection: Int, scroll: ScrollIntent) -> some View {
         let rows = rows
         if rows.isEmpty {
-            EmptyResults(
-                text: store.quicklinks.isEmpty ? "No quicklinks yet" : "No matching quicklinks")
+            EmptyResults(text: library.isEmpty ? "No quicklinks yet" : "No matching quicklinks")
         } else {
             QuicklinkList(
                 results: rows,

--- a/docs/features/custom-commands.md
+++ b/docs/features/custom-commands.md
@@ -20,6 +20,10 @@ without re-registering. "Show in launcher" only hides the section; shortcuts kee
   lives in `CustomCommandCoordinator` and not in the runner.
 - A command that runs arbitrary shell is a security surface: the confirmation step cannot be bypassed, and
   an import of executable commands warns before it applies.
+- **A disabled command is inert, not gone.** `isEnabled == false` takes it out of the launcher slice
+  and `runCustomCommand` refuses it, so neither a row nor its still-registered shortcut can run it.
+  Name, command text, arguments, favorite slot and shortcut stay exactly as they were, and the
+  **Settings → Commands** row is the one place that turns it back on.
 - **An argument value is never spliced into the command text.** It is handed to zsh as a positional
   parameter, so a value carrying `;`, backticks or `$(…)` is data the script reads, never syntax the
   shell runs. `custom-command-test` asserts this directly.
@@ -31,7 +35,9 @@ bundle-scoped `UserDefaults`. Each command has a stable UUID. Its launcher entry
 `custom-command:<uuid>`, and its hotkey uses
 `hotkey.customCommand.<uuid>` plus the `boundCustomCommandIDs` index.
 
-Editing preserves the UUID and therefore its favorite, visibility, and hotkey references. Deleting
+Editing preserves the UUID and therefore its favorite, visibility, and hotkey references. The row's
+**Enabled** checkbox is the only writer of `isEnabled`, so the editor sheet carries the flag through a
+save rather than offering a second control for it. Deleting
 goes through `AppCore`, which unregisters the hotkey and clears those references before removing the
 command. Native settings backups include both commands and bindings; import warns before accepting
 executable content.

--- a/docs/features/quicklinks.md
+++ b/docs/features/quicklinks.md
@@ -20,6 +20,11 @@ every shortcut without re-registering.
   `Service/QuicklinkArgumentSession` the prompt state.
 - **`Quicklink.precedes` is the one display order**, sorted through by both the store and the `AppIndex`
   slice.
+- **A disabled quicklink is inert, not gone.** `isEnabled == false` takes it out of root search and out
+  of Search Quicklinks, and `openQuicklink` refuses it, so no surface can offer or open it. Everything
+  attached — name, link, alias, shortcut, favorite slot, ranking — stays exactly as it was. The
+  **Settings → Quicklinks** row is the one place that turns it back on, through the checkbox launcher
+  items and custom commands carry: last in the row, dimming the alias field and shortcut recorder.
 - **There is one template engine.** Quicklinks expand through `SnippetTemplateEngine` rather than a
   second parser, which is what makes `| raw` mean something — it opts a value out of the automatic
   percent-encoding a URL destination asks for. `{selectedText}` is accepted as an alias for
@@ -128,6 +133,10 @@ field. Per-quicklink "Show in root search" filters the slice;
 the pane's "Show in launcher" takes the section and the four Quicklink commands out of the
 launcher together, leaving shortcuts and the pane itself working.
 
+Three levers, narrowing in that order: the pane's switches take the whole feature out, the row's
+**Enabled** checkbox makes one quicklink inert, and **Show in root search** keeps a quicklink openable
+from Search Quicklinks and its shortcut while dropping it from the root list.
+
 `Quicklink.precedes` is the one display order — pinned first in the order they were pinned, then the
 rest by name — and both the store and the launcher slice sort through it, so the two can never
 disagree. **Pinned means the top of the Quicklinks section**, not above Applications: a second
@@ -154,14 +163,18 @@ and use the system handler, once, without changing what is saved.
 
 Quicklinks are **authored data**, which decides the one way `QuicklinkStore` differs from
 `ClipboardStore` — they are neighbours in Application Support, and otherwise mirror each other (WAL,
-`PRAGMA table_info` column sniffing plus `ALTER TABLE` for migrations, prepared statements, an
-`isolated deinit`):
+prepared statements, an `isolated deinit`):
 
 - **A database that won't open is never deleted.** `ClipboardStore` discards and recreates a corrupt
   file because a history is captured rather than authored; doing that here would destroy the user's
   library. The store publishes `isAvailable == false`, every mutation refuses with
   `QuicklinkError.storageUnavailable`, and the pane says so. `Tests/quicklink-test.swift` asserts the
   file survives byte-for-byte.
+
+`CREATE TABLE IF NOT EXISTS` leaves an existing table alone, so a new column arrives as an unchecked
+`ALTER TABLE … ADD COLUMN … DEFAULT` right after the schema, which fails harmlessly once the column is
+there. That appends it physically, so the prepared statements **name their columns in the struct's
+order** rather than the table's, and the row reader stays a straight top-to-bottom read.
 
 Editing preserves the UUID, and with it the quicklink's shortcut, favorite slot, visibility and
 learned ranking. Deleting goes through `AppCore`, which unwinds all four before removing the row.


### PR DESCRIPTION
## Related issue

Closes #394

## What changed

A per-item **Enabled** checkbox for quicklinks and for custom commands, so one can be parked without
losing its setup.

`Quicklink.isEnabled` and `CustomCommand.isEnabled` both default to true and decode with
`decodeIfPresent … ?? true`, so stored records, exports and older backups load enabled. A disabled
item is **inert, not gone**:

- it leaves its `AppIndex` slice, so it is out of root search (and out of Search Quicklinks);
- the one open/run funnel refuses it — `openQuicklink` and `runCustomCommand` — so a still-registered
  global shortcut fires into a no-op rather than needing to be unregistered;
- name, link/command text, alias, shortcut, favorite slot and learned ranking are all untouched.

Non-obvious bits in the diff:

- **The quicklinks table needed a migration.** `CREATE TABLE IF NOT EXISTS` leaves an existing table
  alone, so `is_enabled` arrives as an unchecked `ALTER TABLE … ADD COLUMN … DEFAULT 1` right after the
  schema; it fails harmlessly once the column is there. SQLite appends the column physically, so the
  prepared statements now name their columns in the **struct's** order rather than the table's, keeping
  `QuicklinkStore.row` a straight top-to-bottom read. `custom-commands` needed nothing — it is JSON in
  `UserDefaults`.
- **The editor sheets carry the flag rather than owning it.** Both build a fresh value on save, so each
  passes `existing?.isEnabled ?? true` through. The row's checkbox stays the only writer; a second
  control in the sheet would have been a second source of truth.
- **The palette's ⌘K menu deliberately gained no Enable/Disable item.** A disabled quicklink is absent
  from Search Quicklinks, so a disable action there would make the row vanish with no way back except
  Settings — a one-way trap. Settings is the one place that flips it.

The checkbox is the same control launcher items already use for Applications and System Settings —
`labelsHidden`, `.checkbox` style, last in the row — and the shortcut recorder (plus the quicklink's
alias field) dims beside it, since neither reaches anything while the item is off.

## Memory footprint

No new long-lived state: one `Bool` per record, and the two filters are on arrays the index already
rebuilt on every change. Not profiled — nothing here allocates or retains differently from the
`showsInRootSearch` flag beside it.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no.

## Drawbacks

- **Three visibility levers now sit on a quicklink**: the pane's feature switches, this checkbox, and
  "Show in root search". They narrow in that order, and `docs/features/quicklinks.md` now spells the
  ladder out — but it is one more thing to explain.
- **Re-enabling is Settings-only.** Deliberate, per the ⌘K note above, though it does mean a quicklink
  disabled by mistake has to be found in the pane.
- A disabled item keeps its Carbon hotkey registration. That matches how the feature-level switch
  already behaves ("bindings stay registered, so re-enabling restores every shortcut"), but it does
  mean the chord stays claimed from the system's point of view while the item is off.

## Tests & validation

`./Scripts/run-tests.sh` — all 50 harnesses pass. `./Scripts/lint.sh` clean, Debug build with no new
warnings, and `Features/*/Model/` still imports no AppKit or SwiftUI.

Cases added:

- `Tests/quicklink-test.swift` — the default, `setEnabled` storing without disturbing other fields,
  duplication inheriting the flag, survival across a close and reopen, an omitted flag in a
  hand-written archive, a round trip through export/import, and **loading a table written before
  `is_enabled` existed** (plus reopening the migrated file, so the `ALTER TABLE` cannot run twice).
- `Tests/custom-command-test.swift` — the default, `setEnabled` storing, and a record written before
  the flag existed decoding as enabled.

By hand: disabled a quicklink and a custom command, confirmed each drops out of root search, that
Search Quicklinks no longer lists the quicklink, and that the bound global shortcut does nothing while
off and works again once re-enabled — with the alias, shortcut and pin all intact.
