### PR TITLE
Add action chains

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -191,6 +191,9 @@ run custom-command-test    Tinycast/Platform/PseudoTerminal.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift \
                            Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift \
                            Tinycast/Features/CustomCommands/Service/CustomCommandArgumentSession.swift
+run action-chain-test      Tinycast/Features/ActionChains/Model/ActionChain.swift \
+                           Tinycast/Features/ActionChains/Model/ActionChainRunner.swift \
+                           Tinycast/Features/ActionChains/Model/ActionChainStore.swift
 run uninstall-test         Tinycast/Features/Uninstall/Model/UninstallTarget.swift \
                            Tinycast/Features/Uninstall/Model/UninstallSearchRoot.swift \
                            Tinycast/Features/Uninstall/Model/UninstallRules.swift \

--- a/Tests/action-chain-test.swift
+++ b/Tests/action-chain-test.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+@main
+@MainActor
+struct ActionChainTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func main() async {
+        let first = ActionChainStep.application(bundleID: "com.apple.Safari")
+        let second = ActionChainStep.windowCommand(id: "left-half")
+        let chain = ActionChain(name: "Focus", steps: [first, second])
+
+        var performed: [ActionChainStep] = []
+        let completed = await ActionChainRunner.run(chain) { step in
+            performed.append(step)
+        }
+        expect(performed == [first, second], "runs every step in order")
+        expect(completed == .completed, "reports a completed chain")
+
+        if let encoded = try? JSONEncoder().encode(chain),
+            let decoded = try? JSONDecoder().decode(ActionChain.self, from: encoded)
+        {
+            expect(decoded == chain, "round-trips a chain through JSON")
+        } else {
+            expect(false, "round-trips a chain through JSON")
+        }
+
+        let defaults = UserDefaults(suiteName: "action-chain-test-\(UUID().uuidString)")!
+        if let stored = try? ActionChainStore(defaults: defaults).add(chain) {
+            expect(
+                ActionChainStore(defaults: defaults).chain(id: stored.id) == chain,
+                "loads a persisted chain after a store reload")
+        } else {
+            expect(false, "loads a persisted chain after a store reload")
+        }
+
+        let blocked = ActionChainStep.systemAction(id: "lock-screen")
+        let skipped = ActionChainStep.quicklink(id: UUID())
+        var attempted: [ActionChainStep] = []
+        let failed = await ActionChainRunner.run(ActionChain(name: "Stop", steps: [first, blocked, skipped]))
+        { step in
+            attempted.append(step)
+            if step == blocked { throw ActionChainFailure.unavailable }
+        }
+        expect(attempted == [first, blocked], "stops after the first failed step")
+        expect(failed == .failed(step: blocked), "reports the failed step")
+
+        print("\(passes)/\(passes + failures) passed")
+        if failures > 0 { exit(1) }
+    }
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ name: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(name)")
+        }
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		56E4958BCEF1FED10B4A796E /* UpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */; };
 		5770FB1A3FD29E27C25C944E /* SearchRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB9DB77DCE25C41D86BB955 /* SearchRelevance.swift */; };
 		57784875AA132F7756399363 /* SnippetsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E419A4DA5AB5B3A87B80F2 /* SnippetsListView.swift */; };
+		58C5F954B083852569BED9C1 /* ActionChainsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1BC6473BA115DD053BFFB2 /* ActionChainsSettingsView.swift */; };
 		58D369977E702AD66F070913 /* SnippetMarkdownSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3331A5E8F892CC257AD31B /* SnippetMarkdownSerializer.swift */; };
 		5970306ABC24B03028E66D45 /* FileSearchIgnoreList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFF39C46E98D0808B188E2E /* FileSearchIgnoreList.swift */; };
 		5A91C58340D02ED0939BCAE2 /* CurrencyFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE35B5E7B1CC94F759116097 /* CurrencyFeed.swift */; };
@@ -240,6 +241,7 @@
 		86C36C0885D5820E70184CF6 /* PaletteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */; };
 		8855C67C7EE196E3F9EDE778 /* KeyCapChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BA06E4CC7E8D40E3285F16 /* KeyCapChip.swift */; };
 		8865A4577BAEE98DF6019500 /* CameraPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5190901FD14510C82D1C0E /* CameraPreviewPanel.swift */; };
+		89866A1DF292EA983CEB725F /* ActionChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6788BE562713F91C6A88ADD8 /* ActionChain.swift */; };
 		89872774514D83EC2BD60F1E /* CommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0A68B2040582996EFBA877 /* CommandCatalog.swift */; };
 		89B3CC1AB417D04CE39FB70C /* Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5F9675F2090C3AA9EEBF65 /* Appearance.swift */; };
 		8A11D87B31A2BC5D8C778475 /* MarkdownInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164DCBE855B7136AE08712D8 /* MarkdownInline.swift */; };
@@ -285,6 +287,7 @@
 		A1F267E9D9914DB60DEEE0AD /* DoubleTapDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C54F3A609CD1C2CDF304FB /* DoubleTapDetector.swift */; };
 		A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B89168050723B7221F04A2 /* ClipboardCoordinator.swift */; };
 		A33EA048BC22D7313F4D480C /* EventDraftFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8553E1626E985013046C47 /* EventDraftFields.swift */; };
+		A372BACAE14692AF90441ED4 /* ActionChainRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D96E88D2DF38B707E19F74 /* ActionChainRunner.swift */; };
 		A41185C975CBF97A8C6EAC19 /* SystemPromptEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF36BDC9ACE867DCC2CCF746 /* SystemPromptEditor.swift */; };
 		A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */; };
 		A500AF3BF8910B335A7A936C /* HUDPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1752929BA1ACC0BC54865C /* HUDPanel.swift */; };
@@ -341,6 +344,7 @@
 		C0642512B709EF0517ABF4CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37CCD024267EB21876C7E9 /* AppDelegate.swift */; };
 		C215695FE671BC591DC99C2B /* DialogPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB241B179A08518424F7C1B /* DialogPanel.swift */; };
 		C21CAD7076793A5625F6B80C /* ChatHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B715A0256D2D0DDE1D28FC98 /* ChatHistoryStore.swift */; };
+		C2821C371ABDC82A0DE97BAE /* ActionChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED950DF9F71B7284BBEC2517 /* ActionChainStore.swift */; };
 		C33FF829408F4B2218416743 /* AIRetention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A82786725DFEB5467778E68 /* AIRetention.swift */; };
 		C385AEF3C8C5A6B2BACC1D9A /* OverflowFade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88499DF2F503F2A3A19DEF07 /* OverflowFade.swift */; };
 		C396379DCAD85611D4C6F587 /* UpdateDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD81541882CBCC5B06F718F /* UpdateDownloader.swift */; };
@@ -378,6 +382,7 @@
 		D68E7585496722BEC72E788C /* AliasStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0AD89CB2C805C50D2C80E1 /* AliasStore.swift */; };
 		D6D8169527668572F0073F94 /* RelaunchRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01488803F8025B0523D44BA /* RelaunchRunner.swift */; };
 		D736A0FE574A343AA0FD3911 /* AppIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E58EBB08450BA3426DF0565 /* AppIndex.swift */; };
