### PR TITLE
Title an unnamed note from its first line

### DIFF
--- a/Tests/notes-test.swift
+++ b/Tests/notes-test.swift
@@ -7,6 +7,8 @@ struct NotesTests {
 
     static func main() async throws {
         try testRepositoryAndSearch()
+        testDerivedTitles()
+        try testUnnamedNotesTitleThemselves()
         testSwitcherInteraction()
         try await testStoreCollectionAndAutosave()
         try await testCollectionMutationsFlushTheDraft()
@@ -127,6 +129,62 @@ struct NotesTests {
             (try FileManager.default.contentsOfDirectory(atPath: empty.notesDirectory.path)).isEmpty)
     }
 
+    private static func testDerivedTitles() {
+        check(
+            "the names Create claims are unnamed",
+            NoteTitle.isUnnamed("Untitled") && NoteTitle.isUnnamed("Untitled 12"))
+        check(
+            "a typed title is never unnamed",
+            !NoteTitle.isUnnamed("Plan") && !NoteTitle.isUnnamed("untitled")
+                && !NoteTitle.isUnnamed("Untitled notes") && !NoteTitle.isUnnamed("Untitled 2b"))
+
+        check(
+            "a heading marker is not part of the derived title",
+            NoteTitle.firstLine(of: "#  Groceries \n\nmilk") == "Groceries")
+        check(
+            "leading blank lines are skipped",
+            NoteTitle.firstLine(of: "\n \t \n  café snow\nmore") == "café snow")
+        check(
+            "a hashtag is literal text, not a heading",
+            NoteTitle.firstLine(of: "####### seven\n") == "####### seven"
+                && NoteTitle.firstLine(of: "#tag") == "#tag")
+        check(
+            "a blank note derives no title",
+            NoteTitle.firstLine(of: "") == nil && NoteTitle.firstLine(of: "\n  \n\t\n") == nil)
+        check(
+            "a wall of text is capped to one row",
+            NoteTitle.firstLine(of: String(repeating: "a", count: 400))?.count == 120)
+    }
+
+    private static func testUnnamedNotesTitleThemselves() throws {
+        let root = temporaryRoot("derived")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let repository = try repository(in: root)
+
+        let unnamed = try repository.create()
+        try repository.save(id: unnamed.id, source: "# Groceries\n\nmilk\n")
+        let named = try repository.create(title: "Plan")
+        try repository.save(id: named.id, source: "# Ignored heading\n")
+
+        let summaries = try repository.list()
+        let unnamedSummary = try require(summaries.first { $0.id == unnamed.id })
+        check("an unnamed note shows its first line", unnamedSummary.displayTitle == "Groceries")
+        check("an unnamed note keeps its filename as its title", unnamedSummary.title == "Untitled")
+        let namedSummary = try require(summaries.first { $0.id == named.id })
+        check(
+            "a named note ignores its first line",
+            namedSummary.firstLine == nil && namedSummary.displayTitle == "Plan")
+
+        let fuzzy = repository.search(NoteSearch.Query("Grcrs"), summaries: summaries, limit: 10)
+        check(
+            "search matches a derived title the body never spells out",
+            fuzzy.count == 1 && fuzzy.first?.id == unnamed.id)
+
+        let renamed = try repository.rename(id: unnamed.id, title: "Shopping")
+        let afterRename = try require((try repository.list()).first { $0.id == renamed })
+        check("naming a note retires its derived title", afterRename.firstLine == nil)
+    }
+
     private static func testSwitcherInteraction() {
         let id = NoteID(rawValue: "Project.md")
         var rename = NoteSwitcherRenameState()
@@ -178,6 +236,11 @@ struct NotesTests {
             "Create Note is one file when it is the first action",
             started && store.activeTitle == "Untitled" && store.summaries.count == 1)
         check("active selection is persisted separately from note files", selection.id == store.activeID)
+
+        store.updateSource("# Draft heading\nbody")
+        check(
+            "an unnamed note titles itself from the live draft",
+            store.activeTitle == "Draft heading")
 
         store.updateSource("first")
         store.updateSource("latest searchable body")

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		6B8351E3D100E81F169BCFED /* UninstallPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD838940E655559E32BE8EA /* UninstallPlan.swift */; };
 		6BAE3112ED110F1363617A79 /* NoteTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F088EC0B4D97B3C9D0D0569 /* NoteTextView.swift */; };
 		6C052B83FAE453D1011E3FB4 /* PopoverMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAE24CC14F7DFECD1BD7FB1 /* PopoverMenu.swift */; };
