### PR TITLE
Deliver text reliably into renderer-based editors

### DIFF
--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -649,6 +649,65 @@ struct SnippetsTests {
             !AccessibilityReplacement.rejected.fallsBackToEvents)
 
         check(
+            "an AX keyword one character behind the event stream remains pending",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "!tcaxprob",
+                selectedRange: NSRange(location: 9, length: 0),
+                keyword: "!tcaxprobe") == .pending)
+        check(
+            "a converged AX keyword resolves to its exact replacement range",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "prefix !tcaxprobe",
+                selectedRange: NSRange(location: 17, length: 0),
+                keyword: "!tcaxprobe") == .matched(NSRange(location: 7, length: 10)))
+        check(
+            "an AX state with enough text but the wrong suffix is a genuine rejection",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "prefix !tcaxwrong",
+                selectedRange: NSRange(location: 17, length: 0),
+                keyword: "!tcaxprobe") == .rejected)
+        check(
+            "an empty editor AX snapshot remains pending instead of becoming a false mismatch",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "",
+                selectedRange: NSRange(location: 0, length: 0),
+                keyword: "!tcaxprobe") == .pending)
+        check(
+            "a non-empty selection is a mismatch rather than a lagging caret",
+            AccessibilityReplacementPolicy.keywordState(
+                value: "prefix !tcaxprobe",
+                selectedRange: NSRange(location: 7, length: 10),
+                keyword: "!tcaxprobe") == .rejected)
+        check(
+            "AX replacement confirmation requires the observable text to actually change",
+            AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: "!tcprobe",
+                replacementRange: NSRange(location: 0, length: 8),
+                insertedText: "PROBE_OK",
+                observedValue: "PROBE_OK"))
+        check(
+            "an AX setter success with unchanged text is not accepted as delivery",
+            !AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: "!tcprobe",
+                replacementRange: NSRange(location: 0, length: 8),
+                insertedText: "PROBE_OK",
+                observedValue: "!tcprobe"))
+        check(
+            "an AX write that lands somewhere unexpected is not accepted as delivery",
+            !AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: "keep !tcprobe",
+                replacementRange: NSRange(location: 5, length: 8),
+                insertedText: "PROBE_OK",
+                observedValue: "PROBE_OK !tcprobe"))
+        check(
+            "an unreadable value after the write is not accepted as delivery",
+            !AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: "!tcprobe",
+                replacementRange: NSRange(location: 0, length: 8),
+                insertedText: "PROBE_OK",
+                observedValue: nil))
+
+        check(
             "a Unicode keystroke never carries more than Blink's four-unit cap",
             UnicodeTypingChunk.split(String(repeating: "a", count: 30))
                 .allSatisfy { $0.count <= UnicodeTypingChunk.maxUTF16Units })
@@ -1573,8 +1632,9 @@ struct SnippetsTests {
             now: { Date(timeIntervalSince1970: 1_000) },
             syntheticEventTag: 123,
             logsTapFailures: false)
+        var activityCount = 0
 
-        listener.start { _, _, _, _ in }
+        listener.start(onUserActivity: { activityCount += 1 }, onMatch: { _, _, _, _ in })
         check(
             "real listener waits without permissions and does not install",
             listener.status == .needsAccessibility && tap.installCount == 0)
@@ -1593,7 +1653,25 @@ struct SnippetsTests {
                 && tap.installCount == 2
                 && tap.state == .active)
 
-        listener.start { _, _, _, _ in }
+        listener.processEvent(
+            typeRaw: CGEventType.keyDown.rawValue,
+            keyCode: 0,
+            flagsRaw: 0,
+            text: "x",
+            eventUserData: 0,
+            secureEventInputEnabled: false)
+        listener.processEvent(
+            typeRaw: CGEventType.keyDown.rawValue,
+            keyCode: 0,
+            flagsRaw: 0,
+            text: "x",
+            eventUserData: 123,
+            secureEventInputEnabled: false)
+        check(
+            "real user input invalidates pending automatic delivery while Tinycast events do not",
+            activityCount == 1)
+
+        listener.start(onUserActivity: { activityCount += 1 }, onMatch: { _, _, _, _ in })
         check(
             "real listener repeated start does not install a second tap",
             listener.status == .active && tap.installCount == 2)
