### PR TITLE
Add window workspaces (#431)

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -185,6 +185,7 @@ run volume-test            Tinycast/Features/SystemActions/Model/VolumeLevel.swi
 run window-command-test    Tinycast/Features/WindowManagement/WindowCommand.swift \
                            Tinycast/Features/WindowManagement/WindowLayout.swift \
                            Tinycast/Features/WindowManagement/WindowActionMemory.swift
+run workspace-test         Tinycast/Features/WindowManagement/WindowWorkspace.swift
 run space-gesture-test     Tinycast/Features/WindowManagement/WindowCommand.swift \
                            Tinycast/Features/WindowManagement/SpaceGesture.swift
 run custom-command-test    Tinycast/Platform/PseudoTerminal.swift \

--- a/Tests/window-command-test.swift
+++ b/Tests/window-command-test.swift
@@ -71,7 +71,7 @@ struct WindowCommandTests {
 
     static func testCatalog() {
         let commands = WindowCommandCatalog.all
-        expect(commands.count == 34, "catalog contains all 34 agreed commands")
+        expect(commands.count == 35, "catalog contains all 35 agreed commands")
         expect(commands.map(\.id) == WindowCommand.ID.allCases, "catalog covers every ID once")
         expect(
             Set(commands.map { $0.name.lowercased() }).count == commands.count, "names are unique")
@@ -113,6 +113,9 @@ struct WindowCommandTests {
         expect(
             Set(commands.filter { $0.kind == .space }.map(\.id)) == [.previousSpace, .nextSpace],
             "only the two Space switches are space commands")
+        expect(
+            Set(commands.filter { $0.kind == .workspace }.map(\.id)) == [.restoreWorkspace],
+            "only Restore Workspace runs the selected workspace")
         expect(
             commands.filter { $0.kind == .space }.allSatisfy {
                 WindowLayout.placement(

--- a/Tests/workspace-test.swift
+++ b/Tests/workspace-test.swift
@@ -1,0 +1,72 @@
+import CoreGraphics
+import Foundation
+
+@main
+@MainActor
+struct WorkspaceTests {
+    private static var passes = 0
+    private static var failures = 0
+
+    static func main() {
+        testNormalizedFrameUsesVisibleScreenCoordinates()
+        testRestoredFrameScalesAndStaysReachable()
+        testWorkspaceRoundTripsThroughJSON()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    private static func expect(_ actual: CGRect?, _ expected: CGRect, _ message: String) {
+        guard actual == expected else {
+            failures += 1
+            print("FAIL: \(message) — got \(String(describing: actual)), expected \(expected)")
+            return
+        }
+        passes += 1
+    }
+
+    private static func expect(_ condition: Bool, _ message: String) {
+        if condition {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    private static func testNormalizedFrameUsesVisibleScreenCoordinates() {
+        let visible = CGRect(x: -1600, y: 24, width: 1600, height: 1000)
+        let frame = CGRect(x: -1440, y: 124, width: 800, height: 500)
+
+        let normalized = WindowWorkspace.NormalizedFrame(frame: frame, in: visible)
+
+        expect(normalized?.x == 0.1, "capture stores x as a visible-frame fraction")
+        expect(normalized?.y == 0.1, "capture stores y as a visible-frame fraction")
+        expect(normalized?.width == 0.5, "capture stores width as a visible-frame fraction")
+        expect(normalized?.height == 0.5, "capture stores height as a visible-frame fraction")
+    }
+
+    private static func testRestoredFrameScalesAndStaysReachable() {
+        let normalized = WindowWorkspace.NormalizedFrame(x: 0.8, y: 0.8, width: 0.4, height: 0.4)
+        let visible = CGRect(x: 100, y: -50, width: 1000, height: 500)
+
+        expect(
+            normalized.frame(in: visible), CGRect(x: 700, y: 250, width: 400, height: 200),
+            "restore rescales the saved frame and clamps its trailing edges")
+    }
+
+    private static func testWorkspaceRoundTripsThroughJSON() {
+        let workspace = WindowWorkspace(
+            id: UUID(uuidString: "01234567-89AB-CDEF-0123-456789ABCDEF")!, name: "Writing",
+            windows: [
+                .init(
+                    bundleID: "com.apple.TextEdit", screenID: 42,
+                    frame: .init(x: 0.125, y: 0.25, width: 0.5, height: 0.5))
+            ])
+
+        let decoded = try? JSONDecoder().decode(
+            WindowWorkspace.self, from: JSONEncoder().encode(workspace))
+
+        expect(decoded == workspace, "workspace serialization preserves its selected app and geometry")
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -369,8 +369,10 @@
 		D02DD53E9BE6C679EA0C0375 /* NoteSwitcherInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AD14D51F74D1891D5532B0 /* NoteSwitcherInteraction.swift */; };
 		D07983DDEA61E5F2B8681F01 /* QuicklinkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CD7B0E866AEF486F9EC5E9 /* QuicklinkCoordinator.swift */; };
 		D07F272D0E095B6000D53716 /* NotesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5AFB680B55BBAFF2207F99 /* NotesCoordinator.swift */; };
+		D17893FCBED00D041C86EB3A /* WindowWorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C77AA1FDEEAB556CAC8F2D /* WindowWorkspaceStore.swift */; };
 		D1F9C28CA4048480DB818EE9 /* LauncherList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132C5A534C02305C1A29CC74 /* LauncherList.swift */; };
 		D3F07F4AEBEAA489EDCD0763 /* FileSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FE27F894A8777C8ACCF1D /* FileSearchList.swift */; };
+		D42B47191A7F3FE379646FD1 /* WindowWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2E82D26CAB9CA085F846C1 /* WindowWorkspace.swift */; };
 		D44E20726F1EB11C8C297C4D /* WindowActionMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A97C1CFD02D55E955AFA72B /* WindowActionMemory.swift */; };
 		D4A45373662D6658706E4DA4 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27773F8955543E8A24CC0D28 /* ClipboardSettingsView.swift */; };
 		D4AC94686EEEF4B792B58593 /* CalendarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0AA95CA13E86370661D01C /* CalendarSettingsView.swift */; };
@@ -652,6 +654,7 @@
 		7B711492A6DA473E6DC9646C /* RaycastImportSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportSelection.swift; sourceTree = "<group>"; };
 		7BFFB1471D30C915BBC5DCBA /* SnippetRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetRepository.swift; sourceTree = "<group>"; };
 		7C0FB3A9CA762A7A8DB99BA6 /* ExtensionPaletteModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPaletteModifiers.swift; sourceTree = "<group>"; };
+		7C2E82D26CAB9CA085F846C1 /* WindowWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowWorkspace.swift; sourceTree = "<group>"; };
 		7D35CA0655717E1798AFDA7B /* FrequentEmojiStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentEmojiStore.swift; sourceTree = "<group>"; };
 		7D61199EE7B60E91ACBDE2E2 /* WindowChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChrome.swift; sourceTree = "<group>"; };
 		7E7DAF3FFEE6CAB656B0FA8A /* UninstallRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallRules.swift; sourceTree = "<group>"; };
@@ -858,6 +861,7 @@
 		F023729C84682E9231F3D73B /* ExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstaller.swift; sourceTree = "<group>"; };
 		F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		F097C9983DF27A99694C8BC5 /* Zlib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zlib.swift; sourceTree = "<group>"; };
+		F1C77AA1FDEEAB556CAC8F2D /* WindowWorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowWorkspaceStore.swift; sourceTree = "<group>"; };
 		F3F97240A718D95DFD9343DB /* UpcomingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingWindow.swift; sourceTree = "<group>"; };
 		F513217C40F0B8199DC57A35 /* QuickActionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionPrompt.swift; sourceTree = "<group>"; };
 		F524FA7B33C0F861995EB1E6 /* QuicklinkArgumentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsScreen.swift; sourceTree = "<group>"; };
@@ -1947,6 +1951,8 @@
 				E779B6EF738591CB935F3F95 /* WindowLayout.swift */,
 				B21678BAD7BA4A4E300FDA2C /* WindowManagementSettingsView.swift */,
 				AA99178E0DCF6CBB521FB098 /* WindowMover.swift */,
+				7C2E82D26CAB9CA085F846C1 /* WindowWorkspace.swift */,
+				F1C77AA1FDEEAB556CAC8F2D /* WindowWorkspaceStore.swift */,
 			);
 			path = WindowManagement;
 			sourceTree = "<group>";
@@ -2714,6 +2720,8 @@
 				0360C7038877B9CB656DB697 /* WindowManagementSettingsView.swift in Sources */,
 				A6A8CD2B71A15625F47498EA /* WindowMover.swift in Sources */,
 				6AF8D4CB26C1B1F53C71B5E4 /* WindowReader.swift in Sources */,
+				D42B47191A7F3FE379646FD1 /* WindowWorkspace.swift in Sources */,
+				D17893FCBED00D041C86EB3A /* WindowWorkspaceStore.swift in Sources */,
 				6CDA82FD63F87D07E30E3F82 /* Zlib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -19,6 +19,7 @@ final class AppCore {
     let hotKeys = HotKeyManager()
     let hyperKeyTap = HyperKeyTap()
     let windowMover = WindowMover()
+    let windowWorkspaces = WindowWorkspaceStore()
     let spaceSwitcher = SpaceSwitcher()
     let inputSourceSwitcher = InputSourceSwitcher()
     let settings: AppSettings
@@ -91,7 +92,8 @@ final class AppCore {
         settingsCoordinator: settingsCoordinator, settings: settings, core: self)
     @ObservationIgnored private(set) lazy var windowCommandCoordinator = WindowCommandCoordinator(
         settings: settings, paletteCoordinator: paletteCoordinator, windowMover: windowMover,
-        spaceSwitcher: spaceSwitcher)
+        workspaceStore: windowWorkspaces, spaceSwitcher: spaceSwitcher,
+        showMessage: { [unowned self] in self.showMessage($0) })
     @ObservationIgnored private(set) lazy var customCommandCoordinator = CustomCommandCoordinator(
         store: customCommands, argumentSession: customCommandArguments, settings: settings,
         appIndex: appIndex,

--- a/Tinycast/Features/Settings/SettingsCoordinator.swift
+++ b/Tinycast/Features/Settings/SettingsCoordinator.swift
@@ -38,6 +38,7 @@ final class SettingsCoordinator {
             .environment(navigation)
             .environment(core)
             .environment(core.settings)
+            .environment(core.windowWorkspaces)
             .environment(core.appIndex)
             .environment(core.hotKeys)
             .environment(core.visibility)

--- a/Tinycast/Features/WindowManagement/WindowCommand.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommand.swift
@@ -36,6 +36,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case toggleFullscreen = "toggle-fullscreen"
         case previousSpace = "previous-space"
         case nextSpace = "next-space"
+        case restoreWorkspace = "restore-workspace"
     }
 
     /// What the mover has to do, so its dispatch stays exhaustive over the catalog.
@@ -48,6 +49,8 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case fullscreen
         /// No window at all — a synthetic Dock gesture that moves between Spaces.
         case space
+        /// Restore the workspace selected in Settings.
+        case workspace
     }
 
     /// The launcher section a command belongs to, and the order the Settings panel lists them in.
@@ -60,6 +63,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
         case moving
         case fullscreen
         case spaces
+        case workspaces
 
         var title: String {
             switch self {
@@ -71,6 +75,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
             case .moving: return "Moving"
             case .fullscreen: return "Fullscreen"
             case .spaces: return "Spaces"
+            case .workspaces: return "Workspaces"
             }
         }
     }
@@ -154,6 +159,7 @@ enum WindowCommandCatalog {
         case .toggleFullscreen: return "Toggle Fullscreen"
         case .previousSpace: return "Switch to Previous Space"
         case .nextSpace: return "Switch to Next Space"
+        case .restoreWorkspace: return "Restore Workspace"
         }
     }
 
@@ -191,6 +197,7 @@ enum WindowCommandCatalog {
         case .toggleFullscreen: return "arrow.up.left.and.arrow.down.right.square"
         case .previousSpace: return "chevron.backward.2"
         case .nextSpace: return "chevron.forward.2"
+        case .restoreWorkspace: return "square.3.layers.3d.top.filled"
         }
     }
 
@@ -199,6 +206,7 @@ enum WindowCommandCatalog {
         case .restore: return .restore
         case .toggleFullscreen: return .fullscreen
         case .previousSpace, .nextSpace: return .space
+        case .restoreWorkspace: return .workspace
         default: return .geometry
         }
     }
@@ -222,6 +230,8 @@ enum WindowCommandCatalog {
             return .fullscreen
         case .previousSpace, .nextSpace:
             return .spaces
+        case .restoreWorkspace:
+            return .workspaces
         }
     }
 }

--- a/Tinycast/Features/WindowManagement/WindowCommandCoordinator.swift
+++ b/Tinycast/Features/WindowManagement/WindowCommandCoordinator.swift
@@ -6,21 +6,31 @@ final class WindowCommandCoordinator {
     private let settings: AppSettings
     private let paletteCoordinator: PaletteCoordinator
     private let windowMover: WindowMover
+    private let workspaceStore: WindowWorkspaceStore
     private let spaceSwitcher: SpaceSwitcher
+    private let showMessage: (String) -> Void
 
     init(
         settings: AppSettings, paletteCoordinator: PaletteCoordinator, windowMover: WindowMover,
-        spaceSwitcher: SpaceSwitcher
+        workspaceStore: WindowWorkspaceStore, spaceSwitcher: SpaceSwitcher,
+        showMessage: @escaping (String) -> Void
     ) {
         self.settings = settings
         self.paletteCoordinator = paletteCoordinator
         self.windowMover = windowMover
+        self.workspaceStore = workspaceStore
         self.spaceSwitcher = spaceSwitcher
+        self.showMessage = showMessage
     }
 
     /// The one funnel for palette and hotkey alike. See docs/features/window-management.md#wiring.
     func runWindowCommand(id: WindowCommand.ID) {
         guard settings.windowManagementEnabled else { return }
+        if id == .restoreWorkspace {
+            if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: false) }
+            restoreSelectedWorkspace()
+            return
+        }
         if let direction = SpaceDirection(id) {
             // Restoring focus reactivates an app elsewhere, pulling its Space forward.
             if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: false) }
@@ -32,5 +42,27 @@ final class WindowCommandCoordinator {
         windowMover.perform(
             id, target: target, gap: CGFloat(settings.windowGap),
             cycleOnRepeat: settings.windowCycleOnRepeat)
+    }
+
+    func saveWorkspace(named name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let windows = windowMover.captureWorkspace()
+        guard !windows.isEmpty else {
+            showMessage("No accessible windows to save")
+            return
+        }
+        workspaceStore.save(name: trimmed, windows: windows)
+        showMessage("Saved \(trimmed)")
+    }
+
+    func restoreSelectedWorkspace() {
+        guard let workspace = workspaceStore.selected else {
+            showMessage("Choose a workspace in Settings first")
+            return
+        }
+        let restored = windowMover.restoreWorkspace(workspace)
+        showMessage(
+            restored == 0 ? "Opened available apps for \(workspace.name)" : "Restored \(workspace.name)")
     }
 }

--- a/Tinycast/Features/WindowManagement/WindowManagementSettingsView.swift
+++ b/Tinycast/Features/WindowManagement/WindowManagementSettingsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct WindowManagementSettingsView: View {
     @Environment(AppSettings.self) private var settings
+    @Environment(AppCore.self) private var core
+    @Environment(WindowWorkspaceStore.self) private var workspaces
+    @State private var workspaceName = "Workspace"
 
     var body: some View {
         @Bindable var settings = settings
@@ -17,11 +20,48 @@ struct WindowManagementSettingsView: View {
 
             Group {
                 options
+                workspaceLayouts
                 commands
             }
             .settingsEnabled(settings.windowManagementEnabled)
         }
         .formStyle(.grouped)
+    }
+
+    private var workspaceLayouts: some View {
+        Section {
+            HStack(spacing: Theme.Spacing.sm) {
+                TextField("Workspace name", text: $workspaceName)
+                Button("Save current layout") {
+                    core.windowCommandCoordinator.saveWorkspace(named: workspaceName)
+                }
+            }
+            if workspaces.workspaces.isEmpty {
+                Text("Save a layout to restore it later from the launcher or a shortcut.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(workspaces.workspaces) { workspace in
+                    HStack {
+                        Button {
+                            workspaces.selectedID = workspace.id
+                        } label: {
+                            Image(
+                                systemName: workspaces.selectedID == workspace.id
+                                    ? "checkmark.circle.fill" : "circle")
+                        }
+                        .buttonStyle(.plain)
+                        Text(workspace.name)
+                        Spacer()
+                        Button("Restore") { core.windowCommandCoordinator.restoreSelectedWorkspace() }
+                        Button("Delete", role: .destructive) { workspaces.remove(id: workspace.id) }
+                    }
+                }
+            }
+        } header: {
+            Text("Workspaces")
+        } footer: {
+            Text("Frames use each display’s usable area, so a layout adapts to resolution changes.")
+        }
     }
 
     private var options: some View {

--- a/Tinycast/Features/WindowManagement/WindowMover.swift
+++ b/Tinycast/Features/WindowManagement/WindowMover.swift
@@ -112,6 +112,62 @@ final class WindowMover {
         return !applied.equalTo(current)
     }
 
+    /// Reads every eligible app window only when the user asks to save a workspace.
+    func captureWorkspace() -> [WindowWorkspace.Window] {
+        guard Permissions.ensureAccessibility() else { return [] }
+        let geometry = AXGeometry(screens: NSScreen.screens)
+        let screens = Self.screens(NSScreen.screens, geometry: geometry)
+        var captured: [WindowWorkspace.Window] = []
+        for app in NSWorkspace.shared.runningApplications where !app.isTerminated {
+            guard let bundleID = app.bundleIdentifier else { continue }
+            let application = AXUIElementCreateApplication(app.processIdentifier)
+            AXUIElementSetMessagingTimeout(application, Self.messagingTimeout)
+            for window in windows(in: application) where isEligible(window) {
+                guard let frame = frame(of: window),
+                    let screen = WindowLayout.screen(containing: frame, in: screens),
+                    screen.id >= 0,
+                    let normalized = WindowWorkspace.NormalizedFrame(frame: frame, in: screen.visibleFrame)
+                else { continue }
+                captured.append(.init(bundleID: bundleID, screenID: UInt32(screen.id), frame: normalized))
+            }
+        }
+        return captured
+    }
+
+    /// Replays a saved workspace once; unavailable apps are launched but never polled for windows.
+    @discardableResult
+    func restoreWorkspace(_ workspace: WindowWorkspace) -> Int {
+        guard Permissions.ensureAccessibility() else { return 0 }
+        let geometry = AXGeometry(screens: NSScreen.screens)
+        let screens = Self.screens(NSScreen.screens, geometry: geometry)
+        guard !screens.isEmpty else { return 0 }
+        let apps = Dictionary(grouping: NSWorkspace.shared.runningApplications, by: \.bundleIdentifier)
+            .compactMapValues { $0.first }
+        var restored = 0
+        for (bundleID, savedWindows) in Dictionary(grouping: workspace.windows, by: \.bundleID) {
+            guard let app = apps[bundleID], !app.isTerminated else {
+                if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+                    NSWorkspace.shared.open(url)
+                }
+                continue
+            }
+            let application = AXUIElementCreateApplication(app.processIdentifier)
+            AXUIElementSetMessagingTimeout(application, Self.messagingTimeout)
+            let windows = windows(in: application).filter(isEligible)
+            for (saved, window) in zip(savedWindows, windows) {
+                guard let target = screens.first(where: { $0.id == Int(saved.screenID) }) ?? screens.first,
+                    let frame = saved.frame.frame(in: target.visibleFrame),
+                    isSettable(kAXPositionAttribute, on: window)
+                else { continue }
+                if isSettable(kAXSizeAttribute, on: window) { _ = setSize(frame.size, on: window) }
+                guard setPosition(frame.origin, on: window) else { continue }
+                if isSettable(kAXSizeAttribute, on: window) { _ = setSize(frame.size, on: window) }
+                restored += 1
+            }
+        }
+        return restored
+    }
+
     // MARK: - Applying a placement
 
     private func apply(
@@ -172,13 +228,14 @@ final class WindowMover {
             if let window = element(application, attribute), isEligible(window) { return window }
         }
         // Last resort for apps that report neither: the first window that isn't a sheet or a panel.
+        return windows(in: application).first(where: isEligible)
+    }
+
+    private func windows(in application: AXUIElement) -> [AXUIElement] {
         var value: CFTypeRef?
-        guard
-            AXUIElementCopyAttributeValue(application, kAXWindowsAttribute as CFString, &value)
-                == .success,
-            let windows = value as? [AXUIElement]
-        else { return nil }
-        return windows.first(where: isEligible)
+        guard AXUIElementCopyAttributeValue(application, kAXWindowsAttribute as CFString, &value) == .success
+        else { return [] }
+        return value as? [AXUIElement] ?? []
     }
 
     /// A real, restorable window: not a sheet, popover or minimized one, and it reports geometry.

--- a/Tinycast/Features/WindowManagement/WindowWorkspace.swift
+++ b/Tinycast/Features/WindowManagement/WindowWorkspace.swift
@@ -1,0 +1,72 @@
+import CoreGraphics
+import Foundation
+
+/// A named snapshot of windows, expressed relative to each screen's usable area.
+struct WindowWorkspace: Codable, Equatable, Identifiable, Sendable {
+    struct Window: Codable, Equatable, Identifiable, Sendable {
+        let id: UUID
+        let bundleID: String
+        let screenID: UInt32
+        let frame: NormalizedFrame
+
+        init(id: UUID = UUID(), bundleID: String, screenID: UInt32, frame: NormalizedFrame) {
+            self.id = id
+            self.bundleID = bundleID
+            self.screenID = screenID
+            self.frame = frame
+        }
+    }
+
+    /// A frame relative to `NSScreen.visibleFrame`, independent of the display's resolution.
+    struct NormalizedFrame: Codable, Equatable, Sendable {
+        let x: Double
+        let y: Double
+        let width: Double
+        let height: Double
+
+        init(x: Double, y: Double, width: Double, height: Double) {
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+        }
+
+        init?(frame: CGRect, in visibleFrame: CGRect) {
+            guard visibleFrame.width > 0, visibleFrame.height > 0 else { return nil }
+            x = (frame.minX - visibleFrame.minX) / visibleFrame.width
+            y = (frame.minY - visibleFrame.minY) / visibleFrame.height
+            width = frame.width / visibleFrame.width
+            height = frame.height / visibleFrame.height
+        }
+
+        /// Reconstitutes a reachable rect even if a saved layout no longer fits the display.
+        func frame(in visibleFrame: CGRect) -> CGRect? {
+            guard
+                visibleFrame.width > 0, visibleFrame.height > 0,
+                x.isFinite, y.isFinite, width.isFinite, height.isFinite,
+                width >= 0, height >= 0
+            else { return nil }
+
+            let raw = CGRect(
+                x: visibleFrame.minX + CGFloat(x) * visibleFrame.width,
+                y: visibleFrame.minY + CGFloat(y) * visibleFrame.height,
+                width: min(CGFloat(width) * visibleFrame.width, visibleFrame.width),
+                height: min(CGFloat(height) * visibleFrame.height, visibleFrame.height))
+            guard raw.width.isFinite, raw.height.isFinite else { return nil }
+            return CGRect(
+                x: min(max(raw.minX, visibleFrame.minX), visibleFrame.maxX - raw.width),
+                y: min(max(raw.minY, visibleFrame.minY), visibleFrame.maxY - raw.height),
+                width: raw.width, height: raw.height)
+        }
+    }
+
+    let id: UUID
+    var name: String
+    var windows: [Window]
+
+    init(id: UUID = UUID(), name: String, windows: [Window]) {
+        self.id = id
+        self.name = name
+        self.windows = windows
+    }
+}

--- a/Tinycast/Features/WindowManagement/WindowWorkspaceStore.swift
+++ b/Tinycast/Features/WindowManagement/WindowWorkspaceStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class WindowWorkspaceStore {
+    private struct Saved: Codable {
+        var selectedID: UUID?
+        var workspaces: [WindowWorkspace]
+    }
+
+    private let fileURL: URL
+    private(set) var workspaces: [WindowWorkspace]
+    var selectedID: UUID? { didSet { persist() } }
+
+    init(fileURL: URL = AppPaths.applicationSupport().appending(path: "window-workspaces.json")) {
+        self.fileURL = fileURL
+        let saved =
+            (try? Data(contentsOf: fileURL)).flatMap {
+                try? JSONDecoder().decode(Saved.self, from: $0)
+            } ?? Saved(selectedID: nil, workspaces: [])
+        workspaces = saved.workspaces
+        selectedID = saved.selectedID.flatMap { id in
+            saved.workspaces.contains(where: { $0.id == id }) ? id : nil
+        }
+    }
+
+    var selected: WindowWorkspace? {
+        guard let selectedID else { return nil }
+        return workspaces.first { $0.id == selectedID }
+    }
+
+    func save(name: String, windows: [WindowWorkspace.Window]) {
+        let workspace = WindowWorkspace(name: name, windows: windows)
+        workspaces.append(workspace)
+        selectedID = workspace.id
+        persist()
+    }
+
+    func remove(id: UUID) {
+        workspaces.removeAll { $0.id == id }
+        if selectedID == id { selectedID = workspaces.first?.id }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(Saved(selectedID: selectedID, workspaces: workspaces))
+        else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/docs/features/window-management.md
+++ b/docs/features/window-management.md
@@ -2,7 +2,7 @@
 
 Rectangle-style window actions — halves, quarters, fourths, thirds, sizing, nudging, display moves,
 native fullscreen and Space switching — searchable in the palette and bindable to global shortcuts.
-34 commands, no new dependencies and no new permission: they reuse the Accessibility grant clipboard
+35 commands, no new dependencies and no new permission: they reuse the Accessibility grant clipboard
 paste already needs.
 
 Ships **off**. Settings › Window Management is the switch, and while it is off there are no launcher
@@ -40,6 +40,19 @@ The first three compile into `Tests/window-command-test.swift` and `SpaceGesture
 dependency, and all must stay pure — `WindowActionMemory` takes `now` as a parameter rather than
 reading a clock. CoreGraphics is needed only because `CGRect`'s `Equatable` conformance lives in that
 overlay rather than in Foundation.
+
+## Workspaces
+
+Settings › Window Management saves named window snapshots on demand. A snapshot records each eligible
+Accessibility window's application bundle identifier, display identifier and frame as fractions of that
+display's `visibleFrame`. Restore resolves the saved display first and uses the primary available display
+when it is gone; frames are rescaled and clamped into the usable area. A missing application is opened
+once when macOS can locate its bundle. Tinycast never polls for its eventual window: a later Restore
+places it after launch.
+
+`Restore Workspace` is a normal launcher command and can be assigned a global shortcut. It restores the
+workspace selected in Settings. Saving, restoring and application launch all happen only from that user
+gesture; the feature adds no timers, observers or idle background work.
 
 Adding a command is four edits in `WindowCommand.swift` (a case in `ID`, plus `name`, `symbol` and
 `group` arms), an arm in `WindowLayout.placement` or `tileFractions`, and bumping


### PR DESCRIPTION
## Summary
- save named Accessibility-window layouts by application and display
- restore the Settings-selected layout through Launcher or a global shortcut
- keep frames resolution-independent by storing visible-frame fractions; launch missing apps once when available

## Idle impact
No polling, timers, observers, dependencies, Electron, or JavaScript runtime. Accessibility work occurs only on explicit Save or Restore gestures.

## Verification
- workspace and extension harnesses pass
- `./Scripts/lint.sh`
- `./Scripts/format.sh --check`
- Debug `xcodebuild` succeeds

A parallel full-suite run hit a pre-existing flaky `ext-test`; its isolated rerun passed.