+		6C38707B90B4D235C8935916 /* NoteTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264B68DBB21C3752E39ECC29 /* NoteTitle.swift */; };
 		6C915A60C3C2F2682645C32B /* UpdateInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9188FA8A06EAE3E55FFCBC70 /* UpdateInstaller.swift */; };
 		6CDA82FD63F87D07E30E3F82 /* Zlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F097C9983DF27A99694C8BC5 /* Zlib.swift */; };
 		6E2C2F65456E0981FC548C55 /* CustomCommandArgumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0926BBB9980400F4E94D1942 /* CustomCommandArgumentsView.swift */; };
@@ -526,6 +527,7 @@
 		2438C33DEAF16B26E4F195EB /* ExecutableLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecutableLocator.swift; sourceTree = "<group>"; };
 		255C39B045A1E21AB9A5BF9E /* StorageRelocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRelocation.swift; sourceTree = "<group>"; };
 		2575583134BE03EA9FA719CD /* ActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicy.swift; sourceTree = "<group>"; };
+		264B68DBB21C3752E39ECC29 /* NoteTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTitle.swift; sourceTree = "<group>"; };
 		26AD346C8FD5F2D4F00FF2B6 /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		27021D72339800AA6DA3D3FF /* AIScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIScreen.swift; sourceTree = "<group>"; };
 		2702F140F8DBF373D2ED11A5 /* SelectionFollowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionFollowing.swift; sourceTree = "<group>"; };
@@ -1143,6 +1145,7 @@
 				D8B10DA3A9B1CBD9A03F3DE5 /* NoteDocument.swift */,
 				6D594CB90475093D58A2AB1E /* NoteSearch.swift */,
 				A8AD14D51F74D1891D5532B0 /* NoteSwitcherInteraction.swift */,
+				264B68DBB21C3752E39ECC29 /* NoteTitle.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2656,6 +2659,7 @@
 				32C65BE018B7107FFA92DDA2 /* NoteSwitcherView.swift in Sources */,
 				22FD39D92B6AC3E3E2D9D6FB /* NoteSwitcherWindowController.swift in Sources */,
 				6BAE3112ED110F1363617A79 /* NoteTextView.swift in Sources */,
+				6C38707B90B4D235C8935916 /* NoteTitle.swift in Sources */,
 				D07F272D0E095B6000D53716 /* NotesCoordinator.swift in Sources */,
 				F71FC7195AC8D6626BEE8931 /* NotesPanel.swift in Sources */,
 				75AED41394E66D6E9CBDA7EA /* NotesRepository.swift in Sources */,

