### PR TITLE
Size a grid item's content to its tile (#406)

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -242,6 +242,7 @@ run slow ext-test          -parse-as-library \
                            Tinycast/Platform/Images/IconCache.swift \
                            Tinycast/DesignSystem/Theme.swift \
                            $E/Model/ExtensionBootConfig.swift \
+                           $E/Model/ExtensionGridLayout.swift \
                            $E/Model/ExtensionManifest.swift \
                            $E/Model/RenderNode.swift \
                            $E/Service/ExtensionCatalog.swift \

--- a/Tests/ext-test.swift
+++ b/Tests/ext-test.swift
@@ -412,7 +412,38 @@ struct ExtensionTests {
                 {"id":2,"type":"Grid","props":{"columns":4},"children":[
                   {"id":3,"type":"Grid.Item","props":{"title":"One"},"children":[]}]}
                 """), query: "")
-        check("kind is grid with columns", grid.kind == .grid(columns: 4), String(describing: grid.kind))
+        check(
+            "kind is grid with columns", grid.kind == .grid(ExtensionGridLayout(columns: 4)),
+            String(describing: grid.kind))
+
+        let shaped = ExtensionScreen(
+            tree: tree(
+                """
+                {"id":2,"type":"Grid","props":{"columns":3,"aspectRatio":"16/9","fit":"fill",
+                  "inset":"lg"},"children":[
+                  {"id":3,"type":"Grid.Item","props":{"title":"One"},"children":[]}]}
+                """), query: "")
+        check(
+            "grid layout props parsed",
+            shaped.kind
+                == .grid(
+                    ExtensionGridLayout(
+                        columns: 3, aspectRatio: 16.0 / 9, fills: true, inset: .large)),
+            String(describing: shaped.kind))
+
+        let legacy = ExtensionScreen(
+            tree: tree(#"{"id":2,"type":"Grid","props":{"itemSize":"small"},"children":[]}"#),
+            query: "")
+        check("itemSize still sets columns", legacy.kind == .grid(ExtensionGridLayout(columns: 8)))
+
+        let layout = ExtensionGridLayout(columns: 5)
+        check(
+            "tile width divides the space",
+            layout.tileWidth(inWidth: 100, spacing: 5) == 16,
+            String(layout.tileWidth(inWidth: 100, spacing: 5)))
+        check("columns clamp to Raycast's range", ExtensionGridLayout(columns: 99).columns == 8)
+        check("a bad aspect ratio falls back to square", ExtensionGridLayout(aspectRatio: 0).aspectRatio == 1)
+        check("large inset insets a quarter of the tile", ExtensionGridLayout.Inset.large.fraction == 0.24)
 
         let form = ExtensionScreen(
             tree: tree(

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		4549280508130B232069071E /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112551581ECF83B53D405334 /* BackupSettingsView.swift */; };
 		45739848B8C2B00E0BFC208F /* FileSearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D1A69B721AA863AFFE176F /* FileSearchScope.swift */; };
 		45799EE1F41091B32544B6AE /* ExtensionManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BBF211CE6A076EAF8D6C33 /* ExtensionManifest.swift */; };
+		462CE7617EC4EED7E7B5A072 /* ExtensionGridLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220CECFE780E8BE18FAE0A1C /* ExtensionGridLayout.swift */; };
 		4640C7CC8DCA6E6FA49394A8 /* CommandsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D303E193CFEFE455778C150 /* CommandsSettingsView.swift */; };
 		464F93E1F16A3242396F32F9 /* SearchScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4A7E45F7D1CC5FB8868715 /* SearchScopes.swift */; };
 		46F5D522E6F5470D3694A218 /* RaycastImportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD7591D273A6484DD48018A /* RaycastImportReader.swift */; };
@@ -496,6 +497,7 @@
 		1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
 		201FCD08ACA933378876385B /* ClipboardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardStore.swift; sourceTree = "<group>"; };
 		209D951FDD587A040F1F76F3 /* PaletteWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteWindowController.swift; sourceTree = "<group>"; };
+		220CECFE780E8BE18FAE0A1C /* ExtensionGridLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionGridLayout.swift; sourceTree = "<group>"; };
 		2258D4A6B6C22AB7C5D421BE /* DoubleTapMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapMonitor.swift; sourceTree = "<group>"; };
 		23591B301A183579098AA019 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		2384FC4A96FDAD19D0737312 /* CameraPreviewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewSession.swift; sourceTree = "<group>"; };
@@ -1275,6 +1277,7 @@
 				D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */,
 				ED5AAA98FFF7A4D34D7B490D /* ExtensionBootConfig.swift */,
 				F85C82C66132C7723272E873 /* ExtensionGridGeometry.swift */,
+				220CECFE780E8BE18FAE0A1C /* ExtensionGridLayout.swift */,
 				30BBF211CE6A076EAF8D6C33 /* ExtensionManifest.swift */,
 				0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */,
 				810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */,
@@ -2439,6 +2442,7 @@
 				B566FC125D9D193F234EC1AB /* ExtensionFetcher.swift in Sources */,
 				5D3E51C5FDA9EE53AFD12181 /* ExtensionFormView.swift in Sources */,
 				C9A7290682E9D0881713C009 /* ExtensionGridGeometry.swift in Sources */,
+				462CE7617EC4EED7E7B5A072 /* ExtensionGridLayout.swift in Sources */,
 				5B90A314CF4801995EA0EE01 /* ExtensionHostBridge.swift in Sources */,
 				0288221BA580DFA8F5B116B7 /* ExtensionIconCache.swift in Sources */,
 				9E5B694969D3F99BF7D0D9E1 /* ExtensionImage.swift in Sources */,

--- a/Tinycast/Features/Extensions/Model/ExtensionGridLayout.swift
+++ b/Tinycast/Features/Extensions/Model/ExtensionGridLayout.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// A `Grid`'s layout props: the tile shape and how an item's content sits inside it.
+struct ExtensionGridLayout: Equatable, Sendable {
+    /// Space between a tile's border and its content. Raycast scales it with the tile, so this does.
+    enum Inset: String, Sendable {
+        case zero
+        case small = "sm"
+        case medium = "md"
+        case large = "lg"
+
+        var fraction: Double {
+            switch self {
+            case .zero: return 0
+            case .small: return 0.08
+            case .medium: return 0.16
+            case .large: return 0.24
+            }
+        }
+    }
+
+    /// The tile's own corner, owned here rather than in `Theme`: no launcher surface is this size.
+    static let tileRadius: Double = 12
+
+    /// Raycast clamps to 1…8.
+    var columns: Int
+    /// Tile width ÷ height.
+    var aspectRatio: Double
+    /// `Grid.Fit.Fill` crops content to the tile; `.Contain` fits it inside.
+    var fills: Bool
+    var inset: Inset
+
+    init(columns: Int = 5, aspectRatio: Double = 1, fills: Bool = false, inset: Inset = .zero) {
+        self.columns = min(max(columns, 1), 8)
+        self.aspectRatio = aspectRatio > 0 ? aspectRatio : 1
+        self.fills = fills
+        self.inset = inset
+    }
+
+    init(_ root: RenderNode) {
+        self.init(
+            columns: ExtensionGridLayout.columns(root),
+            aspectRatio: ExtensionGridLayout.ratio(root.string("aspectRatio")) ?? 1,
+            fills: root.string("fit") == "fill",
+            inset: root.string("inset").flatMap(Inset.init(rawValue:)) ?? .zero)
+    }
+
+    /// Tile width for the space the grid is given, so one measure feeds every cell.
+    func tileWidth(inWidth width: Double, spacing: Double) -> Double {
+        max(1, (width - spacing * Double(columns - 1)) / Double(columns))
+    }
+
+    private static func columns(_ root: RenderNode) -> Int {
+        if let columns = root.double("columns").map({ Int($0) }), columns > 0 { return columns }
+        // Raycast's default is 5; `itemSize` is the legacy way of saying the same thing.
+        switch root.string("itemSize") {
+        case "small": return 8
+        case "large": return 3
+        default: return 5
+        }
+    }
+
+    /// `aspectRatio` arrives as `"1"` or `"16/9"`.
+    private static func ratio(_ text: String?) -> Double? {
+        guard let text else { return nil }
+        let parts = text.split(separator: "/").compactMap { Double($0) }
+        switch parts.count {
+        case 1: return parts[0] > 0 ? parts[0] : nil
+        case 2: return parts[0] > 0 && parts[1] > 0 ? parts[0] / parts[1] : nil
+        default: return nil
+        }
+    }
+}

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
@@ -20,10 +20,11 @@ struct ExtensionCommandScreen: PaletteScreen {
 
     /// A Grid needs both axes: without this ↓ walks sideways one tile at a time.
     func move(_ delta: Int, axis: PaletteAxis, from selection: Int) -> Int? {
-        guard case .grid(let columns) = screen.kind, columns > 0, !rows.isEmpty else { return nil }
+        guard case .grid(let layout) = screen.kind, !rows.isEmpty else { return nil }
         switch axis {
         case .vertical:
-            let geometry = ExtensionGridGeometry(counts: screen.sectionCounts, columns: columns)
+            let geometry = ExtensionGridGeometry(
+                counts: screen.sectionCounts, columns: layout.columns)
             return delta > 0 ? geometry.down(from: selection) : geometry.up(from: selection)
         case .horizontal:
             return min(max(selection + delta, 0), rows.count - 1)

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -357,6 +357,28 @@ enum ExtensionImage {
     ]
 }
 
+extension ExtensionImage {
+    /// An animating tile takes the image as shipped; the fitted path would hand back one frame.
+    static func load(_ resolved: Resolved?, isDark: Bool, animates: Bool) async -> NSImage? {
+        switch resolved?.source {
+        case .file(let path):
+            return animates
+                ? await ExtensionIconCache.loadOriginalAsync(atPath: path)
+                : await ExtensionIconCache.loadAsync(atPath: path)
+        case .fileIcon(let path):
+            // Fitted, not raw: only the normalized draw keeps bundles and documents one size.
+            return await IconCache.loadFittedAsync(forFile: path)
+        case .remote(let url):
+            return await ExtensionIconCache.loadRemoteAsync(url, asIcon: !animates)
+        case .inline(let url):
+            return await ExtensionIconCache.loadInlineAsync(
+                url, palette: svgPalette(isDark: isDark))
+        default:
+            return nil
+        }
+    }
+}
+
 /// A resolved icon at row size; an unresolvable one draws the faint tile, so rows never jump.
 struct ExtensionIconView: View {
     @Environment(\.isDarkAppearance) private var isDark
@@ -372,7 +394,7 @@ struct ExtensionIconView: View {
             .clipShape(shape)
             // Keyed on appearance too: an inline SVG's palette resolves at decode.
             .task(id: ExtensionImage.LoadKey(source: resolved?.source, isDark: isDark)) {
-                await load()
+                loaded = await ExtensionImage.load(resolved, isDark: isDark, animates: animates)
             }
     }
 
@@ -421,24 +443,4 @@ struct ExtensionIconView: View {
             : AnyShape(RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous))
     }
 
-    /// An animating tile takes the image as shipped; the fitted path would hand back one frame.
-    private func load() async {
-        switch resolved?.source {
-        case .file(let path):
-            loaded =
-                animates
-                ? await ExtensionIconCache.loadOriginalAsync(atPath: path)
-                : await ExtensionIconCache.loadAsync(atPath: path)
-        case .fileIcon(let path):
-            // Fitted, not raw: only the normalized draw keeps bundles and documents one size.
-            loaded = await IconCache.loadFittedAsync(forFile: path)
-        case .remote(let url):
-            loaded = await ExtensionIconCache.loadRemoteAsync(url, asIcon: !animates)
-        case .inline(let url):
-            loaded = await ExtensionIconCache.loadInlineAsync(
-                url, palette: ExtensionImage.svgPalette(isDark: isDark))
-        default:
-            loaded = nil
-        }
-    }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionListView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListView.swift
@@ -23,8 +23,8 @@ struct ExtensionListView: View {
                     Rectangle().fill(Theme.Colors.separator).frame(width: 1)
                     detailPane
                 }
-            } else if case .grid(let columns) = screen.kind {
-                gridBody(columns: columns)
+            } else if case .grid(let layout) = screen.kind {
+                gridBody(layout: layout)
             } else {
                 rowList
             }
@@ -101,18 +101,30 @@ struct ExtensionListView: View {
         screen.items.indices.contains(selection) ? screen.items[selection].id : nil
     }
 
-    private func gridBody(columns: Int) -> some View {
+    /// Measured once for the whole grid: a tile's own `GeometryReader` would cost a pass per cell.
+    private func gridBody(layout: ExtensionGridLayout) -> some View {
+        GeometryReader { geometry in
+            grid(
+                layout: layout,
+                tileWidth: layout.tileWidth(
+                    inWidth: geometry.size.width - Theme.Spacing.md * 2,
+                    spacing: Theme.Spacing.sm))
+        }
+    }
+
+    private func grid(layout: ExtensionGridLayout, tileWidth: Double) -> some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVGrid(
                     columns: Array(
-                        repeating: GridItem(.flexible(), spacing: Theme.Spacing.sm), count: columns),
+                        repeating: GridItem(.flexible(), spacing: Theme.Spacing.sm),
+                        count: layout.columns),
                     spacing: Theme.Spacing.sm
                 ) {
                     ForEach(screen.items) { item in
                         ExtensionGridCell(
                             node: item.node, selected: item.index == selection,
-                            assetsPath: assetsPath
+                            assetsPath: assetsPath, layout: layout, width: tileWidth
                         )
                         .contentShape(Rectangle())
                         .onTapGesture {
@@ -132,7 +144,7 @@ struct ExtensionListView: View {
             .edgeDissolve()
             .thinScrollbar()
             .scrollFollowsSelection(
-                scroll, row: selectedRowID, atOrigin: selection < columns, proxy: proxy)
+                scroll, row: selectedRowID, atOrigin: selection < layout.columns, proxy: proxy)
         }
     }
 
@@ -277,31 +289,39 @@ struct ExtensionAccessoriesView: View {
     }
 }
 
-/// One `Grid.Item`: a large content tile with its title underneath.
+/// One `Grid.Item`: content sized to the tile the `Grid`'s props ask for, title underneath.
 private struct ExtensionGridCell: View {
     @Environment(\.isDarkAppearance) private var isDark
     let node: RenderNode
     let selected: Bool
     let assetsPath: String?
+    let layout: ExtensionGridLayout
+    let width: Double
     @State private var hovered = false
 
-    /// `content` is an `ImageLike`, `{value, tooltip}` or `{color}` — all `resolve`'s job.
-    private var resolved: ExtensionImage.Resolved? {
-        ExtensionImage.resolve(node.props["content"], assetsPath: assetsPath, isDark: isDark)
+    private var content: RenderValue? { node.props["content"] }
+
+    /// A tile may be a bare `{color}` swatch instead, which has no image to resolve.
+    private var swatch: Color? {
+        guard let fields = content?.objectValue else { return nil }
+        return ExtensionImage.color((fields["value"]?.objectValue ?? fields)["color"], isDark: isDark)
+    }
+
+    private var height: Double { width / layout.aspectRatio }
+
+    private var contentSize: CGSize {
+        let inset = width * layout.inset.fraction
+        return CGSize(width: width - inset * 2, height: height - inset * 2)
+    }
+
+    private var background: Color {
+        if selected { return Theme.Colors.selection }
+        return hovered ? Theme.Colors.rowHover : ExtensionColors.gridItemFill
     }
 
     var body: some View {
         VStack(spacing: Theme.Spacing.xs) {
-            ExtensionIconView(resolved: resolved, size: 56, animates: true)
-                .frame(maxWidth: .infinity)
-                .padding(Theme.Spacing.sm)
-                .background(
-                    RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
-                        .fill(
-                            selected
-                                ? Theme.Colors.selection
-                                : (hovered ? Theme.Colors.rowHover : ExtensionColors.gridItemFill))
-                )
+            tile
             if let title = node.string("title") {
                 Text(title)
                     .font(Theme.Typography.rowTrailing)
@@ -314,6 +334,109 @@ private struct ExtensionGridCell: View {
                     .lineLimit(1)
             }
         }
+        .frame(width: width)
         .armedHover($hovered)
+    }
+
+    private var tile: some View {
+        tileContent
+            .frame(width: contentSize.width, height: contentSize.height)
+            .clipShape(RoundedRectangle(cornerRadius: contentRadius, style: .continuous))
+            .frame(width: width, height: height)
+            .background(
+                RoundedRectangle(cornerRadius: ExtensionGridLayout.tileRadius, style: .continuous)
+                    .fill(background)
+            )
+            // A tile filled edge to edge hides that fill, so the ring is what marks the selection.
+            .overlay {
+                RoundedRectangle(cornerRadius: ExtensionGridLayout.tileRadius, style: .continuous)
+                    .strokeBorder(Theme.Colors.border, lineWidth: 2)
+                    .opacity(selected ? 1 : 0)
+            }
+    }
+
+    /// Filling content shares the tile's corner; inset artwork is small enough to need a tighter one.
+    private var contentRadius: Double {
+        layout.inset == .zero ? ExtensionGridLayout.tileRadius : Theme.Radius.thumbnail
+    }
+
+    /// `content` is an `ImageLike` or `{value, tooltip}` wrapping one — both `resolve`'s job.
+    @ViewBuilder
+    private var tileContent: some View {
+        let resolved = ExtensionImage.resolve(content, assetsPath: assetsPath, isDark: isDark)
+        if resolved == nil, let swatch {
+            Rectangle().fill(swatch)
+        } else {
+            ExtensionGridContentView(resolved: resolved, fills: layout.fills, size: contentSize)
+        }
+    }
+}
+
+/// A tile's image, scaled to the tile it is given — unlike `ExtensionIconView`'s fixed icon box.
+private struct ExtensionGridContentView: View {
+    @Environment(\.isDarkAppearance) private var isDark
+    let resolved: ExtensionImage.Resolved?
+    let fills: Bool
+    /// Passed down rather than measured: the grid already knows every tile's size.
+    let size: CGSize
+    @State private var loaded: NSImage?
+
+    var body: some View {
+        content
+            // Keyed on appearance too: an inline SVG's palette resolves at decode.
+            .task(id: ExtensionImage.LoadKey(source: resolved?.source, isDark: isDark)) {
+                loaded = await ExtensionImage.load(resolved, isDark: isDark, animates: true)
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch resolved?.source {
+        case .symbol(let name):
+            // A symbol has no artwork to scale, so it takes a share of the tile rather than all of it.
+            Image(systemName: name)
+                .resizable()
+                .scaledToFit()
+                .symbolRenderingMode(resolved?.tint == nil ? .hierarchical : .monochrome)
+                .foregroundStyle(resolved?.tint ?? Theme.Colors.textSecondary)
+                .padding(min(size.width, size.height) * 0.2)
+        case .glyph(let text):
+            Text(text)
+                .font(.system(size: min(size.width, size.height) * 0.72))
+        case .file, .fileIcon, .remote, .inline:
+            if let loaded {
+                image(loaded)
+            } else {
+                placeholder
+            }
+        case nil:
+            placeholder
+        }
+    }
+
+    /// The tile is clipped already, so the faint fill needs no corner of its own.
+    private var placeholder: some View { Rectangle().fill(Theme.Colors.iconPlaceholder) }
+
+    @ViewBuilder
+    private func image(_ image: NSImage) -> some View {
+        // Only a multi-frame image pays for `NSImageView`; a still stays on SwiftUI's path.
+        if image.isAnimated {
+            AnimatedImageView(image: image)
+                .scaleEffect(fills ? coverScale(image) : 1)
+        } else {
+            // A `tintColor` masks the artwork, which is what colours a `currentColor` SVG.
+            Image(nsImage: image)
+                .resizable()
+                .renderingMode(resolved?.tint == nil ? .original : .template)
+                .aspectRatio(contentMode: fills ? .fill : .fit)
+                .foregroundStyle(resolved?.tint ?? .primary)
+        }
+    }
+
+    /// `NSImageView` only ever fits proportionally, so `Grid.Fit.Fill` scales that draw up to cover.
+    private func coverScale(_ image: NSImage) -> Double {
+        let scales = [size.width / image.size.width, size.height / image.size.height]
+        guard let low = scales.min(), let high = scales.max(), low > 0, high.isFinite else { return 1 }
+        return high / low
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionScreen.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ExtensionScreen: Equatable {
     enum Kind: Equatable {
         case list
-        case grid(columns: Int)
+        case grid(ExtensionGridLayout)
         case detail
         case form
         /// A root component Tinycast doesn't render (`MenuBarExtra`), or nothing rendered yet.
@@ -97,7 +97,7 @@ struct ExtensionScreen: Equatable {
         case "List":
             kind = .list
         case "Grid":
-            kind = .grid(columns: ExtensionScreen.gridColumns(root))
+            kind = .grid(ExtensionGridLayout(root))
         case "Detail":
             kind = .detail
         case "Form":
@@ -185,16 +185,6 @@ struct ExtensionScreen: Equatable {
         if let subtitle = item.string("subtitle") { haystack.append(subtitle) }
         haystack.append(contentsOf: item.array("keywords").compactMap(\.stringValue))
         return haystack.contains { FuzzyMatch.score(needle, candidate: $0) != nil }
-    }
-
-    private static func gridColumns(_ root: RenderNode) -> Int {
-        if let columns = root.double("columns").map({ Int($0) }), columns > 0 { return columns }
-        // Raycast's default is 5; `itemSize` is the legacy way of saying the same thing.
-        switch root.string("itemSize") {
-        case "small": return 8
-        case "large": return 3
-        default: return 5
-        }
     }
 
     /// The `ActionPanel` that applies to the current selection: the item's own, else the screen's.

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -161,6 +161,14 @@ screens hold (see [palette.md](palette.md)).
   whole signal. `ExtensionScreen.Item`
   carries both the flat `selection` index and the scroll id, and is the `ForEach` identity of the row
   and the grid cell alike — see the scroll-id rule in [ui.md](../ui.md#rows-selection-hover).
+- **Grid tiles** — `ExtensionGridLayout` reads the `Grid`'s `columns`, `aspectRatio`, `fit` and `inset`
+  and is the one place tile geometry is decided. A tile is a column wide and `aspectRatio` tall, and its
+  content is scaled to that tile rather than drawn at an icon size, which is what makes an image-heavy
+  grid (GIFs, logos) look as it does in Raycast; `inset` is the extension's own knob for pulling small
+  artwork back in, so **never compensate for a too-large tile by clamping the content**. The grid is
+  measured once for every cell — a tile that measured itself would cost a layout pass each. A symbol or
+  glyph has no artwork to scale, so it takes a share of the tile; `Grid.Section` props are not read,
+  since the grid draws one column count throughout.
 - **Detail** — markdown rendered block-by-block (headings, lists, code fences, quotes, rules, fetched
   and inline images) with `AttributedString` handling inline styling, plus `Detail.Metadata`.
 - **Appearance** — `environment.appearance` reports the real one, so an extension that branches on it


### PR DESCRIPTION
## Related issue

Closes #406

## What changed

A `Grid.Item` drew its content through `ExtensionIconView` at a fixed 56pt, so an image-heavy grid
showed a small centred thumbnail inside a much larger cell.

The fix is the `Grid` props Raycast already defines, rather than a heuristic that guesses what an
extension meant. New `ExtensionGridLayout` (a `Model/` type, so the harness covers it) reads
`columns`, `aspectRatio`, `fit` and `inset` and is the one place tile geometry is decided:
`ExtensionScreen.Kind.grid` now carries it instead of a bare column count. A tile is a column wide by
`aspectRatio` tall, and its content is scaled to that tile.

That leaves `inset` as the extension's own knob for pulling small artwork back in — which is what the
three extensions in the issue thread already say. `lucide-icons` passes `Grid.Inset.Large` with
`columns: 8`, `svgl` the same with `columns: 6`; `gif-search` passes only `columns`. So the universal
grid serves all three and nothing needs to sniff an extension's identity. Inset steps are 8% / 16% /
24% of tile width — Raycast documents them as relative to `columns` but not their values, so these are
picked by eye.

Non-obvious bits, all consequences of a tile that can now fill edge to edge:

- **A selection ring.** A full-bleed image hides the selection *fill*, which was the only marker.
- **`{color}` content.** Only `Grid.Item` can carry a bare colour swatch; it resolved to nil before, so
  it drew the placeholder tile.
- **`fit=fill` for animated images.** `NSImageView` only ever fits proportionally, so `Grid.Fit.Fill`
  scales that contained draw up to cover and the tile clips it.
- **A symbol or emoji takes a share of the tile.** An `Icon` value has no artwork to scale, and a
  hierarchical symbol stretched over a 130pt tile reads as a bug. Real images are untouched.
- **The grid is measured once for all cells.** A tile that measured itself would cost a layout pass
  each; `ExtensionGridContentView` is handed its size instead.
- The tile corner goes 6 → 12, owned by `ExtensionGridLayout.tileRadius` rather than bolted onto
  `Theme` — no launcher surface is this size. Inset artwork keeps a tighter 6pt clip, since a 12pt
  corner cuts into a ~40pt icon box.
- `ExtensionImage.load(_:isDark:animates:)` is extracted so the row icon and the tile share one loader.

`Grid.Section`'s own `columns` / `aspectRatio` / `fit` / `inset` are still not read: the grid draws one
column count throughout, and per-section geometry would mean restructuring `ExtensionGridGeometry`
navigation too. Worth its own issue if an extension turns out to need it.

## Memory footprint

Not measured — I don't relaunch the maintainer's `Tinycast Dev` to profile, and this change adds no
new long-lived state. Worth a look before merge for one reason: a grid tile now decodes at full size
rather than at icon size, which is a real increase for a 5-column GIF grid.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no.

## Demo

Not attached — a before/after clip needs the extensions running on a machine with the palette open.
Attach one from a local run before merging.

## Drawbacks

- The inset fractions and the symbol's share of the tile are eyeballed, not measured against Raycast.
  Both are one constant each if they turn out to be off.
- An extension that passes an `Icon` as grid content with no `inset` now gets a large symbol where it
  used to get a 56pt one. That is what the API says, but it is a visible change for such a grid.
- A grid tile decodes at full size, so an image-heavy grid holds more pixels than it did.

## Tests & validation

- `./Scripts/run-tests.sh` — all 52 harnesses pass. `ext-test` gains cases for the layout props
  (`aspectRatio: "16/9"`, `fit`, `inset`), the legacy `itemSize` mapping, the column clamp, the
  square fallback for a bad ratio, and the tile-width maths.
- Debug build clean, no new warnings. `./Scripts/lint.sh` clean. No `Model/` file imports AppKit or
  SwiftUI.
- Tile geometry was probed by rendering the shipped layout maths to PNG at each column count, inset
  and aspect ratio — that is how the corner radius and the symbol share were chosen. **Not yet
  exercised against the live extensions in the palette**; that check is still owed.