+		D7B488256FCECBCC1E9A0117 /* ActionChainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F83C6B5AADBD1950F8484F2 /* ActionChainCoordinator.swift */; };
 		D9113113F828FD6983715D6B /* UninstallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */; };
 		D99DAF62B746E6009E1BFB1F /* QuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A4DEF28F120FE354EB5599 /* QuickAction.swift */; };
 		D9F77EF819BE3A06AA6B25A3 /* QuickActionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F513217C40F0B8199DC57A35 /* QuickActionPrompt.swift */; };
@@ -597,6 +602,7 @@
 		53DBA322BA1F117530075F51 /* QuickActionFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionFailure.swift; sourceTree = "<group>"; };
 		548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardScreen.swift; sourceTree = "<group>"; };
 		54E48A8D5E2BC00E9E1CD5BF /* QuicklinkArgumentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentSession.swift; sourceTree = "<group>"; };
+		55D96E88D2DF38B707E19F74 /* ActionChainRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionChainRunner.swift; sourceTree = "<group>"; };
 		56D6EE5144AEF889C95B3758 /* QuickActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionCoordinator.swift; sourceTree = "<group>"; };
 		570CE37C7133E28F7495ED91 /* MarkdownCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeView.swift; sourceTree = "<group>"; };
 		5844785DFED1196342431F18 /* MenuBarLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabel.swift; sourceTree = "<group>"; };
@@ -622,6 +628,7 @@
 		648F0F43FEEE537F6451756B /* SelectionReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReveal.swift; sourceTree = "<group>"; };
 		64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolImage.swift; sourceTree = "<group>"; };
 		6621A88681E993D49EEF07A3 /* tinycast.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = tinycast.icon; sourceTree = "<group>"; };
+		6788BE562713F91C6A88ADD8 /* ActionChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionChain.swift; sourceTree = "<group>"; };
 		67B6CA2ED2DDD9A89C7EE874 /* EmojiScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiScreen.swift; sourceTree = "<group>"; };
 		67CEAD8FAB5CD097D8F1C851 /* AIConversationOpenPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConversationOpenPolicy.swift; sourceTree = "<group>"; };
 		682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardFilter.swift; sourceTree = "<group>"; };
@@ -631,6 +638,7 @@
 		6D594CB90475093D58A2AB1E /* NoteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSearch.swift; sourceTree = "<group>"; };
 		6DA4145CFBB855DF1699C744 /* BackupCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupCategory.swift; sourceTree = "<group>"; };
 		6E06AA30E7BA44BC211B667F /* SnippetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsScreen.swift; sourceTree = "<group>"; };
+		6F83C6B5AADBD1950F8484F2 /* ActionChainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionChainCoordinator.swift; sourceTree = "<group>"; };
 		71B96B69CB4E52319BB3EC7D /* FileSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchService.swift; sourceTree = "<group>"; };
 		72DF1178CD8AD726AC6F9874 /* CalculatorCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCardView.swift; sourceTree = "<group>"; };
 		72F0F0DDA5FC1F6ED59E73E9 /* DoubleTapModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTapModifier.swift; sourceTree = "<group>"; };
@@ -849,11 +857,13 @@
 		E8E97E59C7338458DB797507 /* QuickActionPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionPanelState.swift; sourceTree = "<group>"; };
 		E9AEDF156B61DD90C5ADA8FA /* FallbackActionsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackActionsMenu.swift; sourceTree = "<group>"; };
 		E9D41B9E6F2C617D28C83AFF /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
+		EA1BC6473BA115DD053BFFB2 /* ActionChainsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionChainsSettingsView.swift; sourceTree = "<group>"; };
 		EA9A0079D05A5D9B21A1CFCE /* FocusRelease.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusRelease.swift; sourceTree = "<group>"; };
 		EAC662BDA6856590DCF96B94 /* AIChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatState.swift; sourceTree = "<group>"; };
 		EB76FDBFE1E306C2A5B1A29B /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
 		EC2EF66267B0141279A43613 /* SnippetsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsSettingsView.swift; sourceTree = "<group>"; };
 		ED5AAA98FFF7A4D34D7B490D /* ExtensionBootConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionBootConfig.swift; sourceTree = "<group>"; };
+		ED950DF9F71B7284BBEC2517 /* ActionChainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionChainStore.swift; sourceTree = "<group>"; };
 		EEAFF79E9897975CAC5EAC0E /* NoteEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorView.swift; sourceTree = "<group>"; };
 		F023729C84682E9231F3D73B /* ExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstaller.swift; sourceTree = "<group>"; };
 		F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
@@ -1297,6 +1307,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		5C672A46EC748B793FBA120A /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				EA1BC6473BA115DD053BFFB2 /* ActionChainsSettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		5DCDC77D6BA32FC905DA30CF /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -1520,6 +1538,16 @@
 			path = Snippets;
 			sourceTree = "<group>";
 		};
+		7DC3DBC8CB24C0E309206C5F /* ActionChains */ = {
+			isa = PBXGroup;
+			children = (
+				E5E8B5B10060833BDAFC7B85 /* Model */,
+				5C672A46EC748B793FBA120A /* Settings */,
+				EE6E0A6A31321FC710FF4FB6 /* UI */,
+			);
+			path = ActionChains;
+			sourceTree = "<group>";
+		};
 		7DE06EE636C14E50EE172D9E /* Launcher */ = {
 			isa = PBXGroup;
 			children = (
@@ -1650,6 +1678,7 @@
 		95CA98985928A88B33F82556 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				7DC3DBC8CB24C0E309206C5F /* ActionChains */,
 				87070A80E9E3AB3E4B0A9E54 /* AI */,
 				4852DB90D637B9D8E0B2556C /* Backup */,
 				356F452DB0F8F9834817455B /* Calculator */,
@@ -2078,6 +2107,16 @@
 			path = TextInjection;
 			sourceTree = "<group>";
 		};
+		E5E8B5B10060833BDAFC7B85 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				6788BE562713F91C6A88ADD8 /* ActionChain.swift */,
+				55D96E88D2DF38B707E19F74 /* ActionChainRunner.swift */,
+				ED950DF9F71B7284BBEC2517 /* ActionChainStore.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		E98B3DB43012A362EF8DAE1D /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -2124,6 +2163,14 @@
 				DF0880635E294D9DF55BAADA /* CustomCommand.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		EE6E0A6A31321FC710FF4FB6 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				6F83C6B5AADBD1950F8484F2 /* ActionChainCoordinator.swift */,
+			);
+			path = UI;
 			sourceTree = "<group>";
 		};
 		F02431EE95C114090BDD07B2 /* Model */ = {
@@ -2310,6 +2357,11 @@
 				F4A75F90028F57D6DC1EF7DB /* ASCIIKeyboardLayout.swift in Sources */,
 				540F1433DC46BC97C9F80E06 /* AboutView.swift in Sources */,
 				CD04C9CA00C002C0EC82756A /* AccessibilityText.swift in Sources */,
+				89866A1DF292EA983CEB725F /* ActionChain.swift in Sources */,
+				D7B488256FCECBCC1E9A0117 /* ActionChainCoordinator.swift in Sources */,
+				A372BACAE14692AF90441ED4 /* ActionChainRunner.swift in Sources */,
+				C2821C371ABDC82A0DE97BAE /* ActionChainStore.swift in Sources */,
+				58C5F954B083852569BED9C1 /* ActionChainsSettingsView.swift in Sources */,
 				16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */,
 				D68E7585496722BEC72E788C /* AliasStore.swift in Sources */,
 				EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -10,6 +10,7 @@ final class AppCore {
     let appIndex: AppIndex
     let customCommands = CustomCommandStore()
     let quicklinks = QuicklinkStore()
+    let actionChains = ActionChainStore()
     let clipboardStore = ClipboardStore()
     let clipboardManager: ClipboardManager
     let snippetsStore: SnippetsStore
@@ -98,6 +99,9 @@ final class AppCore {
         paletteCoordinator: paletteCoordinator, settingsCoordinator: settingsCoordinator,
         hotKeys: hotKeys, favorites: favorites, visibility: visibility,
         ranking: launcherRanking, aliases: aliases, activationPolicy: activationPolicy, core: self)
+    @ObservationIgnored private(set) lazy var actionChainCoordinator = ActionChainCoordinator(
+        store: actionChains, appIndex: appIndex, hotKeys: hotKeys, favorites: favorites,
+        visibility: visibility, ranking: launcherRanking, core: self)
     @ObservationIgnored private(set) lazy var notesCoordinator = NotesCoordinator(
         store: notesStore,
         settings: settings,
@@ -209,6 +213,10 @@ final class AppCore {
             // Before `hotKeys.start` even when off: the prune reads it. docs/features/quicklinks.md
             quicklinks.load()
             quicklinkCoordinator.applyQuicklinksPresence()
+            actionChains.onChange = { [weak self] _ in
+                self?.actionChainCoordinator.applyActionChainsPresence()
+            }
+            actionChainCoordinator.applyActionChainsPresence()
             updateCoordinator.applyEnabled()
             calendarCoordinator.applyEnabled()
             Task { await appIndex.refresh() }
@@ -239,6 +247,9 @@ final class AppCore {
             hotKeys.onOpenQuicklink = { [weak self] id in
                 self?.quicklinkCoordinator.openQuicklink(id: id)
             }
+            hotKeys.onRunActionChain = { [weak self] id in
+                self?.actionChainCoordinator.runActionChain(id: id)
+            }
             hotKeys.onRunExtensionCommand = { [weak self] entryID in
                 self?.extensionCoordinator.runExtensionCommand(entryID: entryID)
             }
@@ -261,7 +272,8 @@ final class AppCore {
             }
             hotKeys.start(
                 customCommandIDs: Set(customCommands.commands.map(\.id)),
-                quicklinkIDs: Set(quicklinks.quicklinks.map(\.id)))
+                quicklinkIDs: Set(quicklinks.quicklinks.map(\.id)),
+                actionChainIDs: Set(actionChains.chains.map(\.id)))
             // Keeps running while Carbon pauses: the recorder needs its rewritten flags.
             hyperKeyTap.start(settings: settings)
 
@@ -321,6 +333,8 @@ final class AppCore {
             return customCommands.command(id: id)?.name
         case .quicklink(let id):
             return quicklinks.quicklink(id: id)?.name
+        case .actionChain(let id):
+            return actionChains.chain(id: id)?.name
         case .extensionCommand(let entryID):
             return appIndex.apps.first { $0.kind == .extensionCommand && $0.id == entryID }?.name
         case .togglePalette, .command, .systemAction, .windowCommand:

--- a/Tinycast/Features/ActionChains/Model/ActionChain.swift
+++ b/Tinycast/Features/ActionChains/Model/ActionChain.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A named sequence of existing Tinycast actions.
+struct ActionChain: Codable, Hashable, Identifiable, Sendable {
+    static let entryIDPrefix = "action-chain:"
+    static let sfSymbol = "point.3.connected.trianglepath.dotted"
+
+    let id: UUID
+    var name: String
+    var steps: [ActionChainStep]
+
+    init(id: UUID = UUID(), name: String, steps: [ActionChainStep]) {
+        self.id = id
+        self.name = name
+        self.steps = steps
+    }
+
+    var entryID: String { Self.entryIDPrefix + id.uuidString.lowercased() }
+
+    static func id(fromEntryID entryID: String) -> UUID? {
+        guard entryID.hasPrefix(entryIDPrefix) else { return nil }
+        return UUID(uuidString: String(entryID.dropFirst(entryIDPrefix.count)))
+    }
+}
+
+/// A persisted reference to an action that can run without typed input.
+enum ActionChainStep: Codable, Hashable, Sendable {
+    case application(bundleID: String)
+    case systemAction(id: String)
+    case windowCommand(id: String)
+    case customCommand(id: UUID)
+    case quicklink(id: UUID)
+}
+
+enum ActionChainFailure: Error, Sendable {
+    case unavailable
+}

--- a/Tinycast/Features/ActionChains/Model/ActionChainRunner.swift
+++ b/Tinycast/Features/ActionChains/Model/ActionChainRunner.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum ActionChainRunResult: Equatable, Sendable {
+    case completed
+    case failed(step: ActionChainStep)
+}
+
+/// Runs one chain serially and never starts a step after a failure.
+@MainActor
+enum ActionChainRunner {
+    static func run(
+        _ chain: ActionChain, perform: (ActionChainStep) async throws -> Void
+    ) async -> ActionChainRunResult {
+        for step in chain.steps {
+            do {
+                try await perform(step)
+            } catch {
+                return .failed(step: step)
+            }
+        }
+        return .completed
+    }
+}

--- a/Tinycast/Features/ActionChains/Model/ActionChainStore.swift
+++ b/Tinycast/Features/ActionChains/Model/ActionChainStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+enum ActionChainValidationError: LocalizedError {
+    case emptyName
+    case emptySteps
+    case duplicateName
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName: return "Enter a name for the action chain."
+        case .emptySteps: return "Add at least one action."
+        case .duplicateName: return "An action chain with this name already exists."
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class ActionChainStore {
+    private static let defaultsKey = "actionChains"
+
+    private let defaults: UserDefaults
+    private(set) var chains: [ActionChain]
+    @ObservationIgnored var onChange: (([ActionChain]) -> Void)?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        chains =
+            defaults.data(forKey: Self.defaultsKey)
+            .flatMap { try? JSONDecoder().decode([ActionChain].self, from: $0) } ?? []
+    }
+
+    func chain(id: UUID) -> ActionChain? { chains.first { $0.id == id } }
+
+    @discardableResult
+    func add(_ draft: ActionChain) throws -> ActionChain {
+        let value = try validated(draft)
+        commit(chains + [value])
+        return value
+    }
+
+    func update(_ draft: ActionChain) throws {
+        guard let index = chains.firstIndex(where: { $0.id == draft.id }) else { return }
+        var updated = chains
+        updated[index] = try validated(draft)
+        commit(updated)
+    }
+
+    func remove(id: UUID) {
+        guard let index = chains.firstIndex(where: { $0.id == id }) else { return }
+        var updated = chains
+        updated.remove(at: index)
+        commit(updated)
+    }
+
+    @discardableResult
+    func replace(with incoming: [ActionChain]) -> Int {
+        var accepted: [ActionChain] = []
+        for chain in incoming {
+            guard let value = try? validated(chain, among: accepted) else { continue }
+            accepted.append(value)
+        }
+        commit(accepted)
+        return accepted.count
+    }
+
+    private func validated(_ draft: ActionChain) throws -> ActionChain {
+        try validated(draft, among: chains)
+    }
+
+    private func validated(_ draft: ActionChain, among existing: [ActionChain]) throws -> ActionChain {
+        var value = draft
+        value.name = value.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.name.isEmpty else { throw ActionChainValidationError.emptyName }
+        guard !value.steps.isEmpty else { throw ActionChainValidationError.emptySteps }
+        guard
+            !existing.contains(where: {
+                $0.id != value.id && $0.name.localizedCaseInsensitiveCompare(value.name) == .orderedSame
+            })
+        else { throw ActionChainValidationError.duplicateName }
+        return value
+    }
+
+    private func commit(_ updated: [ActionChain]) {
+        chains = updated.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        defaults.set(try? JSONEncoder().encode(chains), forKey: Self.defaultsKey)
+        onChange?(chains)
+    }
+}

--- a/Tinycast/Features/ActionChains/Settings/ActionChainsSettingsView.swift
+++ b/Tinycast/Features/ActionChains/Settings/ActionChainsSettingsView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+/// The small library editor for named, reusable action sequences.
+struct ActionChainsSettingsView: View {
+    @Environment(ActionChainStore.self) private var store
+    @Environment(AppCore.self) private var core
+    @State private var editor: ActionChainEditorTarget?
+    @State private var pendingDeletion: ActionChain?
+
+    var body: some View {
+        Form {
+            Section {
+                if store.chains.isEmpty {
+                    Text("Add a chain to run several existing actions from one launcher row or shortcut.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(store.chains) { chain in
+                        ActionChainSettingsRow(
+                            chain: chain,
+                            onEdit: { editor = ActionChainEditorTarget(chain: chain) },
+                            onDelete: { pendingDeletion = chain })
+                    }
+                }
+                Button("Add Action Chain…") { editor = ActionChainEditorTarget(chain: nil) }
+            } header: {
+                Text("Action Chains")
+            } footer: {
+                Text("Steps run in order. A missing or ineligible step stops the chain.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .sheet(item: $editor) { target in ActionChainEditorSheet(chain: target.chain) }
+        .alert(item: $pendingDeletion) { chain in
+            Alert(
+                title: Text("Delete “\(chain.name)”?"),
+                message: Text("Its global shortcut and launcher references will also be removed."),
+                primaryButton: .destructive(Text("Delete")) {
+                    core.actionChainCoordinator.deleteActionChain(id: chain.id)
+                },
+                secondaryButton: .cancel())
+        }
+    }
+}
+
+private struct ActionChainEditorTarget: Identifiable {
+    let id = UUID()
+    let chain: ActionChain?
+}
+
+private struct ActionChainSettingsRow: View {
+    let chain: ActionChain
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        SettingsRow(title: chain.name, subtitle: "\(chain.steps.count) actions") {
+            Image(systemName: ActionChain.sfSymbol)
+        } trailing: {
+            ShortcutRecorder(action: .actionChain(id: chain.id))
+            Button(action: onEdit) { Image(systemName: "pencil") }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Edit \(chain.name)")
+            Button(action: onDelete) { Image(systemName: "trash").foregroundStyle(.red) }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Delete \(chain.name)")
+        }
+    }
+}
+
+private struct ActionChainEditorSheet: View {
+    @Environment(AppCore.self) private var core
+    @Environment(ActionChainStore.self) private var store
+    @Environment(\.dismiss) private var dismiss
+    let chain: ActionChain?
+    @State private var name = ""
+    @State private var steps: [ActionChainStep] = []
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+            Text(chain == nil ? "Add Action Chain" : "Edit Action Chain")
+                .font(.title2.weight(.semibold))
+            TextField("Name", text: $name)
+            List {
+                ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                    HStack {
+                        Text(step.label(apps: applications, commands: commands, quicklinks: quicklinks))
+                        Spacer()
+                        Button {
+                            steps.remove(at: index)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .onMove { steps.move(fromOffsets: $0, toOffset: $1) }
+            }
+            .frame(minHeight: 140)
+            Menu("Add Action") {
+                Menu("Application") {
+                    ForEach(applications) { app in
+                        Button(app.name) { steps.append(.application(bundleID: app.bundleID!)) }
+                    }
+                }
+                Menu("System Action") {
+                    ForEach(SystemAction.ID.allCases, id: \.self) { id in
+                        let action = SystemActionCatalog.action(id: id)
+                        if case .none = action.confirmation {
+                            Button(action.name) { steps.append(.systemAction(id: id.rawValue)) }
+                        }
+                    }
+                }
+                Menu("Window Command") {
+                    ForEach(WindowCommand.ID.allCases, id: \.self) { id in
+                        if SpaceDirection(id) == nil {
+                            Button(WindowCommandCatalog.command(id: id)?.name ?? id.rawValue) {
+                                steps.append(.windowCommand(id: id.rawValue))
+                            }
+                        }
+                    }
+                }
+                Menu("Custom Command") {
+                    ForEach(
+                        commands.filter {
+                            $0.isEnabled && $0.arguments.isEmpty && !$0.requiresConfirmation
+                        }
+                    ) { command in
+                        Button(command.name) { steps.append(.customCommand(id: command.id)) }
+                    }
+                }
+                Menu("Quicklink") {
+                    ForEach(
+                        quicklinks.filter {
+                            $0.isEnabled && !QuicklinkDestination.containsPlaceholder($0.link)
+                        }
+                    ) { quicklink in
+                        Button(quicklink.name) { steps.append(.quicklink(id: quicklink.id)) }
+                    }
+                }
+            }
+            if let error { Text(error).foregroundStyle(.red) }
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save", action: save).buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(Theme.Spacing.xl)
+        .frame(width: 460)
+        .onAppear {
+            name = chain?.name ?? ""
+            steps = chain?.steps ?? []
+        }
+    }
+
+    private var applications: [AppEntry] {
+        core.appIndex.apps.filter { $0.kind == .application && $0.bundleID != nil }
+    }
+
+    private var commands: [CustomCommand] { core.customCommands.commands }
+    private var quicklinks: [Quicklink] { core.quicklinks.quicklinks }
+
+    private func save() {
+        do {
+            let value = ActionChain(id: chain?.id ?? UUID(), name: name, steps: steps)
+            if chain == nil {
+                _ = try core.actionChainCoordinator.addActionChain(value)
+            } else {
+                try core.actionChainCoordinator.updateActionChain(value)
+            }
+            dismiss()
+        } catch { self.error = error.localizedDescription }
+    }
+}
+
+private extension ActionChainStep {
+    func label(apps: [AppEntry], commands: [CustomCommand], quicklinks: [Quicklink]) -> String {
+        switch self {
+        case .application(let bundleID):
+            return apps.first { $0.bundleID == bundleID }?.name ?? "Missing application"
+        case .systemAction(let id):
+            return SystemAction.ID(rawValue: id).map { SystemActionCatalog.action(id: $0).name }
+                ?? "Missing system action"
+        case .windowCommand(let id):
+            return WindowCommand.ID(rawValue: id).flatMap { WindowCommandCatalog.command(id: $0)?.name }
+                ?? "Missing window command"
+        case .customCommand(let id): return commands.first { $0.id == id }?.name ?? "Missing custom command"
+        case .quicklink(let id): return quicklinks.first { $0.id == id }?.name ?? "Missing quicklink"
+        }
+    }
+}

--- a/Tinycast/Features/ActionChains/UI/ActionChainCoordinator.swift
+++ b/Tinycast/Features/ActionChains/UI/ActionChainCoordinator.swift
@@ -1,0 +1,135 @@
+import AppKit
+
+/// Owns the library and one serial execution funnel for action chains.
+@MainActor
+final class ActionChainCoordinator {
+    private let store: ActionChainStore
+    private let appIndex: AppIndex
+    private let hotKeys: HotKeyManager
+    private let favorites: FavoritesStore
+    private let visibility: VisibilityStore
+    private let ranking: LauncherRankingStore
+    private unowned let core: AppCore
+    private var isRunning = false
+
+    init(
+        store: ActionChainStore, appIndex: AppIndex, hotKeys: HotKeyManager,
+        favorites: FavoritesStore, visibility: VisibilityStore, ranking: LauncherRankingStore,
+        core: AppCore
+    ) {
+        self.store = store
+        self.appIndex = appIndex
+        self.hotKeys = hotKeys
+        self.favorites = favorites
+        self.visibility = visibility
+        self.ranking = ranking
+        self.core = core
+    }
+
+    func applyActionChainsPresence() { appIndex.setActionChains(store.chains) }
+
+    func runActionChain(id: UUID) {
+        guard let chain = store.chain(id: id), !isRunning else { return }
+        isRunning = true
+        let target = core.paletteCoordinator.targetApp
+        if core.paletteCoordinator.isVisible { core.paletteCoordinator.hidePalette(restoreFocus: false) }
+        Task {
+            defer { isRunning = false }
+            let result = await ActionChainRunner.run(chain) { [weak self] step in
+                guard let self else { throw ActionChainFailure.unavailable }
+                try await self.perform(step, target: target)
+            }
+            guard case .failed(let step) = result else { return }
+            await core.showNotice(
+                title: "“\(chain.name)” Stopped", message: "\(step.title) is no longer available.",
+                symbol: ActionChain.sfSymbol, tone: .danger)
+        }
+    }
+
+    @discardableResult
+    func addActionChain(_ draft: ActionChain) throws -> ActionChain { try store.add(draft) }
+
+    func updateActionChain(_ draft: ActionChain) throws { try store.update(draft) }
+
+    @discardableResult
+    func replaceActionChains(_ chains: [ActionChain]) -> Int {
+        let previous = Dictionary(uniqueKeysWithValues: store.chains.map { ($0.id, $0) })
+        let count = store.replace(with: chains)
+        let removed = Set(previous.keys).subtracting(store.chains.map(\.id))
+        removeActionChainReferences(
+            ids: removed, entryIDs: Set(removed.compactMap { previous[$0]?.entryID }))
+        return count
+    }
+
+    func deleteActionChain(id: UUID) {
+        guard let chain = store.chain(id: id) else { return }
+        store.remove(id: id)
+        removeActionChainReferences(ids: [id], entryIDs: [chain.entryID])
+    }
+
+    private func removeActionChainReferences(ids: Set<UUID>, entryIDs: Set<String>) {
+        for id in ids {
+            let action = HotKeyAction.actionChain(id: id)
+            if hotKeys.recordingAction == action { hotKeys.recordingAction = nil }
+            hotKeys.setBinding(nil, for: action)
+        }
+        favorites.remove(keys: entryIDs)
+        visibility.removeItemKeys(entryIDs)
+        for entryID in entryIDs { ranking.reset(itemKey: entryID) }
+    }
+
+    private func perform(_ step: ActionChainStep, target: NSRunningApplication?) async throws {
+        switch step {
+        case .application(let bundleID):
+            guard
+                let app = appIndex.apps.first(where: {
+                    $0.kind == .application && $0.bundleID == bundleID
+                })
+            else { throw ActionChainFailure.unavailable }
+            AppLauncher.launch(app.url)
+        case .systemAction(let rawID):
+            guard let id = SystemAction.ID(rawValue: rawID),
+                SystemActionCatalog.action(id: id).confirmation == .none
+            else { throw ActionChainFailure.unavailable }
+            _ = try await SystemActionRunner.run(
+                id, previousApp: target)
+        case .windowCommand(let rawID):
+            guard let id = WindowCommand.ID(rawValue: rawID),
+                core.settings.windowManagementEnabled
+                    && SpaceDirection(id) == nil
+            else { throw ActionChainFailure.unavailable }
+            guard
+                core.windowMover.perform(
+                    id, target: target, gap: CGFloat(core.settings.windowGap),
+                    cycleOnRepeat: core.settings.windowCycleOnRepeat)
+            else { throw ActionChainFailure.unavailable }
+        case .customCommand(let id):
+            guard let command = core.customCommands.command(id: id), command.isEnabled,
+                command.arguments.isEmpty, !command.requiresConfirmation
+            else { throw ActionChainFailure.unavailable }
+            let result = await ShellCommandRunner.run(
+                command.command, loadingShellEnvironment: command.loadsShellEnvironment,
+                workingDirectory: command.workingDirectory)
+            guard result.succeeded else { throw ActionChainFailure.unavailable }
+        case .quicklink(let id):
+            guard let quicklink = core.quicklinks.quicklink(id: id), quicklink.isEnabled,
+                !QuicklinkDestination.containsPlaceholder(quicklink.link)
+            else { throw ActionChainFailure.unavailable }
+            try await QuicklinkLauncher.open(
+                quicklink.link, openWithBundleID: quicklink.openWithBundleID,
+                inNewWindow: core.settings.quicklinkOpensNewWindow)
+        }
+    }
+}
+
+extension ActionChainStep {
+    var title: String {
+        switch self {
+        case .application: return "Application"
+        case .systemAction: return "System action"
+        case .windowCommand: return "Window command"
+        case .customCommand: return "Custom command"
+        case .quicklink: return "Quicklink"
+        }
+    }
+}

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -7,6 +7,7 @@ struct SettingsBackup: Codable {
     var hotkeys: HotkeyBackup?
     var customCommands: [CustomCommand]?
     var quicklinks: [Quicklink]?
+    var actionChains: [ActionChain]?
     var favoriteApps: [String]?
     var hiddenLauncherItems: [String]?
     var hiddenLauncherKinds: [String]?
@@ -76,6 +77,7 @@ struct SettingsBackup: Codable {
         var systemActions: [String: HotKeyBinding]?
         var windowCommands: [String: HotKeyBinding]?
         var quicklinks: [String: HotKeyBinding]?
+        var actionChains: [String: HotKeyBinding]?
     }
 
     /// A tally of what an import touched, for user-facing confirmation.
@@ -87,6 +89,7 @@ struct SettingsBackup: Codable {
         var aliases = 0
         var customCommands = 0
         var quicklinks = 0
+        var actionChains = 0
     }
 }
 
@@ -171,10 +174,15 @@ extension SettingsBackup {
             uniqueKeysWithValues: hk.boundQuicklinkIDs.compactMap { id in
                 hk.binding(for: .quicklink(id: id)).map { (id.uuidString.lowercased(), $0) }
             })
+        hotkeys.actionChains = Dictionary(
+            uniqueKeysWithValues: hk.boundActionChainIDs.compactMap { id in
+                hk.binding(for: .actionChain(id: id)).map { (id.uuidString.lowercased(), $0) }
+            })
         backup.hotkeys = hotkeys
 
         backup.customCommands = core.customCommands.commands
         backup.quicklinks = core.quicklinks.quicklinks
+        backup.actionChains = core.actionChains.chains
         backup.favoriteApps = core.favorites.keys
         backup.hiddenLauncherItems = Array(core.visibility.hiddenItemKeys)
         backup.hiddenLauncherKinds = Array(core.visibility.disabledKinds)
@@ -192,6 +200,9 @@ extension SettingsBackup {
         // Before the hotkeys, so a restored binding has its quicklink to attach to.
         if let quicklinks {
             summary.quicklinks = core.quicklinkCoordinator.replaceQuicklinks(quicklinks)
+        }
+        if let actionChains {
+            summary.actionChains = core.actionChainCoordinator.replaceActionChains(actionChains)
         }
         if let hotkeys { summary.hotkeys = applyHotkeys(hotkeys, to: core) }
         if let favoriteApps {
@@ -417,6 +428,12 @@ extension SettingsBackup {
                 continue
             }
             apply(b, .quicklink(id: id))
+        }
+        for (rawID, b) in hotkeys.actionChains ?? [:] {
+            guard let id = UUID(uuidString: rawID), core.actionChains.chain(id: id) != nil else {
+                continue
+            }
+            apply(b, .actionChain(id: id))
         }
         return count
     }

--- a/Tinycast/Features/Backup/Service/BackupActions.swift
+++ b/Tinycast/Features/Backup/Service/BackupActions.swift
@@ -247,6 +247,7 @@ enum BackupActions {
         if s.aliases > 0 { parts.append("\(s.aliases) aliases") }
         if s.customCommands > 0 { parts.append("\(s.customCommands) custom commands") }
         if s.quicklinks > 0 { parts.append("\(s.quicklinks) quicklinks") }
+        if s.actionChains > 0 { parts.append("\(s.actionChains) action chains") }
         guard !parts.isEmpty else { return nil }
         return "Applied " + parts.joined(separator: ", ") + "."
     }

--- a/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
+++ b/Tinycast/Features/HotKeys/Model/HotKeyAction.swift
@@ -12,6 +12,7 @@ enum HotKeyAction: Hashable, Sendable {
     case systemAction(id: SystemAction.ID)
     case windowCommand(id: WindowCommand.ID)
     case quicklink(id: UUID)
+    case actionChain(id: UUID)
     /// Keyed by `AppEntry.id`, which is what survives a reinstall of the extension.
     case extensionCommand(entryID: String)
 
@@ -26,6 +27,7 @@ enum HotKeyAction: Hashable, Sendable {
         case .systemAction(let id): "hotkey.systemAction." + id.rawValue
         case .windowCommand(let id): "hotkey.windowCommand." + id.rawValue
         case .quicklink(let id): "hotkey.quicklink." + id.uuidString.lowercased()
+        case .actionChain(let id): "hotkey.actionChain." + id.uuidString.lowercased()
         case .extensionCommand(let entryID): "hotkey.extensionCommand." + entryID
         }
     }

--- a/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
+++ b/Tinycast/Features/HotKeys/Service/HotKeyManager.swift
@@ -11,6 +11,7 @@ final class HotKeyManager {
     var onRunSystemAction: ((SystemAction.ID) -> Void)?
     var onRunWindowCommand: ((WindowCommand.ID) -> Void)?
     var onOpenQuicklink: ((UUID) -> Void)?
+    var onRunActionChain: ((UUID) -> Void)?
     var onRunExtensionCommand: ((String) -> Void)?
     /// Names what only the stores know; the fixed catalogs resolve here. Set in `AppCore.start()`.
     var displayName: ((HotKeyAction) -> String?)?
@@ -48,11 +49,13 @@ final class HotKeyManager {
     private let boundPaneKey = "boundPaneBundleIDs"
     private let boundCustomCommandKey = "boundCustomCommandIDs"
     private let boundQuicklinkKey = "boundQuicklinkIDs"
+    private let boundActionChainKey = "boundActionChainIDs"
     private let boundExtensionCommandKey = "boundExtensionCommandEntryIDs"
 
-    func start(customCommandIDs: Set<UUID>, quicklinkIDs: Set<UUID>) {
+    func start(customCommandIDs: Set<UUID>, quicklinkIDs: Set<UUID>, actionChainIDs: Set<UUID>) {
         prune(key: boundCustomCommandKey, live: customCommandIDs) { .customCommand(id: $0) }
         prune(key: boundQuicklinkKey, live: quicklinkIDs) { .quicklink(id: $0) }
+        prune(key: boundActionChainKey, live: actionChainIDs) { .actionChain(id: $0) }
         // After the prunes, so a dropped record can't survive in memory this session.
         for action in candidateActions { bindings[action] = storedBinding(for: action) }
 
@@ -87,6 +90,8 @@ final class HotKeyManager {
 
     /// Quicklink UUIDs with a binding — the same index, its own namespace.
     var boundQuicklinkIDs: [UUID] { boundIDs(key: boundQuicklinkKey) }
+
+    var boundActionChainIDs: [UUID] { boundIDs(key: boundActionChainKey) }
 
     func binding(for action: HotKeyAction) -> HotKeyBinding? { bindings[action] }
 
@@ -129,6 +134,8 @@ final class HotKeyManager {
             index(id, bound: binding != nil, key: boundCustomCommandKey)
         case .quicklink(let id):
             index(id, bound: binding != nil, key: boundQuicklinkKey)
+        case .actionChain(let id):
+            index(id, bound: binding != nil, key: boundActionChainKey)
         case .extensionCommand(let entryID):
             var set = Set(boundExtensionCommandEntryIDs)
             if binding == nil { set.remove(entryID) } else { set.insert(entryID) }
@@ -173,6 +180,7 @@ final class HotKeyManager {
         actions += boundPaneBundleIDs.map { .settingsPane(bundleID: $0) }
         actions += boundCustomCommandIDs.map { .customCommand(id: $0) }
         actions += boundQuicklinkIDs.map { .quicklink(id: $0) }
+        actions += boundActionChainIDs.map { .actionChain(id: $0) }
         actions += boundExtensionCommandEntryIDs.map { .extensionCommand(entryID: $0) }
         actions += SystemAction.ID.allCases.map { .systemAction(id: $0) }
         actions += WindowCommand.ID.allCases.map { .windowCommand(id: $0) }
@@ -196,6 +204,8 @@ final class HotKeyManager {
             return WindowCommandCatalog.command(id: id)?.name ?? "Window Command"
         case .quicklink:
             return displayName?(action) ?? "Quicklink"
+        case .actionChain:
+            return displayName?(action) ?? "Action Chain"
         case .extensionCommand:
             return displayName?(action) ?? "Extension Command"
         }
@@ -231,6 +241,7 @@ final class HotKeyManager {
         case .systemAction(let id): onRunSystemAction?(id)
         case .windowCommand(let id): onRunWindowCommand?(id)
         case .quicklink(let id): onOpenQuicklink?(id)
+        case .actionChain(let id): onRunActionChain?(id)
         case .extensionCommand(let entryID): onRunExtensionCommand?(entryID)
         }
     }

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -10,6 +10,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
         case systemAction
         case windowCommand
         case quicklink
+        case actionChain
         case extensionCommand
         case meeting
 
@@ -47,6 +48,10 @@ struct AppEntry: Identifiable, Hashable, Sendable {
                 return KindDescriptor(
                     label: "Quicklink", sectionTitle: "Quicklinks",
                     openVerb: "Open Quicklink", canRevealInFinder: false, isSymbolIcon: true)
+            case .actionChain:
+                return KindDescriptor(
+                    label: "Action Chain", sectionTitle: "Action Chains",
+                    openVerb: "Run Action Chain", canRevealInFinder: false, isSymbolIcon: true)
             case .extensionCommand:
                 // The label is per-entry, the owning extension's title; this is the fallback.
                 return KindDescriptor(
@@ -119,6 +124,8 @@ struct AppEntry: Identifiable, Hashable, Sendable {
             return WindowCommandCatalog.command(forEntryID: id).map { .windowCommand(id: $0.id) }
         case .quicklink:
             return Quicklink.id(fromEntryID: id).map { .quicklink(id: $0) }
+        case .actionChain:
+            return ActionChain.id(fromEntryID: id).map { .actionChain(id: $0) }
         case .snippet, .extensionCommand, .meeting:
             return nil
         }
@@ -139,6 +146,7 @@ struct AppEntry: Identifiable, Hashable, Sendable {
     private var kindSymbol: String {
         switch kind {
         case .quicklink: return Quicklink.sfSymbol
+        case .actionChain: return ActionChain.sfSymbol
         case .snippet: return "text.quote"
         case .customCommand: return CustomCommand.sfSymbol
         case .command: return CommandCatalog.command(for: self)?.sfSymbol ?? "questionmark"
@@ -191,6 +199,7 @@ final class AppIndex {
     private(set) var apps: [AppEntry] = []
 
     private var snippetEntries: [AppEntry] = []
+    private var actionChainEntries: [AppEntry] = []
 
     private struct MatchKey: Equatable {
         let query: String
@@ -298,6 +307,18 @@ final class AppIndex {
             .map(AppEntry.init)
         guard entries != quicklinkEntries else { return }
         quicklinkEntries = entries
+        publishEntries()
+    }
+
+    func setActionChains(_ chains: [ActionChain]) {
+        let entries = chains.map { chain in
+            AppEntry(
+                id: chain.entryID, name: chain.name,
+                url: URL(string: "tinycast://action-chain/" + chain.id.uuidString)!,
+                bundleID: nil, kind: .actionChain, symbolName: ActionChain.sfSymbol)
+        }
+        guard entries != actionChainEntries else { return }
+        actionChainEntries = entries
         publishEntries()
     }
 
@@ -427,7 +448,8 @@ final class AppIndex {
     private func publishEntries() {
         // Each slice arrives in its own display order; the slice order is the section order.
         let updated =
-            meetingEntries + discoveredEntries + extensionEntries + quicklinkEntries + snippetEntries
+            meetingEntries + discoveredEntries + extensionEntries + quicklinkEntries + actionChainEntries
+            + snippetEntries
             + Self.systemActionEntries + windowCommandEntries + customCommandEntries
             + commandEntries
         guard updated != apps else { return }

--- a/Tinycast/Features/Launcher/Service/VisibilityStore.swift
+++ b/Tinycast/Features/Launcher/Service/VisibilityStore.swift
@@ -71,7 +71,8 @@ final class VisibilityStore {
         case .settingsPane: isKindEnabled(.systemSettings)
         case .systemAction: isKindEnabled(.systemAction)
         case .command: isKindEnabled(.command)
-        case .togglePalette, .customCommand, .windowCommand, .quicklink, .extensionCommand:
+        case .togglePalette, .customCommand, .windowCommand, .quicklink, .actionChain,
+            .extensionCommand:
             true
         }
     }

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -79,6 +79,11 @@ final class LauncherCoordinator {
             customCommandCoordinator.runCustomCommand(id: id)
             return
         }
+        if app.kind == .actionChain {
+            guard let id = ActionChain.id(fromEntryID: app.id) else { return }
+            core.actionChainCoordinator.runActionChain(id: id)
+            return
+        }
         if app.kind == .systemAction {
             guard let action = SystemActionCatalog.action(forEntryID: app.id) else { return }
             systemActionCoordinator.runSystemAction(id: action.id)
@@ -116,7 +121,7 @@ final class LauncherCoordinator {
         case .snippet:
             let snippetID = String(app.id.dropFirst("snippet:".count))
             snippetCoordinator.expandSnippet(id: snippetID, targetApp: previous)
-        case .command, .customCommand, .systemAction, .windowCommand, .quicklink,
+        case .command, .customCommand, .systemAction, .windowCommand, .quicklink, .actionChain,
             .extensionCommand, .meeting:
             break  // handled above
         }

--- a/Tinycast/Features/Settings/SettingsCoordinator.swift
+++ b/Tinycast/Features/Settings/SettingsCoordinator.swift
@@ -44,6 +44,7 @@ final class SettingsCoordinator {
             .environment(core.aliases)
             .environment(core.fallbacks)
             .environment(core.customCommands)
+            .environment(core.actionChains)
             .environment(core.snippetsStore)
             .environment(core.quicklinks)
             .environment(core.calendarStore)

--- a/Tinycast/Features/Settings/SettingsDetailView.swift
+++ b/Tinycast/Features/Settings/SettingsDetailView.swift
@@ -14,6 +14,7 @@ struct SettingsDetailView: View {
             case .systemActions: SystemActionsSettingsView()
             case .commands: CommandsSettingsView()
             case .quicklinks: QuicklinksSettingsView()
+            case .actionChains: ActionChainsSettingsView()
             case .fallbacks: FallbacksSettingsView()
             case .ai: AISettingsView()
             case .quickActions: QuickActionsSettingsView()

--- a/Tinycast/Features/Settings/SettingsTab.swift
+++ b/Tinycast/Features/Settings/SettingsTab.swift
@@ -1,5 +1,6 @@
 enum SettingsTab: CaseIterable, Identifiable {
-    case general, applications, systemSettings, systemActions, commands, quicklinks, fallbacks, ai,
+    case general, applications, systemSettings, systemActions, commands, quicklinks, actionChains, fallbacks,
+        ai,
         quickActions, fileSearch, notes, snippets, windowManagement, clipboard, emoji, calendar,
         extensions, permissions, backup, about
     /// The case, never an index: a selectable `List` flattens section and row IDs together.
@@ -13,6 +14,7 @@ enum SettingsTab: CaseIterable, Identifiable {
         case .systemActions: return "System Actions"
         case .commands: return "Commands"
         case .quicklinks: return "Quicklinks"
+        case .actionChains: return "Action Chains"
         case .fallbacks: return "Fallbacks"
         case .ai: return "AI"
         case .quickActions: return "Quick Actions"
@@ -38,6 +40,7 @@ enum SettingsTab: CaseIterable, Identifiable {
         case .systemActions: return "bolt"
         case .commands: return "terminal"
         case .quicklinks: return "link"
+        case .actionChains: return "point.3.connected.trianglepath.dotted"
         case .fallbacks: return "arrow.turn.down.right"
         case .ai: return "sparkles"
         case .quickActions: return "wand.and.sparkles"
@@ -76,7 +79,8 @@ enum SettingsSection: CaseIterable, Identifiable {
         case .general: return [.general, .permissions]
         case .launcher:
             return [
-                .applications, .systemSettings, .systemActions, .commands, .quicklinks, .fallbacks
+                .applications, .systemSettings, .systemActions, .commands, .quicklinks, .actionChains,
+                .fallbacks
             ]
         case .features:
             return [

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ open with an `## Invariants` section; read it before changing anything in that a
 [notes](features/notes.md) ·
 [snippets](features/snippets.md) ·
 [quicklinks](features/quicklinks.md) ·
+[action chains](features/action-chains.md) ·
 [hotkeys](features/hotkeys.md) ·
 [window management](features/window-management.md) ·
 [custom commands](features/custom-commands.md) ·

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,7 @@ the shared primitives and system shims every feature draws on. Neither may depen
 
 `AppCore.shared` (`App/AppCore.swift`) is a `@MainActor` singleton owning every long-lived thing in the
 app: the stores (`AppIndex`, `ClipboardStore`, `SnippetsStore`, `QuicklinkStore`, `CustomCommandStore`,
+`ActionChainStore`,
 `FavoritesStore`, `VisibilityStore`, `AliasStore`, `LauncherRankingStore`, `CalculatorHistoryStore`,
 `CurrencyRateStore`, `FrequentEmojiStore`, `CalendarStore`), the managers, monitors and clocks
 (`ClipboardManager`,
@@ -202,7 +203,7 @@ Tinycast/
   Features/
     PaletteRowIndex.swift   the flat selection index — palette-owned, so it sits at the top
     Launcher/ Clipboard/ Calculator/ Calendar/ Emoji/ FileSearch/ Notes/ Quicklinks/ Snippets/
-    Uninstall/ SystemActions/ CustomCommands/ HotKeys/ Backup/ WindowManagement/ Onboarding/
+    Uninstall/ SystemActions/ CustomCommands/ ActionChains/ HotKeys/ Backup/ WindowManagement/ Onboarding/
     Updates/ Support/ AI/ Settings/
     Extensions/
         Model/      pure — the harness inputs

--- a/docs/features/action-chains.md
+++ b/docs/features/action-chains.md
@@ -1,0 +1,31 @@
+# Action Chains
+
+Action Chains are named, ordered sequences of existing Tinycast actions. They appear in launcher
+search and can receive the same global shortcut recorder as other addressable actions.
+
+## Invariants
+
+- A chain stores references, never copied actions: application bundle IDs, fixed action IDs, and the
+  stable UUIDs of custom commands and quicklinks.
+- The runner starts each step only after the preceding step returns. It stops at the first missing or
+  ineligible reference and reports that step to the user.
+- Chains only offer targets that do not require typed input. A custom command with arguments, a
+  templated quicklink, and a system action requiring confirmation remain available on their own rows,
+  but cannot silently acquire input or bypass a confirmation inside a chain.
+- State is one `UserDefaults` JSON value. The feature owns no monitor, timer, task, cache, or launch
+  work, so an unused chain adds no idle CPU or RAM activity.
+- A run is single-flight: a repeated shortcut while a chain is running is ignored. The launcher closes
+  once, and window and system steps keep the app that was active when the chain started as their target.
+  Launching an application does not wait for it to activate, so it cannot be used as a prerequisite for
+  tiling that newly launched app in the same chain.
+
+## Wiring
+
+`ActionChainStore` owns persisted records. `ActionChainCoordinator` projects them into `AppIndex`,
+registers UUID-keyed hotkeys through `HotKeyManager`, and owns the serial execution funnel. Deleting a
+chain clears its shortcut, favorite, visibility and ranking references with the record.
+Settings backup carries chains and their shortcuts with custom commands and quicklinks.
+
+Settings ▸ Action Chains provides the whole editing surface: add a named chain, append eligible actions,
+reorder or remove its steps, assign a shortcut, edit, and delete. The editor lists applications, safe
+system actions, window commands, argument-free custom commands, and non-templated quicklinks.

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -42,8 +42,8 @@ the keycap rendering — only the _engine_ differs.
 Bindings persist as JSON strings under `hotkey.<action>` UserDefaults keys, computed in one place —
 `HotKeyAction.defaultsKey`, which doubles as the `HotKeyCenter` registration id. The set of bound
 bundle IDs lives in `boundAppBundleIDs` and is re-registered on launch. System Settings panes use
-`boundPaneBundleIDs`; custom commands and quicklinks use their stable UUIDs in
-`boundCustomCommandIDs` and `boundQuicklinkIDs`. Those two are the per-item case — unlike a fixed
+`boundPaneBundleIDs`; custom commands, quicklinks and action chains use stable UUIDs in
+`boundCustomCommandIDs`, `boundQuicklinkIDs` and `boundActionChainIDs`. Those are the per-item case — unlike a fixed
 catalog, there is no `allCases` to walk — so each needs an index for `start()` to re-register from
 and to prune bindings whose record was deleted while Tinycast wasn't running. That prune is why
 `QuicklinkStore` loads at launch even when the feature is off


### PR DESCRIPTION
## Related issue

Closes #433

## What changed

- Adds a Settings > Action Chains library for creating, editing, reordering, and deleting named sequences.
- Supports compatible application launches, non-confirming system actions, window commands, enabled no-argument custom commands, and enabled non-templated quicklinks.
- Publishes chains in the launcher and lets them receive individual hotkeys. Steps run serially; the first unavailable or failing step stops the chain and reports it.
- Persists chains in UserDefaults, includes them in settings backup/import, and cleans stale hotkeys, favorites, visibility, and ranking state when a chain is removed.

## Memory footprint

Action chains add no polling, timers, resident worker, or new dependency. The store is a small UserDefaults-backed in-memory value and execution creates work only on invocation. A separate runtime memory measurement was not taken for this PR.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | No additional background work |
| Palette open            | No additional background work |
| Feature in use (peak)   | Depends on selected existing actions |
| Palette closed, settled | No additional background work |

Leak-tested: Not separately measured.

## Drawbacks

- Application-launch steps begin launch but do not wait for the launched app before a later window-command step.
- Chains intentionally exclude destructive confirmation-gated actions, custom-command arguments, and templated quicklinks.

## Tests & validation

- `TINYCAST_TEST_JOBS=1 ./Scripts/run-tests.sh`
- `./Scripts/run-tests.sh action-chain-test`
- `./Scripts/run-tests.sh settings-history-test`
- `./Scripts/run-tests.sh settings-backup-test`
- `./Scripts/format.sh`
- `./Scripts/lint.sh`
- `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`

Added focused coverage for step ordering, successful completion, JSON and UserDefaults round trips, and failure short-circuiting.