### PR TITLE
Deliver text reliably into renderer-based editors

### DIFF
--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -622,12 +622,24 @@ struct SnippetsTests {
         check("automatic cancellation cannot run a queued stale delivery", !automaticRan)
 
         var completionCount = 0
-        let completion = DeliveryCompletion { completionCount += 1 }
+        var failureCount = 0
+        let completion = DeliveryCompletion(
+            onDelivered: { completionCount += 1 }, onFailed: { failureCount += 1 })
         completion.confirm()
         completion.confirm()
+        completion.settle()
         check(
             "delivery completion invokes its callback exactly once after confirmation",
-            completion.isConfirmed && completionCount == 1)
+            completion.isConfirmed && completionCount == 1 && failureCount == 0)
+
+        var unconfirmedFailures = 0
+        let unconfirmed = DeliveryCompletion(onFailed: { unconfirmedFailures += 1 })
+        unconfirmed.settle()
+        unconfirmed.settle()
+        unconfirmed.confirm()
+        check(
+            "a delivery that returned early reports failure exactly once and stays unconfirmed",
+            !unconfirmed.isConfirmed && unconfirmedFailures == 1)
 
         check(
             "unavailable AX text attributes use the event delivery fallback",
@@ -635,6 +647,21 @@ struct SnippetsTests {
         check(
             "a rejected AX keyword replacement fails closed instead of deleting by events",
             !AccessibilityReplacement.rejected.fallsBackToEvents)
+
+        check(
+            "a Unicode keystroke never carries more than Blink's four-unit cap",
+            UnicodeTypingChunk.split(String(repeating: "a", count: 30))
+                .allSatisfy { $0.count <= UnicodeTypingChunk.maxUTF16Units })
+        check(
+            "chunked Unicode keystrokes reassemble into the original text",
+            UnicodeTypingChunk.split("Fix this sentence, 雪が降る 👨‍👩‍👧 — done.")
+                .flatMap { $0 } == Array("Fix this sentence, 雪が降る 👨‍👩‍👧 — done.".utf16))
+        check(
+            "a surrogate pair is never split across two keystrokes",
+            UnicodeTypingChunk.split("ab👩🏽‍🚀").allSatisfy { chunk in
+                String(decoding: chunk, as: UTF16.self).unicodeScalars.allSatisfy { $0.value != 0xFFFD }
+            })
+        check("empty text produces no keystrokes", UnicodeTypingChunk.split("").isEmpty)
         check(
             "unreadable AX state accepts a posted paste after the conservative delay",
             PasteConfirmationPolicy.acceptsUnconfirmedDelivery(
@@ -717,23 +744,34 @@ struct SnippetsTests {
                 && pasteboard.string(forType: .string) == "Newer copy")
 
         _ = pasteboard.replaceObjects([])
+        let emptyLease = TemporaryPasteboardLease.begin(
+            text: "Temporary from empty",
+            pasteboard: pasteboard)
         check(
-            "an empty clipboard declines temporary ownership for the Unicode fallback",
-            TemporaryPasteboardLease.begin(
-                text: "Temporary from empty",
-                pasteboard: pasteboard) == nil
+            "an empty clipboard still lends a temporary string to paste",
+            emptyLease?.isOwned == true
+                && pasteboard.string(forType: .string) == "Temporary from empty")
+        check(
+            "restoring a borrowed empty clipboard leaves it empty again",
+            emptyLease?.restoreIfOwned() != nil
                 && pasteboard.pasteboardItems?.isEmpty != false)
 
         let imageOnlyItem = NSPasteboardItem()
         imageOnlyItem.setData(Data([9, 8, 7]), forType: .png)
         _ = pasteboard.replaceObjects([imageOnlyItem])
+        let imageLease = TemporaryPasteboardLease.begin(
+            text: "Temporary over image",
+            pasteboard: pasteboard)
         check(
-            "a non-text clipboard declines temporary ownership without changing its payload",
-            TemporaryPasteboardLease.begin(
-                text: "Temporary over image",
-                pasteboard: pasteboard) == nil
+            "a non-text clipboard still lends a temporary string to paste",
+            imageLease?.isOwned == true
+                && pasteboard.string(forType: .string) == "Temporary over image")
+        check(
+            "restoring a borrowed image clipboard returns the original payload",
+            imageLease?.restoreIfOwned() != nil
                 && pasteboard.pasteboardItems?.count == 1
-                && pasteboard.data(forType: .png) == Data([9, 8, 7]))
+                && pasteboard.data(forType: .png) == Data([9, 8, 7])
+                && pasteboard.string(forType: .string) == nil)
     }
 
     private static func testStoreWatcher() async throws {

--- a/Tinycast/Features/QuickActions/UI/QuickActionCoordinator.swift
+++ b/Tinycast/Features/QuickActions/UI/QuickActionCoordinator.swift
@@ -180,10 +180,17 @@ final class QuickActionCoordinator {
             })
     }
 
+    /// A replacement that never lands would otherwise lose the reply, so the clipboard keeps it.
     private func deliver(_ text: String, to target: NSRunningApplication?, action: QuickAction) {
-        injector.replaceSelection(with: text, in: target) { [weak self] in
-            self?.core.showMessage("\(action.title) applied")
-        }
+        injector.replaceSelection(
+            with: text, in: target,
+            onDelivered: { [weak self] in self?.core.showMessage("\(action.title) applied") },
+            onFailed: { [weak self] in
+                Paster.copyPlainText(text)
+                self?.core.showMessage(
+                    "\(action.title) couldn't replace the selection — copied instead",
+                    tone: .danger)
+            })
     }
 
     /// A failure the reader cannot see is a hotkey that silently did nothing.

--- a/Tinycast/Features/TextInjection/Service/TextInjector.swift
+++ b/Tinycast/Features/TextInjection/Service/TextInjector.swift
@@ -18,23 +18,37 @@ enum AccessibilityReplacement: Equatable {
     case unavailable
     case rejected
 
-    /// Only `.unavailable` falls back to events; `.rejected` means the text moved, so fail closed.
+    /// `.rejected` is only ever returned before anything is written, so the text cannot have moved.
     var fallsBackToEvents: Bool { self == .unavailable }
 }
 
 @MainActor
 final class DeliveryCompletion {
-    private let callback: @MainActor () -> Void
+    private let onDelivered: @MainActor () -> Void
+    private let onFailed: @MainActor () -> Void
     private(set) var isConfirmed = false
+    private var isSettled = false
 
-    init(callback: @escaping @MainActor () -> Void = {}) {
-        self.callback = callback
+    init(
+        onDelivered: @escaping @MainActor () -> Void = {},
+        onFailed: @escaping @MainActor () -> Void = {}
+    ) {
+        self.onDelivered = onDelivered
+        self.onFailed = onFailed
     }
 
     func confirm() {
-        guard !isConfirmed else { return }
+        guard !isSettled else { return }
+        isSettled = true
         isConfirmed = true
-        callback()
+        onDelivered()
+    }
+
+    /// Driven from a `defer`, so a delivery that returned early still says so instead of vanishing.
+    func settle() {
+        guard !isSettled else { return }
+        isSettled = true
+        onFailed()
     }
 }
 
@@ -138,11 +152,12 @@ final class TextInjector {
     func replaceSelection(
         with text: String,
         in targetApp: NSRunningApplication?,
-        onDelivered: @escaping @MainActor () -> Void = {}
+        onDelivered: @escaping @MainActor () -> Void = {},
+        onFailed: @escaping @MainActor () -> Void = {}
     ) {
         deliver(
             InjectedText(text), targetApp: targetApp, expectedKeyword: nil, keywordLength: 0,
-            automaticGeneration: nil, onDelivered: onDelivered)
+            automaticGeneration: nil, onDelivered: onDelivered, onFailed: onFailed)
     }
 
     /// A `changeCount` that never moves means nothing was selected, not that the old clipboard won.
@@ -195,7 +210,8 @@ final class TextInjector {
         expectedKeyword: String?,
         keywordLength: Int,
         automaticGeneration: AutomaticGeneration?,
-        onDelivered: @escaping @MainActor () -> Void = {}
+        onDelivered: @escaping @MainActor () -> Void = {},
+        onFailed: @escaping @MainActor () -> Void = {}
     ) {
         activate(targetApp)
         if let automaticGeneration {
@@ -205,7 +221,10 @@ final class TextInjector {
                     targetApp: targetApp)
             else { return }
         } else {
-            guard prepareInteractiveExpansion(targetApp: targetApp) else { return }
+            guard prepareInteractiveExpansion(targetApp: targetApp) else {
+                onFailed()
+                return
+            }
         }
 
         deliveryQueue.enqueue(isAutomatic: automaticGeneration != nil) { [weak self] in
@@ -216,7 +235,7 @@ final class TextInjector {
                 expectedKeyword: expectedKeyword,
                 keywordLength: keywordLength,
                 automaticGeneration: automaticGeneration,
-                onDelivered: onDelivered)
+                completion: DeliveryCompletion(onDelivered: onDelivered, onFailed: onFailed))
         }
     }
 
@@ -226,8 +245,9 @@ final class TextInjector {
         expectedKeyword: String?,
         keywordLength: Int,
         automaticGeneration: AutomaticGeneration?,
-        onDelivered: @escaping @MainActor () -> Void
+        completion: DeliveryCompletion
     ) async {
+        defer { completion.settle() }
         guard finishPendingPasteboardOwnership(),
             await activateAndWaitForTarget(
                 targetApp,
@@ -238,8 +258,7 @@ final class TextInjector {
                 promptForInteractiveAccessibility: true)
         else { return }
 
-        let completion = DeliveryCompletion(callback: onDelivered)
-        let accessibilityReplacement = replaceUsingAccessibility(
+        let accessibilityReplacement = await replaceUsingAccessibility(
             injected,
             targetApp: targetApp,
             expectedKeyword: expectedKeyword,
@@ -314,7 +333,7 @@ final class TextInjector {
                 automaticGeneration: automaticGeneration,
                 targetApp: targetApp,
                 promptForInteractiveAccessibility: false),
-            await postDeletionEvents(
+            await postEventGroups(
                 deletionEvents,
                 targetApp: targetApp,
                 automaticGeneration: automaticGeneration),
@@ -347,22 +366,22 @@ final class TextInjector {
                 automaticGeneration: automaticGeneration,
                 targetApp: targetApp,
                 promptForInteractiveAccessibility: false),
-            await postDeletionEvents(
+            await postEventGroups(
                 deletionEvents,
                 targetApp: targetApp,
                 automaticGeneration: automaticGeneration),
             await waitAfterKeywordDeletion(keywordLength),
-            deliveryIsAllowed(
-                automaticGeneration: automaticGeneration,
+            await postEventGroups(
+                insertionEvents,
                 targetApp: targetApp,
-                promptForInteractiveAccessibility: false)
+                automaticGeneration: automaticGeneration)
         else { return false }
 
-        post(insertionEvents, targetApp: targetApp)
         return await wait(for: .milliseconds(100))
     }
 
-    private func postDeletionEvents(
+    /// Each group is one keystroke, spaced so a target that stops accepting them halts the rest.
+    private func postEventGroups(
         _ events: [[CGEvent]],
         targetApp: NSRunningApplication?,
         automaticGeneration: AutomaticGeneration?
@@ -416,7 +435,7 @@ final class TextInjector {
             break
         case .failed:
             // Still ours, so leave `activePasteboardLease` in place for the retry below.
-            return
+            if lease.isOwned { return }
         }
         if activePasteboardLease === lease { activePasteboardLease = nil }
     }
@@ -489,7 +508,7 @@ final class TextInjector {
         targetApp: NSRunningApplication?,
         expectedKeyword: String?,
         keywordLength: Int
-    ) -> AccessibilityReplacement {
+    ) async -> AccessibilityReplacement {
         guard let targetApp,
             let element = AccessibilityText.focusedElement(in: targetApp),
             isAttributeSettable(kAXSelectedTextRangeAttribute, in: element),
@@ -497,8 +516,9 @@ final class TextInjector {
             let value = stringValue(in: element),
             let originalRange = selectedRange(in: element)
         else { return .unavailable }
+        // Offsets its own value cannot address are a broken tier, not proof the document moved.
         guard let selectedStringRange = Range(originalRange, in: value) else {
-            return .rejected
+            return .unavailable
         }
 
         let replacementRange: NSRange
@@ -521,10 +541,11 @@ final class TextInjector {
             AXUIElementSetAttributeValue(
                 element,
                 kAXSelectedTextAttribute as CFString,
-                injected.text as CFString) == .success
+                injected.text as CFString) == .success,
+            await accessibilityValue(in: element, movedFrom: value)
         else {
             _ = setSelectedRange(originalRange, in: element)
-            return .rejected
+            return .unavailable
         }
 
         let cursorOffset = min(injected.cursorOffsetFromEnd ?? 0, injected.text.count)
@@ -535,6 +556,23 @@ final class TextInjector {
             in: element)
         return .delivered
     }
+
+    /// Chromium answers `.success` and applies nothing, so only a moved value counts as delivered.
+    private func accessibilityValue(
+        in element: AXUIElement, movedFrom previous: String
+    ) async -> Bool {
+        for attempt in 0..<Self.accessibilityVerifyAttempts {
+            if let current = stringValue(in: element), current != previous { return true }
+            guard attempt < Self.accessibilityVerifyAttempts - 1,
+                await wait(for: Self.accessibilityVerifyInterval)
+            else { return false }
+        }
+        return false
+    }
+
+    /// Long enough for a renderer round-trip, short enough that the event tiers still feel prompt.
+    private static let accessibilityVerifyAttempts = 12
+    private static let accessibilityVerifyInterval = Duration.milliseconds(25)
 
     private func waitForPasteConfirmation(
         previousState: AccessibilityTextState?,
@@ -639,10 +677,19 @@ final class TextInjector {
         return AccessibilityText.selection(in: targetApp)
     }
 
-    private func makeUnicodeEvents(_ text: String) -> [CGEvent]? {
+    private func makeUnicodeEvents(_ text: String) -> [[CGEvent]]? {
         guard !text.isEmpty else { return [] }
+        var groups: [[CGEvent]] = []
+        for chunk in UnicodeTypingChunk.split(text) {
+            guard let pair = makeUnicodeEvent(chunk) else { return nil }
+            groups.append(pair)
+        }
+        return groups
+    }
+
+    private func makeUnicodeEvent(_ chunk: [UniChar]) -> [CGEvent]? {
         let source = CGEventSource(stateID: .combinedSessionState)
-        var characters = Array(text.utf16)
+        var characters = chunk
         guard
             let down = CGEvent(
                 keyboardEventSource: source,
@@ -731,6 +778,27 @@ final class TextInjector {
     }
 }
 
+/// Blink keeps one key event's text in a fixed four-unit array, so Chromium drops everything past it.
+enum UnicodeTypingChunk {
+    static let maxUTF16Units = 4
+
+    /// Split on scalar boundaries: a lone surrogate half is not text, and a scalar always fits four.
+    static func split(_ text: String) -> [[UniChar]] {
+        var chunks: [[UniChar]] = []
+        var current: [UniChar] = []
+        current.reserveCapacity(maxUTF16Units)
+        for scalar in text.unicodeScalars {
+            if current.count + UTF16.width(scalar) > maxUTF16Units {
+                chunks.append(current)
+                current = []
+            }
+            UTF16.encode(scalar) { current.append($0) }
+        }
+        if !current.isEmpty { chunks.append(current) }
+        return chunks
+    }
+}
+
 enum PasteConfirmationPolicy {
     static func acceptsUnconfirmedDelivery(
         attempt: Int,
@@ -811,8 +879,9 @@ final class TemporaryPasteboardLease {
 
     private let pasteboard: any PasteboardAccess
     private let ownedChangeCount: Int
-    private let originalStringData: Data
-    private let temporaryItem: NSPasteboardItem
+    private let original: PasteboardSnapshot
+    /// Set only when the clipboard already held a string, which restores in place at no cost.
+    private let temporaryItem: NSPasteboardItem?
     private var isFinished = false
 
     var isOwned: Bool {
@@ -822,12 +891,12 @@ final class TemporaryPasteboardLease {
     private init(
         pasteboard: any PasteboardAccess,
         ownedChangeCount: Int,
-        originalStringData: Data,
-        temporaryItem: NSPasteboardItem
+        original: PasteboardSnapshot,
+        temporaryItem: NSPasteboardItem?
     ) {
         self.pasteboard = pasteboard
         self.ownedChangeCount = ownedChangeCount
-        self.originalStringData = originalStringData
+        self.original = original
         self.temporaryItem = temporaryItem
     }
 
@@ -837,16 +906,14 @@ final class TemporaryPasteboardLease {
         onMutation: (Int) -> Void = { _ in }
     ) -> TemporaryPasteboardLease? {
         guard let snapshot = PasteboardSnapshot(pasteboard: pasteboard),
-            let temporaryItems = snapshot.items(replacingFirstStringWith: text),
+            let temporaryItems = snapshot.items(borrowingFor: text),
             let originalItems = snapshot.pasteboardItems(),
-            let originalStringData = snapshot.firstStringData,
-            let temporaryItem = temporaryItems.first,
             pasteboard.changeCount == snapshot.changeCount
         else { return nil }
 
         pasteboard.clearContents()
         guard pasteboard.writeObjects(temporaryItems) else {
-            if pasteboard.writeObjects(originalItems) {
+            if originalItems.isEmpty || pasteboard.writeObjects(originalItems) {
                 onMutation(pasteboard.changeCount)
             }
             return nil
@@ -856,8 +923,8 @@ final class TemporaryPasteboardLease {
         return TemporaryPasteboardLease(
             pasteboard: pasteboard,
             ownedChangeCount: ownedChangeCount,
-            originalStringData: originalStringData,
-            temporaryItem: temporaryItem)
+            original: snapshot,
+            temporaryItem: snapshot.firstStringData == nil ? nil : temporaryItems.first)
     }
 
     func restoreIfOwned() -> RestoreResult {
@@ -865,6 +932,9 @@ final class TemporaryPasteboardLease {
         guard pasteboard.changeCount == ownedChangeCount else {
             isFinished = true
             return .superseded
+        }
+        guard let temporaryItem, let originalStringData = original.firstStringData else {
+            return rewriteOriginal()
         }
         guard temporaryItem.setData(originalStringData, forType: .string) else {
             if pasteboard.changeCount != ownedChangeCount {
@@ -879,6 +949,15 @@ final class TemporaryPasteboardLease {
         }
         isFinished = true
         return .restored(changeCount: ownedChangeCount)
+    }
+
+    /// A borrowed board has no original string to write back into, so the whole board is rewritten.
+    private func rewriteOriginal() -> RestoreResult {
+        guard let items = original.pasteboardItems() else { return .failed }
+        pasteboard.clearContents()
+        isFinished = true
+        guard items.isEmpty || pasteboard.writeObjects(items) else { return .failed }
+        return .restored(changeCount: pasteboard.changeCount)
     }
 }
 
@@ -915,8 +994,15 @@ struct PasteboardSnapshot {
         makePasteboardItems(firstString: nil)
     }
 
-    func items(replacingFirstStringWith text: String) -> [NSPasteboardItem]? {
-        guard firstStringData != nil else { return nil }
+    /// A board with no string of its own lends a fresh item instead of declining the loan.
+    func items(borrowingFor text: String) -> [NSPasteboardItem]? {
+        guard firstStringData != nil else {
+            let item = NSPasteboardItem()
+            guard item.setString(text, forType: .string),
+                item.setData(Data(), forType: ClipboardManager.internalType)
+            else { return nil }
+            return [item]
+        }
         return makePasteboardItems(firstString: text)
     }
 

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -172,10 +172,18 @@ The Accessibility tier replaces the live selection atomically. The event tiers b
 paste over it, which every app treats as replacing a selection — but that is the target app's
 behaviour rather than something Tinycast asserts, so it is the part worth checking by hand.
 
+**A replacement that never lands says so, and keeps the reply.** Every tier can decline, and a shortcut
+that quietly did nothing is indistinguishable from a shortcut that is not bound. `DeliveryCompletion`
+now settles either way, so a delivery that returned early reports failure exactly once; Quick Actions
+put the generated text on the clipboard and raise a HUD rather than dropping it. Snippets pass no
+failure handler, so automatic expansion stays silent as before.
+
 ### Manual sweep
 
-- Select text in Safari, Chrome, Slack, Mail, Notes, VS Code and Terminal, press Fix Grammar, and
-  confirm the selection is **replaced** rather than appended to.
+- Select text in Safari, Chrome, Brave, Slack, Mail, Notes, VS Code and Terminal, press Fix Grammar,
+  and confirm the selection is **replaced** rather than appended to.
+- In a Chromium target, run one on a **short** selection whose result stays under 100 characters on
+  one line: the whole result lands, not its first four characters.
 - Replace mode, with a slow route selected: the message pill says `Fixing Grammar…` with a blue
   spinner while the model works, and the result message takes its place.
 - Run one from the launcher (⌘Space → "Fix Grammar") with text selected behind it: the palette

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -241,7 +241,14 @@ not report completion and therefore cannot show it.
 The preferred path is one atomic Accessibility replacement. Tinycast requires a focused element with
 readable text plus writable selected-range and selected-text attributes. For an automatic expansion it
 also verifies that the exact captured keyword is immediately before the cursor before replacing it.
-An Accessibility mismatch is rejected rather than guessed.
+A keyword mismatch is rejected rather than guessed, and rejection is the only outcome that stops
+delivery outright — it is returned before anything is written, so the document cannot have moved.
+
+**A `kAXErrorSuccess` from the setter is not evidence.** Chromium answers success and applies nothing,
+so the element's value has to be seen to change — polled for up to 300 ms, since a browser applies the
+edit in its renderer rather than in the process that answered. An unmoved value is `.unavailable`, not
+`.delivered`, so the event tiers still get their turn instead of a "applied" message over unchanged
+text.
 
 Some editors grant Accessibility but do not expose writable text attributes. In that case Tinycast
 falls back to tagged keyboard events while keeping the same permission, consent, Secure Event Input,
@@ -249,14 +256,23 @@ target-app and cancellation gates. The fallback deletes the keyword first, waits
 settle, then inserts the expansion. Short single-line expansions of at most 100 characters use Unicode
 keyboard events.
 
-Longer or multiline fallback text uses a temporary paste only when the existing pasteboard's first
-item has plain text that can be restored without another pasteboard write. Tinycast snapshots every
-item, type and data payload, takes temporary ownership with the same item shape, and changes only the
-first plain-text payload. Restoration mutates that owned item back in place; it never clears the
-clipboard before a fallible restore. The pasteboard change count is checked before restoration, so a
-newer copy is never overwritten. Empty, image-first, unreadable or otherwise unsafe pasteboards use
-the Unicode-event fallback instead. The clipboard poller synchronizes to Tinycast's ownership changes
-so temporary or restored text is not added as new history.
+**A Unicode keystroke carries at most four UTF-16 units.** Blink stores one key event's text in a
+fixed `WebKeyboardEvent::kTextLengthCap` array, so a Chromium target — Brave, Chrome, Electron, VS
+Code, Slack — silently drops everything past the fourth unit of a single event. `UnicodeTypingChunk`
+splits the text into four-unit keystrokes on scalar boundaries, because a lone surrogate half is not
+text and a scalar never exceeds four units on its own. The chunks post through the same spaced,
+re-gated loop the deletions use, so a target that goes away mid-word stops the rest.
+
+Longer or multiline fallback text uses a temporary paste. Tinycast snapshots every item, type and data
+payload, takes temporary ownership with the same item shape, and changes only the first plain-text
+payload; restoration mutates that owned item back in place, never clearing the clipboard before a
+fallible restore. A pasteboard with no string of its own — empty, or image-first — **borrows** instead:
+Tinycast writes a single string item and restores by rewriting the snapshot, which is the one path that
+clears first, because there is no original string item left to write back into. Declining the loan
+there would have sent a long multiline expansion down the keystroke path a character at a time. The
+pasteboard change count is checked before restoration, so a newer copy is never overwritten, and the
+clipboard poller synchronizes to Tinycast's ownership changes so temporary or restored text is not
+added as new history.
 
 When Accessibility text state is readable, a long paste waits for evidence that the target changed.
 If the editor cannot expose post-paste text state, a successfully posted paste is accepted only after


### PR DESCRIPTION
## Related issue

Closes #410. Also fixes Quick Actions' replace failing in Brave, which had no issue of its own.

Supersedes #412 — its two mechanisms are folded in here rather than merged separately, because both PRs rewrote the same tier decision in `replaceUsingAccessibility` and reconciling them in a third PR would have left two overlapping verification paths in the tree with no way to tell which was load-bearing. Credited via `Co-authored-by`.

## What changed

Three symptoms, one cause: the Accessibility tier decides *by itself*, in three places, whether a target can be written to — and renderer-based editors lie to it in three different ways.

- **ChatGPT composer** (#410): `AXValue` trails the key stream by ~4.5 ms, so the keyword check ran one character early and refused.
- **VSCodium / Monaco** (#410): `AXValue` stays empty and caret-zero indefinitely while the real editor holds the text.
- **Brave, Quick Actions**: the AX write reported `kAXErrorSuccess` and changed nothing; when it did fall through to events, Blink truncated the whole result to 4 characters.

### The contract

Delivery is now one ordered rule set, in one function:

```
1. Element exposes AXSelectedTextMarkerRange?  → renderer surface, skip Accessibility
2. Keyword at the caret?
     not yet → wait up to 40 ms   never → events   wrong → refuse
3. Write, read the value back
     matches → done   unchanged → events   moved otherwise → refuse
4. Events: delete the keyword, then paste (long/multiline) or type in 4-unit keystrokes
5. Nothing landed → say so
```

**Rule 1** is the decisive one. A marker range is the reliable tell that selection lives in a renderer model rather than in the element answering us, so those targets never take the AX write at all. `accessibilityTextState` skips them too — a value that never moves cannot confirm a paste either.

**Rule 2** separates "a few milliseconds behind" from "a different document". `AccessibilityReplacementPolicy.keywordState` returns `.pending` when the value is shorter than the keyword and `.rejected` when there was enough text and it did not match. Only automatic expansion waits; an interactive one has no keyword race to lose.

**Rule 3** replaces the 300 ms value poll from the first commit. With renderer surfaces already excluded by rule 1, the remaining controls answer synchronously, so `confirmsReplacement` rebuilding the exact expected string and comparing once is both stricter and cheaper. Failure is split: unchanged → `.unavailable` (events are safe), changed into something we did not write → `.rejected` (events would edit a document we can no longer describe). That split is the one place #412 and the first commit genuinely disagreed.

**Rule 4** is why #412 could not land alone. Blink keeps one key event's text in a fixed array:

```cpp
static const size_t kTextLengthCap = 4;
std::array<char16_t, kTextLengthCap> text = {};
```

`deliverUsingUnicodeEvents` packed the whole string into a single `keyboardSetUnicodeString` pair, so every Chromium target kept the first four UTF-16 units. Routing renderer editors to the event tier without this fix converts "keyword stays put" into "keyword deleted, `pers` typed". `UnicodeTypingChunk.split` now cuts on **scalar** boundaries — a lone surrogate half is not text, and a scalar never exceeds four units — and the chunks post through `postEventGroups` (the renamed `postDeletionEvents`), so insertions inherit the deletions' spacing and per-keystroke re-gating.

**Rule 5.** `DeliveryCompletion` gains `onFailed` and settles from a `defer`, so a delivery that returned early reports failure exactly once. Quick Actions raise a HUD and keep the reply on the clipboard; snippets pass no handler and stay silent, because a speculative expansion that declined is not news. An automatic expansion is additionally abandoned on the reader's next real keystroke or click — Tinycast's own tagged events classify as `.ignored`, so a fallback never cancels itself.

### Also

A clipboard holding no string of its own used to decline the temporary lease, sending long multiline text down the keystroke path a character at a time. `items(borrowingFor:)` now writes a single string item and `rewriteOriginal()` restores the snapshot — the one restore path that clears first, because there is no original string item to write back into.

## Memory footprint

No new long-lived state. `UnicodeTypingChunk` and `AccessibilityReplacementPolicy` are pure statics; the lease swaps one stored `Data` for the `PasteboardSnapshot` it already held; `onUserActivity` is one closure released on `stop()`. The chunked path allocates one `[UniChar]` and one `CGEvent` pair per four characters, all released when `deliverUsingUnicodeEvents` returns.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no. Nothing here outlives `performDelivery`, and the one new closure is cleared in `SnippetKeywordListener.stop()` alongside `onMatch`.

## Drawbacks

- **Rule 1 is a heuristic.** An app that exposes a marker range *and* has a working AX write now uses events instead. Slower and clipboard-borrowing, but correct; I could not find a way to distinguish the two that does not involve writing first and checking.
- **Typing is slower.** A 100-character single-line result is 25 keystrokes at 8 ms rather than one event, about 200 ms. That is the cost of it arriving at all in Chromium.
- **Rule 3 can false-negative** on a control that is synchronous *except* under load. It then falls to events and the text could land twice. Rule 1 excludes the targets where this is likely; the alternative was the false-success HUD.
- **`onFailed` can fire on a paste that actually landed**, if the confirmation poll times out or the lease is raced. The reply then goes to the clipboard as the same text already in the document — a wrong HUD rather than lost work.
- **A borrowed clipboard clears before its restore**, unlike the in-place path. Only reachable when the board was empty or image-only.
- The 100-character routing threshold is unchanged. Preferring paste for every selection replace would have changed snippet behaviour too, and chunking makes typing correct on its own.

## Tests & validation

`./Scripts/run-tests.sh` — all 52 harnesses pass. Debug build compiles with no new warnings; `./Scripts/lint.sh` clean; no AppKit/SwiftUI import in any `Model/`.

Added to `snippets-test`, all against the pure policies so they need no editor in the room:

- an AX keyword one character behind the event stream remains pending
- a converged keyword resolves to its exact replacement range
- enough text but the wrong suffix is a genuine rejection
- an empty editor snapshot remains pending rather than a false mismatch
- a non-empty selection is a mismatch rather than a lagging caret
- confirmation requires the observable text to actually change
- a setter success with unchanged text is not accepted as delivery
- a write that landed somewhere unexpected is not accepted as delivery
- an unreadable value after the write is not accepted as delivery
- real user input invalidates pending automatic delivery while Tinycast's tagged events do not
- a Unicode keystroke never carries more than Blink's four-unit cap
- chunked keystrokes reassemble into the original text (ASCII, CJK, ZWJ emoji)
- a surrogate pair is never split across two keystrokes
- a delivery that returned early reports failure exactly once and stays unconfirmed
- an empty clipboard still lends a temporary string, and restoring leaves it empty
- an image-only clipboard still lends one, and restoring returns the PNG with no string left behind

Verified against Chromium's source rather than guessed: `kTextLengthCap` is 4 in `third_party/blink/public/common/input/web_keyboard_event.h`.

**Which rule a given app takes is not testable in a harness — needs a manual sweep** (this shell had no Accessibility grant, so I could measure none of it):

- ChatGPT composer in a Chromium browser: a keyword expands (rules 1 + 4)
- VSCodium editor pane: a keyword expands where `AXValue` stays empty
- Notes, Mail, TextEdit: still the atomic AX replacement, not events
- Brave, short single-line Fix Grammar: the whole result lands, not its first four characters
- Brave, multi-paragraph Rewrite: the paste path replaces rather than appends
- keep typing while an expansion is in flight: abandoned rather than landing mid-word
- a keyword whose text the app changed underneath it: refused, keyword left alone
- empty clipboard, then a long Quick Action: pastes rather than types, clipboard empty afterwards
