### PR TITLE
Fix snippet expansion in web and Electron editors

### DIFF
--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -1573,8 +1573,9 @@ struct SnippetsTests {
             now: { Date(timeIntervalSince1970: 1_000) },
             syntheticEventTag: 123,
             logsTapFailures: false)
+        var activityCount = 0
 
-        listener.start { _, _, _, _ in }
+        listener.start(onUserActivity: { activityCount += 1 }, onMatch: { _, _, _, _ in })
         check(
             "real listener waits without permissions and does not install",
             listener.status == .needsAccessibility && tap.installCount == 0)
@@ -1593,7 +1594,25 @@ struct SnippetsTests {
                 && tap.installCount == 2
                 && tap.state == .active)
 
-        listener.start { _, _, _, _ in }
+        listener.processEvent(
+            typeRaw: CGEventType.keyDown.rawValue,
+            keyCode: 0,
+            flagsRaw: 0,
+            text: "x",
+            eventUserData: 0,
+            secureEventInputEnabled: false)
+        listener.processEvent(
+            typeRaw: CGEventType.keyDown.rawValue,
+            keyCode: 0,
+            flagsRaw: 0,
+            text: "x",
+            eventUserData: 123,
+            secureEventInputEnabled: false)
+        check(
+            "real user input invalidates pending automatic delivery while Tinycast events do not",
+            activityCount == 1)
+
+        listener.start(onUserActivity: { activityCount += 1 }, onMatch: { _, _, _, _ in })
         check(
             "real listener repeated start does not install a second tap",
             listener.status == .active && tap.installCount == 2)
