### PR TITLE
Make every built-in command bindable to a shortcut

### DIFF
--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -105,16 +105,18 @@ struct DoubleTapDetectorTests {
     // MARK: - Built-in command mappings
 
     static func commandActions() {
-        let unbindable = CommandID.allCases.filter { $0.hotKeyAction == nil }
+        let unbindable = Set(CommandID.allCases.filter { $0.hotKeyAction == nil })
         expect(
-            unbindable == [.openInBrowser, .runShellCommand],
-            "only the query-driven pair is unbindable — got \(unbindable.map(\.name))")
+            unbindable == [.openInBrowser, .runShellCommand, .quit],
+            "only the query-driven pair and Quit are unbindable — got \(unbindable.map(\.name))")
         expect(
-            CommandID.allCases.allSatisfy { $0.isQueryDriven || $0.hotKeyAction == .command($0) },
+            CommandID.allCases.allSatisfy {
+                unbindable.contains($0) || $0.hotKeyAction == .command($0)
+            },
             "every other command binds to its own action, so every row gets a recorder")
 
         // Keyed on the raw value, not the position, so reordering the enum cannot move a binding.
-        for id in CommandID.allCases where !id.isQueryDriven {
+        for id in CommandID.allCases where !unbindable.contains(id) {
             expect(
                 id.hotKeyAction?.defaultsKey == "hotkey.\(id.rawValue)",
                 "\(id.name) persists under hotkey.\(id.rawValue)")

--- a/Tests/hotkey-test.swift
+++ b/Tests/hotkey-test.swift
@@ -105,36 +105,26 @@ struct DoubleTapDetectorTests {
     // MARK: - Built-in command mappings
 
     static func commandActions() {
-        let expected: [(CommandID, HotKeyAction, String)] =
-            [
-                (.clipboardHistory, .toggleClipboard, "hotkey.toggleClipboard"),
-                (.searchEmoji, .toggleEmoji, "hotkey.toggleEmoji"),
-                (.searchFiles, .searchFiles, "hotkey.searchFiles"),
-                (.searchSnippets, .searchSnippets, "hotkey.searchSnippets"),
-                (.joinNextMeeting, .joinNextMeeting, "hotkey.joinNextMeeting"),
-                (.mySchedule, .mySchedule, "hotkey.mySchedule"),
-                (.createEvent, .createEvent, "hotkey.createEvent"),
-                (.showNotes, .showNotes, "hotkey.showNotes"),
-                (.createNote, .createNote, "hotkey.createNote"),
-                (.searchNotes, .searchNotes, "hotkey.searchNotes"),
-                (.aiChat, .aiChat, "hotkey.aiChat")
-            ]
-            + QuickAction.allCases.map {
-                (CommandID($0), .quickAction($0), "hotkey.quickAction.\($0.rawValue)")
-            }
-        let answers = CommandID.allCases.compactMap { id in id.hotKeyAction.map { (id, $0) } }
+        let unbindable = CommandID.allCases.filter { $0.hotKeyAction == nil }
         expect(
-            answers.count == expected.count,
-            "exactly the bindable commands answer — got \(answers.map(\.0.name))")
-        for (id, action, key) in expected {
+            unbindable == [.openInBrowser, .runShellCommand],
+            "only the query-driven pair is unbindable — got \(unbindable.map(\.name))")
+        expect(
+            CommandID.allCases.allSatisfy { $0.isQueryDriven || $0.hotKeyAction == .command($0) },
+            "every other command binds to its own action, so every row gets a recorder")
+
+        // Keyed on the raw value, not the position, so reordering the enum cannot move a binding.
+        for id in CommandID.allCases where !id.isQueryDriven {
             expect(
-                id.hotKeyAction == action && action.defaultsKey == key,
-                "\(id.name) maps to \(key)")
+                id.hotKeyAction?.defaultsKey == "hotkey.\(id.rawValue)",
+                "\(id.name) persists under hotkey.\(id.rawValue)")
+            expect(
+                HotKeyAction.builtInActions.contains(.command(id)),
+                "\(id.name) is registered at launch like every other fixed action")
         }
         expect(
-            Set(HotKeyAction.builtInActions)
-                .isSuperset(of: Set(CommandID.allCases.compactMap(\.hotKeyAction))),
-            "every bindable command appears among the built-in hotkey actions")
+            HotKeyAction.builtInActions.contains(.togglePalette),
+            "the launcher toggle is bindable without a command row of its own")
 
         // Every action reaches the launcher as well as a shortcut; `CommandID.init` is exhaustive.
         expect(
@@ -143,17 +133,6 @@ struct DoubleTapDetectorTests {
         expect(
             Set(QuickAction.allCases.map(CommandID.init)).count == QuickAction.allCases.count,
             "no two Quick Actions share a launcher command")
-
-        // Parameterised, so a new Quick Action must arrive bindable without editing this enum.
-        for action in QuickAction.allCases {
-            let hotKey = HotKeyAction.quickAction(action)
-            expect(
-                hotKey.defaultsKey == "hotkey.quickAction.\(action.rawValue)",
-                "\(action.title) keys its binding on its raw value, not its position")
-            expect(
-                HotKeyAction.builtInActions.contains(hotKey),
-                "\(action.title) is registered at launch like every other fixed action")
-        }
         expect(
             Set(HotKeyAction.builtInActions.map(\.defaultsKey)).count
                 == HotKeyAction.builtInActions.count,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -226,20 +226,7 @@ final class AppCore {
             snippetListener.healthTicker = healthTicker
 
             hotKeys.onTogglePalette = { [weak self] in self?.paletteCoordinator.togglePalette() }
-            hotKeys.onToggleClipboard = { [weak self] in self?.paletteCoordinator.toggleClipboard() }
-            hotKeys.onToggleEmoji = { [weak self] in self?.paletteCoordinator.toggleEmoji() }
-            hotKeys.onShowNotes = { [weak self] in self?.notesCoordinator.show() }
-            hotKeys.onCreateNote = { [weak self] in self?.notesCoordinator.createNote() }
-            hotKeys.onSearchNotes = { [weak self] in self?.notesCoordinator.searchNotes() }
-            hotKeys.onSearchFiles = { [weak self] in self?.fileSearchCoordinator.show() }
-            hotKeys.onSearchSnippets = { [weak self] in self?.snippetCoordinator.showSnippets() }
-            hotKeys.onShowAIChat = { [weak self] in self?.aiChatCoordinator.showChat() }
-            hotKeys.onQuickAction = { [weak self] in self?.quickActionCoordinator.run($0) }
-            hotKeys.onJoinNextMeeting = { [weak self] in
-                self?.calendarCoordinator.joinNextMeeting()
-            }
-            hotKeys.onShowSchedule = { [weak self] in self?.calendarCoordinator.showSchedule() }
-            hotKeys.onCreateEvent = { [weak self] in self?.calendarCoordinator.createEvent() }
+            hotKeys.onRunCommand = { [weak self] id in self?.launcherCoordinator.runCommand(id) }
             hotKeys.onRunCustomCommand = { [weak self] id in
                 self?.customCommandCoordinator.runCustomCommand(id: id)
             }
@@ -260,7 +247,10 @@ final class AppCore {
             }
             hotKeys.displayName = { [weak self] action in self?.hotKeyDisplayName(for: action) }
             hotKeys.allowsAction = { [weak self] action in
-                self?.visibility.allowsHotKey(action) ?? false
+                guard let self, visibility.allowsHotKey(action) else { return false }
+                // A disabled feature drops its commands from the launcher; their shortcuts go too.
+                guard case .command(let id) = action else { return true }
+                return appIndex.isCommandEnabled(id)
             }
             KeyShortcut.displayedHyperChord = { [settings] in
                 guard settings.hyperKey != .none else { return nil }
@@ -333,9 +323,7 @@ final class AppCore {
             return quicklinks.quicklink(id: id)?.name
         case .extensionCommand(let entryID):
             return appIndex.apps.first { $0.kind == .extensionCommand && $0.id == entryID }?.name
-        case .togglePalette, .toggleClipboard, .toggleEmoji, .searchFiles, .searchSnippets,
-            .systemAction, .showNotes, .createNote, .searchNotes, .windowCommand, .joinNextMeeting,
-            .mySchedule, .createEvent, .aiChat, .quickAction:
+        case .togglePalette, .command, .systemAction, .windowCommand:
             return nil
         }
     }

--- a/Tinycast/Features/AI/Settings/AICommandSection.swift
+++ b/Tinycast/Features/AI/Settings/AICommandSection.swift
@@ -13,7 +13,7 @@ struct AICommandSection: View {
                     Image(systemName: CommandID.aiChat.sfSymbol)
                         .frame(width: Theme.Size.settingsRowIcon)
                 } trailing: {
-                    ShortcutRecorder(action: .aiChat)
+                    ShortcutRecorder(action: .command(.aiChat))
                     Toggle("", isOn: visibilityBinding(entry))
                         .labelsHidden()
                         .toggleStyle(.checkbox)

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -53,6 +53,11 @@ final class AIChatCoordinator {
 
     func showChat() {
         guard settings.aiEnabled else { return }
+        // Not `togglePalette`: the open policy decides a chat only on the way in.
+        guard !paletteCoordinator.isShowing(.ai) else {
+            paletteCoordinator.hidePalette()
+            return
+        }
         applyOpenPolicy()
         paletteCoordinator.showPalette(mode: .ai)
     }

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -65,19 +65,11 @@ struct SettingsBackup: Codable {
         var supportReminders: Bool?
     }
 
-    /// Combos keep the legacy shape, so older files import. docs/features/hotkeys.md#persistence
+    /// One entry per bindable action. docs/features/hotkeys.md#persistence
     struct HotkeyBackup: Codable {
+        /// Named apart from `commands`: the launcher toggle is the one action with no command row.
         var togglePalette: HotKeyBinding?
-        var toggleClipboard: HotKeyBinding?
-        var toggleEmoji: HotKeyBinding?
-        var showNotes: HotKeyBinding?
-        var createNote: HotKeyBinding?
-        var searchNotes: HotKeyBinding?
-        var searchFiles: HotKeyBinding?
-        var searchSnippets: HotKeyBinding?
-        var joinNextMeeting: HotKeyBinding?
-        var mySchedule: HotKeyBinding?
-        var createEvent: HotKeyBinding?
+        var commands: [String: HotKeyBinding]?
         var apps: [String: HotKeyBinding]?
         var panes: [String: HotKeyBinding]?
         var customCommands: [String: HotKeyBinding]?
@@ -151,16 +143,10 @@ extension SettingsBackup {
         let hk = core.hotKeys
         var hotkeys = HotkeyBackup()
         hotkeys.togglePalette = hk.binding(for: .togglePalette)
-        hotkeys.toggleClipboard = hk.binding(for: .toggleClipboard)
-        hotkeys.toggleEmoji = hk.binding(for: .toggleEmoji)
-        hotkeys.showNotes = hk.binding(for: .showNotes)
-        hotkeys.createNote = hk.binding(for: .createNote)
-        hotkeys.searchNotes = hk.binding(for: .searchNotes)
-        hotkeys.searchFiles = hk.binding(for: .searchFiles)
-        hotkeys.searchSnippets = hk.binding(for: .searchSnippets)
-        hotkeys.joinNextMeeting = hk.binding(for: .joinNextMeeting)
-        hotkeys.mySchedule = hk.binding(for: .mySchedule)
-        hotkeys.createEvent = hk.binding(for: .createEvent)
+        hotkeys.commands = Dictionary(
+            uniqueKeysWithValues: CommandID.allCases.compactMap { id in
+                id.hotKeyAction.flatMap(hk.binding(for:)).map { (id.rawValue, $0) }
+            })
         hotkeys.apps = Dictionary(
             uniqueKeysWithValues: hk.boundBundleIDs.compactMap { id in
                 hk.binding(for: .app(bundleID: id)).map { (id, $0) }
@@ -406,16 +392,10 @@ extension SettingsBackup {
             count += 1
         }
         if let b = hotkeys.togglePalette { apply(b, .togglePalette) }
-        if let b = hotkeys.toggleClipboard { apply(b, .toggleClipboard) }
-        if let b = hotkeys.toggleEmoji { apply(b, .toggleEmoji) }
-        if let b = hotkeys.showNotes { apply(b, .showNotes) }
-        if let b = hotkeys.createNote { apply(b, .createNote) }
-        if let b = hotkeys.searchNotes { apply(b, .searchNotes) }
-        if let b = hotkeys.searchFiles { apply(b, .searchFiles) }
-        if let b = hotkeys.searchSnippets { apply(b, .searchSnippets) }
-        if let b = hotkeys.joinNextMeeting { apply(b, .joinNextMeeting) }
-        if let b = hotkeys.mySchedule { apply(b, .mySchedule) }
-        if let b = hotkeys.createEvent { apply(b, .createEvent) }
+        for (rawID, b) in hotkeys.commands ?? [:] {
+            guard let action = CommandID(rawValue: rawID)?.hotKeyAction else { continue }
+            apply(b, action)
+        }
         for (id, b) in hotkeys.apps ?? [:] { apply(b, .app(bundleID: id)) }
         for (id, b) in hotkeys.panes ?? [:] { apply(b, .settingsPane(bundleID: id)) }
         for (rawID, b) in hotkeys.customCommands ?? [:] {

--- a/Tinycast/Features/Backup/Service/RaycastImportReader.swift
+++ b/Tinycast/Features/Backup/Service/RaycastImportReader.swift
@@ -84,6 +84,7 @@ enum RaycastImportReader {
         let settings = json["settings"] as? [String: Any]
         var hotkeys = SettingsBackup.HotkeyBackup()
         var apps: [String: HotKeyBinding] = [:]
+        var commands: [String: HotKeyBinding] = [:]
         var mapped = false
 
         if let general = settings?["general"] as? [String: Any],
@@ -97,10 +98,10 @@ enum RaycastImportReader {
             guard let binding = binding(from: command["macosHotkey"]) else { continue }
             switch command["extensionId"] as? String {
             case "e:r:clipboard-history":
-                hotkeys.toggleClipboard = binding
+                commands[CommandID.clipboardHistory.rawValue] = binding
                 mapped = true
             case "e:r:emoji-picker":
-                hotkeys.toggleEmoji = binding
+                commands[CommandID.searchEmoji.rawValue] = binding
                 mapped = true
             case "e:r:applications":
                 if let path = appPath(fromCommandID: command["id"] as? String),
@@ -114,6 +115,7 @@ enum RaycastImportReader {
             }
         }
         if !apps.isEmpty { hotkeys.apps = apps }
+        if !commands.isEmpty { hotkeys.commands = commands }
         return mapped ? hotkeys : nil
     }
 

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -305,7 +305,7 @@ final class CalendarCoordinator {
     }
 
     func showSchedule() {
-        paletteCoordinator.showPalette(mode: .schedule)
+        paletteCoordinator.togglePalette(mode: .schedule)
     }
 
     /// A miss is transient, so it reports through the HUD rather than a dialog needing dismissal.

--- a/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
@@ -12,7 +12,7 @@ struct ClipboardSettingsView: View {
         return Form {
             Section {
                 SettingsRow(title: "Clipboard History") {
-                    ShortcutRecorder(action: .toggleClipboard)
+                    ShortcutRecorder(action: .command(.clipboardHistory))
                 }
             } header: {
                 Text("Global Shortcuts")

--- a/Tinycast/Features/Emoji/Settings/EmojiSettingsView.swift
+++ b/Tinycast/Features/Emoji/Settings/EmojiSettingsView.swift
@@ -8,7 +8,7 @@ struct EmojiSettingsView: View {
         return Form {
             Section {
                 SettingsRow(title: "Emoji & Symbols") {
-                    ShortcutRecorder(action: .toggleEmoji)
+                    ShortcutRecorder(action: .command(.searchEmoji))
                 }
             } header: {
                 Text("Global Shortcuts")

--- a/Tinycast/Features/FileSearch/Settings/FileSearchSettingsView.swift
+++ b/Tinycast/Features/FileSearch/Settings/FileSearchSettingsView.swift
@@ -39,7 +39,7 @@ private struct SearchFilesCommandSection: View {
                     Image(systemName: CommandID.searchFiles.sfSymbol)
                         .frame(width: Theme.Size.settingsRowIcon)
                 } trailing: {
-                    ShortcutRecorder(action: .searchFiles)
+                    ShortcutRecorder(action: .command(.searchFiles))
                     Toggle("", isOn: visibilityBinding(entry))
                         .labelsHidden()
                         .toggleStyle(.checkbox)

--- a/Tinycast/Features/FileSearch/UI/FileSearchCoordinator.swift
+++ b/Tinycast/Features/FileSearch/UI/FileSearchCoordinator.swift
@@ -36,7 +36,11 @@ final class FileSearchCoordinator {
     /// `query` is the fallback row's: the screen opens already narrowed to what was typed.
     func show(query: String = "") {
         guard settings.fileSearchEnabled else { return }
-        paletteCoordinator.showPalette(mode: .fileSearch, seeding: query.isEmpty ? nil : query)
+        guard query.isEmpty else {
+            paletteCoordinator.showPalette(mode: .fileSearch, seeding: query)
+            return
+        }
+        paletteCoordinator.togglePalette(mode: .fileSearch)
     }
 
     func open(_ result: FileSearchResult) {

--- a/Tinycast/Features/FileSearch/UI/FileSearchCoordinator.swift
+++ b/Tinycast/Features/FileSearch/UI/FileSearchCoordinator.swift
@@ -36,11 +36,7 @@ final class FileSearchCoordinator {
     /// `query` is the fallback row's: the screen opens already narrowed to what was typed.
     func show(query: String = "") {
         guard settings.fileSearchEnabled else { return }
-        guard query.isEmpty else {
-            paletteCoordinator.showPalette(mode: .fileSearch, seeding: query)
-            return
-        }
-        paletteCoordinator.togglePalette(mode: .fileSearch)
+        paletteCoordinator.togglePalette(mode: .fileSearch, seeding: query.isEmpty ? nil : query)
     }
 
     func open(_ result: FileSearchResult) {

--- a/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
+++ b/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
@@ -2,20 +2,10 @@ import Foundation
 
 /// Everything in Tinycast a global shortcut can be bound to.
 enum HotKeyAction: Hashable, Sendable {
+    /// The one fixed action with no command row of its own.
     case togglePalette
-    case toggleClipboard
-    case toggleEmoji
-    case showNotes
-    case createNote
-    case searchNotes
-    case searchFiles
-    case searchSnippets
-    case joinNextMeeting
-    case mySchedule
-    case createEvent
-    case aiChat
-    /// Parameterised, so a fifth action is a `QuickAction` case and nothing here.
-    case quickAction(QuickAction)
+    /// Parameterised over the catalog, so a new built-in command is bindable with no case here.
+    case command(CommandID)
     case app(bundleID: String)
     case settingsPane(bundleID: String)
     case customCommand(id: UUID)
@@ -29,18 +19,7 @@ enum HotKeyAction: Hashable, Sendable {
     var defaultsKey: String {
         switch self {
         case .togglePalette: "hotkey.togglePalette"
-        case .toggleClipboard: "hotkey.toggleClipboard"
-        case .toggleEmoji: "hotkey.toggleEmoji"
-        case .showNotes: "hotkey.showNotes"
-        case .createNote: "hotkey.createNote"
-        case .searchNotes: "hotkey.searchNotes"
-        case .searchFiles: "hotkey.searchFiles"
-        case .searchSnippets: "hotkey.searchSnippets"
-        case .joinNextMeeting: "hotkey.joinNextMeeting"
-        case .mySchedule: "hotkey.mySchedule"
-        case .createEvent: "hotkey.createEvent"
-        case .aiChat: "hotkey.aiChat"
-        case .quickAction(let action): "hotkey.quickAction." + action.rawValue
+        case .command(let id): "hotkey." + id.rawValue
         case .app(let bundleID): "hotkey.app." + bundleID
         case .settingsPane(let bundleID): "hotkey.pane." + bundleID
         case .customCommand(let id): "hotkey.customCommand." + id.uuidString.lowercased()
@@ -53,8 +32,5 @@ enum HotKeyAction: Hashable, Sendable {
 
     /// The fixed actions every install can bind; the per-item catalogs extend them at launch.
     static let builtInActions: [HotKeyAction] =
-        [
-            .togglePalette, .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes,
-            .searchFiles, .searchSnippets, .joinNextMeeting, .mySchedule, .createEvent, .aiChat
-        ] + QuickAction.allCases.map(HotKeyAction.quickAction)
+        [.togglePalette] + CommandID.allCases.compactMap(\.hotKeyAction)
 }

--- a/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
+++ b/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
@@ -5,18 +5,8 @@ import Foundation
 @Observable
 final class HotKeyManager {
     var onTogglePalette: (() -> Void)?
-    var onToggleClipboard: (() -> Void)?
-    var onToggleEmoji: (() -> Void)?
-    var onShowNotes: (() -> Void)?
-    var onCreateNote: (() -> Void)?
-    var onSearchNotes: (() -> Void)?
-    var onSearchFiles: (() -> Void)?
-    var onSearchSnippets: (() -> Void)?
-    var onJoinNextMeeting: (() -> Void)?
-    var onShowSchedule: (() -> Void)?
-    var onCreateEvent: (() -> Void)?
-    var onShowAIChat: (() -> Void)?
-    var onQuickAction: ((QuickAction) -> Void)?
+    /// The launcher's own command funnel, so a shortcut and a palette row run the same thing.
+    var onRunCommand: ((CommandID) -> Void)?
     var onRunCustomCommand: ((UUID) -> Void)?
     var onRunSystemAction: ((SystemAction.ID) -> Void)?
     var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
@@ -143,9 +133,7 @@ final class HotKeyManager {
             var set = Set(boundExtensionCommandEntryIDs)
             if binding == nil { set.remove(entryID) } else { set.insert(entryID) }
             UserDefaults.standard.set(Array(set), forKey: boundExtensionCommandKey)
-        case .togglePalette, .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes,
-            .searchFiles, .searchSnippets, .joinNextMeeting, .mySchedule, .createEvent, .aiChat,
-            .systemAction, .windowCommand, .quickAction:
+        case .togglePalette, .command, .systemAction, .windowCommand:
             break
         }
         candidateActionsCache = nil
@@ -196,30 +184,8 @@ final class HotKeyManager {
         switch action {
         case .togglePalette:
             return "App Launcher"
-        case .toggleClipboard:
-            return CommandID.clipboardHistory.name
-        case .toggleEmoji:
-            return CommandID.searchEmoji.name
-        case .showNotes:
-            return CommandID.showNotes.name
-        case .createNote:
-            return CommandID.createNote.name
-        case .searchNotes:
-            return CommandID.searchNotes.name
-        case .searchFiles:
-            return CommandID.searchFiles.name
-        case .searchSnippets:
-            return CommandID.searchSnippets.name
-        case .joinNextMeeting:
-            return CommandID.joinNextMeeting.name
-        case .mySchedule:
-            return CommandID.mySchedule.name
-        case .createEvent:
-            return CommandID.createEvent.name
-        case .aiChat:
-            return CommandID.aiChat.name
-        case .quickAction(let action):
-            return action.title
+        case .command(let id):
+            return id.name
         case .app(let bundleID), .settingsPane(let bundleID):
             return displayName?(action) ?? bundleID
         case .customCommand:
@@ -258,18 +224,7 @@ final class HotKeyManager {
         guard allowsAction?(action) ?? true else { return }
         switch action {
         case .togglePalette: onTogglePalette?()
-        case .toggleClipboard: onToggleClipboard?()
-        case .toggleEmoji: onToggleEmoji?()
-        case .showNotes: onShowNotes?()
-        case .createNote: onCreateNote?()
-        case .searchNotes: onSearchNotes?()
-        case .searchFiles: onSearchFiles?()
-        case .searchSnippets: onSearchSnippets?()
-        case .joinNextMeeting: onJoinNextMeeting?()
-        case .mySchedule: onShowSchedule?()
-        case .createEvent: onCreateEvent?()
-        case .aiChat: onShowAIChat?()
-        case .quickAction(let action): onQuickAction?(action)
+        case .command(let id): onRunCommand?(id)
         case .app(let bundleID): AppLauncher.toggle(bundleID: bundleID)
         case .settingsPane(let bundleID): AppLauncher.openSettingsPane(bundleID: bundleID)
         case .customCommand(let id): onRunCustomCommand?(id)

--- a/Tinycast/Features/Launcher/Model/CommandCatalog.swift
+++ b/Tinycast/Features/Launcher/Model/CommandCatalog.swift
@@ -1,13 +1,10 @@
 import Foundation
 
 enum CommandCatalog {
-    /// Query-driven: the typed text is their input, so they are built where offered, never listed.
-    nonisolated private static let queryDriven: Set<CommandID> = [.openInBrowser, .runShellCommand]
-
     /// Sorted by name for the `AppIndex` invariant; the URL is a placeholder.
     nonisolated static let all: [AppEntry] =
         CommandID.allCases
-        .filter { !queryDriven.contains($0) }
+        .filter { !$0.isQueryDriven }
         .map { makeEntry($0) }
         .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
 
@@ -22,7 +19,7 @@ enum CommandCatalog {
 
     /// A query-driven row answers one query, so learning or pinning it would misrank a URL.
     static func isQueryDriven(_ entry: AppEntry) -> Bool {
-        command(for: entry).map(queryDriven.contains) ?? false
+        command(for: entry)?.isQueryDriven ?? false
     }
 
     /// The row a typed web address earns; unlike a catalog entry, its URL is the real destination.

--- a/Tinycast/Features/Launcher/Model/CommandID.swift
+++ b/Tinycast/Features/Launcher/Model/CommandID.swift
@@ -127,8 +127,8 @@ enum CommandID: String, CaseIterable, Sendable {
         self == .openInBrowser || self == .runShellCommand
     }
 
-    /// A shortcut carries no query, so the query-driven pair is the one thing it cannot run.
+    /// A chord carries no query, and none should be able to terminate the app outright.
     var hotKeyAction: HotKeyAction? {
-        isQueryDriven ? nil : .command(self)
+        isQueryDriven || self == .quit ? nil : .command(self)
     }
 }

--- a/Tinycast/Features/Launcher/Model/CommandID.swift
+++ b/Tinycast/Features/Launcher/Model/CommandID.swift
@@ -122,25 +122,13 @@ enum CommandID: String, CaseIterable, Sendable {
         }
     }
 
-    /// The built-ins with a global shortcut of their own; the rest open from the launcher.
+    /// Query-driven: the typed text is their input, so they are built where offered, never listed.
+    var isQueryDriven: Bool {
+        self == .openInBrowser || self == .runShellCommand
+    }
+
+    /// A shortcut carries no query, so the query-driven pair is the one thing it cannot run.
     var hotKeyAction: HotKeyAction? {
-        switch self {
-        case .searchFiles: return .searchFiles
-        case .searchSnippets: return .searchSnippets
-        case .clipboardHistory: return .toggleClipboard
-        case .searchEmoji: return .toggleEmoji
-        case .showNotes: return .showNotes
-        case .createNote: return .createNote
-        case .searchNotes: return .searchNotes
-        case .joinNextMeeting: return .joinNextMeeting
-        case .mySchedule: return .mySchedule
-        case .createEvent: return .createEvent
-        case .aiChat: return .aiChat
-        case .fixGrammar: return .quickAction(.fixGrammar)
-        case .rewrite: return .quickAction(.rewrite)
-        case .translate: return .quickAction(.translate)
-        case .summarize: return .quickAction(.summarize)
-        default: return nil
-        }
+        isQueryDriven ? nil : .command(self)
     }
 }

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -262,6 +262,11 @@ final class AppIndex {
         }
     }
 
+    /// Whether the feature behind a command is on, which is what its shortcut has to obey too.
+    func isCommandEnabled(_ command: CommandID) -> Bool {
+        !hiddenCommands.contains(command)
+    }
+
     /// A feature's commands leave the Commands slice when it is off; `visible` restores them.
     func setCommandsVisible(_ commands: Set<CommandID>, _ visible: Bool) {
         let updated = visible ? hiddenCommands.subtracting(commands) : hiddenCommands.union(commands)

--- a/Tinycast/Features/Launcher/Service/VisibilityStore.swift
+++ b/Tinycast/Features/Launcher/Service/VisibilityStore.swift
@@ -70,9 +70,7 @@ final class VisibilityStore {
         case .app: isKindEnabled(.application)
         case .settingsPane: isKindEnabled(.systemSettings)
         case .systemAction: isKindEnabled(.systemAction)
-        case .toggleClipboard, .toggleEmoji, .showNotes, .createNote, .searchNotes, .searchFiles,
-            .searchSnippets, .joinNextMeeting, .mySchedule, .createEvent, .aiChat, .quickAction:
-            isKindEnabled(.command)
+        case .command: isKindEnabled(.command)
         case .togglePalette, .customCommand, .windowCommand, .quicklink, .extensionCommand:
             true
         }

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -64,7 +64,8 @@ final class LauncherCoordinator {
         }
         // Commands dispatch before the palette hides: mode-switching commands keep it open.
         if app.kind == .command {
-            runCommand(app)
+            guard let id = CommandCatalog.command(for: app) else { return }
+            runCommand(id, url: app.url)
             return
         }
         if app.kind == .customCommand {
@@ -115,8 +116,9 @@ final class LauncherCoordinator {
         }
     }
 
-    private func runCommand(_ entry: AppEntry) {
-        switch CommandCatalog.command(for: entry) {
+    /// The one funnel a built-in command runs through, from a palette row or its global shortcut.
+    func runCommand(_ id: CommandID, url: URL? = nil) {
+        switch id {
         case .aiChat:
             core.aiChatCoordinator.showChat()
         case .fixGrammar:
@@ -128,16 +130,18 @@ final class LauncherCoordinator {
         case .summarize:
             core.quickActionCoordinator.run(.summarize)
         case .calculatorHistory:
-            paletteCoordinator.showPalette(mode: .calculatorHistory)
+            paletteCoordinator.togglePalette(mode: .calculatorHistory)
         case .clipboardHistory:
-            paletteCoordinator.showPalette(mode: .clipboard)
+            paletteCoordinator.togglePalette(mode: .clipboard)
         case .searchEmoji:
-            paletteCoordinator.showPalette(mode: .emoji)
+            paletteCoordinator.togglePalette(mode: .emoji)
         case .searchFiles:
             fileSearchCoordinator.show()
         case .openInBrowser:
-            paletteCoordinator.hidePalette(restoreFocus: false)
-            AppLauncher.open(entry.url)
+            // Query-driven, so the row it came from carries the URL nothing else here knows.
+            guard let url else { return }
+            dismissPalette()
+            AppLauncher.open(url)
         case .runShellCommand:
             break  // Only ever a fallback row, which carries the query this funnel does not have.
         case .joinNextMeeting:
@@ -151,56 +155,60 @@ final class LauncherCoordinator {
         case .createEvent:
             calendarCoordinator.createEvent()
         case .showNotes:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             notesCoordinator.show()
         case .createNote:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             notesCoordinator.createNote()
         case .searchNotes:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             notesCoordinator.searchNotes()
         case .searchQuicklinks:
-            paletteCoordinator.showPalette(mode: .quicklinks)
+            paletteCoordinator.togglePalette(mode: .quicklinks)
         case .searchSnippets:
             snippetCoordinator.showSnippets()
         case .createSnippet:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             snippetCoordinator.editSnippet(nil)
         case .createQuicklink:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             quicklinkCoordinator.editQuicklink(nil)
         case .importQuicklinks:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             Task { await quicklinkCoordinator.importQuicklinks() }
         case .exportQuicklinks:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             Task { await quicklinkCoordinator.exportQuicklinks() }
         case .exportSettings:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             Task { await BackupActions.exportSettings(core: core) }
         case .importSettings:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             Task { await BackupActions.importSettings(core: core) }
         case .importFromRaycast:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             settingsCoordinator.showBackupSettings()
         case .checkForUpdates:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             core.updateCoordinator.checkForUpdates()
         case .settings:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             settingsCoordinator.showSettings()
         case .about:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             settingsCoordinator.showAbout()
         case .support:
-            paletteCoordinator.hidePalette(restoreFocus: false)
+            dismissPalette()
             core.supportCoordinator.showSupport()
         case .quit:
             NSApp.terminate(nil)
-        case nil:
-            break
         }
+    }
+
+    /// A shortcut runs these with nothing open, where a plain hide would still reset palette state.
+    private func dismissPalette() {
+        guard paletteCoordinator.isVisible else { return }
+        paletteCoordinator.hidePalette(restoreFocus: false)
     }
 
     // MARK: - Row actions

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -65,7 +65,13 @@ final class LauncherCoordinator {
         // Commands dispatch before the palette hides: mode-switching commands keep it open.
         if app.kind == .command {
             guard let id = CommandCatalog.command(for: app) else { return }
-            runCommand(id, url: app.url)
+            // Query-driven: only this row knows the URL the typed text resolved to.
+            if id == .openInBrowser {
+                paletteCoordinator.hidePalette(restoreFocus: false)
+                AppLauncher.open(app.url)
+                return
+            }
+            runCommand(id)
             return
         }
         if app.kind == .customCommand {
@@ -117,7 +123,7 @@ final class LauncherCoordinator {
     }
 
     /// The one funnel a built-in command runs through, from a palette row or its global shortcut.
-    func runCommand(_ id: CommandID, url: URL? = nil) {
+    func runCommand(_ id: CommandID) {
         switch id {
         case .aiChat:
             core.aiChatCoordinator.showChat()
@@ -137,13 +143,8 @@ final class LauncherCoordinator {
             paletteCoordinator.togglePalette(mode: .emoji)
         case .searchFiles:
             fileSearchCoordinator.show()
-        case .openInBrowser:
-            // Query-driven, so the row it came from carries the URL nothing else here knows.
-            guard let url else { return }
-            dismissPalette()
-            AppLauncher.open(url)
-        case .runShellCommand:
-            break  // Only ever a fallback row, which carries the query this funnel does not have.
+        case .openInBrowser, .runShellCommand:
+            break  // Query-driven: each runs where the typed text is, never through this funnel.
         case .joinNextMeeting:
             calendarCoordinator.joinNextMeeting()
         case .copyMeetingLink:

--- a/Tinycast/Features/QuickActions/Settings/QuickActionsSettingsView.swift
+++ b/Tinycast/Features/QuickActions/Settings/QuickActionsSettingsView.swift
@@ -83,7 +83,7 @@ struct QuickActionsSettingsView: View {
                         .help("Edit \(action.title) instructions")
                         .accessibilityLabel("Edit \(action.title) instructions")
                     }
-                    ShortcutRecorder(action: .quickAction(action), isQuiet: true)
+                    ShortcutRecorder(action: .command(CommandID(action)), isQuiet: true)
                     Picker("", selection: previewBinding(action)) {
                         Text("Replace").tag(false)
                         Text("Preview").tag(true)

--- a/Tinycast/Features/Snippets/Settings/SnippetsSettingsView.swift
+++ b/Tinycast/Features/Snippets/Settings/SnippetsSettingsView.swift
@@ -65,7 +65,7 @@ struct SnippetsSettingsView: View {
 
     private var shortcuts: some View {
         Section {
-            SettingsRow(title: "Search Snippets") { ShortcutRecorder(action: .searchSnippets) }
+            SettingsRow(title: "Search Snippets") { ShortcutRecorder(action: .command(.searchSnippets)) }
         } header: {
             Text("Global Shortcut")
         } footer: {

--- a/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
@@ -103,7 +103,7 @@ final class SnippetCoordinator {
     /// The switch gates the browser, the way Search Files re-checks its own before opening.
     func showSnippets() {
         guard settings.snippetsEnabled else { return }
-        paletteCoordinator.showPalette(mode: .snippets)
+        paletteCoordinator.togglePalette(mode: .snippets)
     }
 
     /// Opens the Snippets pane with the editor showing `record`; nil is a new snippet.

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -41,19 +41,12 @@ final class PaletteCoordinator {
         }
     }
 
-    func toggleClipboard() {
-        if windowController.isVisible, palette.mode == .clipboard {
+    /// A mode command's shortcut closes what it opened; from a launcher row it always re-points.
+    func togglePalette(mode: PaletteMode) {
+        if windowController.isVisible, palette.mode == mode {
             hidePalette()
         } else {
-            showPalette(mode: .clipboard)
-        }
-    }
-
-    func toggleEmoji() {
-        if windowController.isVisible, palette.mode == .emoji {
-            hidePalette()
-        } else {
-            showPalette(mode: .emoji)
+            showPalette(mode: mode)
         }
     }
 

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -46,11 +46,12 @@ final class PaletteCoordinator {
         }
     }
 
-    func togglePalette(mode: PaletteMode) {
-        if isShowing(mode) {
+    /// A carried query always opens: it is new input, not the second press that would close.
+    func togglePalette(mode: PaletteMode, seeding query: String? = nil) {
+        if isShowing(mode), query == nil {
             hidePalette()
         } else {
-            showPalette(mode: mode)
+            showPalette(mode: mode, seeding: query)
         }
     }
 

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -33,17 +33,21 @@ final class PaletteCoordinator {
             ? windowController.previousApp : NSWorkspace.shared.frontmostApplication
     }
 
+    /// Up and pointed at `mode`, which is the state a mode command's second invocation closes.
+    func isShowing(_ mode: PaletteMode) -> Bool {
+        windowController.isVisible && palette.mode == mode
+    }
+
     func togglePalette() {
-        if windowController.isVisible, palette.mode == .launcher {
+        if isShowing(.launcher) {
             hidePalette()
         } else {
             showPalette(mode: .launcher, restoreAnyMode: true)
         }
     }
 
-    /// A mode command's shortcut closes what it opened; from a launcher row it always re-points.
     func togglePalette(mode: PaletteMode) {
-        if windowController.isVisible, palette.mode == mode {
+        if isShowing(mode) {
             hidePalette()
         } else {
             showPalette(mode: mode)

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -149,7 +149,7 @@ a debug description written for a log, so each case maps to a plain sentence ins
 ## Chat surface
 
 The built-in `AI Chat` launcher command enters `AIScreen`, and carries a bindable global shortcut
-(`HotKeyAction.aiChat`) that does the same thing from any app; Tab from the launcher is the third
+(`HotKeyAction.command(.aiChat)`) that does the same thing from any app; Tab from the launcher is the third
 way in. Settings → AI holds both the recorder and a checkbox for the command's place in launcher
 search; the shortcut keeps working while the command is hidden, and does nothing at all while the
 feature is off. The palette search field becomes the single-line composer. The footer pill and

--- a/docs/features/file-search.md
+++ b/docs/features/file-search.md
@@ -134,11 +134,10 @@ guards entry into `.fileSearch`, so neither a stale selected command nor the glo
 the screen after the feature is disabled. Disabling cancels the session and returns an open File Search
 screen to the launcher without changing palette visibility.
 
-Search Files, Clipboard History, Search Emoji & Symbols and the three Notes commands are the built-in
-commands with a `HotKeyAction` of their own, so `AppEntry.hotKeyAction` answers for all of them. Two
-consequences follow: their launcher rows print a bound chord as a keycap, and each row in
-Settings ▸ Commands carries the same recorder as its feature pane — one binding reachable from two
-places, not two settings.
+Search Files is bindable like every other built-in command — `AppEntry.hotKeyAction` answers
+`.command(.searchFiles)`. Two consequences follow: its launcher row prints a bound chord as a keycap,
+and its row in Settings ▸ Commands carries the same recorder as this pane — one binding reachable from
+two places, not two settings.
 
 Launcher visibility is `VisibilityStore`'s, keyed on the entry's `preferenceKey`, which is why the
 pane's checkbox and the one in Settings ▸ Commands move together. The entry behind it comes from

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -17,6 +17,10 @@ the keycap rendering — only the _engine_ differs.
 - **Hotkeys persist as JSON strings under `hotkey.<action>` UserDefaults keys**, and
   `HotKeyAction.defaultsKey` is the one place that computes a key — it is also the `HotKeyCenter`
   registration id, so the two cannot drift.
+- **A command's shortcut and its launcher row run the same funnel.** `HotKeyAction.command(CommandID)`
+  is parameterised over the whole catalog and dispatches through `LauncherCoordinator.runCommand`, so a
+  new built-in command arrives bindable with no hotkey plumbing of its own, and there is one behaviour
+  per command rather than one per invocation route.
 - **`HotKeyBinding` is the one thing an action is bound to, and it has two cases with two engines.** A
   `.combo` is a Carbon registration; a `.doubleTap` is recognized by `DoubleTapMonitor`, because Carbon
   cannot see a lone modifier at all. Its `Codable` is the synthesised one.
@@ -49,18 +53,20 @@ but the guarantee that every decode runs through the initializer that masks devi
 `SettingsBackup.HotkeyBackup` stores the same values, so the backup file carries this shape too; only
 export → import within one build is guaranteed to round-trip.
 
-`hotkey.searchFiles`, `hotkey.searchSnippets`, `hotkey.toggleClipboard`, `hotkey.toggleEmoji`,
-`hotkey.showNotes`, `hotkey.createNote`, `hotkey.searchNotes`, `hotkey.joinNextMeeting`,
-`hotkey.mySchedule` and `hotkey.createEvent` are the built-in launcher commands with an action of their own, alongside `hotkey.togglePalette`, which has no command row. They are the only `CommandID`s whose
-`hotKeyAction` is non-nil — which is what puts a recorder on their rows in Settings ▸ Commands, and a
-keycap on their launcher rows. Each is also reachable from its own feature pane, so it is one binding
-from two places, not two settings. `HotKeyManager` names them all through `CommandID`, so a conflict
-callout spells an action exactly as its command row does.
+Every built-in command is bindable: `CommandID.hotKeyAction` answers `.command(self)` for all but the
+query-driven pair — Open in Browser and Run Shell Command, whose input is the typed text a shortcut has
+none of. A binding therefore persists under `hotkey.<command raw value>`, as in
+`hotkey.command:clipboard-history`, which is also what puts a recorder on every row in
+Settings ▸ Commands and a keycap on every launcher row. `hotkey.togglePalette` is the one fixed action
+with no command row. A command reachable from its own feature pane is one binding shown in two places,
+not two settings, and `HotKeyManager` names them all through `CommandID`, so a conflict callout spells
+an action exactly as its command row does.
 
 Like a window command, the chord registers regardless of the launcher row. Search Files and Notes both
 re-check their feature switches before opening; see [file-search.md](file-search.md#invocation) and
 [notes.md](notes.md#ownership-and-enablement). A hidden launcher row does not disable its shortcut, but
-disabling the feature does. `SettingsBackup.HotkeyBackup` carries every fixed feature binding.
+disabling the feature does. `SettingsBackup.HotkeyBackup` carries them as one `commands` map keyed by
+`CommandID` raw value.
 
 System actions and window commands are the fixed-catalog case: they persist under
 `hotkey.systemAction.<raw-id>` and `hotkey.windowCommand.<raw-id>`

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -21,6 +21,9 @@ the keycap rendering — only the _engine_ differs.
   is parameterised over the whole catalog and dispatches through `LauncherCoordinator.runCommand`, so a
   new built-in command arrives bindable with no hotkey plumbing of its own, and there is one behaviour
   per command rather than one per invocation route.
+- **A command that opens a palette mode toggles it.** Every one of them enters through
+  `PaletteCoordinator.togglePalette(mode:)`, so a second press closes what the first opened. From a
+  launcher row the palette is in `.launcher`, so the row always re-points instead.
 - **`HotKeyBinding` is the one thing an action is bound to, and it has two cases with two engines.** A
   `.combo` is a Carbon registration; a `.doubleTap` is recognized by `DoubleTapMonitor`, because Carbon
   cannot see a lone modifier at all. Its `Codable` is the synthesised one.
@@ -53,9 +56,11 @@ but the guarantee that every decode runs through the initializer that masks devi
 `SettingsBackup.HotkeyBackup` stores the same values, so the backup file carries this shape too; only
 export → import within one build is guaranteed to round-trip.
 
-Every built-in command is bindable: `CommandID.hotKeyAction` answers `.command(self)` for all but the
-query-driven pair — Open in Browser and Run Shell Command, whose input is the typed text a shortcut has
-none of. A binding therefore persists under `hotkey.<command raw value>`, as in
+Every built-in command is bindable: `CommandID.hotKeyAction` answers `.command(self)` by default, and
+names the three exceptions. Open in Browser and Run Shell Command are query-driven — their input is the
+typed text a chord has none of — and Quit is withheld so no chord can terminate the app outright. The
+list is a deny-list rather than an allow-list, so a new command still arrives bindable without an edit
+there. A binding therefore persists under `hotkey.<command raw value>`, as in
 `hotkey.command:clipboard-history`, which is also what puts a recorder on every row in
 Settings ▸ Commands and a keycap on every launcher row. `hotkey.togglePalette` is the one fixed action
 with no command row. A command reachable from its own feature pane is one binding shown in two places,

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -55,8 +55,8 @@ provider protocol and the connections behind it.
 
 `QuickAction` is the extensibility story: a fifth action is one case there, its prompt in
 `QuickActionPrompt`, and one `CommandID` case for its launcher row. The shortcut, the settings row
-and the panel all read `allCases`, `HotKeyAction.quickAction(QuickAction)` is parameterised so the
-hotkey enum never changes again, and `CommandID.init(_ action:)` is exhaustive over `QuickAction`, so
+and the panel all read `allCases`, its shortcut is the `HotKeyAction.command(CommandID)` its launcher
+row already has, and `CommandID.init(_ action:)` is exhaustive over `QuickAction`, so
 a fifth cannot compile without a launcher command of its own.
 
 | Action | Engine | Default result | Diff |


### PR DESCRIPTION
## Related issue

None — raised in conversation: several rows in Settings ▸ Commands had no shortcut recorder, which left
the list looking ragged.

## What changed

**Every built-in command now carries a shortcut recorder**, because `HotKeyAction` stopped enumerating
which ones may have a shortcut. The eleven fixed command cases plus `.quickAction(QuickAction)` collapse
into one parameterised `case command(CommandID)`; `CommandID.hotKeyAction` is now
`isQueryDriven ? nil : .command(self)`. A recorder on the row, a keycap on the launcher row, a name in
the conflict callout and a slot in the backup all fall out of that one case, and a new built-in command
arrives bindable with no hotkey plumbing of its own.

Three commands stay unbindable. **Open in Browser** and **Run Shell Command** are query-driven — the
typed text *is* their input, and a chord carries no query — and neither is ever listed, so no row loses a
recorder. **Quit** is withheld so no chord can terminate the app outright; its row keeps everything else.

**Dispatch collapsed with it.** There used to be two hand-written switches over the same commands: one in
`HotKeyManager.perform`, one in `LauncherCoordinator.runCommand`. A shortcut now runs `runCommand`, the
same funnel a palette row uses, so `HotKeyManager` lost twelve callbacks and `AppCore` thirteen wiring
lines. There is one behaviour per command rather than one per invocation route.

Net **−126 lines**.

### Non-obvious bits in the diff

- **`PaletteCoordinator.togglePalette(mode:)` replaces `toggleClipboard`/`toggleEmoji`.** The two routes
  genuinely differed for the mode commands — the hotkey toggled, the launcher row showed — so the funnel
  had to keep the toggle. It is behaviour-identical from a launcher row (the palette is in `.launcher`
  mode there, so it always re-points), and Calculator History and Search Quicklinks now toggle too,
  which is what a newly bindable mode command should do.
- **`LauncherCoordinator.dismissPalette()` guards on `isVisible`.** Twelve arms hid the palette before
  acting, which was free when only a visible palette could reach them. A shortcut reaches them with
  nothing open, where a plain `hidePalette` would still schedule pop-to-root and purge preview bitmaps.
- **`AppCore` gates a command's shortcut on `AppIndex.isCommandEnabled`.** Previously the bindable
  fifteen each rechecked their own feature switch. Making all 31 bindable would have opened a hole —
  Check for Updates on an App Store build, the Quicklink commands with Quicklinks off — so the check
  moved to the one place that already knows: `hiddenCommands`, the set `setCommandsVisible` maintains.
  `VisibilityStore.allowsHotKey` keeps the category half; this is the feature half it says is not its
  to gate.
- **`SettingsBackup.HotkeyBackup` swapped ten named fields for one `commands` map** keyed by `CommandID`
  raw value, matching the `apps`/`panes`/`systemActions` shape already there. The backup now carries
  every command's binding rather than a subset that never included AI Chat or the Quick Actions. Older
  files no longer restore those ten — the format's stated contract is round-trip within one build.
- **`CommandCatalog.queryDriven` moved onto `CommandID.isQueryDriven`**, so the fact that a command's
  input is the typed text is stated once and read by both the catalog and the hotkey gate.

## Memory footprint

Not measured — I did not profile a running build for this PR.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no.

Reasoning rather than measurement, offered for review and not as a substitute: this is a net deletion
with no new type, cache, timer, observer or task. `HotKeyAction.builtInActions` grows from 16 entries to
32, so `HotKeyManager.start()` decodes 16 more `UserDefaults` reads once at launch and `candidateActions`
holds 16 more enum values — each a `CommandID` raw value, no allocation per binding. Registration is
unchanged: `register` no-ops on an unbound action, so an install that binds nothing registers nothing.

## Demo

None. Nothing moves visually except that rows which showed alias + checkbox now also show the same
`ShortcutRecorder` every other row already had — no new view, no restyling, and the field widths are
`Theme.Size.shortcutRecorder` as before.

## Drawbacks

- **Existing built-in shortcuts reset once.** Keys moved from `hotkey.toggleClipboard` /
  `hotkey.quickAction.fix-grammar` to `hotkey.command:clipboard-history` /
  `hotkey.command:fix-grammar`, so ⇧⌘K, ⇧⌘C, ✦F and friends read as unbound on first launch and need
  re-recording. Deliberate, and chosen over a rename migration: `AGENTS.md` requires an explicit task
  before anything lands in `Tinycast/Migration/`, and that folder is due to go on 2026-09-05. Per-app,
  quicklink, custom-command, window and system-action bindings are untouched.
- **Commands nobody will bind are now bindable** — About, Support, Export Settings, Import from Raycast.
  The alternative was a second allow-list to maintain, which is exactly what this PR deletes; an unbound
  action costs one enum value and one `UserDefaults` read at launch.
- **A backup written before this change no longer restores its ten fixed command shortcuts.** Everything
  else in the file still imports.
- **The launcher row and the shortcut are now the same code path**, so a future change to what a row does
  changes what its shortcut does. That is the point, but it is a coupling that did not exist before.

## Tests & validation

`./Scripts/run-tests.sh` — all 51 harnesses pass; no new harness, as asked. `hotkey-test`'s
`commandActions()` was rewritten around the new shape: it asserts the query-driven pair and Quit are the
*only* unbindable ones, that every other command answers `.command(self)`, and that each persists under
`hotkey.<raw value>` and appears in `builtInActions` — so adding a command no longer needs an edit there,
while removing a recorder from one would fail.

Debug build compiles with no new warnings; `./Scripts/lint.sh` is clean; the `Features/*/Model/`
AppKit-import check is clean. Docs updated in the same commit: `hotkeys.md` (the new invariant and the
persistence section), `file-search.md`, `quick-actions.md`, `ai.md`.

**Not exercised by hand.** I have not run the app, so the recorders, the re-pointed feature panes and the
toggle behaviour of the mode commands are verified by compilation and harness only.