@@ -1632,7 +1710,7 @@ struct SnippetsTests {
         check(
             "real listener stop is authoritative",
             listener.status == .off && tap.state == .absent)
-        listener.start { _, _, _, _ in }
+        listener.start(onUserActivity: { activityCount += 1 }, onMatch: { _, _, _, _ in })
         listener.stop()
         check(
             "real listener rapid on and off leaves no tap",

--- a/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
+++ b/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
@@ -15,7 +15,10 @@ private func snippetKeywordCallback(
 
     // A click relocates the caret, so the buffered prefix no longer describes what precedes it.
     if type == .leftMouseDown || type == .rightMouseDown || type == .otherMouseDown {
-        MainActor.assumeIsolated { listener.clearBuffer() }
+        MainActor.assumeIsolated {
+            listener.userActivity()
+            listener.clearBuffer()
+        }
         return Unmanaged.passUnretained(event)
     }
 
@@ -122,6 +125,7 @@ final class SnippetKeywordListener: HealthCheckable {
     @ObservationIgnored private var observers: [NotificationToken] = []
     /// The keystroke buffer: the tap callback mutates it per event, so it stays untracked.
     @ObservationIgnored private var policy = SnippetKeywordPolicy()
+    @ObservationIgnored private var onUserActivity: (() -> Void)?
     @ObservationIgnored
     private var onMatch: ((StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void)?
     private var sessionActive = true
@@ -158,7 +162,11 @@ final class SnippetKeywordListener: HealthCheckable {
             })
     }
 
-    func start(onMatch: @escaping (StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void) {
+    func start(
+        onUserActivity: @escaping () -> Void,
+        onMatch: @escaping (StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void
+    ) {
+        self.onUserActivity = onUserActivity
         self.onMatch = onMatch
         installObserversIfNeeded()
         healthTicker?.subscribe(self)
@@ -166,6 +174,7 @@ final class SnippetKeywordListener: HealthCheckable {
     }
 
     func stop() {
+        onUserActivity = nil
         onMatch = nil
         healthTicker?.unsubscribe(self)
         observers.removeAll()
@@ -177,6 +186,11 @@ final class SnippetKeywordListener: HealthCheckable {
 
     func clearBuffer() {
         policy.reset()
+    }
+
+    /// A keystroke Tinycast did not synthesize means the caret is the reader's again, not ours.
+    fileprivate func userActivity() {
+        onUserActivity?()
     }
 
     func healthCheck() {
@@ -293,7 +307,7 @@ final class SnippetKeywordListener: HealthCheckable {
         syncTapPresence()
     }
 
-    fileprivate func processEvent(
+    func processEvent(
         typeRaw: UInt32,
         keyCode: Int,
         flagsRaw: UInt64,
@@ -312,6 +326,7 @@ final class SnippetKeywordListener: HealthCheckable {
             hasCommandOrControl: flags.contains(.maskCommand) || flags.contains(.maskControl),
             isResetKey: Self.resetKeyCodes.contains(keyCode),
             isDeleteBackward: keyCode == kVK_Delete)
+        if input != .ignored { onUserActivity?() }
         guard let match = policy.process(input, at: now()) else { return }
         onMatch?(
             match.snippetID,

--- a/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
@@ -124,18 +124,20 @@ final class SnippetCoordinator {
 
     func startSnippetKeywordListener() {
         // `beginAutomaticExpansion` is the gate, so this callback doesn't re-check anything.
-        listener.start { [weak self] id, keyword, keywordLength, targetApp in
-            guard let self,
-                let generation = self.injector.beginAutomaticExpansion(
-                    targetApp: targetApp)
-            else { return }
-            self.expandSnippet(
-                id: id,
-                targetApp: targetApp,
-                expectedKeyword: keyword,
-                keywordLength: keywordLength,
-                automaticGeneration: generation)
-        }
+        listener.start(
+            onUserActivity: { [weak self] in self?.injector.cancelAutomaticExpansion() },
+            onMatch: { [weak self] id, keyword, keywordLength, targetApp in
+                guard let self,
+                    let generation = self.injector.beginAutomaticExpansion(
+                        targetApp: targetApp)
+                else { return }
+                self.expandSnippet(
+                    id: id,
+                    targetApp: targetApp,
+                    expectedKeyword: keyword,
+                    keywordLength: keywordLength,
+                    automaticGeneration: generation)
+            })
     }
 
     /// Recent copies, newest first; the live pasteboard leads, the poller may lag behind.

--- a/Tinycast/Features/TextInjection/Service/TextInjector.swift
+++ b/Tinycast/Features/TextInjection/Service/TextInjector.swift
@@ -18,8 +18,46 @@ enum AccessibilityReplacement: Equatable {
     case unavailable
     case rejected
 
-    /// `.rejected` is only ever returned before anything is written, so the text cannot have moved.
+    /// `.rejected` means the document is not the one we measured, so events would edit the wrong text.
     var fallsBackToEvents: Bool { self == .unavailable }
+}
+
+/// The two judgements the Accessibility tier makes, kept pure so the harness can drive both.
+enum AccessibilityReplacementPolicy {
+    enum KeywordState: Equatable {
+        case matched(NSRange)
+        case pending
+        case rejected
+    }
+
+    /// Too little text yet is a renderer still catching up; enough text but wrong is a real mismatch.
+    static func keywordState(
+        value: String, selectedRange: NSRange, keyword: String
+    ) -> KeywordState {
+        guard selectedRange.length == 0,
+            let selectedStringRange = Range(selectedRange, in: value)
+        else { return .rejected }
+        let beforeCursor = value[..<selectedStringRange.lowerBound]
+        guard beforeCursor.count >= keyword.count else { return .pending }
+        let start = beforeCursor.index(beforeCursor.endIndex, offsetBy: -keyword.count)
+        guard beforeCursor[start...].lowercased() == keyword.lowercased() else { return .rejected }
+        return .matched(NSRange(start..<beforeCursor.endIndex, in: value))
+    }
+
+    /// Chromium answers `.success` and applies nothing, so the value has to read back as we wrote it.
+    static func confirmsReplacement(
+        originalValue: String,
+        replacementRange: NSRange,
+        insertedText: String,
+        observedValue: String?
+    ) -> Bool {
+        guard let observedValue,
+            let stringRange = Range(replacementRange, in: originalValue)
+        else { return false }
+        var expected = originalValue
+        expected.replaceSubrange(stringRange, with: insertedText)
+        return observedValue == expected
+    }
 }
 
 @MainActor
@@ -262,7 +300,8 @@ final class TextInjector {
             injected,
             targetApp: targetApp,
             expectedKeyword: expectedKeyword,
-            keywordLength: keywordLength)
+            keywordLength: keywordLength,
+            automaticGeneration: automaticGeneration)
         if accessibilityReplacement == .delivered {
             completion.confirm()
             return
@@ -503,76 +542,150 @@ final class TextInjector {
         return false
     }
 
+    private struct AccessibilityTarget {
+        let element: AXUIElement
+        let value: String
+        let originalRange: NSRange
+        let replacementRange: NSRange
+    }
+
+    private enum AccessibilityTargetState {
+        case ready(AccessibilityTarget)
+        case pending
+        case unavailable
+        case rejected
+    }
+
+    /// Rule 1: a renderer surface answers about its own model, so it is never written to over AX.
     private func replaceUsingAccessibility(
         _ injected: InjectedText,
         targetApp: NSRunningApplication?,
         expectedKeyword: String?,
-        keywordLength: Int
+        keywordLength: Int,
+        automaticGeneration: AutomaticGeneration?
     ) async -> AccessibilityReplacement {
-        guard let targetApp,
-            let element = AccessibilityText.focusedElement(in: targetApp),
-            isAttributeSettable(kAXSelectedTextRangeAttribute, in: element),
-            isAttributeSettable(kAXSelectedTextAttribute, in: element),
-            let value = stringValue(in: element),
-            let originalRange = selectedRange(in: element)
-        else { return .unavailable }
-        // Offsets its own value cannot address are a broken tier, not proof the document moved.
-        guard let selectedStringRange = Range(originalRange, in: value) else {
+        guard let targetApp else { return .unavailable }
+        let state = await accessibilityTarget(
+            in: targetApp,
+            expectedKeyword: expectedKeyword,
+            keywordLength: keywordLength,
+            automaticGeneration: automaticGeneration)
+        guard case .ready(let target) = state else {
+            if case .rejected = state { return .rejected }
             return .unavailable
         }
 
-        let replacementRange: NSRange
-        if keywordLength > 0 {
-            guard originalRange.length == 0,
-                let expectedKeyword,
-                value[..<selectedStringRange.lowerBound].count >= keywordLength
-            else { return .rejected }
-            let cursor = selectedStringRange.lowerBound
-            let start = value.index(cursor, offsetBy: -keywordLength)
-            let actualKeyword = String(value[start..<cursor]).lowercased()
-            guard actualKeyword == expectedKeyword.lowercased() else { return .rejected }
-            replacementRange = NSRange(start..<cursor, in: value)
-        } else {
-            replacementRange = originalRange
+        guard setSelectedRange(target.replacementRange, in: target.element) else {
+            return .unavailable
         }
-
-        guard setSelectedRange(replacementRange, in: element) else { return .unavailable }
         guard
             AXUIElementSetAttributeValue(
-                element,
+                target.element,
                 kAXSelectedTextAttribute as CFString,
-                injected.text as CFString) == .success,
-            await accessibilityValue(in: element, movedFrom: value)
+                injected.text as CFString) == .success
         else {
-            _ = setSelectedRange(originalRange, in: element)
+            _ = setSelectedRange(target.originalRange, in: target.element)
             return .unavailable
+        }
+
+        let observed = stringValue(in: target.element)
+        guard
+            AccessibilityReplacementPolicy.confirmsReplacement(
+                originalValue: target.value,
+                replacementRange: target.replacementRange,
+                insertedText: injected.text,
+                observedValue: observed)
+        else {
+            _ = setSelectedRange(target.originalRange, in: target.element)
+            // An untouched value is a tier that did nothing; anything else moved text we cannot name.
+            return observed == target.value ? .unavailable : .rejected
         }
 
         let cursorOffset = min(injected.cursorOffsetFromEnd ?? 0, injected.text.count)
         let cursorIndex = injected.text.index(injected.text.endIndex, offsetBy: -cursorOffset)
         let insertedPrefixLength = injected.text[..<cursorIndex].utf16.count
         _ = setSelectedRange(
-            NSRange(location: replacementRange.location + insertedPrefixLength, length: 0),
-            in: element)
+            NSRange(location: target.replacementRange.location + insertedPrefixLength, length: 0),
+            in: target.element)
         return .delivered
     }
 
-    /// Chromium answers `.success` and applies nothing, so only a moved value counts as delivered.
-    private func accessibilityValue(
-        in element: AXUIElement, movedFrom previous: String
-    ) async -> Bool {
-        for attempt in 0..<Self.accessibilityVerifyAttempts {
-            if let current = stringValue(in: element), current != previous { return true }
-            guard attempt < Self.accessibilityVerifyAttempts - 1,
-                await wait(for: Self.accessibilityVerifyInterval)
-            else { return false }
+    /// Rule 2: a renderer applies the keystroke before it says so, so a short lag is not a mismatch.
+    private func accessibilityTarget(
+        in targetApp: NSRunningApplication,
+        expectedKeyword: String?,
+        keywordLength: Int,
+        automaticGeneration: AutomaticGeneration?
+    ) async -> AccessibilityTargetState {
+        for attempt in 0..<Self.accessibilityConvergenceAttempts {
+            let state = inspectAccessibilityTarget(
+                in: targetApp,
+                expectedKeyword: expectedKeyword,
+                keywordLength: keywordLength)
+            guard case .pending = state else { return state }
+            guard attempt < Self.accessibilityConvergenceAttempts - 1,
+                automaticGeneration != nil,
+                deliveryIsAllowed(
+                    automaticGeneration: automaticGeneration,
+                    targetApp: targetApp,
+                    promptForInteractiveAccessibility: false),
+                await wait(for: Self.accessibilityConvergenceInterval)
+            else { return .unavailable }
         }
-        return false
+        return .unavailable
     }
 
-    /// Long enough for a renderer round-trip, short enough that the event tiers still feel prompt.
-    private static let accessibilityVerifyAttempts = 12
-    private static let accessibilityVerifyInterval = Duration.milliseconds(25)
+    private func inspectAccessibilityTarget(
+        in targetApp: NSRunningApplication,
+        expectedKeyword: String?,
+        keywordLength: Int
+    ) -> AccessibilityTargetState {
+        guard let element = AccessibilityText.focusedElement(in: targetApp),
+            !usesTextMarkerSelection(element),
+            isAttributeSettable(kAXSelectedTextRangeAttribute, in: element),
+            isAttributeSettable(kAXSelectedTextAttribute, in: element),
+            let value = stringValue(in: element),
+            let originalRange = selectedRange(in: element)
+        else { return .unavailable }
+
+        guard keywordLength > 0 else {
+            // Offsets its own value cannot address are a broken tier, not proof the document moved.
+            guard Range(originalRange, in: value) != nil else { return .unavailable }
+            return .ready(
+                AccessibilityTarget(
+                    element: element, value: value, originalRange: originalRange,
+                    replacementRange: originalRange))
+        }
+        guard let expectedKeyword, expectedKeyword.count == keywordLength else { return .rejected }
+        switch AccessibilityReplacementPolicy.keywordState(
+            value: value, selectedRange: originalRange, keyword: expectedKeyword)
+        {
+        case .matched(let replacementRange):
+            return .ready(
+                AccessibilityTarget(
+                    element: element, value: value, originalRange: originalRange,
+                    replacementRange: replacementRange))
+        case .pending: return .pending
+        case .rejected: return .rejected
+        }
+    }
+
+    /// Web content and Monaco expose selection only as markers; their `AXValue` trails or is empty.
+    private func usesTextMarkerSelection(_ element: AXUIElement) -> Bool {
+        var value: CFTypeRef?
+        guard
+            AXUIElementCopyAttributeValue(
+                element,
+                kAXSelectedTextMarkerRangeAttribute as CFString,
+                &value) == .success,
+            let value
+        else { return false }
+        return CFGetTypeID(value) == AXTextMarkerRangeGetTypeID()
+    }
+
+    /// A renderer converges in single-digit milliseconds; past this it was never going to.
+    private static let accessibilityConvergenceAttempts = 8
+    private static let accessibilityConvergenceInterval = Duration.milliseconds(5)
 
     private func waitForPasteConfirmation(
         previousState: AccessibilityTextState?,
@@ -612,6 +725,7 @@ final class TextInjector {
     ) -> AccessibilityTextState? {
         guard let targetApp,
             let element = AccessibilityText.focusedElement(in: targetApp),
+            !usesTextMarkerSelection(element),
             let value = stringValue(in: element),
             let selectedRange = selectedRange(in: element)
         else { return nil }

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -168,9 +168,11 @@ selected"; otherwise the app told us nothing either way and says so.
 cancel, because a shortcut is an explicit gesture rather than an expansion the app decided to
 attempt. Its serial delivery queue is what stops two features fighting over the pasteboard lease.
 
-The Accessibility tier replaces the live selection atomically. The event tiers behind it type or
-paste over it, which every app treats as replacing a selection — but that is the target app's
-behaviour rather than something Tinycast asserts, so it is the part worth checking by hand.
+The Accessibility tier replaces the live selection atomically, under the five-rule delivery contract
+in [snippets.md](snippets.md#text-delivery-and-pasteboard-safety) — Quick Actions simply enter it with
+no keyword, so rule 2 never applies. The event tiers behind it type or paste over the selection, which
+every app treats as replacing it — but that is the target app's behaviour rather than something
+Tinycast asserts, so it is the part worth checking by hand.
 
 **A replacement that never lands says so, and keeps the reply.** Every tier can decline, and a shortcut
 that quietly did nothing is indistinguishable from a shortcut that is not bound. `DeliveryCompletion`

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -238,23 +238,38 @@ not report completion and therefore cannot show it.
 
 ## Text delivery and pasteboard safety
 
-The preferred path is one atomic Accessibility replacement. Tinycast requires a focused element with
-readable text plus writable selected-range and selected-text attributes. For an automatic expansion it
-also verifies that the exact captured keyword is immediately before the cursor before replacing it.
-A keyword mismatch is rejected rather than guessed, and rejection is the only outcome that stops
-delivery outright — it is returned before anything is written, so the document cannot have moved.
+Delivery is one contract, in this order, and every clause below is a rule in it.
 
-**A `kAXErrorSuccess` from the setter is not evidence.** Chromium answers success and applies nothing,
-so the element's value has to be seen to change — polled for up to 300 ms, since a browser applies the
-edit in its renderer rather than in the process that answered. An unmoved value is `.unavailable`, not
-`.delivered`, so the event tiers still get their turn instead of a "applied" message over unchanged
-text.
+1. The focused element exposes `AXSelectedTextMarkerRange` → a renderer surface. Skip Accessibility.
+2. The keyword is not at the caret yet → wait, up to 40 ms. Never arrives → events. Wrong → refuse.
+3. Write over Accessibility, read the value back. Matches → done. Unchanged → events. Moved some
+   other way → refuse.
+4. Events: delete the keyword, then paste (long or multiline) or type in four-unit keystrokes.
+5. Nothing landed → say so.
 
-Some editors grant Accessibility but do not expose writable text attributes. In that case Tinycast
-falls back to tagged keyboard events while keeping the same permission, consent, Secure Event Input,
-target-app and cancellation gates. The fallback deletes the keyword first, waits for deletion to
-settle, then inserts the expansion. Short single-line expansions of at most 100 characters use Unicode
-keyboard events.
+**Rule 1: a renderer's Accessibility surface is not authoritative.** Chromium and Monaco publish
+selection as opaque text markers, and their `AXValue` either trails the editor by a few milliseconds
+or — in VSCodium — stays empty and caret-zero indefinitely while the real editor holds the text. A
+marker range is the reliable tell, so those targets never take the Accessibility write at all.
+`accessibilityTextState` skips them for the same reason: a value that never moves cannot confirm a
+paste either.
+
+**Rule 2: too little text is not the same as the wrong text.** `AccessibilityReplacementPolicy`
+`.pending` means the value is shorter than the keyword — the renderer has not caught up — and is
+retried for up to eight 5 ms passes. `.rejected` means there was enough text and it was not the
+keyword, which is a genuine mismatch and stops delivery. Only an automatic expansion waits; an
+interactive one has no keyword race to lose. The convergence window is why an empty Monaco snapshot
+falls through to events instead of reading as a mismatch.
+
+**Rule 3: a `kAXErrorSuccess` from the setter is not evidence.** Chromium answers success and applies
+nothing. `confirmsReplacement` rebuilds the exact string the write should have produced and compares
+it to what the element reports. An unchanged value is `.unavailable`, so the event tiers still get
+their turn instead of an "applied" message over untouched text; a value that changed into something
+we did not write is `.rejected`, because events would then edit a document we can no longer describe.
+
+**Rule 4** keeps the same permission, consent, Secure Event Input, target-app and cancellation gates.
+The fallback deletes the keyword first, waits for deletion to settle, then inserts the expansion.
+Short single-line expansions of at most 100 characters use Unicode keyboard events.
 
 **A Unicode keystroke carries at most four UTF-16 units.** Blink stores one key event's text in a
 fixed `WebKeyboardEvent::kTextLengthCap` array, so a Chromium target — Brave, Chrome, Electron, VS
@@ -283,6 +298,13 @@ finishes successfully. Disabling automatic expansion or
 terminating the app cancels pending delivery and deferred cursor movement; termination also completes
 any pasteboard restoration still owned by Tinycast.
 
+**Rule 5, and the keystroke that outruns it.** An automatic expansion is speculative, so the reader's
+next real keystroke or click cancels whatever is still in flight — the listener reports every
+non-ignored input to `cancelAutomaticExpansion`, and Tinycast's own tagged synthetic events classify
+as `.ignored`, so a fallback never cancels itself. Delivery then settles exactly once either way:
+Quick Actions raise a HUD and keep the reply on the clipboard, while snippets pass no failure handler
+and stay as silent as before, because a speculative expansion that declined is not news.
+
 ## External edits and conflicts
 
 `SnippetsStore` publishes repository snapshots and per-file issues on the main actor while all file
@@ -308,3 +330,18 @@ main-actor watcher against temporary roots:
 ```sh
 ./Scripts/run-tests.sh snippets-test
 ```
+
+The delivery contract's two judgements — `keywordState` and `confirmsReplacement` — are pure, so the
+harness drives renderer lag, a genuine mismatch, an empty editor snapshot, a false-success setter and
+a write that landed elsewhere without an editor in the room. The tiers themselves are not: which rule
+a given app takes is a manual check.
+
+### Manual sweep
+
+- Type a keyword in the **ChatGPT composer inside a Chromium browser**: it expands. This is rule 1 and
+  rule 4 together — the composer is skipped over Accessibility and typed into in four-unit keystrokes.
+- Type one in a **VSCodium editor pane**: it expands, where the Accessibility value stays empty.
+- Type one in **Notes or Mail**: still the atomic Accessibility replacement, not events.
+- Type a keyword, then keep typing before the expansion lands: the expansion is abandoned rather than
+  landing mid-word.
+- Type a keyword whose text the app changed underneath it: refused, with the keyword left alone.


### PR DESCRIPTION
## Related issue

Closes #410.

Supersedes #412 — its two mechanisms are folded in here rather than merged alongside, because both it and #420 rewrote the same tier decision in `replaceUsingAccessibility`, and reconciling them separately would have left two overlapping verification paths in the tree with no way to tell which was load-bearing. Credited via `Co-authored-by`.

Builds on #420, which is already merged. That PR fixed the event tier; this one fixes the Accessibility tier above it. Neither is sufficient alone — see **Why this needs #420** below.

## What changed

#410 reports two distinct failures, both in renderer-based editors:

- **ChatGPT composer** — `AXValue` trails the key stream by ~4.5 ms, so the keyword check ran one character early and refused a real match.
- **VSCodium / Monaco** — `AXValue` stays empty and caret-zero indefinitely while the real editor holds the text, and an AX write reports `kAXErrorSuccess` while changing nothing.

The cause both share is that the Accessibility tier decided *by itself*, in three separate places, whether a target could be written to. It is now one ordered rule set in one function:

```
1. Element exposes AXSelectedTextMarkerRange?  → renderer surface, skip Accessibility
2. Keyword at the caret?
     not yet → wait up to 40 ms   never → events   wrong → refuse
3. Write, read the value back
     matches → done   unchanged → events   moved otherwise → refuse
4. Events: delete the keyword, then paste (long/multiline) or type in 4-unit keystrokes
5. Nothing landed → say so
```

**Rule 1** is the decisive one. A marker range is the reliable tell that selection lives in a renderer model rather than in the element answering us, so those targets never take the AX write at all. `accessibilityTextState` skips them for the same reason — a value that never moves cannot confirm a paste either.

**Rule 2** separates "a few milliseconds behind" from "a different document". `AccessibilityReplacementPolicy.keywordState` returns `.pending` when the value is shorter than the keyword and `.rejected` when there was enough text and it did not match. Only automatic expansion waits; an interactive one has no keyword race to lose. Eight 5 ms passes, so the worst case adds 40 ms before falling through.

**Rule 3** replaces the 300 ms value poll #420 shipped. With renderer surfaces excluded by rule 1, the remaining controls answer synchronously, so `confirmsReplacement` rebuilding the exact expected string and comparing once is both stricter and cheaper. Failure splits two ways: unchanged → `.unavailable` (events are safe), changed into something we did not write → `.rejected` (events would edit a document we can no longer describe). That split is the one place #412 and #420 genuinely disagreed, and it is why `.rejected` can now be returned after a write as well as before one.

**Rule 5** gains a cancellation. An automatic expansion is speculative, so the reader's next real keystroke or click abandons whatever is in flight. Tinycast's own tagged events classify as `.ignored`, so a fallback never cancels itself.

### Why this needs #420

Rules 1 and 2 both end in "→ events", and before #420 the event tier packed a whole expansion into one `keyboardSetUnicodeString` pair, which Blink truncates to four UTF-16 units. Landing this alone would have converted "keyword stays put" into "keyword deleted, `pers` typed" in exactly the editors it targets. #420's `UnicodeTypingChunk` is what makes the fallback a real destination.

## Memory footprint

No new long-lived state. `AccessibilityReplacementPolicy` is a pure static; `onUserActivity` is one closure, cleared in `SnippetKeywordListener.stop()` alongside `onMatch`. The convergence loop holds one `AccessibilityTarget` struct per attempt and nothing across the `await`.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no. Nothing here outlives `performDelivery`, and the new closure has the same lifetime as the listener's existing one.

## Drawbacks

- **Rule 1 is a heuristic.** An app that exposes a marker range *and* has a working AX write now uses events instead — slower and clipboard-borrowing, but correct. I could not find a way to tell the two apart that does not involve writing first and checking, which is the thing rule 1 exists to avoid.
- **Rule 2 costs up to 40 ms** on an automatic expansion into a target that never converges, before it falls through to events.
- **Rule 3 can false-negative** on a control that is synchronous except under load; it then falls to events and the text could land twice. Rule 1 excludes the targets where that is likely.
- **`.rejected` after a write is a judgement call.** A value that changed into something unexpected stops delivery silently for snippets. Retrying with events on a document we cannot describe seemed worse than doing nothing.
- **The listener now fires a closure on every non-ignored keystroke.** It is one optional call before the existing policy work, on a tap that already runs per event, but it is on that path.

## Tests & validation

`./Scripts/run-tests.sh` — all 52 harnesses pass. Debug build compiles with no new warnings; `./Scripts/lint.sh` clean; no AppKit/SwiftUI import in any `Model/`.

Both judgements are pure, so the harness drives them with no editor in the room. Added to `snippets-test`:

- an AX keyword one character behind the event stream remains pending
- a converged keyword resolves to its exact replacement range
- enough text but the wrong suffix is a genuine rejection
- an empty editor snapshot remains pending rather than a false mismatch
- a non-empty selection is a mismatch rather than a lagging caret
- confirmation requires the observable text to actually change
- a setter success with unchanged text is not accepted as delivery
- a write that landed somewhere unexpected is not accepted as delivery
- an unreadable value after the write is not accepted as delivery
- real user input invalidates pending automatic delivery while Tinycast's tagged events do not

**Which rule a given app takes is not testable in a harness.** This shell has no Accessibility grant, so I measured none of the following:

- ChatGPT composer in a Chromium browser: a keyword expands (rules 1 + 4)
- VSCodium editor pane: a keyword expands where `AXValue` stays empty
- Notes, Mail, TextEdit: still the atomic AX replacement, not events
- keep typing while an expansion is in flight: abandoned rather than landing mid-word
- a keyword whose text the app changed underneath it: refused, keyword left alone
- Brave, Quick Actions replace: unchanged from #420, but worth re-checking since rule 1 now routes it

`docs/features/snippets.md` carries a manual sweep for these, and twelve throwaway snippets covering each branch are easy to generate if useful for the pass.