@@ -1632,7 +1651,7 @@ struct SnippetsTests {
         check(
             "real listener stop is authoritative",
             listener.status == .off && tap.state == .absent)
-        listener.start { _, _, _, _ in }
+        listener.start(onUserActivity: { activityCount += 1 }, onMatch: { _, _, _, _ in })
         listener.stop()
         check(
             "real listener rapid on and off leaves no tap",

--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -636,6 +636,44 @@ struct SnippetsTests {
             "a rejected AX keyword replacement fails closed instead of deleting by events",
             !AccessibilityReplacement.rejected.fallsBackToEvents)
         check(
+            "an AX keyword one character behind the event stream remains pending",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "!tcaxprob",
+                selectedRange: NSRange(location: 9, length: 0),
+                keyword: "!tcaxprobe") == .pending)
+        check(
+            "a converged AX keyword resolves to its exact replacement range",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "prefix !tcaxprobe",
+                selectedRange: NSRange(location: 17, length: 0),
+                keyword: "!tcaxprobe") == .matched(NSRange(location: 7, length: 10)))
+        check(
+            "an AX state with enough text but the wrong suffix is a genuine rejection",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "prefix !tcaxwrong",
+                selectedRange: NSRange(location: 17, length: 0),
+                keyword: "!tcaxprobe") == .rejected)
+        check(
+            "an empty editor AX snapshot remains pending instead of becoming a false mismatch",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "",
+                selectedRange: NSRange(location: 0, length: 0),
+                keyword: "!tcaxprobe") == .pending)
+        check(
+            "AX replacement confirmation requires the observable text to actually change",
+            AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: "!tcprobe",
+                replacementRange: NSRange(location: 0, length: 8),
+                insertedText: "PROBE_OK",
+                observedValue: "PROBE_OK"))
+        check(
+            "an AX setter success with unchanged text is not accepted as delivery",
+            !AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: "!tcprobe",
+                replacementRange: NSRange(location: 0, length: 8),
+                insertedText: "PROBE_OK",
+                observedValue: "!tcprobe"))
+        check(
             "unreadable AX state accepts a posted paste after the conservative delay",
             PasteConfirmationPolicy.acceptsUnconfirmedDelivery(
                 attempt: 15,

--- a/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
+++ b/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
@@ -15,7 +15,10 @@ private func snippetKeywordCallback(
 
     // A click relocates the caret, so the buffered prefix no longer describes what precedes it.
     if type == .leftMouseDown || type == .rightMouseDown || type == .otherMouseDown {
-        MainActor.assumeIsolated { listener.clearBuffer() }
+        MainActor.assumeIsolated {
+            listener.userActivity()
+            listener.clearBuffer()
+        }
         return Unmanaged.passUnretained(event)
     }
 
@@ -122,6 +125,7 @@ final class SnippetKeywordListener: HealthCheckable {
     @ObservationIgnored private var observers: [NotificationToken] = []
     /// The keystroke buffer: the tap callback mutates it per event, so it stays untracked.
     @ObservationIgnored private var policy = SnippetKeywordPolicy()
+    @ObservationIgnored private var onUserActivity: (() -> Void)?
     @ObservationIgnored
     private var onMatch: ((StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void)?
     private var sessionActive = true
@@ -158,7 +162,11 @@ final class SnippetKeywordListener: HealthCheckable {
             })
     }
 
-    func start(onMatch: @escaping (StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void) {
+    func start(
+        onUserActivity: @escaping () -> Void,
+        onMatch: @escaping (StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void
+    ) {
+        self.onUserActivity = onUserActivity
         self.onMatch = onMatch
         installObserversIfNeeded()
         healthTicker?.subscribe(self)
@@ -166,6 +174,7 @@ final class SnippetKeywordListener: HealthCheckable {
     }
 
     func stop() {
+        onUserActivity = nil
         onMatch = nil
         healthTicker?.unsubscribe(self)
         observers.removeAll()
@@ -177,6 +186,10 @@ final class SnippetKeywordListener: HealthCheckable {
 
     func clearBuffer() {
         policy.reset()
+    }
+
+    fileprivate func userActivity() {
+        onUserActivity?()
     }
 
     func healthCheck() {
@@ -293,7 +306,7 @@ final class SnippetKeywordListener: HealthCheckable {
         syncTapPresence()
     }
 
-    fileprivate func processEvent(
+    func processEvent(
         typeRaw: UInt32,
         keyCode: Int,
         flagsRaw: UInt64,
@@ -312,6 +325,7 @@ final class SnippetKeywordListener: HealthCheckable {
             hasCommandOrControl: flags.contains(.maskCommand) || flags.contains(.maskControl),
             isResetKey: Self.resetKeyCodes.contains(keyCode),
             isDeleteBackward: keyCode == kVK_Delete)
+        if input != .ignored { onUserActivity?() }
         guard let match = policy.process(input, at: now()) else { return }
         onMatch?(
             match.snippetID,

--- a/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
@@ -124,18 +124,20 @@ final class SnippetCoordinator {
 
     func startSnippetKeywordListener() {
         // `beginAutomaticExpansion` is the gate, so this callback doesn't re-check anything.
-        listener.start { [weak self] id, keyword, keywordLength, targetApp in
-            guard let self,
-                let generation = self.injector.beginAutomaticExpansion(
-                    targetApp: targetApp)
-            else { return }
-            self.expandSnippet(
-                id: id,
-                targetApp: targetApp,
-                expectedKeyword: keyword,
-                keywordLength: keywordLength,
-                automaticGeneration: generation)
-        }
+        listener.start(
+            onUserActivity: { [weak self] in self?.injector.cancelAutomaticExpansion() },
+            onMatch: { [weak self] id, keyword, keywordLength, targetApp in
+                guard let self,
+                    let generation = self.injector.beginAutomaticExpansion(
+                        targetApp: targetApp)
+                else { return }
+                self.expandSnippet(
+                    id: id,
+                    targetApp: targetApp,
+                    expectedKeyword: keyword,
+                    keywordLength: keywordLength,
+                    automaticGeneration: generation)
+            })
     }
 
     /// Recent copies, newest first; the live pasteboard leads, the poller may lag behind.

--- a/Tinycast/Features/TextInjection/Service/TextInjector.swift
+++ b/Tinycast/Features/TextInjection/Service/TextInjector.swift
@@ -22,6 +22,39 @@ enum AccessibilityReplacement: Equatable {
     var fallsBackToEvents: Bool { self == .unavailable }
 }
 
+enum AccessibilityReplacementPolicy {
+    enum KeywordState: Equatable {
+        case matched(NSRange)
+        case pending
+        case rejected
+    }
+
+    static func keywordState(value: String, selectedRange: NSRange, keyword: String) -> KeywordState {
+        guard selectedRange.length == 0,
+            let selectedStringRange = Range(selectedRange, in: value)
+        else { return .rejected }
+        let beforeCursor = value[..<selectedStringRange.lowerBound]
+        guard beforeCursor.count >= keyword.count else { return .pending }
+        let start = beforeCursor.index(beforeCursor.endIndex, offsetBy: -keyword.count)
+        guard beforeCursor[start...].lowercased() == keyword.lowercased() else { return .rejected }
+        return .matched(NSRange(start..<beforeCursor.endIndex, in: value))
+    }
+
+    static func confirmsReplacement(
+        originalValue: String,
+        replacementRange: NSRange,
+        insertedText: String,
+        observedValue: String?
+    ) -> Bool {
+        guard let observedValue,
+            let stringRange = Range(replacementRange, in: originalValue)
+        else { return false }
+        var expected = originalValue
+        expected.replaceSubrange(stringRange, with: insertedText)
+        return observedValue == expected
+    }
+}
+
 @MainActor
 final class DeliveryCompletion {
     private let callback: @MainActor () -> Void
@@ -188,6 +221,8 @@ final class TextInjector {
     /// A copy lands well inside a second; past that the app was never going to answer.
     private static let copyPollAttempts = 40
     private static let copyPollInterval = Duration.milliseconds(25)
+    private static let accessibilityConvergenceAttempts = 8
+    private static let accessibilityConvergenceInterval = Duration.milliseconds(5)
 
     func deliver(
         _ injected: InjectedText,
@@ -239,11 +274,12 @@ final class TextInjector {
         else { return }
 
         let completion = DeliveryCompletion(callback: onDelivered)
-        let accessibilityReplacement = replaceUsingAccessibility(
+        let accessibilityReplacement = await replaceUsingAccessibility(
             injected,
             targetApp: targetApp,
             expectedKeyword: expectedKeyword,
-            keywordLength: keywordLength)
+            keywordLength: keywordLength,
+            automaticGeneration: automaticGeneration)
         if accessibilityReplacement == .delivered {
             completion.confirm()
             return
@@ -484,46 +520,60 @@ final class TextInjector {
         return false
     }
 
+    private struct AccessibilityReplacementTarget {
+        let element: AXUIElement
+        let value: String
+        let originalRange: NSRange
+        let replacementRange: NSRange
+    }
+
+    private enum AccessibilityTargetState {
+        case ready(AccessibilityReplacementTarget)
+        case pending
+        case unavailable
+        case rejected
+    }
+
     private func replaceUsingAccessibility(
         _ injected: InjectedText,
         targetApp: NSRunningApplication?,
         expectedKeyword: String?,
-        keywordLength: Int
-    ) -> AccessibilityReplacement {
-        guard let targetApp,
-            let element = AccessibilityText.focusedElement(in: targetApp),
-            isAttributeSettable(kAXSelectedTextRangeAttribute, in: element),
-            isAttributeSettable(kAXSelectedTextAttribute, in: element),
-            let value = stringValue(in: element),
-            let originalRange = selectedRange(in: element)
-        else { return .unavailable }
-        guard let selectedStringRange = Range(originalRange, in: value) else {
-            return .rejected
+        keywordLength: Int,
+        automaticGeneration: AutomaticGeneration?
+    ) async -> AccessibilityReplacement {
+        guard let targetApp else { return .unavailable }
+        let state = await accessibilityReplacementTarget(
+            in: targetApp,
+            expectedKeyword: expectedKeyword,
+            keywordLength: keywordLength,
+            automaticGeneration: automaticGeneration)
+        guard case .ready(let target) = state else {
+            switch state {
+            case .pending, .unavailable: return .unavailable
+            case .rejected: return .rejected
+            case .ready: return .rejected
+            }
         }
+        if usesTextMarkerSelection(target.element) { return .unavailable }
 
-        let replacementRange: NSRange
-        if keywordLength > 0 {
-            guard originalRange.length == 0,
-                let expectedKeyword,
-                value[..<selectedStringRange.lowerBound].count >= keywordLength
-            else { return .rejected }
-            let cursor = selectedStringRange.lowerBound
-            let start = value.index(cursor, offsetBy: -keywordLength)
-            let actualKeyword = String(value[start..<cursor]).lowercased()
-            guard actualKeyword == expectedKeyword.lowercased() else { return .rejected }
-            replacementRange = NSRange(start..<cursor, in: value)
-        } else {
-            replacementRange = originalRange
+        guard setSelectedRange(target.replacementRange, in: target.element) else {
+            return .unavailable
         }
-
-        guard setSelectedRange(replacementRange, in: element) else { return .unavailable }
+        let writeStatus = AXUIElementSetAttributeValue(
+            target.element,
+            kAXSelectedTextAttribute as CFString,
+            injected.text as CFString)
+        guard writeStatus == .success else {
+            return setSelectedRange(target.originalRange, in: target.element) ? .unavailable : .rejected
+        }
         guard
-            AXUIElementSetAttributeValue(
-                element,
-                kAXSelectedTextAttribute as CFString,
-                injected.text as CFString) == .success
+            AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: target.value,
+                replacementRange: target.replacementRange,
+                insertedText: injected.text,
+                observedValue: stringValue(in: target.element))
         else {
-            _ = setSelectedRange(originalRange, in: element)
+            _ = setSelectedRange(target.originalRange, in: target.element)
             return .rejected
         }
 
@@ -531,9 +581,85 @@ final class TextInjector {
         let cursorIndex = injected.text.index(injected.text.endIndex, offsetBy: -cursorOffset)
         let insertedPrefixLength = injected.text[..<cursorIndex].utf16.count
         _ = setSelectedRange(
-            NSRange(location: replacementRange.location + insertedPrefixLength, length: 0),
-            in: element)
+            NSRange(location: target.replacementRange.location + insertedPrefixLength, length: 0),
+            in: target.element)
         return .delivered
+    }
+
+    private func accessibilityReplacementTarget(
+        in targetApp: NSRunningApplication,
+        expectedKeyword: String?,
+        keywordLength: Int,
+        automaticGeneration: AutomaticGeneration?
+    ) async -> AccessibilityTargetState {
+        for attempt in 0..<Self.accessibilityConvergenceAttempts {
+            let state = inspectAccessibilityTarget(
+                in: targetApp,
+                expectedKeyword: expectedKeyword,
+                keywordLength: keywordLength)
+            guard case .pending = state else { return state }
+            guard attempt < Self.accessibilityConvergenceAttempts - 1,
+                automaticGeneration != nil,
+                deliveryIsAllowed(
+                    automaticGeneration: automaticGeneration,
+                    targetApp: targetApp,
+                    promptForInteractiveAccessibility: false),
+                await wait(for: Self.accessibilityConvergenceInterval)
+            else { return .unavailable }
+        }
+        return .unavailable
+    }
+
+    private func inspectAccessibilityTarget(
+        in targetApp: NSRunningApplication,
+        expectedKeyword: String?,
+        keywordLength: Int
+    ) -> AccessibilityTargetState {
+        guard let element = AccessibilityText.focusedElement(in: targetApp),
+            isAttributeSettable(kAXSelectedTextRangeAttribute, in: element),
+            isAttributeSettable(kAXSelectedTextAttribute, in: element),
+            let value = stringValue(in: element),
+            let originalRange = selectedRange(in: element)
+        else { return .unavailable }
+        if keywordLength == 0 {
+            guard Range(originalRange, in: value) != nil else { return .rejected }
+            return .ready(
+                AccessibilityReplacementTarget(
+                    element: element,
+                    value: value,
+                    originalRange: originalRange,
+                    replacementRange: originalRange))
+        }
+        guard let expectedKeyword, expectedKeyword.count == keywordLength else { return .rejected }
+        switch AccessibilityReplacementPolicy.keywordState(
+            value: value,
+            selectedRange: originalRange,
+            keyword: expectedKeyword)
+        {
+        case .matched(let replacementRange):
+            return .ready(
+                AccessibilityReplacementTarget(
+                    element: element,
+                    value: value,
+                    originalRange: originalRange,
+                    replacementRange: replacementRange))
+        case .pending:
+            return .pending
+        case .rejected:
+            return .rejected
+        }
+    }
+
+    private func usesTextMarkerSelection(_ element: AXUIElement) -> Bool {
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(
+                element,
+                kAXSelectedTextMarkerRangeAttribute as CFString,
+                &value) == .success,
+            let value
+        else { return false }
+        return CFGetTypeID(value) == AXTextMarkerRangeGetTypeID()
     }
 
     private func waitForPasteConfirmation(
@@ -574,6 +700,7 @@ final class TextInjector {
     ) -> AccessibilityTextState? {
         guard let targetApp,
             let element = AccessibilityText.focusedElement(in: targetApp),
+            !usesTextMarkerSelection(element),
             let value = stringValue(in: element),
             let selectedRange = selectedRange(in: element)
         else { return nil }

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -240,14 +240,17 @@ not report completion and therefore cannot show it.
 
 The preferred path is one atomic Accessibility replacement. Tinycast requires a focused element with
 readable text plus writable selected-range and selected-text attributes. For an automatic expansion it
-also verifies that the exact captured keyword is immediately before the cursor before replacing it.
-An Accessibility mismatch is rejected rather than guessed.
+also verifies that the exact captured keyword is immediately before the cursor. A renderer whose
+Accessibility text is briefly behind the key stream gets a bounded convergence window; a readable
+state that contains enough text but disagrees with the keyword is still rejected rather than guessed.
 
-Some editors grant Accessibility but do not expose writable text attributes. In that case Tinycast
-falls back to tagged keyboard events while keeping the same permission, consent, Secure Event Input,
-target-app and cancellation gates. The fallback deletes the keyword first, waits for deletion to
-settle, then inserts the expansion. Short single-line expansions of at most 100 characters use Unicode
-keyboard events.
+Web and editor controls that expose text-marker selections use tagged keyboard events instead of AX
+mutation because text-marker state is authoritative for reading but not a reliable write channel.
+Editors whose AX text remains unavailable after convergence use the same fallback. The fallback keeps
+the permission, consent, Secure Event Input, target-app and cancellation gates, deletes the keyword
+first, waits for deletion to settle, then inserts the expansion. Short single-line expansions of at
+most 100 characters use Unicode keyboard events. Native AX replacement is read back before delivery is
+confirmed, so a successful setter that leaves the text unchanged is not reported as delivered.
 
 Longer or multiline fallback text uses a temporary paste only when the existing pasteboard's first
 item has plain text that can be restored without another pasteboard write. Tinycast snapshots every
@@ -258,9 +261,10 @@ newer copy is never overwritten. Empty, image-first, unreadable or otherwise uns
 the Unicode-event fallback instead. The clipboard poller synchronizes to Tinycast's ownership changes
 so temporary or restored text is not added as new history.
 
-When Accessibility text state is readable, a long paste waits for evidence that the target changed.
-If the editor cannot expose post-paste text state, a successfully posted paste is accepted only after
-a conservative delay instead of being treated as a permanent failure. Cursor movement starts after
+When authoritative Accessibility text state is readable, a long paste waits for evidence that the
+target changed. Text-marker editors and controls that cannot expose post-paste text state accept a
+successfully posted paste only after a conservative delay instead of treating misleading or absent AX
+state as a permanent failure. Cursor movement starts after
 that confirmation or delay and after pasteboard restoration. Delivery completion is reported exactly
 once only after the Accessibility replacement or event fallback (including requested cursor movement)
 finishes successfully. Disabling automatic expansion or


### PR DESCRIPTION
## Related issue

Closes #410

## What changed

- Distinguishes a briefly stale Accessibility snapshot from a genuine keyword mismatch instead of rejecting both immediately.
- Gives automatic delivery a bounded 35 ms convergence window for renderer Accessibility state that is still catching up with the key stream.
- Treats text-marker web/editor controls as event-delivery targets rather than trusting AX mutation setters that can report success without changing the editor model.
- Reads native AX replacements back before reporting delivery, so a false-success setter is not accepted as delivery.
- Stops using non-authoritative text-marker state to confirm long paste fallback delivery.
- Cancels an in-flight automatic delivery on the next real user keyboard or mouse activity; Tinycast's tagged synthetic events do not cancel their own fallback.
- Adds deterministic snippet harness coverage for renderer lag, genuine mismatch, non-authoritative empty AX state, AX false-success read-back, and stale automatic-delivery cancellation.
- Updates the Snippets delivery contract documentation.

## Memory footprint

Measured on a clean temporary channel using the Release build and macOS `footprint` (`phys_footprint`). The temporary channel contained one snippet and no migrated user data.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | 40 MB  |
| Palette open            | 43 MB  |
| Feature in use (peak)   | 45 MB  |
| Palette closed, settled | 43 MB  |

Leak-tested: yes. After the initial one-time warm-up, four consecutive additional palette open/close cycles all settled at 43 MB; the post-close floor did not continue to rise.

## Drawbacks

Automatic expansion can spend up to 35 ms waiting for renderer Accessibility text to converge before using the existing event fallback. A readable state that already contains enough text but disagrees with the captured keyword still rejects immediately rather than guessing.

Text-marker editors deliberately use keyboard-event delivery because their AX mutation channel is not authoritative enough to confirm replacement safely. The fallback is less atomic than a native AX replacement, but it keeps the existing permission, Secure Event Input, target-app and cancellation gates, and now aborts when the user produces new real input before delivery completes.

## Tests & validation

- `./Scripts/run-tests.sh` — all 52 harnesses pass.
- `./Scripts/run-tests.sh snippets-test` — passes after the final safety change.
- `./Scripts/lint.sh` — `lint-clean`; only repository-baseline warnings remain.
- Pure-layer check: no AppKit/SwiftUI/Cocoa imports under `Features/*/Model/`.
- `git diff --check` — clean.
- Clean unsigned Debug build — succeeds with zero `warning:` / `error:` lines in the build log.
- Release build used for the memory sweep — succeeds with zero `warning:` / `error:` lines.
- Deterministic coverage for pending → matched convergence, genuine mismatch rejection, non-authoritative empty AX state, false-success AX writes, and real-vs-synthetic input cancellation.
- Manual: snippet keyword expansion succeeds in the ChatGPT composer in Helium.
- Manual: snippet keyword expansion succeeds in the affected VSCodium editor surface.
- Manual: ordinary/simple Helium text input continues to expand correctly.