--- a/Tinycast/Features/Notes/Model/NoteDocument.swift
+++ b/Tinycast/Features/Notes/Model/NoteDocument.swift
@@ -7,7 +7,11 @@ struct NoteID: RawRepresentable, Hashable, Sendable {
 struct NoteSummary: Identifiable, Sendable, Equatable {
     let id: NoteID
     let title: String
+    /// Stands in for `title` while the note is still unnamed; nil once the user names it.
+    let firstLine: String?
     let modifiedAt: Date
+
+    var displayTitle: String { firstLine ?? title }
 }
 
 struct NoteSearchResult: Identifiable, Sendable, Equatable {

--- a/Tinycast/Features/Notes/Model/NoteSearch.swift
+++ b/Tinycast/Features/Notes/Model/NoteSearch.swift
@@ -21,7 +21,7 @@ enum NoteSearch {
         var titleScore = 0
         var titleMatches = 0
         for term in query.terms {
-            if let match = FuzzyMatch.match(query: term, candidate: summary.title) {
+            if let match = FuzzyMatch.match(query: term, candidate: summary.displayTitle) {
                 titleMatches += 1
                 titleScore += match.score
                 continue
@@ -49,7 +49,7 @@ enum NoteSearch {
         if lhs.summary.modifiedAt != rhs.summary.modifiedAt {
             return lhs.summary.modifiedAt > rhs.summary.modifiedAt
         }
-        return lhs.summary.title.localizedCaseInsensitiveCompare(rhs.summary.title)
+        return lhs.summary.displayTitle.localizedCaseInsensitiveCompare(rhs.summary.displayTitle)
             == .orderedAscending
     }
 }

--- a/Tinycast/Features/Notes/Model/NoteTitle.swift
+++ b/Tinycast/Features/Notes/Model/NoteTitle.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A note's title is its filename; one the user has not named yet borrows its first line to show.
+enum NoteTitle {
+    static let untitled = "Untitled"
+
+    /// Wide enough that the scanned prefix is covered even where every character is four bytes.
+    static let headByteCount = 4096
+
+    private static let scanLimit = 1024
+    private static let displayLimit = 120
+
+    /// True only for the names `create` claims — `Untitled`, `Untitled 2`, … — never a typed one.
+    static func isUnnamed(_ title: String) -> Bool {
+        guard title.hasPrefix(untitled) else { return false }
+        let suffix = title.dropFirst(untitled.count)
+        guard !suffix.isEmpty else { return true }
+        let digits = suffix.dropFirst()
+        return suffix.hasPrefix(" ") && !digits.isEmpty
+            && digits.allSatisfy { $0.isASCII && $0.isNumber }
+    }
+
+    /// The first line carrying visible text, without its heading markers and capped to one row.
+    static func firstLine(of source: String) -> String? {
+        for line in source.prefix(scanLimit).split(whereSeparator: \.isNewline) {
+            let title = stripped(line)
+            guard !title.isEmpty else { continue }
+            return String(title.prefix(displayLimit))
+        }
+        return nil
+    }
+
+    private static func stripped(_ line: Substring) -> String {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let markers = trimmed.prefix { $0 == "#" }
+        guard !markers.isEmpty, markers.count <= 6 else { return trimmed }
+        let heading = trimmed.dropFirst(markers.count)
+        guard heading.first?.isWhitespace == true else { return trimmed }
+        return heading.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Tinycast/Features/Notes/Service/NotesRepository.swift
+++ b/Tinycast/Features/Notes/Service/NotesRepository.swift
@@ -57,9 +57,11 @@ struct NotesRepository: Sendable {
                     values.isHidden != true,
                     let url = try? validatedFileURL(candidate)
                 else { return nil }
+                let title = url.deletingPathExtension().lastPathComponent
                 return NoteSummary(
                     id: NoteID(rawValue: url.lastPathComponent),
-                    title: url.deletingPathExtension().lastPathComponent,
+                    title: title,
+                    firstLine: NoteTitle.isUnnamed(title) ? firstLine(of: url) : nil,
                     modifiedAt: values.contentModificationDate ?? .distantPast)
             }
             .sorted(by: summaryPrecedes)
@@ -177,6 +179,21 @@ struct NotesRepository: Sendable {
         notesDirectory.appendingPathComponent(id.rawValue)
     }
 
+    /// Only an unnamed note pays for this, and only for the head of its file.
+    private func firstLine(of url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let head = try? handle.read(upToCount: NoteTitle.headByteCount), !head.isEmpty
+        else { return nil }
+        // A fixed-size read can land mid-character, so back off to the last complete one.
+        for dropped in 0...3 where head.count > dropped {
+            if let text = String(bytes: head.dropLast(dropped), encoding: .utf8) {
+                return NoteTitle.firstLine(of: text)
+            }
+        }
+        return nil
+    }
+
     private func ensureDirectory() throws {
         try FileManager.default.createDirectory(
             at: notesDirectory, withIntermediateDirectories: true)
@@ -241,7 +258,7 @@ struct NotesRepository: Sendable {
 
     private func summaryPrecedes(_ lhs: NoteSummary, _ rhs: NoteSummary) -> Bool {
         if lhs.modifiedAt != rhs.modifiedAt { return lhs.modifiedAt > rhs.modifiedAt }
-        return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        return lhs.displayTitle.localizedCaseInsensitiveCompare(rhs.displayTitle) == .orderedAscending
     }
 
     private func folded(_ value: String) -> String {

--- a/Tinycast/Features/Notes/Service/NotesStore.swift
+++ b/Tinycast/Features/Notes/Service/NotesStore.swift
@@ -18,10 +18,14 @@ final class NotesStore {
     private(set) var searchQuery = ""
     private(set) var searchResults: [NoteSearchResult] = []
     private(set) var isSearching = false
+    /// Derived from the live draft, not the last listing, so an unnamed note titles itself as typed.
     var activeTitle: String {
-        summaries.first(where: { $0.id == activeID })?.title
-            ?? activeID.map { URL(fileURLWithPath: $0.rawValue).deletingPathExtension().lastPathComponent }
-            ?? "Notes"
+        guard let activeID else { return "Notes" }
+        let title =
+            summaries.first(where: { $0.id == activeID })?.title
+            ?? URL(fileURLWithPath: activeID.rawValue).deletingPathExtension().lastPathComponent
+        guard NoteTitle.isUnnamed(title) else { return title }
+        return NoteTitle.firstLine(of: source) ?? title
     }
     var activeFileURL: URL? { activeID.map(repository.fileURL(for:)) }
     let notesDirectory: URL

--- a/Tinycast/Features/Notes/UI/NoteSwitcherView.swift
+++ b/Tinycast/Features/Notes/UI/NoteSwitcherView.swift
@@ -161,14 +161,14 @@ private struct NoteSwitcherRow: View {
                     .onSubmit(onCommitRename)
                     .onExitCommand(perform: onCancelRename)
             } else {
-                Text(summary.title)
+                Text(summary.displayTitle)
                     .font(Theme.Typography.rowTitle)
                     .lineLimit(1)
             }
             Spacer(minLength: Theme.Spacing.md)
             if !editing, selected || hovered {
-                rowButton(title: "Rename \(summary.title)", symbol: "pencil", action: onBeginRename)
-                rowButton(title: "Move \(summary.title) to Trash", symbol: "trash", action: onTrash)
+                rowButton(title: "Rename \(summary.displayTitle)", symbol: "pencil", action: onBeginRename)
+                rowButton(title: "Move \(summary.displayTitle) to Trash", symbol: "trash", action: onTrash)
                     .foregroundStyle(Theme.Colors.destructive)
             }
         }
@@ -185,17 +185,17 @@ private struct NoteSwitcherRow: View {
         }
         .onHover { hovered = $0 }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(summary.title)
+        .accessibilityLabel(summary.displayTitle)
         .accessibilityAddTraits(selected ? .isSelected : [])
         .accessibilityAction {
             guard !editing else { return }
             onActivate()
         }
-        .accessibilityAction(named: "Rename \(summary.title)") {
+        .accessibilityAction(named: "Rename \(summary.displayTitle)") {
             guard !editing else { return }
             onBeginRename()
         }
-        .accessibilityAction(named: "Move \(summary.title) to Trash") {
+        .accessibilityAction(named: "Move \(summary.displayTitle) to Trash") {
             guard !editing else { return }
             onTrash()
         }

--- a/Tinycast/Features/Notes/UI/NotesCoordinator.swift
+++ b/Tinycast/Features/Notes/UI/NotesCoordinator.swift
@@ -188,6 +188,7 @@ final class NotesCoordinator {
         select(id)
     }
 
+    /// Renaming edits the filename, so the field starts from that and never from a derived line.
     func beginSwitcherRename(_ summary: NoteSummary) {
         switcherRename.begin(id: summary.id, title: summary.title)
     }
@@ -247,7 +248,7 @@ final class NotesCoordinator {
     }
 
     func trash(_ id: NoteID) {
-        guard let title = store.summaries.first(where: { $0.id == id })?.title else { return }
+        guard let title = store.summaries.first(where: { $0.id == id })?.displayTitle else { return }
         runOperation { [weak self] generation in
             guard let self else { return }
             let confirmed = await core.confirm(

--- a/docs/features/notes.md
+++ b/docs/features/notes.md
@@ -8,6 +8,8 @@ commands and global shortcuts can show, search, or extend the collection.
 
 - **One regular, non-hidden `.md` file is one note.** Its filename without the extension is its title;
   the source contains no frontmatter, embedded ID, or title field, and there is no database or sidecar.
+- **A note the user has not named shows its first line instead.** Only the names `create` claims yield
+  it, it is presentation and nothing else, and naming the note replaces it.
 - **The editor displays literal source.** The string in `NSTextView`, `NotesStore`, search, and the
   file are identical; there is no parser, projection, preview, or hidden syntax.
 - **Only the active note can be dirty.** Switching, creating, renaming, and deleting first flush it, so
@@ -15,8 +17,9 @@ commands and global shortcuts can show, search, or extend the collection.
 - **Tinycast is the only writer.** There is no watcher and no revision check: a save replaces the file
   with what is in the editor. Every show re-lists the folder, so a note added outside appears, but the
   active draft is never re-read from disk.
-- **Search is on demand and unindexed.** An empty switcher query reads metadata only; a nonempty query
-  reads bodies sequentially off-main and retains no collection-sized source cache.
+- **Search is on demand and unindexed.** An empty switcher query reads metadata plus the head of every
+  unnamed note; a nonempty query reads bodies sequentially off-main and retains no collection-sized
+  source cache.
 - **Off means no entry point or Notes work.** The feature is off by default; its shortcuts no-op, its
   commands are absent, and enabling alone does not enumerate or create the Notes directory.
 - **The collection may be empty.** Deleting the last note is allowed and creates no replacement; the
@@ -43,6 +46,21 @@ shares a title with rather than over it. Collisions with *another* note are case
 becomes `plán 2.md`. A note never collides with itself: only an exact filename match is a no-op, which
 is what lets a rename change nothing but the case or the accents. The active filename is local UI state
 in UserDefaults and does not ride settings backups.
+
+## Derived titles
+
+A note still carrying a name `create` claimed — `Untitled`, `Untitled 2`, … — shows the first line of
+its source that carries visible text. `NoteTitle` owns that rule: leading blank lines are skipped,
+Markdown heading markers are dropped, and the line is capped to 120 characters so no row or title bar
+has to carry a paragraph. `NoteSummary.title` remains the filename; `displayTitle` is what every
+surface renders — switcher rows and their VoiceOver labels, the Trash confirmation, the window title,
+and the title band of `NoteSearch`, so a fuzzy query reaches a note nobody has named.
+
+`list()` reads at most 4 KB of each unnamed note to derive it, and a named note costs nothing beyond
+the enumeration it already pays for. The **active** note derives from the live draft rather than the
+last listing, so its window title follows the first line as it is typed while its switcher row catches
+up on the next autosave. Renaming edits the filename, so the rename field starts from `title`: a
+derived line stands in for a name, and is never one.
 
 `NotesRepository` owns list, create, load, save, rename, Trash, and search reads. Every
 URL is validated as an immediate child of the injected directory. It lives in `Service/` because it
@@ -129,8 +147,8 @@ the window re-lists the folder before it presents anything.
 ## Verification
 
 `Tests/notes-test.swift` compiles the shipped Notes model and service sources with the real fuzzy
-matcher. It covers repository safety, unique-name claiming, search, selection, autosave, empty
-collections, switcher interaction, and cancellation.
+matcher. It covers repository safety, unique-name claiming, derived titles, search, selection,
+autosave, empty collections, switcher interaction, and cancellation.
 
 `Tests/notes-editor-test.swift` uses real TextKit 2 and AppKit undo objects to cover literal source,
 native Cut/Copy/Paste, Unicode and marked text, and undo isolation. Window chrome is not automated:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -324,7 +324,10 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
   creates
 - Empty switcher search reads the complete recent list; title and body searches rank correctly and a
   superseded query never publishes
-- Inline rename updates the Markdown filename without changing source; collisions receive a suffix
+- An Untitled note titles itself from its first line as it is typed, in the title bar and — after the
+  autosave — in the browse list; naming it replaces that, and clearing the name brings it back
+- Inline rename updates the Markdown filename without changing source, and starts from that filename
+  even where the row shows a derived title; collisions receive a suffix
 - Delete confirms through Tinycast, moves the file to Trash, and selecting another note never loses an
   unsaved edit
 - An existing `Floating Note.md` appears as an ordinary note without conversion


### PR DESCRIPTION
## Related issue

Closes #413

## What changed

A note whose filename is still one `create` claimed — `Untitled`, `Untitled 2`, … — now shows the
first line of its source that carries visible text, so an unrenamed collection stops reading as a
column of identical rows.

This is display only. The filename stays the note's identity, so nothing renames itself on disk while
you type, `NoteID` never churns mid-edit, and naming the note takes the title back the moment it has
one. Renaming a note back to `Untitled` brings the derived line back.

Non-obvious bits in the diff:

- **`NoteTitle`** owns the whole rule: leading blank lines are skipped, Markdown heading markers are
  dropped (`# Groceries` → `Groceries`, but `#tag` and `####### seven` stay literal), and the result is
  capped at 120 characters so no row or title bar has to carry a paragraph.
- **`list()` cost.** Only an *unnamed* note pays for a derived title, and only for the head of its file
  — at most 4 KB through one `FileHandle`. A named note costs nothing beyond the enumeration it already
  paid for. A fixed-size read can land mid-character, so the decode backs off up to three bytes to the
  last complete one rather than decoding lossily.
- **`activeTitle` derives from the live draft**, not the last listing, so the window title follows the
  first line as it is typed; the switcher row catches up on the next autosave (300 ms).
- **Search.** `NoteSearch` fuzzy-matches `displayTitle`, so an unnamed note lands in the title band
  instead of ranking as a body-only hit. The repository's equal-modification-date tiebreak sorts on
  `displayTitle` too, so the list never orders itself by a title the user cannot see.
- **Rename still starts from the filename.** A derived line stands in for a name and is never one, and
  prefilling it would let one Return rename a file to `9/2 standup` — a title the repository correctly
  rejects.

## Memory footprint

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Not profiled, and I don't believe this moves the needle: the only new retention is one optional
`String` per unnamed note on `NoteSummary`, capped at 120 characters, on a list that already existed.
The 4 KB head read is a stack-local `Data` that is dropped inside `list()`. No cache, no new
long-lived state, no new task.

Leak-tested: no — nothing here allocates beyond the summary array's existing lifetime.

## Demo

No recording captured. The visible change is text: an `Untitled` note's title bar and browse-list row
read its first line instead of `Untitled`.

## Drawbacks

- **The switcher row lags the title bar by one autosave.** The active note's window title updates per
  keystroke, but its row in the browse list only refreshes when the 300 ms debounce writes and re-lists.
  Making the row live too would mean patching the published summary array on every keystroke, which is
  not worth it for a list that is usually closed while typing.
- **`list()` now does IO per unnamed note.** Bounded to 4 KB each, off-main, and skipped entirely for
  named notes — but a user who never renames anything pays it on every save-driven re-list. The
  `notes.md` invariant on unindexed search is updated to say so rather than pretend it still reads
  metadata only.
- **`isUnnamed` is an exact match on the generated shape.** A note deliberately renamed to `Untitled`
  is treated as unnamed. That seemed better than a folded compare that would also catch `untitled`.

## Tests & validation

`./Scripts/run-tests.sh` — all 54 harnesses pass. Debug build (`xcodebuild … -configuration Debug`)
succeeds with no new warnings; `./Scripts/lint.sh` adds no warning in `Features/Notes/`.

Added to `Tests/notes-test.swift`:

- `testDerivedTitles` — the `isUnnamed` boundary (`Untitled 12` yes, `untitled` / `Untitled notes` /
  `Untitled 2b` no), heading-marker stripping, skipped blank lines, hashtags left literal, a blank note
  deriving nothing, and the 120-character cap.
- `testUnnamedNotesTitleThemselves` — an unnamed note's `displayTitle` is its first line while `title`
  stays `Untitled`, a named note ignores its first line, naming one retires the derived title, and a
  fuzzy query (`Grcrs`) the body never spells out still finds it through the derived title.
- One case in the store harness: an unnamed note titles itself from the live draft before any save.

`xcodegen generate` was rerun for the new `Model/NoteTitle.swift`, so `project.pbxproj` is in the diff.
The Notes manual sweep in `docs/testing.md` gains the derived-title and rename-prefill rows; not yet
run by hand.
