### PR TITLE
Search Settings, and give it the system titlebar

### DIFF
--- a/Scripts/check-settings-search.js
+++ b/Scripts/check-settings-search.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Every Settings search result must have somewhere to land.
+//
+// A `Form` cannot be asked what sections or rows it holds, so `SettingsSearchCatalog` is written by
+// hand and its targets are matched to the panes textually. An entry with nothing to scroll to still
+// compiles, reads fine, and fails only at runtime — as a result that navigates and then sits there.
+//
+// Usage: node Scripts/check-settings-search.js   (run by ./Scripts/lint.sh)
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const ANCHORS = "Tinycast/Features/Settings/SettingsAnchor.swift";
+const CATALOG = "Tinycast/Features/Settings/SettingsSearchCatalog.swift";
+
+function swiftSources(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) swiftSources(full, found);
+    else if (entry.name.endsWith(".swift")) found.push(full);
+  }
+  return found;
+}
+
+const anchorSource = fs.readFileSync(path.join(ROOT, ANCHORS), "utf8");
+const catalog = fs.readFileSync(path.join(ROOT, CATALOG), "utf8");
+const source = swiftSources(path.join(ROOT, "Tinycast"))
+  .map((f) => fs.readFileSync(f, "utf8"))
+  .join("\n");
+
+const anchorTitles = new Map();
+for (const m of anchorSource.matchAll(
+  /static let (\w+) = Self\(\s*tab: \.\w+, title: "([^"]+)"\)/g
+)) {
+  anchorTitles.set(m[1], m[2]);
+}
+
+const problems = [];
+
+// 1. Every anchor is claimed by a section.
+for (const anchor of anchorTitles.keys()) {
+  const claimed =
+    source.includes(`SettingsSectionHeader(.${anchor})`) ||
+    source.includes(`SettingsSectionHeader(anchor: .${anchor})`) ||
+    source.includes(`settingsAnchor(.${anchor})`) ||
+    source.includes(`anchor: .${anchor}`);
+  if (!claimed) problems.push(`anchor .${anchor} — no Section declares it`);
+}
+
+// 2. Every row entry is marked on a row.
+for (const m of catalog.matchAll(/\.init\(\s*\.(\w+),\s*"((?:[^"\\]|\\.)*)"/g)) {
+  const [, anchor, title] = m;
+  const quoted = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const marked =
+    source.includes(`SettingsRowTitle(.${anchor}, "${title}")`) ||
+    // A `SettingsRow` renders the pill from its own title.
+    new RegExp(`SettingsRow\\(\\s*title: "${quoted}",[\\s\\S]*?anchor: \\.${anchor}`).test(source) ||
+    // A feature pane's master switch, rendered by `FeatureSwitchSection`.
+    new RegExp(`anchor: \\.${anchor},\\s*\\n\\s*enableTitle: "${quoted}"`).test(source) ||
+    // A launcher category's switch, whose title `LauncherItemsSection` derives.
+    title === `Enable ${anchorTitles.get(anchor) ?? ""}`;
+  if (!marked) problems.push(`row “${title}” (.${anchor}) — no SettingsRowTitle marks it`);
+}
+
+if (problems.length > 0) {
+  console.error("\n✗ Settings search targets with nothing to land on:");
+  for (const p of problems) console.error(`  ${p}`);
+  console.error("  Mark the row with SettingsRowTitle, or make the entry a `group:` one.");
+  process.exit(1);
+}

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -17,4 +17,10 @@ if ! swiftlint lint --quiet ${SWIFTLINT_REPORTER:+--reporter "$SWIFTLINT_REPORTE
     echo "Lint errors above. Warnings do not block; errors do." >&2
     exit 1
 fi
+# A `Form` can't be asked what it holds, so an unclaimed anchor or an unmarked row is a silent
+# no-op: the search result navigates and then nothing scrolls or lights up. Nothing else catches it.
+if ! node Scripts/check-settings-search.js; then
+    exit 1
+fi
+
 echo "✓ lint-clean"

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -258,7 +258,9 @@ run slow ext-test          -parse-as-library \
                            $L/SearchRelevance.swift \
                            Tinycast/Platform/Compression/Zlib.swift
 run settings-history-test  Tinycast/Features/Settings/SettingsTab.swift \
-                           Tinycast/Features/Settings/SettingsHistory.swift
+                           Tinycast/Features/Settings/SettingsHistory.swift \
+                           Tinycast/Features/Settings/SettingsSearchCatalog.swift \
+                           $L/SearchRelevance.swift
 run updates-test           Tinycast/Features/Updates/Model/*.swift
 run support-test           Tinycast/Features/Support/Model/*.swift
 run ai-provider-test       Tinycast/Features/Settings/AppSettingsKey.swift \

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -259,6 +259,8 @@ run slow ext-test          -parse-as-library \
                            Tinycast/Platform/Compression/Zlib.swift
 run settings-history-test  Tinycast/Features/Settings/SettingsTab.swift \
                            Tinycast/Features/Settings/SettingsHistory.swift \
+                           Tinycast/Features/Settings/SettingsAnchor.swift \
+                           Tinycast/Features/Settings/SettingsNavigationState.swift \
                            Tinycast/Features/Settings/SettingsSearchCatalog.swift \
                            $L/SearchRelevance.swift
 run updates-test           Tinycast/Features/Updates/Model/*.swift

--- a/Tests/settings-history-test.swift
+++ b/Tests/settings-history-test.swift
@@ -25,6 +25,10 @@ struct SettingsHistoryTests {
         clampsAtBothEnds()
         sidebarCoversEveryPane()
         sidebarIdentityNamespacesAreDisjoint()
+        catalogCoversEveryPane()
+        catalogIdentitiesAreUnique()
+        catalogFindsKnownRows()
+        catalogRanksTitlesFirst()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
@@ -120,5 +124,46 @@ struct SettingsHistoryTests {
             sections.isDisjoint(with: tabs),
             "no sidebar group shares an identity with a pane")
         expect(tabs.count == SettingsTab.allCases.count, "and every pane's identity is its own")
+    }
+
+    // MARK: - Search catalog
+    // A `Form` can't be asked what rows it holds, so the catalog is hand-written and can drift.
+
+    static func catalogCoversEveryPane() {
+        let covered = Set(SettingsSearchCatalog.entries.map(\.tab))
+        expect(
+            covered == Set(SettingsTab.allCases),
+            "every pane is reachable from Settings search")
+    }
+
+    /// The results `List` is keyed by `id`; a duplicate would make two rows select as one.
+    static func catalogIdentitiesAreUnique() {
+        let ids = SettingsSearchCatalog.entries.map(\.id)
+        expect(Set(ids).count == ids.count, "no two catalog entries share an identity")
+    }
+
+    static func catalogFindsKnownRows() {
+        let cases: [(String, SettingsTab)] = [
+            ("hyper", .general),
+            ("caps lock", .general),
+            ("launch at login", .general),
+            ("paste history", .clipboard),
+            ("window manage", .windowManagement),
+            ("skin tone", .emoji),
+            ("mcp", .ai)
+        ]
+        for (query, tab) in cases {
+            let found = SettingsSearchCatalog.results(for: query).first
+            expect(found?.tab == tab, "“\(query)” lands on \(tab.title)")
+        }
+    }
+
+    /// A term found in the title has to beat the same term found only in a breadcrumb.
+    static func catalogRanksTitlesFirst() {
+        let results = SettingsSearchCatalog.results(for: "extensions")
+        expect(results.first?.tab == .extensions, "“extensions” opens on its own pane")
+        expect(
+            SettingsSearchCatalog.results(for: "nothing here matches at all").isEmpty,
+            "and an unmatched query returns nothing")
     }
 }

--- a/Tests/settings-history-test.swift
+++ b/Tests/settings-history-test.swift
@@ -29,6 +29,9 @@ struct SettingsHistoryTests {
         catalogIdentitiesAreUnique()
         catalogFindsKnownRows()
         catalogRanksTitlesFirst()
+        catalogAnchorsMatchTheirPane()
+        revealingRecordsANewRequestEachTime()
+        flashOutlivesThePaneThatLitIt()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
@@ -158,6 +161,16 @@ struct SettingsHistoryTests {
         }
     }
 
+    /// The anchor carries the pane, so a row filed under the wrong one cannot be written.
+    static func catalogAnchorsMatchTheirPane() {
+        for entry in SettingsSearchCatalog.entries {
+            guard let anchor = entry.anchor else { continue }
+            expect(anchor.tab == entry.tab, "“\(entry.title)” is filed under its anchor's pane")
+        }
+        let panes = SettingsSearchCatalog.entries.filter { $0.anchor == nil }.map(\.tab)
+        expect(Set(panes).count == panes.count, "and each pane is listed as a result exactly once")
+    }
+
     /// A term found in the title has to beat the same term found only in a breadcrumb.
     static func catalogRanksTitlesFirst() {
         let results = SettingsSearchCatalog.results(for: "extensions")
@@ -165,5 +178,48 @@ struct SettingsHistoryTests {
         expect(
             SettingsSearchCatalog.results(for: "nothing here matches at all").isEmpty,
             "and an unmatched query returns nothing")
+    }
+
+    // MARK: - Revealing a section
+
+    /// Picking the same result twice has to scroll and pulse again, not compare equal and do nothing.
+    static func revealingRecordsANewRequestEachTime() {
+        let navigation = SettingsNavigationState(tab: .general)
+        expect(navigation.scrollRequest == nil, "a fresh window has nothing to reveal")
+
+        navigation.select(.clipboard)
+        expect(navigation.scrollRequest == nil, "and a plain pane selection asks for no scroll")
+
+        navigation.select(.general, revealing: .section(.generalHyperKey))
+        let first = navigation.scrollRequest
+        expect(first?.target == .section(.generalHyperKey), "a result records what it wants revealed")
+        expect(navigation.tab == .general, "and navigates to that section's pane")
+
+        navigation.select(.general, revealing: .section(.generalHyperKey))
+        expect(navigation.scrollRequest != first, "asking twice is two distinct requests")
+
+        // A stale request must not clear the one that replaced it.
+        if let first { navigation.clear(first) }
+        expect(navigation.scrollRequest != nil, "clearing a superseded request is a no-op")
+        if let live = navigation.scrollRequest { navigation.clear(live) }
+        expect(navigation.scrollRequest == nil, "clearing the live one releases it")
+    }
+
+    /// The pulse outlives the pane that started it, and only its own owner may put it out.
+    static func flashOutlivesThePaneThatLitIt() {
+        let navigation = SettingsNavigationState(tab: .general)
+        navigation.select(.clipboard, revealing: .row(.clipboardHistory, "Keep history for"))
+        navigation.beginFlash(.row(.clipboardHistory, "Keep history for"))
+        expect(navigation.flashing == .row(.clipboardHistory, "Keep history for"), "the revealed row is lit")
+
+        navigation.endFlash(.section(.generalHyperKey))
+        expect(navigation.flashing != nil, "another target can't put it out")
+        navigation.endFlash(.row(.clipboardHistory, "Keep history for"))
+        expect(navigation.flashing == nil, "its own owner can")
+
+        // A jump that lands elsewhere must not leave the old light burning behind it.
+        navigation.beginFlash(.row(.clipboardHistory, "Keep history for"))
+        navigation.select(.general)
+        expect(navigation.flashing == nil, "navigating away clears a stale pulse")
     }
 }

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -315,6 +315,7 @@
 		A7CEBFBFBB46554ACAD73CFB /* QuicklinkArgumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3044106BC42824C79E1803 /* QuicklinkArgumentsView.swift */; };
 		A7D7F8F64B0937D20D97F428 /* ExtensionAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D755EEABA1DA9CA4CE2D0B4F /* ExtensionAppearance.swift */; };
 		A7F4CD74AEBEFF9F07103CD7 /* EmojiIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316A544BF6628C0465DE28D8 /* EmojiIndex.swift */; };
+		A9B237874D2DC49A184FF9B0 /* SettingsSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3F48BE32ACD7799661EBF9 /* SettingsSearchField.swift */; };
 		AAFD2C9276D38719E85B675F /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB76FDBFE1E306C2A5B1A29B /* Memo.swift */; };
 		AB500AC3DEBFF6EB1CE42812 /* DialogController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94507F8F095D3EBD1A9B3007 /* DialogController.swift */; };
 		ABB5079A94F6ACDB276BA461 /* TextDiffEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5870C37FFC77A9B53CA5764 /* TextDiffEngine.swift */; };
@@ -340,6 +341,7 @@
 		B6C39F046F6B09CD7AA53F6B /* MeetingSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09511B0502D1B67F10604D3C /* MeetingSpan.swift */; };
 		B72F17539405522E63D266F3 /* AIPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5861814F16B18935FBF034C /* AIPreamble.swift */; };
 		B748B0BA6AB0780CAB4DA304 /* MCPProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBED1FDAAD4735FDB4B2453A /* MCPProtocol.swift */; };
+		B83D909972DFFC37E2FB1304 /* SettingsSearchCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B580FD584B516AB666F1C81E /* SettingsSearchCatalog.swift */; };
 		B89F00C65C0A01F4BFDB702F /* CalendarMenuBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBBA4F593D396201257883 /* CalendarMenuBarItem.swift */; };
 		B8CECD85524BCCCBC0CDC2B5 /* ExtensionCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */; };
 		BAD4BEF8041665ACCF1CE460 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */; };
@@ -713,6 +715,7 @@
 		8CD7591D273A6484DD48018A /* RaycastImportReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportReader.swift; sourceTree = "<group>"; };
 		8D0371F4748011D45C185444 /* TextTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTranslator.swift; sourceTree = "<group>"; };
 		8DA2EC0303BFCB1212E69B54 /* AISettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsView.swift; sourceTree = "<group>"; };
+		8E3F48BE32ACD7799661EBF9 /* SettingsSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchField.swift; sourceTree = "<group>"; };
 		8E58EBB08450BA3426DF0565 /* AppIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIndex.swift; sourceTree = "<group>"; };
 		8E5F9675F2090C3AA9EEBF65 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		8F088EC0B4D97B3C9D0D0569 /* NoteTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTextView.swift; sourceTree = "<group>"; };
@@ -796,6 +799,7 @@
 		B40049CE320BEE3A4388CDFF /* CustomCommandEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommandEditorSheet.swift; sourceTree = "<group>"; };
 		B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardFilterButton.swift; sourceTree = "<group>"; };
 		B4984C964DC144E213DF4F63 /* Quarantine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quarantine.swift; sourceTree = "<group>"; };
+		B580FD584B516AB666F1C81E /* SettingsSearchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchCatalog.swift; sourceTree = "<group>"; };
 		B5ABB8CDB1469F8755B12567 /* AICommandSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AICommandSection.swift; sourceTree = "<group>"; };
 		B620894347E87EC4130CA4C8 /* BackupStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupStaging.swift; sourceTree = "<group>"; };
 		B675C14B308FA33896A8AE49 /* RaycastImportError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImportError.swift; sourceTree = "<group>"; };
@@ -2153,6 +2157,8 @@
 				C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */,
 				3C504229760FFFFA9D8A7799 /* SettingsHistory.swift */,
 				364BEC0805A8F5C39444EAF5 /* SettingsNavigationState.swift */,
+				B580FD584B516AB666F1C81E /* SettingsSearchCatalog.swift */,
+				8E3F48BE32ACD7799661EBF9 /* SettingsSearchField.swift */,
 				03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */,
 				B7AA1305D43303E055DEE1E9 /* SettingsSplitViewController.swift */,
 				4AA61A2FAF4E49E466DA8F37 /* SettingsTab.swift */,
@@ -2756,6 +2762,8 @@
 				11EF7061ED64616FFB13423F /* SettingsHistory.swift in Sources */,
 				109E27ACDAADDA42FE33E119 /* SettingsNavigationState.swift in Sources */,
 				8CFF2D2BF36F60659C8570A3 /* SettingsPaneScanner.swift in Sources */,
+				B83D909972DFFC37E2FB1304 /* SettingsSearchCatalog.swift in Sources */,
+				A9B237874D2DC49A184FF9B0 /* SettingsSearchField.swift in Sources */,
 				1CA10DE219BAB97BFC29E54A /* SettingsSidebarView.swift in Sources */,
 				74ACDD85B9F03C36E9258695 /* SettingsSplitViewController.swift in Sources */,
 				26DB736F18280E1BE6C6B8BE /* SettingsTab.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		3C23AEA2FDDB7BD61278BD77 /* QuickActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5941CE8F08FD5986FED12E9 /* QuickActionsSettingsView.swift */; };
 		3C2812B921530D45B802B44C /* PaletteTabAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B107F5E532C8DE74430723B /* PaletteTabAction.swift */; };
 		3C30FB1AD99237898B4401C7 /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7DC9AD5E54C26387F29F6 /* MarkdownView.swift */; };
+		3D00EF47CECC95BAEDD372FA /* SettingsScrollTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC407C844BE73916C6C526F1 /* SettingsScrollTarget.swift */; };
 		3D56F518ABEF5851534A710C /* AISettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C975F928132D3DAB1BB569F0 /* AISettingsStore.swift */; };
 		3DAB1821040DCA295BEB4437 /* AICommandSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ABB8CDB1469F8755B12567 /* AICommandSection.swift */; };
 		3E2E0C5B564C828D7ECA2759 /* RegionCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */; };
@@ -407,6 +408,7 @@
 		DAD994F5F42542805F8CF801 /* CameraPreviewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2384FC4A96FDAD19D0737312 /* CameraPreviewSession.swift */; };
 		DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B0374FD5D74DBE23243CD /* PaletteScreen.swift */; };
 		DCAC5BBB64C93F559B25E6FD /* ExtensionAnimatedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF31AF26A4786B234ABB64 /* ExtensionAnimatedImage.swift */; };
+		DD0DE9D16B0BAA8126EE9DB6 /* SettingsAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */; };
 		DD25D0E22E5729CF612FA1AE /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1545635C1E94D5E7DFECF1 /* WindowDragHandle.swift */; };
 		DDFA439EA7942183414375DC /* AppPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A96350EBE68EC79497FA2D /* AppPaths.swift */; };
 		DDFF8A9F420A4733DFA32A07 /* ReleaseFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28281DFC434C75F8A594635 /* ReleaseFeed.swift */; };
@@ -827,6 +829,7 @@
 		C2EAA357A9F0317320CFAADF /* TerminalLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLogView.swift; sourceTree = "<group>"; };
 		C3C83D437500107168E12647 /* QuickActionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionSettings.swift; sourceTree = "<group>"; };
 		C3E30EFA3197FC5EF1E85C21 /* BundleSignature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSignature.swift; sourceTree = "<group>"; };
+		C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAnchor.swift; sourceTree = "<group>"; };
 		C45190564C9D9F1722E83943 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C49AE1E917BF6EA7783F4CAD /* CodexAppServerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerProtocol.swift; sourceTree = "<group>"; };
 		C54C4540AD6F188A2455473F /* ExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRuntime.swift; sourceTree = "<group>"; };
@@ -842,6 +845,7 @@
 		CBFF39C46E98D0808B188E2E /* FileSearchIgnoreList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchIgnoreList.swift; sourceTree = "<group>"; };
 		CC02192DE787DBE081C589B8 /* KeychainSecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainSecretStore.swift; sourceTree = "<group>"; };
 		CC39721B6964B279FB5D5DC3 /* FileIconStamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconStamp.swift; sourceTree = "<group>"; };
+		CC407C844BE73916C6C526F1 /* SettingsScrollTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScrollTarget.swift; sourceTree = "<group>"; };
 		CC67BADEB6FEC76C88585361 /* CalcUnits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnits.swift; sourceTree = "<group>"; };
 		CCCBDD92DEAD780A1DC423CA /* ExtensionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionScreen.swift; sourceTree = "<group>"; };
 		CEEF20B209EEEAB7ED97DF36 /* QuickActionPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionPanel.swift; sourceTree = "<group>"; };
@@ -2153,10 +2157,12 @@
 				A5A8F78D3F1BFA8E86F9CB47 /* AppAppearance.swift */,
 				7F64F4362989516482853CDB /* AppSettings.swift */,
 				384485BD1794D25503534525 /* AppSettingsKey.swift */,
+				C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */,
 				8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */,
 				C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */,
 				3C504229760FFFFA9D8A7799 /* SettingsHistory.swift */,
 				364BEC0805A8F5C39444EAF5 /* SettingsNavigationState.swift */,
+				CC407C844BE73916C6C526F1 /* SettingsScrollTarget.swift */,
 				B580FD584B516AB666F1C81E /* SettingsSearchCatalog.swift */,
 				8E3F48BE32ACD7799661EBF9 /* SettingsSearchField.swift */,
 				03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */,
@@ -2754,6 +2760,7 @@
 				4F938D799099931DDA1D1876 /* SectionHeader.swift in Sources */,
 				CFBD94098A1F79035DD53ED4 /* SelectionFollowing.swift in Sources */,
 				3917193B62450F226297B3F1 /* SelectionReveal.swift in Sources */,
+				DD0DE9D16B0BAA8126EE9DB6 /* SettingsAnchor.swift in Sources */,
 				A769FFB50D3ED9E458028255 /* SettingsBackup.swift in Sources */,
 				7CC503824FDF49F788C85BB3 /* SettingsBackupCoverage.swift in Sources */,
 				FD49FAFAA34FC1A41AFAC10F /* SettingsComponents.swift in Sources */,
@@ -2762,6 +2769,7 @@
 				11EF7061ED64616FFB13423F /* SettingsHistory.swift in Sources */,
 				109E27ACDAADDA42FE33E119 /* SettingsNavigationState.swift in Sources */,
 				8CFF2D2BF36F60659C8570A3 /* SettingsPaneScanner.swift in Sources */,
+				3D00EF47CECC95BAEDD372FA /* SettingsScrollTarget.swift in Sources */,
 				B83D909972DFFC37E2FB1304 /* SettingsSearchCatalog.swift in Sources */,
 				A9B237874D2DC49A184FF9B0 /* SettingsSearchField.swift in Sources */,
 				1CA10DE219BAB97BFC29E54A /* SettingsSidebarView.swift in Sources */,

--- a/Tinycast/DesignSystem/SettingsComponents.swift
+++ b/Tinycast/DesignSystem/SettingsComponents.swift
@@ -6,6 +6,8 @@ import SwiftUI
 struct SettingsRow<Icon: View, Trailing: View>: View {
     let title: String
     var subtitle: String?
+    /// Set when a search result points at this row, so its title can carry the pulse.
+    var anchor: SettingsAnchor?
     @ViewBuilder var icon: Icon
     @ViewBuilder var trailing: Trailing
 
@@ -13,8 +15,14 @@ struct SettingsRow<Icon: View, Trailing: View>: View {
         HStack(spacing: Theme.Spacing.lg) {
             icon
             VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
-                Text(title)
-                    .lineLimit(1)
+                Group {
+                    if let anchor {
+                        SettingsRowTitle(anchor, title)
+                    } else {
+                        Text(title)
+                    }
+                }
+                .lineLimit(1)
                 if let subtitle {
                     Text(subtitle)
                         .font(.caption)
@@ -31,8 +39,13 @@ struct SettingsRow<Icon: View, Trailing: View>: View {
 }
 
 extension SettingsRow where Icon == EmptyView {
-    init(title: String, subtitle: String? = nil, @ViewBuilder trailing: () -> Trailing) {
-        self.init(title: title, subtitle: subtitle, icon: { EmptyView() }, trailing: trailing)
+    init(
+        title: String, subtitle: String? = nil, anchor: SettingsAnchor? = nil,
+        @ViewBuilder trailing: () -> Trailing
+    ) {
+        self.init(
+            title: title, subtitle: subtitle, anchor: anchor, icon: { EmptyView() },
+            trailing: trailing)
     }
 }
 
@@ -45,7 +58,7 @@ extension View {
 
 /// A feature pane's opening section: the master switch, then its launcher-visibility companion.
 struct FeatureSwitchSection: View {
-    let header: String
+    let anchor: SettingsAnchor
     let enableTitle: String
     let enableSubtitle: String
     let launcherSubtitle: String
@@ -55,7 +68,7 @@ struct FeatureSwitchSection: View {
     var body: some View {
         Section {
             Toggle(isOn: $isEnabled) {
-                Text(enableTitle)
+                SettingsRowTitle(anchor, enableTitle)
                 Text(enableSubtitle)
             }
             Toggle(isOn: $showsInLauncher) {
@@ -65,7 +78,7 @@ struct FeatureSwitchSection: View {
             // The switch above stays live so the feature can always be turned back on.
             .settingsEnabled(isEnabled)
         } header: {
-            Text(header)
+            SettingsSectionHeader(anchor)
         }
     }
 }

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -145,6 +145,8 @@ enum Theme {
         /// The narrowest the pane column may get before a grouped row's control starts colliding.
         static let settingsDetailMinimum: CGFloat = 420
         static let settingsRowIcon: CGFloat = 20
+        /// The sidebar's search field; matches a grouped `Form` row's control height.
+        static let settingsSearchField: CGFloat = 28
         /// Settings editor modals (Custom Commands, Snippets): fixed width, intrinsic height.
         static let editorSheetWidth: CGFloat = 480
         /// Label column of an extension's `Form`, so every field's input starts on one line.

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -195,6 +195,10 @@ enum Theme {
         static let tooltip: TimeInterval = 0.15
         static let copyFeedback: TimeInterval = 1.2
         static let chatFooter: TimeInterval = 0.12
+        /// A Settings search result scrolling its section into view, then the pulse that marks it.
+        static let settingsReveal: TimeInterval = 0.28
+        static let settingsFlash: TimeInterval = 2.0
+        static let settingsFlashOut: TimeInterval = 0.6
     }
 
     /// System text styles (not hardcoded sizes) so the UI honors Dynamic Type.
@@ -270,6 +274,8 @@ enum Theme {
         static let cardStroke = ramp(dark: 0.10, light: 0.10)
         /// White in both: the frost brightens glass, and light glass needs more to read at all.
         static let glassFrost = adaptive(dark: .srgbInk(1, alpha: 0.05), light: .srgbInk(1, alpha: 0.25))
+        /// The pill behind the header of the section a Settings search jumped to.
+        static let searchFlash = Color.accentColor.opacity(0.35)
         /// The violet of the app mark, used only to tint the About support callout.
         static let brand = Color(red: 0.525, green: 0.231, blue: 1.0)
         /// The palette's drop guides while dragging, and once a release would snap it home.

--- a/Tinycast/Features/AI/Settings/AICommandSection.swift
+++ b/Tinycast/Features/AI/Settings/AICommandSection.swift
@@ -21,7 +21,7 @@ struct AICommandSection: View {
                 }
             }
         } header: {
-            Text("Commands")
+            SettingsSectionHeader(.aiCommands)
         } footer: {
             Text("The shortcut works even when the command is hidden from the launcher.")
                 .font(.caption)

--- a/Tinycast/Features/AI/Settings/AISettingsView.swift
+++ b/Tinycast/Features/AI/Settings/AISettingsView.swift
@@ -19,11 +19,11 @@ struct AISettingsView: View {
         return Form {
             Section {
                 Toggle(isOn: $appSettings.aiEnabled) {
-                    Text("Enable AI")
+                    SettingsRowTitle(.aiAI, "Enable AI")
                     Text("Chat with the model you choose; nothing is loaded or sent until it is on.")
                 }
             } header: {
-                Text("AI")
+                SettingsSectionHeader(.aiAI)
             }
 
             AICommandSection()
@@ -41,6 +41,7 @@ struct AISettingsView: View {
             .settingsEnabled(appSettings.aiEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.ai)
         .sheet(item: $editor) { target in
             AIConnectionEditorSheet(
                 target: target,
@@ -91,7 +92,7 @@ struct AISettingsView: View {
                         }
                     }
                 } label: {
-                    Text("Default model")
+                    SettingsRowTitle(.aiDefault, "Default model")
                     Text("Used by Tinycast features unless they ask you to choose another model.")
                 }
                 if let efforts = selectedSubscriptionModel?.efforts, !efforts.isEmpty {
@@ -100,13 +101,13 @@ struct AISettingsView: View {
                             Text(effort.title).tag(effort.id)
                         }
                     } label: {
-                        Text("Reasoning effort")
+                        SettingsRowTitle(.aiDefault, "Reasoning effort")
                         Text("Applied when the default model uses your ChatGPT subscription.")
                     }
                 }
             }
         } header: {
-            Text("Default")
+            SettingsSectionHeader(.aiDefault)
         } footer: {
             Text(defaultModelFooter)
                 .font(.caption)
@@ -132,12 +133,12 @@ struct AISettingsView: View {
         @Bindable var settings = settings
         return Section {
             Toggle(isOn: $settings.webSearchEnabled) {
-                Text("Web search")
+                SettingsRowTitle(.aiChat, "Web search")
                 Text(
                     "Sends prompts on to a search engine when the route offers one — ChatGPT and OpenRouter.")
             }
         } header: {
-            Text("Chat")
+            SettingsSectionHeader(.aiChat)
         } footer: {
             Text("Images pasted into the chat go to any model that accepts them; others never see one.")
                 .font(.caption)
@@ -151,26 +152,26 @@ struct AISettingsView: View {
             Picker(selection: $settings.opensTo) {
                 ForEach(AIOpensTo.allCases) { Text($0.title).tag($0) }
             } label: {
-                Text("Opens to")
+                SettingsRowTitle(.aiConversations, "Opens to")
                 Text("What summoning AI Chat lands on.")
             }
             if settings.opensTo == .recent {
                 Picker(selection: $settings.newChatAfter) {
                     ForEach(AINewChatAfter.allCases) { Text($0.title).tag($0) }
                 } label: {
-                    Text("Start a new conversation after")
+                    SettingsRowTitle(.aiConversations, "Start a new conversation after")
                     Text("Idle this long and the next summon starts fresh instead.")
                 }
             }
             Picker(selection: $settings.retention) {
                 ForEach(AIRetention.allCases) { Text($0.title).tag($0) }
             } label: {
-                Text("Keep conversations")
+                SettingsRowTitle(.aiConversations, "Keep conversations")
                 Text("Older conversations are deleted permanently.")
             }
             .onChange(of: settings.retention) { core.aiChatCoordinator.applyRetention() }
         } header: {
-            Text("Conversations")
+            SettingsSectionHeader(.aiConversations)
         } footer: {
             Text(
                 "Conversations stay on this Mac. Nothing here is carried in a settings backup — which "
@@ -185,13 +186,13 @@ struct AISettingsView: View {
         @Bindable var settings = settings
         return Section {
             Toggle(isOn: $settings.systemPromptEnabled) {
-                Text("Send a system prompt")
+                SettingsRowTitle(.aiSystemPrompt, "Send a system prompt")
                 Text("Off sends nothing ahead of your message, not even what Tinycast says about itself.")
             }
             SystemPromptEditor(text: $settings.systemPrompt)
                 .settingsEnabled(settings.systemPromptEnabled)
         } header: {
-            Text("System prompt")
+            SettingsSectionHeader(.aiSystemPrompt)
         } footer: {
             Text(
                 "Your text is sent ahead of every message in every chat, after what Tinycast already tells the model about itself — so both are billed again on each turn."
@@ -213,7 +214,7 @@ struct AISettingsView: View {
                 }
             }
         } header: {
-            Text("ChatGPT Subscription")
+            SettingsSectionHeader(.aiChatGPTSubscription)
         } footer: {
             Text(
                 "Uses OpenAI’s supported Codex App Server. The sign-in is stored in Tinycast’s "
@@ -302,16 +303,22 @@ struct AISettingsView: View {
                         onRemove: { pendingRemoval = connection })
                 }
             }
-            Button("Add API Connection…", systemImage: "plus") {
+            Button {
                 editor = AIConnectionEditorTarget(
                     connection: AIConnection(), hasStoredKey: false, isNew: true)
+            } label: {
+                Label {
+                    SettingsRowTitle(.aiAPIConnections, "Add API Connection")
+                } icon: {
+                    Image(systemName: "plus")
+                }
             }
             if keyError {
                 Label("The login Keychain could not be accessed.", systemImage: "exclamationmark.triangle")
                     .foregroundStyle(.orange)
             }
         } header: {
-            Text("API Connections")
+            SettingsSectionHeader(.aiAPIConnections)
         } footer: {
             Text(
                 "OpenAI, Claude, Gemini and OpenRouter are presets. Custom OpenAI-compatible "

--- a/Tinycast/Features/Backup/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Backup/Settings/BackupSettingsView.swift
@@ -46,20 +46,20 @@ struct BackupSettingsView: View {
                         Button("Export…") { runExport() }.disabled(exportSelection.isEmpty)
                     }
                 } label: {
-                    Text("Export Backup")
+                    SettingsRowTitle(.backupExport, "Export Backup")
                     Text("Choose what to include, then save it as a single .tinycast file.")
                 }
                 BackupCategorySelection(selection: $exportSelection)
                 if let backupStatus { statusRow(backupStatus) }
             } header: {
-                Text("Export")
+                SettingsSectionHeader(.backupExport)
             }
 
             Section {
                 LabeledContent {
                     Button("Choose…") { chooseBackupFile() }
                 } label: {
-                    Text("Backup File")
+                    SettingsRowTitle(.backupImport, "Backup File")
                     Text(backupFileSubtitle)
                 }
                 if let manifest = openedManifest {
@@ -78,14 +78,14 @@ struct BackupSettingsView: View {
                     }
                 }
             } header: {
-                Text("Import")
+                SettingsSectionHeader(.backupImport)
             }
 
             Section {
                 LabeledContent {
                     Button("Choose…") { chooseRaycastFile() }
                 } label: {
-                    Text("Raycast Export")
+                    SettingsRowTitle(.backupImportFromRaycast, "Raycast Export")
                     Text(raycastFileSubtitle)
                 }
                 LabeledContent {
@@ -111,10 +111,11 @@ struct BackupSettingsView: View {
                 conflictNotice
                 if let status { statusRow(status) }
             } header: {
-                Text("Import from Raycast")
+                SettingsSectionHeader(.backupImportFromRaycast)
             }
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.backup)
         .onDisappear { if !importingBackup { discardStagedBackup() } }
     }
 

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -9,7 +9,7 @@ struct CalendarSettingsView: View {
         @Bindable var settings = settings
         Form {
             FeatureSwitchSection(
-                header: "Calendar",
+                anchor: .calendarCalendar,
                 enableTitle: "Join meetings from Tinycast",
                 enableSubtitle:
                     "Reads \(core.calendarCoordinator.span.possessivePhrase) events to find join "
@@ -24,7 +24,7 @@ struct CalendarSettingsView: View {
                         Text(limit.title).tag(limit)
                     }
                 } label: {
-                    Text("Upcoming meetings in launcher")
+                    SettingsRowTitle(.calendarSchedule, "Upcoming meetings in launcher")
                     Text("Choose how many upcoming meetings appear alongside apps and commands.")
                 }
             }
@@ -43,11 +43,11 @@ struct CalendarSettingsView: View {
 
             Section {
                 Toggle(isOn: $settings.calendarIncludesTomorrow) {
-                    Text("Include Tomorrow's Events")
+                    SettingsRowTitle(.calendarSchedule, "Include Tomorrow's Events")
                     Text("Read tomorrow as well as the rest of today, everywhere meetings appear.")
                 }
             } header: {
-                Text("Schedule")
+                SettingsSectionHeader(.calendarSchedule)
             }
             .settingsEnabled(settings.calendarEnabled)
 
@@ -57,24 +57,24 @@ struct CalendarSettingsView: View {
                         Text(window.title).tag(window)
                     }
                 } label: {
-                    Text("Show the join card")
+                    SettingsRowTitle(.calendarJoining, "Show the join card")
                     Text("How early the card appears, and how long past the start it stays.")
                 }
                 Toggle(isOn: $settings.autoJoinMeetings) {
-                    Text("Auto Join Meetings")
+                    SettingsRowTitle(.calendarJoining, "Auto Join Meetings")
                     Text("Automatically join meetings as they start.")
                 }
                 Toggle(isOn: $settings.autoJoinConfirms) {
-                    Text("Confirm before joining")
+                    SettingsRowTitle(.calendarJoining, "Confirm before joining")
                 }
                 .toggleStyle(.checkbox)
                 .settingsEnabled(settings.autoJoinMeetings)
                 Toggle(isOn: $settings.cameraPreview) {
-                    Text("Camera Preview")
+                    SettingsRowTitle(.calendarJoining, "Camera Preview")
                     Text("Open camera preview before joining meetings.")
                 }
             } header: {
-                Text("Joining")
+                SettingsSectionHeader(.calendarJoining)
             }
             .settingsEnabled(settings.calendarEnabled)
 
@@ -84,7 +84,7 @@ struct CalendarSettingsView: View {
                         Text(display.title).tag(display)
                     }
                 } label: {
-                    Text("Calendar in Menu Bar")
+                    SettingsRowTitle(.calendarMenuBar, "Calendar in Menu Bar")
                     Text(
                         "Its own menu bar item, showing a meeting icon or its title and countdown."
                     )
@@ -94,7 +94,7 @@ struct CalendarSettingsView: View {
                         Text(lead.title).tag(lead)
                     }
                 } label: {
-                    Text("Show Upcoming Events")
+                    SettingsRowTitle(.calendarMenuBar, "Show Upcoming Events")
                     Text(
                         "When the next event reaches the menu bar. Today includes the next 30 "
                             + "minutes after midnight."
@@ -102,7 +102,7 @@ struct CalendarSettingsView: View {
                 }
                 .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
                 Toggle(isOn: $settings.menuBarLinkedEventsOnly) {
-                    Text("Only show events with meetings")
+                    SettingsRowTitle(.calendarMenuBar, "Only show events with meetings")
                 }
                 .toggleStyle(.checkbox)
                 .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
@@ -111,12 +111,12 @@ struct CalendarSettingsView: View {
                         Text(hide.title).tag(hide)
                     }
                 } label: {
-                    Text("Hide Current Event")
+                    SettingsRowTitle(.calendarMenuBar, "Hide Current Event")
                     Text("Choose whether to hide a started event or show its time left.")
                 }
                 .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
             } header: {
-                Text("Menu Bar")
+                SettingsSectionHeader(.calendarMenuBar)
             }
             .settingsEnabled(settings.calendarEnabled)
 
@@ -127,6 +127,7 @@ struct CalendarSettingsView: View {
                 .settingsEnabled(settings.calendarEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.calendar)
         .releasesFocusOnOutsideClick()
     }
 
@@ -166,7 +167,7 @@ private struct CalendarCommandsSection: View {
                 }
             }
         } header: {
-            Text("Calendar")
+            SettingsSectionHeader(.calendarCalendar)
         } footer: {
             Text("A shortcut works even when its command is hidden from the launcher.")
                 .font(.caption)
@@ -215,7 +216,7 @@ private struct CalendarPickerSection: View {
                 .padding(.vertical, -Self.rowPadding)
             }
         } header: {
-            Text("Calendars")
+            SettingsSectionHeader(.calendarCalendars)
         }
     }
 

--- a/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
@@ -11,11 +11,11 @@ struct ClipboardSettingsView: View {
         @Bindable var settings = settings
         return Form {
             Section {
-                SettingsRow(title: "Clipboard History") {
+                SettingsRow(title: "Clipboard History", anchor: .clipboardGlobalShortcuts) {
                     ShortcutRecorder(action: .command(.clipboardHistory))
                 }
             } header: {
-                Text("Global Shortcuts")
+                SettingsSectionHeader(.clipboardGlobalShortcuts)
             } footer: {
                 Text("Open the clipboard history browser.")
                     .font(.caption)
@@ -28,14 +28,14 @@ struct ClipboardSettingsView: View {
                         Text(retention.title).tag(retention)
                     }
                 } label: {
-                    Text("Keep history for")
+                    SettingsRowTitle(.clipboardHistory, "Keep history for")
                     Text("Entries older than this are deleted automatically.")
                 }
                 .onChange(of: settings.clipboardRetention) {
                     core.clipboardCoordinator.applyRetention(settings.clipboardRetention)
                 }
             } header: {
-                Text("History")
+                SettingsSectionHeader(.clipboardHistory)
             }
 
             Section {
@@ -53,7 +53,7 @@ struct ClipboardSettingsView: View {
                         }
                     }
             } header: {
-                Text("Disabled Applications")
+                SettingsSectionHeader(.clipboardDisabledApplications)
             } footer: {
                 Text("Clipboard changes from these apps won't be recorded.")
                     .font(.caption)
@@ -64,12 +64,13 @@ struct ClipboardSettingsView: View {
                 LabeledContent {
                     Button("Clear…", role: .destructive) { confirmingClear = true }
                 } label: {
-                    Text("Clear history")
+                    SettingsRowTitle(.clipboardDisabledApplications, "Clear history")
                     Text("Permanently remove every saved clip and image.")
                 }
             }
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.clipboard)
         .confirmationDialog(
             "Clear clipboard history?",
             isPresented: $confirmingClear,

--- a/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
@@ -13,11 +13,11 @@ struct CommandsSettingsView: View {
         return Form {
             LauncherItemsSection(
                 kind: .command,
-                header: "Commands",
+                anchor: .commandsCommands,
                 searchPrompt: "Search commands…")
 
             FeatureSwitchSection(
-                header: "Custom Commands",
+                anchor: .commandsCustomCommands,
                 enableTitle: "Enable custom commands",
                 enableSubtitle:
                     "Commands run with your user account in /bin/zsh, so use full executable paths.",
@@ -43,7 +43,11 @@ struct CommandsSettingsView: View {
                             onDelete: { pendingDeletion = command })
                     }
                 }
-                Button("Add Custom Command…") { editor = EditorTarget(command: nil) }
+                Button {
+                    editor = EditorTarget(command: nil)
+                } label: {
+                    SettingsRowTitle(.commandsCustomCommands, "Add Custom Command")
+                }
             } footer: {
                 Text("Name it, then give it a shortcut if you want one.")
                     .font(.caption)
@@ -52,6 +56,7 @@ struct CommandsSettingsView: View {
             .settingsEnabled(settings.customCommandsEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.commands)
         .releasesFocusOnOutsideClick()
         .sheet(item: $editor) { target in
             CustomCommandEditorSheet(command: target.command)

--- a/Tinycast/Features/Emoji/Settings/EmojiSettingsView.swift
+++ b/Tinycast/Features/Emoji/Settings/EmojiSettingsView.swift
@@ -7,11 +7,11 @@ struct EmojiSettingsView: View {
         @Bindable var settings = settings
         return Form {
             Section {
-                SettingsRow(title: "Emoji & Symbols") {
+                SettingsRow(title: "Emoji & Symbols", anchor: .emojiGlobalShortcuts) {
                     ShortcutRecorder(action: .command(.searchEmoji))
                 }
             } header: {
-                Text("Global Shortcuts")
+                SettingsSectionHeader(.emojiGlobalShortcuts)
             } footer: {
                 Text("Summon the emoji and symbols palette.")
                     .font(.caption)
@@ -20,14 +20,16 @@ struct EmojiSettingsView: View {
 
             Section {
                 // A hand per tone, quicker to scan than a dropdown of tone names.
-                Picker("Emoji Skin Tone", selection: $settings.emojiSkinTone) {
+                Picker(selection: $settings.emojiSkinTone) {
                     ForEach(EmojiSkinTone.allCases) { tone in
                         Text(tone.sample).tag(tone)
                     }
+                } label: {
+                    SettingsRowTitle(.emojiAppearance, "Emoji Skin Tone")
                 }
                 .pickerStyle(.segmented)
             } header: {
-                Text("Appearance")
+                SettingsSectionHeader(.emojiAppearance)
             } footer: {
                 Text("Applied when an emoji supports skin tones; pastes use it too.")
                     .font(.caption)
@@ -35,5 +37,6 @@ struct EmojiSettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.emoji)
     }
 }

--- a/Tinycast/Features/Extensions/Settings/ExtensionsSettingsView.swift
+++ b/Tinycast/Features/Extensions/Settings/ExtensionsSettingsView.swift
@@ -21,7 +21,7 @@ struct ExtensionsSettingsView: View {
         @Bindable var settings = core.settings
         return Form {
             FeatureSwitchSection(
-                header: "Extensions",
+                anchor: .extensionsExtensions,
                 enableTitle: "Enable extensions",
                 enableSubtitle:
                     "Run Raycast extensions natively. A running command holds a JavaScript engine "
@@ -44,6 +44,7 @@ struct ExtensionsSettingsView: View {
             storage
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.extensions)
         .releasesFocusOnOutsideClick()
         // Escape and Return are the keyboard way out of the same field.
         .onExitCommand { NSApp.keyWindow?.makeFirstResponder(nil) }
@@ -99,7 +100,7 @@ struct ExtensionsSettingsView: View {
                         + "Raycast's AI, browser and window-management services.")
             }
         } header: {
-            Text("Compatibility")
+            SettingsSectionHeader(.extensionsCompatibility)
         } footer: {
             Text("An extension that needs something missing says so when you run it.")
                 .font(.caption)
@@ -145,9 +146,11 @@ struct ExtensionsSettingsView: View {
                 }
             }
         } header: {
-            Text(
-                core.extensions.installed.isEmpty
-                    ? "Installed" : "Installed (\(core.extensions.installed.count))")
+            SettingsSectionHeader(anchor: .extensionsInstalled) {
+                Text(
+                    core.extensions.installed.isEmpty
+                        ? "Installed" : "Installed (\(core.extensions.installed.count))")
+            }
         } footer: {
             if let error {
                 Label(error, systemImage: "exclamationmark.triangle")
@@ -173,7 +176,7 @@ struct ExtensionsSettingsView: View {
     /// Three rows rather than a menu: search, copy and folder behave differently.
     private var install: some View {
         Section {
-            SettingsRow(title: "Search extensions", subtitle: searchSubtitle) {
+            SettingsRow(title: "Search extensions", subtitle: searchSubtitle, anchor: .extensionsInstall) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
             } trailing: {
@@ -182,7 +185,10 @@ struct ExtensionsSettingsView: View {
                 Button("Search…") { browsingStore = true }
             }
             // A state of this row, not a card: the same job as the button beside it.
-            SettingsRow(title: "Import from Raycast", subtitle: importSubtitle) {
+            SettingsRow(
+                title: "Import from Raycast", subtitle: importSubtitle,
+                anchor: .extensionsInstall
+            ) {
                 Image(systemName: "arrow.down.doc")
                     .foregroundStyle(pending.isEmpty ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tint))
             } trailing: {
@@ -198,7 +204,8 @@ struct ExtensionsSettingsView: View {
             }
             SettingsRow(
                 title: "Add from folder",
-                subtitle: "A folder holding package.json and the built command files."
+                subtitle: "A folder holding package.json and the built command files.",
+                anchor: .extensionsInstall
             ) {
                 Image(systemName: "folder")
                     .foregroundStyle(.secondary)
@@ -206,7 +213,7 @@ struct ExtensionsSettingsView: View {
                 Button("Choose…", action: addFolder)
             }
         } header: {
-            Text("Install")
+            SettingsSectionHeader(.extensionsInstall)
         } footer: {
             if let error {
                 // Under the buttons that caused it: it used to sit beneath the list, far above.
@@ -220,7 +227,10 @@ struct ExtensionsSettingsView: View {
     /// An install cleans up after itself, so in normal use this row has nothing to offer.
     private var storage: some View {
         Section {
-            SettingsRow(title: "Leftover files", subtitle: reclaimableSubtitle) {
+            SettingsRow(
+                title: "Leftover files", subtitle: reclaimableSubtitle,
+                anchor: .extensionsStorage
+            ) {
                 Image(systemName: "internaldrive")
                     .foregroundStyle(reclaimable.isEmpty ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tint))
             } trailing: {
@@ -233,7 +243,7 @@ struct ExtensionsSettingsView: View {
                 .disabled(reclaimable.isEmpty)
             }
         } header: {
-            Text("Storage")
+            SettingsSectionHeader(.extensionsStorage)
         }
     }
 

--- a/Tinycast/Features/FileSearch/Settings/FileSearchSettingsView.swift
+++ b/Tinycast/Features/FileSearch/Settings/FileSearchSettingsView.swift
@@ -8,11 +8,11 @@ struct FileSearchSettingsView: View {
         return Form {
             Section {
                 Toggle(isOn: $settings.fileSearchEnabled) {
-                    Text("Enable File Search")
+                    SettingsRowTitle(.fileSearchFileSearch, "Enable File Search")
                     Text("Find files and folders through the system Spotlight index, only on demand.")
                 }
             } header: {
-                Text("File Search")
+                SettingsSectionHeader(.fileSearchFileSearch)
             }
 
             SearchFilesCommandSection()
@@ -23,6 +23,7 @@ struct FileSearchSettingsView: View {
                 .settingsEnabled(settings.fileSearchEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.fileSearch)
     }
 }
 
@@ -47,7 +48,7 @@ private struct SearchFilesCommandSection: View {
                 }
             }
         } header: {
-            Text("Commands")
+            SettingsSectionHeader(.fileSearchCommands)
         } footer: {
             Text("The shortcut works even when the command is hidden from the launcher.")
                 .font(.caption)
@@ -89,7 +90,7 @@ private struct FileSearchScopesSection: View {
                 }
             }
         } header: {
-            Text("Search Scopes")
+            SettingsSectionHeader(.fileSearchSearchScopes)
         } footer: {
             Text(
                 """
@@ -178,7 +179,7 @@ private struct FileSearchIgnoreSection: View {
             TextField("Add pattern…", text: $draft)
                 .onSubmit(addPattern)
         } header: {
-            Text("Ignore Patterns")
+            SettingsSectionHeader(.fileSearchIgnorePatterns)
         } footer: {
             Text(
                 """

--- a/Tinycast/Features/Launcher/Settings/ApplicationsSettingsView.swift
+++ b/Tinycast/Features/Launcher/Settings/ApplicationsSettingsView.swift
@@ -8,10 +8,11 @@ struct ApplicationsSettingsView: View {
 
             LauncherItemsSection(
                 kind: .application,
-                header: "Applications",
+                anchor: .applicationsApplications,
                 searchPrompt: "Search applications…")
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.applications)
         .releasesFocusOnOutsideClick()
     }
 }

--- a/Tinycast/Features/Launcher/Settings/FallbacksSettingsView.swift
+++ b/Tinycast/Features/Launcher/Settings/FallbacksSettingsView.swift
@@ -17,7 +17,7 @@ struct FallbacksSettingsView: View {
                 )
                 .foregroundStyle(.secondary)
             } header: {
-                Text("Fallbacks")
+                SettingsSectionHeader(.fallbacksFallbacks)
             }
 
             Section {
@@ -47,6 +47,7 @@ struct FallbacksSettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.fallbacks)
         .releasesFocusOnOutsideClick()
     }
 

--- a/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
+++ b/Tinycast/Features/Launcher/Settings/LauncherItemsSection.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// One category's Settings sections; never filters by visibility, so hidden rows stay listed.
 struct LauncherItemsSection: View {
     let kind: AppEntry.Kind
-    let header: String
+    let anchor: SettingsAnchor
     let searchPrompt: String
 
     @Environment(AppIndex.self) private var appIndex
@@ -21,11 +21,11 @@ struct LauncherItemsSection: View {
     var body: some View {
         Section {
             Toggle(isOn: enabledBinding) {
-                Text("Enable \(header)")
+                SettingsRowTitle(anchor, "Enable \(anchor.title)")
                 Text("Off hides them all and stops their shortcuts. Uncheck one below to hide just that one.")
             }
         } header: {
-            Text(header)
+            SettingsSectionHeader(anchor)
         }
 
         Section {

--- a/Tinycast/Features/Launcher/Settings/SearchScopesSection.swift
+++ b/Tinycast/Features/Launcher/Settings/SearchScopesSection.swift
@@ -25,7 +25,7 @@ struct SearchScopesSection: View {
                 }
             }
         } header: {
-            Text("Search Scopes")
+            SettingsSectionHeader(.applicationsSearchScopes)
         } footer: {
             Text("Folders searched when indexing applications.")
                 .font(.caption)

--- a/Tinycast/Features/Launcher/Settings/SystemSettingsSettingsView.swift
+++ b/Tinycast/Features/Launcher/Settings/SystemSettingsSettingsView.swift
@@ -6,10 +6,11 @@ struct SystemSettingsSettingsView: View {
         Form {
             LauncherItemsSection(
                 kind: .systemSettings,
-                header: "System Settings",
+                anchor: .systemSettingsSystemSettings,
                 searchPrompt: "Search System Settings…")
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.systemSettings)
         .releasesFocusOnOutsideClick()
     }
 }

--- a/Tinycast/Features/MCP/Settings/MCPSettingsSection.swift
+++ b/Tinycast/Features/MCP/Settings/MCPSettingsSection.swift
@@ -11,7 +11,9 @@ struct MCPSettingsSection: View {
     var body: some View {
         @Bindable var appSettings = appSettings
         Section {
-            Toggle("Enable MCP servers", isOn: $appSettings.mcpEnabled)
+            Toggle(isOn: $appSettings.mcpEnabled) {
+                SettingsRowTitle(.aiMCPServers, "Enable MCP servers")
+            }
             Group {
                 if store.servers.isEmpty {
                     Text("No MCP servers yet.")
@@ -24,13 +26,19 @@ struct MCPSettingsSection: View {
                             onRemove: { pendingRemoval = server })
                     }
                 }
-                Button("Add MCP Server…", systemImage: "plus") {
+                Button {
                     editor = MCPServerEditorTarget(server: MCPServer(), isNew: true)
+                } label: {
+                    Label {
+                        SettingsRowTitle(.aiMCPServers, "Add MCP Server")
+                    } icon: {
+                        Image(systemName: "plus")
+                    }
                 }
             }
             .settingsEnabled(appSettings.mcpEnabled)
         } header: {
-            Text("MCP Servers")
+            SettingsSectionHeader(.aiMCPServers)
         } footer: {
             Text(
                 "Tools from every enabled server are offered to the model; type @slug to address "

--- a/Tinycast/Features/Notes/Settings/NotesSettingsView.swift
+++ b/Tinycast/Features/Notes/Settings/NotesSettingsView.swift
@@ -8,17 +8,18 @@ struct NotesSettingsView: View {
         return Form {
             Section {
                 Toggle(isOn: $settings.notesEnabled) {
-                    Text("Enable Notes")
+                    SettingsRowTitle(.notesNotes, "Enable Notes")
                     Text("Keep plain Markdown notes in a floating editor, loaded only when needed.")
                 }
             } header: {
-                Text("Notes")
+                SettingsSectionHeader(.notesNotes)
             }
 
             NotesCommandsSection()
                 .settingsEnabled(settings.notesEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.notes)
     }
 }
 
@@ -45,7 +46,7 @@ private struct NotesCommandsSection: View {
                 }
             }
         } header: {
-            Text("Commands")
+            SettingsSectionHeader(.notesCommands)
         } footer: {
             Text("A shortcut works even when its command is hidden from the launcher.")
                 .font(.caption)

--- a/Tinycast/Features/QuickActions/Settings/QuickActionsSettingsView.swift
+++ b/Tinycast/Features/QuickActions/Settings/QuickActionsSettingsView.swift
@@ -18,7 +18,7 @@ struct QuickActionsSettingsView: View {
         Form {
             Section {
                 Toggle(isOn: enabledBinding) {
-                    Text("Enable Quick Actions")
+                    SettingsRowTitle(.quickActionsQuickActions, "Enable Quick Actions")
                     Text(
                         "Act on the text you have selected in any app. Nothing is read until you "
                             + "press a shortcut.")
@@ -37,7 +37,7 @@ struct QuickActionsSettingsView: View {
                     }
                 }
             } header: {
-                Text("Quick Actions")
+                SettingsSectionHeader(.quickActionsQuickActions)
             }
 
             Group {
@@ -48,6 +48,7 @@ struct QuickActionsSettingsView: View {
             .settingsEnabled(appSettings.quickActionsEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.quickActions)
         .onReceive(refreshTimer) { _ in isTrusted = Permissions.isAccessibilityTrusted() }
         .sheet(item: $editingAction) { action in
             InstructionsEditorSheet(
@@ -101,7 +102,7 @@ struct QuickActionsSettingsView: View {
                 }
             }
         } header: {
-            Text("Actions")
+            SettingsSectionHeader(.quickActionsActions)
         } footer: {
             Text(
                 "Replace puts the result straight into your document — undo in the app you were in "
@@ -124,12 +125,12 @@ struct QuickActionsSettingsView: View {
                         Text(choice.menuTitle).tag(Optional(choice.selection))
                     }
                 } label: {
-                    Text("Model")
+                    SettingsRowTitle(.quickActionsModel, "Model")
                     Text("Used by every action except Translate.")
                 }
             }
         } header: {
-            Text("Model")
+            SettingsSectionHeader(.quickActionsModel)
         } footer: {
             Text(
                 "Separate from chat's model on purpose: a shortcut you press all day should not "
@@ -148,11 +149,11 @@ struct QuickActionsSettingsView: View {
                     Text(TextTranslator.displayName(of: $0)).tag($0.minimalIdentifier)
                 }
             } label: {
-                Text("Translate to")
+                SettingsRowTitle(.quickActionsTranslate, "Translate to")
                 Text("The panel can still translate into another language once it is open.")
             }
         } header: {
-            Text("Translate")
+            SettingsSectionHeader(.quickActionsTranslate)
         } footer: {
             Text(
                 "Translation uses Apple's own translator on this Mac, so it costs nothing and "

--- a/Tinycast/Features/Quicklinks/Settings/QuicklinksSettingsView.swift
+++ b/Tinycast/Features/Quicklinks/Settings/QuicklinksSettingsView.swift
@@ -13,7 +13,7 @@ struct QuicklinksSettingsView: View {
         @Bindable var settings = settings
         return Form {
             FeatureSwitchSection(
-                header: "Quicklinks",
+                anchor: .quicklinksQuicklinks,
                 enableTitle: "Enable quicklinks",
                 enableSubtitle:
                     "Open saved destinations from the launcher, a shortcut, or Search Quicklinks.",
@@ -30,6 +30,7 @@ struct QuicklinksSettingsView: View {
             .settingsEnabled(settings.quicklinksEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.quicklinks)
         // Presented from the pane, so "Create Quicklink" can open it from the palette.
         .sheet(item: $core.pendingQuicklinkEdit) { request in
             QuicklinkEditorSheet(quicklink: request.quicklink)
@@ -86,7 +87,11 @@ struct QuicklinksSettingsView: View {
                         onDelete: { pendingDeletion = quicklink })
                 }
             }
-            Button("Add Quicklink…") { core.quicklinkCoordinator.editQuicklink(nil) }
+            Button {
+                core.quicklinkCoordinator.editQuicklink(nil)
+            } label: {
+                SettingsRowTitle(.quicklinksQuicklinks, "Add Quicklink")
+            }
         } footer: {
             Text("Name it, paste a link, then add an alias or a shortcut if you want one.")
                 .font(.caption)
@@ -98,7 +103,7 @@ struct QuicklinksSettingsView: View {
         @Bindable var settings = settings
         return Section {
             Toggle(isOn: $settings.quicklinkOpensNewWindow) {
-                Text("Open in a new window")
+                SettingsRowTitle(.quicklinksBehaviour, "Open in a new window")
                 Text(
                     "Ask the handler for a new window instead of reusing its frontmost tab. "
                         + "Only apps that accept a new-window argument can honour this.")
@@ -108,15 +113,15 @@ struct QuicklinksSettingsView: View {
                     Text(option.title).tag(option)
                 }
             } label: {
-                Text("When there's no selected text")
+                SettingsRowTitle(.quicklinksBehaviour, "When there's no selected text")
                 Text("What {selection} does when the app in front exposes nothing to read.")
             }
             Toggle(isOn: $settings.quicklinkConfirmsBeforeDelete) {
-                Text("Confirm before deleting")
+                SettingsRowTitle(.quicklinksBehaviour, "Confirm before deleting")
                 Text("Ask first when deleting a quicklink from the launcher's Actions menu.")
             }
         } header: {
-            Text("Behaviour")
+            SettingsSectionHeader(.quicklinksBehaviour)
         }
     }
 
@@ -125,18 +130,18 @@ struct QuicklinksSettingsView: View {
             LabeledContent {
                 Button("Import…") { Task { await core.quicklinkCoordinator.importQuicklinks() } }
             } label: {
-                Text("Import quicklinks")
+                SettingsRowTitle(.quicklinksImportExport, "Import quicklinks")
                 Text("Add quicklinks from a JSON file, skipping any you already have.")
             }
             LabeledContent {
                 Button("Export…") { Task { await core.quicklinkCoordinator.exportQuicklinks() } }
                     .disabled(store.quicklinks.isEmpty)
             } label: {
-                Text("Export quicklinks")
+                SettingsRowTitle(.quicklinksImportExport, "Export quicklinks")
                 Text("Write your whole library to a JSON file.")
             }
         } header: {
-            Text("Import & Export")
+            SettingsSectionHeader(.quicklinksImportExport)
         }
     }
 

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -28,11 +28,11 @@ struct GeneralSettingsView: View {
         @Bindable var settings = settings
         return Form {
             Section {
-                SettingsRow(title: "App Launcher") {
+                SettingsRow(title: "App Launcher", anchor: .generalGlobalShortcuts) {
                     ShortcutRecorder(action: .togglePalette)
                 }
             } header: {
-                Text("Global Shortcuts")
+                SettingsSectionHeader(.generalGlobalShortcuts)
             } footer: {
                 Text("Summon the fuzzy app launcher.")
                     .font(.caption)
@@ -40,14 +40,16 @@ struct GeneralSettingsView: View {
             }
 
             Section {
-                LabeledContent("Learned ranking") {
+                LabeledContent {
                     Button("Reset…", role: .destructive) {
                         confirmingRankingReset = true
                     }
                     .disabled(launcherRanking.isEmpty)
+                } label: {
+                    SettingsRowTitle(.generalSearch, "Learned ranking")
                 }
             } header: {
-                Text("Search")
+                SettingsSectionHeader(.generalSearch)
             } footer: {
                 Text(
                     "Tinycast privately learns which results you choose for each query. Reset all learned choices to restore the default order."
@@ -62,7 +64,7 @@ struct GeneralSettingsView: View {
                         Text(key.title).tag(key)
                     }
                 } label: {
-                    Text("Hyper Key")
+                    SettingsRowTitle(.generalHyperKey, "Hyper Key")
                     Text(hyperSubtitle)
                 }
                 .onChange(of: settings.hyperKey) { _, newKey in
@@ -91,7 +93,7 @@ struct GeneralSettingsView: View {
                         }
                         Text("Trigger Escape").tag(HyperKeyQuickPress.escape)
                     } label: {
-                        Text("Quick Press")
+                        SettingsRowTitle(.generalHyperKey, "Quick Press")
                         Text(
                             "Select an action to perform when \(settings.hyperKey.title) is pressed without any other keys."
                         )
@@ -99,13 +101,13 @@ struct GeneralSettingsView: View {
                 }
 
                 Toggle(isOn: $settings.hyperKeyIncludesShift) {
-                    Text("Include Shift (⇧)")
+                    SettingsRowTitle(.generalHyperKey, "Include Shift (⇧)")
                     Text("Hyper Key will remap to the \(hyperGlyphs) modifier keys.")
                 }
                 // Flipping it re-points recorded chords, so it needs a chord to mean.
                 .settingsEnabled(settings.hyperKey != .none)
             } header: {
-                Text("Hyper Key")
+                SettingsSectionHeader(.generalHyperKey)
             }
 
             Section {
@@ -114,43 +116,43 @@ struct GeneralSettingsView: View {
                         Text(appearance.title).tag(appearance)
                     }
                 } label: {
-                    Text("Theme")
+                    SettingsRowTitle(.generalAppearance, "Theme")
                     Text("Match macOS, or pin Tinycast to Light or Dark.")
                 }
                 Toggle(isOn: $settings.compactMode) {
-                    Text("Compact mode")
+                    SettingsRowTitle(.generalAppearance, "Compact mode")
                     Text(
                         "Open the launcher as a slim search bar that expands into the full list as you type."
                     )
                 }
                 Toggle(isOn: $settings.showFavoritesInCompactMode) {
-                    Text("Show favorites in compact mode")
+                    SettingsRowTitle(.generalAppearance, "Show favorites in compact mode")
                     Text("Pin favorite app icons to the right of the compact bar (⌘1–⌘5 to launch).")
                 }
                 .disabled(!settings.compactMode)
                 Toggle(isOn: $settings.openOnCursorScreen) {
-                    Text("Follow the cursor across displays")
+                    SettingsRowTitle(.generalAppearance, "Follow the cursor across displays")
                     Text(
                         "Open the launcher on whichever display the pointer is on, rather than the one with the menu bar."
                     )
                 }
                 Toggle(isOn: $settings.paletteDraggable) {
-                    Text("Drag to reposition")
+                    SettingsRowTitle(.generalAppearance, "Drag to reposition")
                     Text(
                         "Grab the thin strip just above the search field to move the launcher out of the way."
                     )
                 }
             } header: {
-                Text("Appearance")
+                SettingsSectionHeader(.generalAppearance)
             }
 
             Section {
                 Toggle(isOn: $settings.launchAtLogin) {
-                    Text("Launch at login")
+                    SettingsRowTitle(.generalGeneral, "Launch at login")
                     Text("Start Tinycast automatically when you log in.")
                 }
                 Toggle(isOn: $showInMenuBar) {
-                    Text("Show in menu bar")
+                    SettingsRowTitle(.generalGeneral, "Show in menu bar")
                     Text("Keep the Tinycast icon in the menu bar. Shortcuts still work when hidden.")
                 }
                 Picker(selection: $settings.popToRootTimeout) {
@@ -158,7 +160,7 @@ struct GeneralSettingsView: View {
                         Text(timeout.title).tag(timeout)
                     }
                 } label: {
-                    Text("Pop to Root Search")
+                    SettingsRowTitle(.generalGeneral, "Pop to Root Search")
                     Text("Reset to the launcher this long after the window closes.")
                 }
                 // Empty only when TIS fails; one layout still lists, so the row stays put.
@@ -169,15 +171,16 @@ struct GeneralSettingsView: View {
                             Text(source.title).tag(Optional(source.id))
                         }
                     } label: {
-                        Text("Auto-switch input source")
+                        SettingsRowTitle(.generalGeneral, "Auto-switch input source")
                         Text("Switch the keyboard to this source while the launcher is open.")
                     }
                 }
             } header: {
-                Text("General")
+                SettingsSectionHeader(.generalGeneral)
             }
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.general)
         .confirmationDialog(
             "Reset learned launcher ranking?",
             isPresented: $confirmingRankingReset,

--- a/Tinycast/Features/Settings/Panes/PermissionsSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/PermissionsSettingsView.swift
@@ -17,7 +17,7 @@ struct PermissionsSettingsView: View {
                     )
                     .foregroundStyle(accessibilityTrusted ? Color.green : Color.orange)
                 } label: {
-                    Text("Accessibility")
+                    SettingsRowTitle(.permissionsAccessibility, "Accessibility")
                     Text("Lets Tinycast paste a clipboard item into the app you were using.")
                 }
 
@@ -30,7 +30,7 @@ struct PermissionsSettingsView: View {
                     Text("Opens Privacy & Security › Accessibility.")
                 }
             } header: {
-                Text("Accessibility")
+                SettingsSectionHeader(.permissionsAccessibility)
             } footer: {
                 Text("Access Tinycast needs to work with other apps.")
                     .font(.caption)
@@ -42,7 +42,7 @@ struct PermissionsSettingsView: View {
                     Label(calendarStatus.title, systemImage: calendarStatus.symbol)
                         .foregroundStyle(calendarStatus.tint)
                 } label: {
-                    Text("Calendars")
+                    SettingsRowTitle(.permissionsCalendars, "Calendars")
                     Text("Lets Tinycast find the join link for the meeting you are about to be in.")
                 }
 
@@ -54,10 +54,11 @@ struct PermissionsSettingsView: View {
                     Text("Opens Privacy & Security › Calendars.")
                 }
             } header: {
-                Text("Calendars")
+                SettingsSectionHeader(.permissionsCalendars)
             }
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.permissions)
         .onAppear(perform: refresh)
         .onReceive(refreshTimer) { _ in refresh() }
     }

--- a/Tinycast/Features/Settings/SettingsAnchor.swift
+++ b/Tinycast/Features/Settings/SettingsAnchor.swift
@@ -1,0 +1,115 @@
+/// One `Section` inside a pane, named once so the catalog and the pane cannot disagree: the search
+/// result carries the anchor, the pane's `.settingsAnchor(_:)` marks the section it scrolls to.
+struct SettingsAnchor: Hashable, Sendable {
+    let tab: SettingsTab
+    /// The `Section`'s own header text, which is also what a result's breadcrumb reads.
+    let title: String
+}
+
+// Named `<pane><Section>` throughout, so the constant for a section is always guessable from it.
+extension SettingsAnchor {
+    static let generalGlobalShortcuts = Self(tab: .general, title: "Global Shortcuts")
+    static let generalSearch = Self(tab: .general, title: "Search")
+    static let generalHyperKey = Self(tab: .general, title: "Hyper Key")
+    static let generalAppearance = Self(tab: .general, title: "Appearance")
+    static let generalGeneral = Self(tab: .general, title: "General")
+
+    static let applicationsSearchScopes = Self(tab: .applications, title: "Search Scopes")
+    static let applicationsApplications = Self(tab: .applications, title: "Applications")
+
+    static let systemSettingsSystemSettings = Self(tab: .systemSettings, title: "System Settings")
+
+    static let systemActionsSystemActions = Self(tab: .systemActions, title: "System Actions")
+
+    static let commandsCommands = Self(tab: .commands, title: "Commands")
+    static let commandsCustomCommands = Self(tab: .commands, title: "Custom Commands")
+
+    static let quicklinksQuicklinks = Self(tab: .quicklinks, title: "Quicklinks")
+    static let quicklinksBehaviour = Self(tab: .quicklinks, title: "Behaviour")
+    static let quicklinksImportExport = Self(tab: .quicklinks, title: "Import & Export")
+
+    static let fallbacksFallbacks = Self(tab: .fallbacks, title: "Fallbacks")
+
+    static let aiAI = Self(tab: .ai, title: "AI")
+    static let aiDefault = Self(tab: .ai, title: "Default")
+    static let aiChat = Self(tab: .ai, title: "Chat")
+    static let aiConversations = Self(tab: .ai, title: "Conversations")
+    static let aiSystemPrompt = Self(tab: .ai, title: "System prompt")
+    static let aiChatGPTSubscription = Self(tab: .ai, title: "ChatGPT Subscription")
+    static let aiAPIConnections = Self(tab: .ai, title: "API Connections")
+    static let aiMCPServers = Self(tab: .ai, title: "MCP Servers")
+    static let aiCommands = Self(tab: .ai, title: "Commands")
+
+    static let quickActionsQuickActions = Self(tab: .quickActions, title: "Quick Actions")
+    static let quickActionsActions = Self(tab: .quickActions, title: "Actions")
+    static let quickActionsModel = Self(tab: .quickActions, title: "Model")
+    static let quickActionsTranslate = Self(tab: .quickActions, title: "Translate")
+
+    static let fileSearchFileSearch = Self(tab: .fileSearch, title: "File Search")
+    static let fileSearchCommands = Self(tab: .fileSearch, title: "Commands")
+    static let fileSearchSearchScopes = Self(tab: .fileSearch, title: "Search Scopes")
+    static let fileSearchIgnorePatterns = Self(tab: .fileSearch, title: "Ignore Patterns")
+
+    static let notesNotes = Self(tab: .notes, title: "Notes")
+    static let notesCommands = Self(tab: .notes, title: "Commands")
+
+    static let snippetsSnippets = Self(tab: .snippets, title: "Snippets")
+    static let snippetsGlobalShortcut = Self(tab: .snippets, title: "Global Shortcut")
+    static let snippetsLibrary = Self(tab: .snippets, title: "Library")
+
+    static let windowManagementWindowManagement = Self(
+        tab: .windowManagement, title: "Window Management")
+    static let windowManagementOptions = Self(tab: .windowManagement, title: "Options")
+
+    static let clipboardGlobalShortcuts = Self(tab: .clipboard, title: "Global Shortcuts")
+    static let clipboardHistory = Self(tab: .clipboard, title: "History")
+    static let clipboardDisabledApplications = Self(
+        tab: .clipboard, title: "Disabled Applications")
+
+    static let emojiGlobalShortcuts = Self(tab: .emoji, title: "Global Shortcuts")
+    static let emojiAppearance = Self(tab: .emoji, title: "Appearance")
+
+    static let calendarCalendar = Self(tab: .calendar, title: "Calendar")
+    static let calendarSchedule = Self(tab: .calendar, title: "Schedule")
+    static let calendarJoining = Self(tab: .calendar, title: "Joining")
+    static let calendarMenuBar = Self(tab: .calendar, title: "Menu Bar")
+    static let calendarCalendars = Self(tab: .calendar, title: "Calendars")
+
+    static let extensionsExtensions = Self(tab: .extensions, title: "Extensions")
+    static let extensionsCompatibility = Self(tab: .extensions, title: "Compatibility")
+    static let extensionsInstalled = Self(tab: .extensions, title: "Installed")
+    static let extensionsInstall = Self(tab: .extensions, title: "Install")
+    static let extensionsStorage = Self(tab: .extensions, title: "Storage")
+
+    static let permissionsAccessibility = Self(tab: .permissions, title: "Accessibility")
+    static let permissionsCalendars = Self(tab: .permissions, title: "Calendars")
+
+    static let backupExport = Self(tab: .backup, title: "Export")
+    static let backupImport = Self(tab: .backup, title: "Import")
+    static let backupImportFromRaycast = Self(tab: .backup, title: "Import from Raycast")
+
+    static let aboutAbout = Self(tab: .about, title: "About")
+    static let aboutLinks = Self(tab: .about, title: "Links")
+}
+
+/// Where a search result lands: a whole section, or one row inside it.
+enum SettingsTarget: Hashable, Sendable {
+    case section(SettingsAnchor)
+    /// The row's visible title, which is also the catalog entry's — they are the same string.
+    case row(SettingsAnchor, String)
+
+    var anchor: SettingsAnchor {
+        switch self {
+        case .section(let anchor), .row(let anchor, _): return anchor
+        }
+    }
+
+    var tab: SettingsTab { anchor.tab }
+}
+
+/// One jump asked for by a search result. The token is what makes picking the same result twice
+/// scroll and pulse again, rather than comparing equal and doing nothing.
+struct SettingsScrollRequest: Equatable, Sendable {
+    let target: SettingsTarget
+    let token: Int
+}

--- a/Tinycast/Features/Settings/SettingsNavigationState.swift
+++ b/Tinycast/Features/Settings/SettingsNavigationState.swift
@@ -5,6 +5,7 @@ import Observation
 @Observable
 final class SettingsNavigationState {
     private var history: SettingsHistory
+    private var requests = 0
 
     init(tab: SettingsTab) {
         history = SettingsHistory(current: tab)
@@ -14,7 +15,38 @@ final class SettingsNavigationState {
     var canGoBack: Bool { history.canGoBack }
     var canGoForward: Bool { history.canGoForward }
 
-    func select(_ tab: SettingsTab) { history.select(tab) }
+    /// Set by a search result, consumed by the pane that scrolls to it.
+    private(set) var scrollRequest: SettingsScrollRequest?
+    /// The section lit right now. One source for the whole window, so a pane swap can't lose it.
+    private(set) var flashing: SettingsTarget?
+
+    /// A search result navigates and asks the pane to reveal one section; a sidebar row just navigates.
+    func select(_ tab: SettingsTab, revealing target: SettingsTarget? = nil) {
+        history.select(tab)
+        // Any navigation puts the previous pulse out, so a stale light can't outlive its pane.
+        flashing = nil
+        guard let target else { return }
+        requests += 1
+        scrollRequest = SettingsScrollRequest(target: target, token: requests)
+    }
+
+    func beginFlash(_ target: SettingsTarget) {
+        flashing = target
+    }
+
+    /// Ends the pulse, unless a later jump has already lit something else.
+    func endFlash(_ target: SettingsTarget) {
+        guard flashing == target else { return }
+        flashing = nil
+    }
+
+    /// Released only once the pulse is over: it keys the pane's task, so clearing it early would
+    /// cancel the very task doing the revealing.
+    func clear(_ request: SettingsScrollRequest) {
+        guard scrollRequest == request else { return }
+        scrollRequest = nil
+    }
+
     func goBack() { history.goBack() }
     func goForward() { history.goForward() }
 }

--- a/Tinycast/Features/Settings/SettingsScrollTarget.swift
+++ b/Tinycast/Features/Settings/SettingsScrollTarget.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+extension View {
+    /// A pane's `Form`: lets a search result scroll one of its sections into view and pulse it.
+    /// The pane names itself because both panes are briefly alive across a swap, and by then
+    /// `navigation.tab` already reads as the incoming one.
+    func settingsScrollTarget(_ tab: SettingsTab) -> some View {
+        modifier(SettingsScrollTarget(tab: tab))
+    }
+
+    /// A `Section` with no header of its own: still somewhere a result can scroll to, with no pulse
+    /// to paint. Every section that *has* a header uses `SettingsSectionHeader` instead.
+    func settingsAnchor(_ anchor: SettingsAnchor) -> some View {
+        id(SettingsTarget.section(anchor))
+    }
+}
+
+/// The pulse a search result leaves on arrival: a pill behind the name it matched, and nothing else.
+/// A `Form` applies a `.background` to a row's whole *content* box, so lighting the row or the
+/// section paints ragged blocks around every label, button and footer paragraph in it.
+private struct SearchPill: ViewModifier {
+    let target: SettingsTarget
+    @Environment(SettingsNavigationState.self) private var navigation
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.xxs)
+            .background(
+                Capsule().fill(navigation.flashing == target ? Theme.Colors.searchFlash : .clear)
+            )
+            // Given back, so the pill's own padding can't shift the label off its row's edge.
+            .padding(.horizontal, -Theme.Spacing.sm)
+            .padding(.vertical, -Theme.Spacing.xxs)
+            .id(target)
+    }
+}
+
+/// A `Section`'s name, and where a result that matched the whole group lands.
+struct SettingsSectionHeader<Label: View>: View {
+    let anchor: SettingsAnchor
+    @ViewBuilder var label: Label
+
+    var body: some View {
+        label.modifier(SearchPill(target: .section(anchor)))
+    }
+}
+
+extension SettingsSectionHeader where Label == Text {
+    /// The title comes from the anchor, so a section's name and its search breadcrumb are one string.
+    init(_ anchor: SettingsAnchor) {
+        self.init(anchor: anchor) { Text(anchor.title) }
+    }
+}
+
+/// One setting's own name, in place of the `Text` a row's label would otherwise hold. This is what
+/// a row-level search result scrolls to and lights up.
+struct SettingsRowTitle: View {
+    let anchor: SettingsAnchor
+    let title: String
+
+    init(_ anchor: SettingsAnchor, _ title: String) {
+        self.anchor = anchor
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title).modifier(SearchPill(target: .row(anchor, title)))
+    }
+}
+
+private struct SettingsScrollTarget: ViewModifier {
+    let tab: SettingsTab
+    @Environment(SettingsNavigationState.self) private var navigation
+
+    func body(content: Content) -> some View {
+        ScrollViewReader { proxy in
+            content
+                // Keyed on the request, so a second jump cancels the first mid-pulse.
+                .task(id: navigation.scrollRequest) { await reveal(with: proxy) }
+        }
+    }
+
+    private func reveal(with proxy: ScrollViewProxy) async {
+        guard let request = navigation.scrollRequest, request.target.tab == tab else { return }
+        // This pane may have just mounted, so let its `Form` lay the anchor out before scrolling.
+        await Task.yield()
+        withAnimation(.easeOut(duration: Theme.Duration.settingsReveal)) {
+            proxy.scrollTo(request.target, anchor: .center)
+        }
+        navigation.beginFlash(request.target)
+        // Cancelled means a later jump replaced this one, and it owns the light now.
+        do {
+            try await Task.sleep(for: .seconds(Theme.Duration.settingsFlash))
+        } catch {
+            return
+        }
+        withAnimation(.easeOut(duration: Theme.Duration.settingsFlashOut)) {
+            navigation.endFlash(request.target)
+        }
+        // Released last: it keys this task, so clearing it earlier would cancel the reveal itself.
+        navigation.clear(request)
+    }
+}

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -1,0 +1,476 @@
+import Foundation
+
+/// One searchable place in Settings: a pane, or a row inside one of its `Form` sections.
+struct SettingsSearchEntry: Identifiable, Hashable, Sendable {
+    let tab: SettingsTab
+    /// The `Section` header the row sits under; nil for the pane itself.
+    var section: String?
+    let title: String
+    /// Words a user might type that the visible title doesn't contain.
+    var keywords: [String] = []
+
+    var id: String { "\(tab.title)/\(section ?? "")/\(title)" }
+
+    /// The result row's second line — "General", or "General › Hyper Key".
+    var breadcrumb: String {
+        guard let section, section != tab.title else { return tab.title }
+        return "\(tab.title) › \(section)"
+    }
+}
+
+/// What Settings offers to search. Hand-written: a `Form` can't be asked what rows it holds, so a
+/// new row is searchable only once it is listed here.
+enum SettingsSearchCatalog {
+    struct Query: Sendable {
+        let terms: [FuzzyMatch.Query]
+
+        init(_ raw: String) {
+            terms = raw.split(whereSeparator: \Character.isWhitespace).map {
+                FuzzyMatch.Query(String($0))
+            }
+        }
+
+        var isEmpty: Bool { terms.isEmpty }
+    }
+
+    static func results(for raw: String, limit: Int = 50) -> [SettingsSearchEntry] {
+        let query = Query(raw)
+        guard !query.isEmpty else { return [] }
+        // Catalog order is the tie-break, so results don't reshuffle between equal-scoring rows.
+        return
+            entries
+            .enumerated()
+            .compactMap { item -> (entry: SettingsSearchEntry, score: Int, rank: Int)? in
+                guard let score = score(query, item.element) else { return nil }
+                return (item.element, score, item.offset)
+            }
+            .sorted { $0.score != $1.score ? $0.score > $1.score : $0.rank < $1.rank }
+            .prefix(limit)
+            .map(\.entry)
+    }
+
+    /// Every term must land somewhere; a term matched in the title outranks one found off it.
+    private static func score(_ query: Query, _ entry: SettingsSearchEntry) -> Int? {
+        var titleScore = 0
+        var titleMatches = 0
+        for term in query.terms {
+            if let match = FuzzyMatch.match(term, candidate: entry.title) {
+                titleMatches += 1
+                titleScore += match.score
+                continue
+            }
+            guard
+                entry.keywords.contains(where: { FuzzyMatch.match(term, candidate: $0) != nil })
+                    || FuzzyMatch.match(term, candidate: entry.breadcrumb) != nil
+            else { return nil }
+        }
+
+        let band: Int
+        if titleMatches == query.terms.count {
+            band = 2_000_000
+        } else if titleMatches > 0 {
+            band = 1_000_000
+        } else {
+            band = 0
+        }
+        // A pane outranks its own rows, so a bare "clipboard" lands on the pane rather than a row.
+        return band + titleScore + (entry.section == nil ? 500_000 : 0)
+    }
+
+    // MARK: - The index
+    // Pane order, then section order within a pane, so this reads as a table of contents.
+
+    static let entries: [SettingsSearchEntry] =
+        general + applications + systemSettings
+        + systemActions + commands + quicklinks + fallbacks + ai + quickActions + fileSearch + notes
+        + snippets + windowManagement + clipboard + emoji + calendar + extensions + permissions
+        + backup + about
+
+    private static let general: [SettingsSearchEntry] = [
+        .init(tab: .general, title: "General", keywords: ["preferences", "settings"]),
+        .init(
+            tab: .general, section: "Global Shortcuts", title: "App Launcher",
+            keywords: ["hotkey", "shortcut", "summon", "palette"]),
+        .init(
+            tab: .general, section: "Search", title: "Learned ranking",
+            keywords: ["reset", "history", "order", "privacy"]),
+        .init(
+            tab: .general, section: "Hyper Key", title: "Hyper Key",
+            keywords: ["modifier", "remap", "caps lock", "capslock"]),
+        .init(
+            tab: .general, section: "Hyper Key", title: "Quick Press",
+            keywords: ["tap", "escape", "single press"]),
+        .init(
+            tab: .general, section: "Hyper Key", title: "Include Shift (⇧)",
+            keywords: ["modifier", "chord"]),
+        .init(
+            tab: .general, section: "Appearance", title: "Theme",
+            keywords: ["dark", "light", "mode", "appearance"]),
+        .init(
+            tab: .general, section: "Appearance", title: "Compact mode",
+            keywords: ["slim", "search bar", "small"]),
+        .init(
+            tab: .general, section: "Appearance", title: "Show favorites in compact mode",
+            keywords: ["pinned", "apps", "compact"]),
+        .init(
+            tab: .general, section: "Appearance", title: "Follow the cursor across displays",
+            keywords: ["monitor", "screen", "pointer", "multi display"]),
+        .init(
+            tab: .general, section: "Appearance", title: "Drag to reposition",
+            keywords: ["move", "position", "window"]),
+        .init(
+            tab: .general, section: "General", title: "Launch at login",
+            keywords: ["startup", "login item", "start", "boot"]),
+        .init(
+            tab: .general, section: "General", title: "Show in menu bar",
+            keywords: ["menubar", "status item", "icon", "hide"]),
+        .init(
+            tab: .general, section: "General", title: "Pop to Root Search",
+            keywords: ["reset", "timeout", "back"]),
+        .init(
+            tab: .general, section: "General", title: "Auto-switch input source",
+            keywords: ["keyboard", "layout", "language", "abc"])
+    ]
+
+    private static let applications: [SettingsSearchEntry] = [
+        .init(tab: .applications, title: "Applications", keywords: ["apps", "index", "launcher"]),
+        .init(
+            tab: .applications, section: "Search Scopes", title: "Search Scopes",
+            keywords: ["folders", "indexed", "locations", "add folder"]),
+        .init(
+            tab: .applications, section: "Applications", title: "Enable Applications",
+            keywords: ["hide apps", "visibility"]),
+        .init(
+            tab: .applications, section: "Applications", title: "Aliases and shortcuts",
+            keywords: ["alias", "hotkey", "per app", "hide"])
+    ]
+
+    private static let systemSettings: [SettingsSearchEntry] = [
+        .init(
+            tab: .systemSettings, title: "System Settings",
+            keywords: ["panes", "preferences", "macos"]),
+        .init(
+            tab: .systemSettings, section: "System Settings", title: "Enable System Settings",
+            keywords: ["hide panes", "visibility"])
+    ]
+
+    private static let systemActions: [SettingsSearchEntry] = [
+        .init(
+            tab: .systemActions, title: "System Actions",
+            keywords: ["sleep", "lock", "restart", "shut down", "empty trash"]),
+        .init(
+            tab: .systemActions, section: "System Actions", title: "Enable System Actions",
+            keywords: ["hide", "visibility"])
+    ]
+
+    private static let commands: [SettingsSearchEntry] = [
+        .init(
+            tab: .commands, title: "Commands",
+            keywords: ["custom", "script", "shell", "terminal"]),
+        .init(
+            tab: .commands, section: "Commands", title: "Enable Commands",
+            keywords: ["hide", "visibility"]),
+        .init(
+            tab: .commands, section: "Custom Commands", title: "Enable custom commands",
+            keywords: ["script", "shell"]),
+        .init(
+            tab: .commands, section: "Custom Commands", title: "Add Custom Command",
+            keywords: ["new", "script", "shell", "shortcut"])
+    ]
+
+    private static let quicklinks: [SettingsSearchEntry] = [
+        .init(tab: .quicklinks, title: "Quicklinks", keywords: ["url", "bookmark", "link"]),
+        .init(
+            tab: .quicklinks, section: "Quicklinks", title: "Enable quicklinks",
+            keywords: ["url", "bookmark"]),
+        .init(
+            tab: .quicklinks, section: "Quicklinks", title: "Add Quicklink",
+            keywords: ["new", "url", "bookmark", "alias"]),
+        .init(
+            tab: .quicklinks, section: "Behaviour", title: "Open in a new window",
+            keywords: ["browser", "tab"]),
+        .init(
+            tab: .quicklinks, section: "Behaviour", title: "When there's no selected text",
+            keywords: ["selection", "fallback", "placeholder"]),
+        .init(
+            tab: .quicklinks, section: "Behaviour", title: "Confirm before deleting",
+            keywords: ["ask", "delete", "prompt"]),
+        .init(
+            tab: .quicklinks, section: "Import & Export", title: "Import quicklinks",
+            keywords: ["json", "restore"]),
+        .init(
+            tab: .quicklinks, section: "Import & Export", title: "Export quicklinks",
+            keywords: ["json", "backup"])
+    ]
+
+    private static let fallbacks: [SettingsSearchEntry] = [
+        .init(
+            tab: .fallbacks, title: "Fallbacks",
+            keywords: ["no results", "empty", "search web", "order"])
+    ]
+
+    private static let ai: [SettingsSearchEntry] = [
+        .init(tab: .ai, title: "AI", keywords: ["chat", "llm", "model", "openai", "anthropic"]),
+        .init(tab: .ai, section: "AI", title: "Enable AI", keywords: ["chat", "llm"]),
+        .init(
+            tab: .ai, section: "Default", title: "Default model",
+            keywords: ["llm", "gpt", "claude"]),
+        .init(
+            tab: .ai, section: "Default", title: "Reasoning effort",
+            keywords: ["thinking", "chatgpt"]),
+        .init(tab: .ai, section: "Chat", title: "Web search", keywords: ["browse", "internet"]),
+        .init(
+            tab: .ai, section: "Conversations", title: "Opens to",
+            keywords: ["new chat", "last", "summon"]),
+        .init(
+            tab: .ai, section: "Conversations", title: "Start a new conversation after",
+            keywords: ["idle", "timeout", "fresh"]),
+        .init(
+            tab: .ai, section: "Conversations", title: "Keep conversations",
+            keywords: ["retention", "delete", "history", "privacy"]),
+        .init(
+            tab: .ai, section: "System prompt", title: "Send a system prompt",
+            keywords: ["instructions", "persona"]),
+        .init(
+            tab: .ai, section: "ChatGPT Subscription", title: "ChatGPT Subscription",
+            keywords: ["sign in", "connect", "plus", "codex", "openai"]),
+        .init(
+            tab: .ai, section: "API Connections", title: "Add API Connection",
+            keywords: ["key", "provider", "openai", "anthropic", "ollama", "base url"]),
+        .init(
+            tab: .ai, section: "MCP Servers", title: "Enable MCP servers",
+            keywords: ["tools", "model context protocol"]),
+        .init(
+            tab: .ai, section: "MCP Servers", title: "Add MCP Server",
+            keywords: ["tools", "model context protocol", "stdio"]),
+        .init(
+            tab: .ai, section: "Commands", title: "AI commands",
+            keywords: ["shortcut", "launcher", "chat"])
+    ]
+
+    private static let quickActions: [SettingsSearchEntry] = [
+        .init(
+            tab: .quickActions, title: "Quick Actions",
+            keywords: ["selected text", "rewrite", "translate", "summarize"]),
+        .init(
+            tab: .quickActions, section: "Quick Actions", title: "Enable Quick Actions",
+            keywords: ["selected text", "accessibility"]),
+        .init(
+            tab: .quickActions, section: "Actions", title: "Actions",
+            keywords: ["shortcut", "replace", "preview", "customize"]),
+        .init(
+            tab: .quickActions, section: "Model", title: "Model",
+            keywords: ["llm", "ai", "default"]),
+        .init(
+            tab: .quickActions, section: "Translate", title: "Translate to",
+            keywords: ["language", "locale"])
+    ]
+
+    private static let fileSearch: [SettingsSearchEntry] = [
+        .init(
+            tab: .fileSearch, title: "File Search",
+            keywords: ["spotlight", "files", "folders", "find"]),
+        .init(
+            tab: .fileSearch, section: "File Search", title: "Enable File Search",
+            keywords: ["spotlight", "index"]),
+        .init(
+            tab: .fileSearch, section: "Commands", title: "File search commands",
+            keywords: ["shortcut", "launcher"]),
+        .init(
+            tab: .fileSearch, section: "Search Scopes", title: "Search Scopes",
+            keywords: ["folders", "locations", "home", "add folder"]),
+        .init(
+            tab: .fileSearch, section: "Ignore Patterns", title: "Ignore Patterns",
+            keywords: ["exclude", "glob", "node_modules", "skip"])
+    ]
+
+    private static let notes: [SettingsSearchEntry] = [
+        .init(tab: .notes, title: "Notes", keywords: ["markdown", "scratchpad", "floating"]),
+        .init(
+            tab: .notes, section: "Notes", title: "Enable Notes",
+            keywords: ["markdown", "scratchpad"]),
+        .init(
+            tab: .notes, section: "Commands", title: "Notes commands",
+            keywords: ["shortcut", "new note", "search notes"])
+    ]
+
+    private static let snippets: [SettingsSearchEntry] = [
+        .init(
+            tab: .snippets, title: "Snippets",
+            keywords: ["expansion", "keyword", "text replacement", "template"]),
+        .init(
+            tab: .snippets, section: "Snippets", title: "Enable snippets",
+            keywords: ["expansion", "keystrokes", "accessibility"]),
+        .init(
+            tab: .snippets, section: "Global Shortcut", title: "Search Snippets",
+            keywords: ["hotkey", "browser"]),
+        .init(
+            tab: .snippets, section: "Library", title: "New Snippet",
+            keywords: ["add", "keyword", "expansion"]),
+        .init(
+            tab: .snippets, section: "Library", title: "Snippets Folder",
+            keywords: ["reveal", "finder", "markdown", "files"])
+    ]
+
+    private static let windowManagement: [SettingsSearchEntry] = [
+        .init(
+            tab: .windowManagement, title: "Window Management",
+            keywords: ["tile", "halves", "thirds", "maximize", "snap"]),
+        .init(
+            tab: .windowManagement, section: "Window Management",
+            title: "Enable window management", keywords: ["tile", "accessibility"]),
+        .init(
+            tab: .windowManagement, section: "Options", title: "Cycle sizes on repeat",
+            keywords: ["repeat", "thirds", "halves"]),
+        .init(
+            tab: .windowManagement, section: "Options", title: "Gap between windows",
+            keywords: ["padding", "spacing", "margin", "points"]),
+        .init(
+            tab: .windowManagement, section: "Options", title: "Window commands",
+            keywords: ["shortcut", "left half", "maximize", "center"])
+    ]
+
+    private static let clipboard: [SettingsSearchEntry] = [
+        .init(
+            tab: .clipboard, title: "Clipboard",
+            keywords: ["paste", "history", "copy", "pasteboard"]),
+        .init(
+            tab: .clipboard, section: "Global Shortcuts", title: "Clipboard History",
+            keywords: ["hotkey", "paste", "browser"]),
+        .init(
+            tab: .clipboard, section: "History", title: "Keep history for",
+            keywords: ["retention", "delete", "privacy", "expire"]),
+        .init(
+            tab: .clipboard, section: "Disabled Applications", title: "Disabled Applications",
+            keywords: ["exclude", "password manager", "ignore", "privacy"]),
+        .init(
+            tab: .clipboard, section: "Disabled Applications", title: "Clear history",
+            keywords: ["delete", "erase", "wipe"])
+    ]
+
+    private static let emoji: [SettingsSearchEntry] = [
+        .init(
+            tab: .emoji, title: "Emoji & Symbols",
+            keywords: ["picker", "character", "unicode", "smiley"]),
+        .init(
+            tab: .emoji, section: "Global Shortcuts", title: "Emoji & Symbols",
+            keywords: ["hotkey", "picker"]),
+        .init(
+            tab: .emoji, section: "Appearance", title: "Emoji Skin Tone",
+            keywords: ["colour", "color", "fitzpatrick", "default"])
+    ]
+
+    private static let calendar: [SettingsSearchEntry] = [
+        .init(
+            tab: .calendar, title: "Calendar",
+            keywords: ["meetings", "events", "zoom", "join", "schedule"]),
+        .init(
+            tab: .calendar, section: "Calendar", title: "Join meetings from Tinycast",
+            keywords: ["zoom", "meet", "teams", "permission"]),
+        .init(
+            tab: .calendar, section: "Schedule", title: "Upcoming meetings in launcher",
+            keywords: ["count", "limit", "events"]),
+        .init(
+            tab: .calendar, section: "Schedule", title: "Include Tomorrow's Events",
+            keywords: ["next day", "range"]),
+        .init(
+            tab: .calendar, section: "Joining", title: "Show the join card",
+            keywords: ["hud", "timing", "early", "reminder"]),
+        .init(
+            tab: .calendar, section: "Joining", title: "Auto Join Meetings",
+            keywords: ["automatic", "start"]),
+        .init(
+            tab: .calendar, section: "Joining", title: "Confirm before joining",
+            keywords: ["ask", "prompt"]),
+        .init(
+            tab: .calendar, section: "Joining", title: "Camera Preview",
+            keywords: ["webcam", "mirror", "video", "check"]),
+        .init(
+            tab: .calendar, section: "Menu Bar", title: "Calendar in Menu Bar",
+            keywords: ["status item", "menubar", "date"]),
+        .init(
+            tab: .calendar, section: "Menu Bar", title: "Show Upcoming Events",
+            keywords: ["menubar", "next event", "title"]),
+        .init(
+            tab: .calendar, section: "Menu Bar", title: "Only show events with meetings",
+            keywords: ["links", "filter", "menubar"]),
+        .init(
+            tab: .calendar, section: "Menu Bar", title: "Hide Current Event",
+            keywords: ["started", "time left", "menubar"]),
+        .init(
+            tab: .calendar, section: "Calendars", title: "Calendars",
+            keywords: ["accounts", "sources", "choose", "icloud", "google"])
+    ]
+
+    private static let extensions: [SettingsSearchEntry] = [
+        .init(
+            tab: .extensions, title: "Extensions",
+            keywords: ["raycast", "plugins", "store", "javascript"]),
+        .init(
+            tab: .extensions, section: "Extensions", title: "Enable extensions",
+            keywords: ["raycast", "third party", "javascript"]),
+        .init(
+            tab: .extensions, section: "Compatibility", title: "Compatibility",
+            keywords: ["supported", "unsupported", "raycast api"]),
+        .init(
+            tab: .extensions, section: "Installed", title: "Installed extensions",
+            keywords: ["library", "uninstall", "preferences", "appearance"]),
+        .init(
+            tab: .extensions, section: "Install", title: "Search extensions",
+            keywords: ["store", "browse", "install", "registry"]),
+        .init(
+            tab: .extensions, section: "Install", title: "Registries",
+            keywords: ["github", "source", "store"]),
+        .init(
+            tab: .extensions, section: "Install", title: "Import from Raycast",
+            keywords: ["migrate", "existing"]),
+        .init(
+            tab: .extensions, section: "Install", title: "Add from folder",
+            keywords: ["local", "develop", "sideload"]),
+        .init(
+            tab: .extensions, section: "Storage", title: "Leftover files",
+            keywords: ["clean up", "disk", "reclaim", "cache"])
+    ]
+
+    private static let permissions: [SettingsSearchEntry] = [
+        .init(
+            tab: .permissions, title: "Permissions",
+            keywords: ["privacy", "tcc", "access", "grant"]),
+        .init(
+            tab: .permissions, section: "Accessibility", title: "Accessibility",
+            keywords: ["paste", "keystrokes", "privacy", "grant"]),
+        .init(
+            tab: .permissions, section: "Calendars", title: "Calendars",
+            keywords: ["events", "privacy", "grant", "eventkit"])
+    ]
+
+    private static let backup: [SettingsSearchEntry] = [
+        .init(
+            tab: .backup, title: "Backup",
+            keywords: ["export", "import", "restore", "migrate", "raycast"]),
+        .init(
+            tab: .backup, section: "Export", title: "Export Backup",
+            keywords: ["save", "tinycast file", "archive"]),
+        .init(
+            tab: .backup, section: "Import", title: "Backup File",
+            keywords: ["restore", "choose", "tinycast file"]),
+        .init(
+            tab: .backup, section: "Import from Raycast", title: "Raycast Export",
+            keywords: ["migrate", "rayconfig", "passphrase"])
+    ]
+
+    private static let about: [SettingsSearchEntry] = [
+        .init(
+            tab: .about, title: "About",
+            keywords: ["version", "licence", "license", "credits"]),
+        .init(
+            tab: .about, section: "About", title: "Check for Updates",
+            keywords: ["version", "upgrade", "release"]),
+        .init(
+            tab: .about, section: "Links", title: "Links",
+            keywords: ["github", "source", "issues", "website"]),
+        .init(
+            tab: .about, section: "Links", title: "Support",
+            keywords: ["donate", "sponsor", "funding"])
+    ]
+}

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -3,18 +3,45 @@ import Foundation
 /// One searchable place in Settings: a pane, or a row inside one of its `Form` sections.
 struct SettingsSearchEntry: Identifiable, Hashable, Sendable {
     let tab: SettingsTab
-    /// The `Section` header the row sits under; nil for the pane itself.
-    var section: String?
+    /// Where picking this result lands; nil for the pane itself, which is its own result.
+    let target: SettingsTarget?
     let title: String
     /// Words a user might type that the visible title doesn't contain.
-    var keywords: [String] = []
+    let keywords: [String]
 
-    var id: String { "\(tab.title)/\(section ?? "")/\(title)" }
+    /// Taking the pane from the target is what makes a row filed under the wrong pane unwritable.
+    private init(_ target: SettingsTarget, _ title: String, _ keywords: [String]) {
+        self.tab = target.tab
+        self.target = target
+        self.title = title
+        self.keywords = keywords
+    }
+
+    /// One setting, which its pane marks with a matching `SettingsRowTitle`.
+    init(_ anchor: SettingsAnchor, _ title: String, keywords: [String] = []) {
+        self.init(.row(anchor, title), title, keywords)
+    }
+
+    /// A whole group, for a result no single row answers — a list, or a section's master switch.
+    init(group anchor: SettingsAnchor, _ title: String, keywords: [String] = []) {
+        self.init(.section(anchor), title, keywords)
+    }
+
+    init(pane: SettingsTab, keywords: [String] = []) {
+        self.tab = pane
+        self.target = nil
+        self.title = pane.title
+        self.keywords = keywords
+    }
+
+    var anchor: SettingsAnchor? { target?.anchor }
+
+    var id: String { "\(tab.title)/\(anchor?.title ?? "")/\(title)" }
 
     /// The result row's second line — "General", or "General › Hyper Key".
     var breadcrumb: String {
-        guard let section, section != tab.title else { return tab.title }
-        return "\(tab.title) › \(section)"
+        guard let anchor, anchor.title != tab.title else { return tab.title }
+        return "\(tab.title) › \(anchor.title)"
     }
 }
 
@@ -74,7 +101,7 @@ enum SettingsSearchCatalog {
             band = 0
         }
         // A pane outranks its own rows, so a bare "clipboard" lands on the pane rather than a row.
-        return band + titleScore + (entry.section == nil ? 500_000 : 0)
+        return band + titleScore + (entry.anchor == nil ? 500_000 : 0)
     }
 
     // MARK: - The index
@@ -87,390 +114,390 @@ enum SettingsSearchCatalog {
         + backup + about
 
     private static let general: [SettingsSearchEntry] = [
-        .init(tab: .general, title: "General", keywords: ["preferences", "settings"]),
+        .init(pane: .general, keywords: ["preferences", "settings"]),
         .init(
-            tab: .general, section: "Global Shortcuts", title: "App Launcher",
+            .generalGlobalShortcuts, "App Launcher",
             keywords: ["hotkey", "shortcut", "summon", "palette"]),
         .init(
-            tab: .general, section: "Search", title: "Learned ranking",
+            .generalSearch, "Learned ranking",
             keywords: ["reset", "history", "order", "privacy"]),
         .init(
-            tab: .general, section: "Hyper Key", title: "Hyper Key",
+            .generalHyperKey, "Hyper Key",
             keywords: ["modifier", "remap", "caps lock", "capslock"]),
         .init(
-            tab: .general, section: "Hyper Key", title: "Quick Press",
+            .generalHyperKey, "Quick Press",
             keywords: ["tap", "escape", "single press"]),
         .init(
-            tab: .general, section: "Hyper Key", title: "Include Shift (⇧)",
+            .generalHyperKey, "Include Shift (⇧)",
             keywords: ["modifier", "chord"]),
         .init(
-            tab: .general, section: "Appearance", title: "Theme",
+            .generalAppearance, "Theme",
             keywords: ["dark", "light", "mode", "appearance"]),
         .init(
-            tab: .general, section: "Appearance", title: "Compact mode",
+            .generalAppearance, "Compact mode",
             keywords: ["slim", "search bar", "small"]),
         .init(
-            tab: .general, section: "Appearance", title: "Show favorites in compact mode",
+            .generalAppearance, "Show favorites in compact mode",
             keywords: ["pinned", "apps", "compact"]),
         .init(
-            tab: .general, section: "Appearance", title: "Follow the cursor across displays",
+            .generalAppearance, "Follow the cursor across displays",
             keywords: ["monitor", "screen", "pointer", "multi display"]),
         .init(
-            tab: .general, section: "Appearance", title: "Drag to reposition",
+            .generalAppearance, "Drag to reposition",
             keywords: ["move", "position", "window"]),
         .init(
-            tab: .general, section: "General", title: "Launch at login",
+            .generalGeneral, "Launch at login",
             keywords: ["startup", "login item", "start", "boot"]),
         .init(
-            tab: .general, section: "General", title: "Show in menu bar",
+            .generalGeneral, "Show in menu bar",
             keywords: ["menubar", "status item", "icon", "hide"]),
         .init(
-            tab: .general, section: "General", title: "Pop to Root Search",
+            .generalGeneral, "Pop to Root Search",
             keywords: ["reset", "timeout", "back"]),
         .init(
-            tab: .general, section: "General", title: "Auto-switch input source",
+            .generalGeneral, "Auto-switch input source",
             keywords: ["keyboard", "layout", "language", "abc"])
     ]
 
     private static let applications: [SettingsSearchEntry] = [
-        .init(tab: .applications, title: "Applications", keywords: ["apps", "index", "launcher"]),
+        .init(pane: .applications, keywords: ["apps", "index", "launcher"]),
         .init(
-            tab: .applications, section: "Search Scopes", title: "Search Scopes",
+            group: .applicationsSearchScopes, "Search Scopes",
             keywords: ["folders", "indexed", "locations", "add folder"]),
         .init(
-            tab: .applications, section: "Applications", title: "Enable Applications",
+            .applicationsApplications, "Enable Applications",
             keywords: ["hide apps", "visibility"]),
         .init(
-            tab: .applications, section: "Applications", title: "Aliases and shortcuts",
+            group: .applicationsApplications, "Aliases and shortcuts",
             keywords: ["alias", "hotkey", "per app", "hide"])
     ]
 
     private static let systemSettings: [SettingsSearchEntry] = [
         .init(
-            tab: .systemSettings, title: "System Settings",
+            pane: .systemSettings,
             keywords: ["panes", "preferences", "macos"]),
         .init(
-            tab: .systemSettings, section: "System Settings", title: "Enable System Settings",
+            .systemSettingsSystemSettings, "Enable System Settings",
             keywords: ["hide panes", "visibility"])
     ]
 
     private static let systemActions: [SettingsSearchEntry] = [
         .init(
-            tab: .systemActions, title: "System Actions",
+            pane: .systemActions,
             keywords: ["sleep", "lock", "restart", "shut down", "empty trash"]),
         .init(
-            tab: .systemActions, section: "System Actions", title: "Enable System Actions",
+            .systemActionsSystemActions, "Enable System Actions",
             keywords: ["hide", "visibility"])
     ]
 
     private static let commands: [SettingsSearchEntry] = [
         .init(
-            tab: .commands, title: "Commands",
+            pane: .commands,
             keywords: ["custom", "script", "shell", "terminal"]),
         .init(
-            tab: .commands, section: "Commands", title: "Enable Commands",
+            .commandsCommands, "Enable Commands",
             keywords: ["hide", "visibility"]),
         .init(
-            tab: .commands, section: "Custom Commands", title: "Enable custom commands",
+            .commandsCustomCommands, "Enable custom commands",
             keywords: ["script", "shell"]),
         .init(
-            tab: .commands, section: "Custom Commands", title: "Add Custom Command",
+            .commandsCustomCommands, "Add Custom Command",
             keywords: ["new", "script", "shell", "shortcut"])
     ]
 
     private static let quicklinks: [SettingsSearchEntry] = [
-        .init(tab: .quicklinks, title: "Quicklinks", keywords: ["url", "bookmark", "link"]),
+        .init(pane: .quicklinks, keywords: ["url", "bookmark", "link"]),
         .init(
-            tab: .quicklinks, section: "Quicklinks", title: "Enable quicklinks",
+            .quicklinksQuicklinks, "Enable quicklinks",
             keywords: ["url", "bookmark"]),
         .init(
-            tab: .quicklinks, section: "Quicklinks", title: "Add Quicklink",
+            .quicklinksQuicklinks, "Add Quicklink",
             keywords: ["new", "url", "bookmark", "alias"]),
         .init(
-            tab: .quicklinks, section: "Behaviour", title: "Open in a new window",
+            .quicklinksBehaviour, "Open in a new window",
             keywords: ["browser", "tab"]),
         .init(
-            tab: .quicklinks, section: "Behaviour", title: "When there's no selected text",
+            .quicklinksBehaviour, "When there's no selected text",
             keywords: ["selection", "fallback", "placeholder"]),
         .init(
-            tab: .quicklinks, section: "Behaviour", title: "Confirm before deleting",
+            .quicklinksBehaviour, "Confirm before deleting",
             keywords: ["ask", "delete", "prompt"]),
         .init(
-            tab: .quicklinks, section: "Import & Export", title: "Import quicklinks",
+            .quicklinksImportExport, "Import quicklinks",
             keywords: ["json", "restore"]),
         .init(
-            tab: .quicklinks, section: "Import & Export", title: "Export quicklinks",
+            .quicklinksImportExport, "Export quicklinks",
             keywords: ["json", "backup"])
     ]
 
     private static let fallbacks: [SettingsSearchEntry] = [
         .init(
-            tab: .fallbacks, title: "Fallbacks",
+            pane: .fallbacks,
             keywords: ["no results", "empty", "search web", "order"])
     ]
 
     private static let ai: [SettingsSearchEntry] = [
-        .init(tab: .ai, title: "AI", keywords: ["chat", "llm", "model", "openai", "anthropic"]),
-        .init(tab: .ai, section: "AI", title: "Enable AI", keywords: ["chat", "llm"]),
+        .init(pane: .ai, keywords: ["chat", "llm", "model", "openai", "anthropic"]),
+        .init(.aiAI, "Enable AI", keywords: ["chat", "llm"]),
         .init(
-            tab: .ai, section: "Default", title: "Default model",
+            .aiDefault, "Default model",
             keywords: ["llm", "gpt", "claude"]),
         .init(
-            tab: .ai, section: "Default", title: "Reasoning effort",
+            .aiDefault, "Reasoning effort",
             keywords: ["thinking", "chatgpt"]),
-        .init(tab: .ai, section: "Chat", title: "Web search", keywords: ["browse", "internet"]),
+        .init(.aiChat, "Web search", keywords: ["browse", "internet"]),
         .init(
-            tab: .ai, section: "Conversations", title: "Opens to",
+            .aiConversations, "Opens to",
             keywords: ["new chat", "last", "summon"]),
         .init(
-            tab: .ai, section: "Conversations", title: "Start a new conversation after",
+            .aiConversations, "Start a new conversation after",
             keywords: ["idle", "timeout", "fresh"]),
         .init(
-            tab: .ai, section: "Conversations", title: "Keep conversations",
+            .aiConversations, "Keep conversations",
             keywords: ["retention", "delete", "history", "privacy"]),
         .init(
-            tab: .ai, section: "System prompt", title: "Send a system prompt",
+            .aiSystemPrompt, "Send a system prompt",
             keywords: ["instructions", "persona"]),
         .init(
-            tab: .ai, section: "ChatGPT Subscription", title: "ChatGPT Subscription",
+            group: .aiChatGPTSubscription, "ChatGPT Subscription",
             keywords: ["sign in", "connect", "plus", "codex", "openai"]),
         .init(
-            tab: .ai, section: "API Connections", title: "Add API Connection",
+            .aiAPIConnections, "Add API Connection",
             keywords: ["key", "provider", "openai", "anthropic", "ollama", "base url"]),
         .init(
-            tab: .ai, section: "MCP Servers", title: "Enable MCP servers",
+            .aiMCPServers, "Enable MCP servers",
             keywords: ["tools", "model context protocol"]),
         .init(
-            tab: .ai, section: "MCP Servers", title: "Add MCP Server",
+            .aiMCPServers, "Add MCP Server",
             keywords: ["tools", "model context protocol", "stdio"]),
         .init(
-            tab: .ai, section: "Commands", title: "AI commands",
+            group: .aiCommands, "AI commands",
             keywords: ["shortcut", "launcher", "chat"])
     ]
 
     private static let quickActions: [SettingsSearchEntry] = [
         .init(
-            tab: .quickActions, title: "Quick Actions",
+            pane: .quickActions,
             keywords: ["selected text", "rewrite", "translate", "summarize"]),
         .init(
-            tab: .quickActions, section: "Quick Actions", title: "Enable Quick Actions",
+            .quickActionsQuickActions, "Enable Quick Actions",
             keywords: ["selected text", "accessibility"]),
         .init(
-            tab: .quickActions, section: "Actions", title: "Actions",
+            group: .quickActionsActions, "Actions",
             keywords: ["shortcut", "replace", "preview", "customize"]),
         .init(
-            tab: .quickActions, section: "Model", title: "Model",
+            .quickActionsModel, "Model",
             keywords: ["llm", "ai", "default"]),
         .init(
-            tab: .quickActions, section: "Translate", title: "Translate to",
+            .quickActionsTranslate, "Translate to",
             keywords: ["language", "locale"])
     ]
 
     private static let fileSearch: [SettingsSearchEntry] = [
         .init(
-            tab: .fileSearch, title: "File Search",
+            pane: .fileSearch,
             keywords: ["spotlight", "files", "folders", "find"]),
         .init(
-            tab: .fileSearch, section: "File Search", title: "Enable File Search",
+            .fileSearchFileSearch, "Enable File Search",
             keywords: ["spotlight", "index"]),
         .init(
-            tab: .fileSearch, section: "Commands", title: "File search commands",
+            group: .fileSearchCommands, "File search commands",
             keywords: ["shortcut", "launcher"]),
         .init(
-            tab: .fileSearch, section: "Search Scopes", title: "Search Scopes",
+            group: .fileSearchSearchScopes, "Search Scopes",
             keywords: ["folders", "locations", "home", "add folder"]),
         .init(
-            tab: .fileSearch, section: "Ignore Patterns", title: "Ignore Patterns",
+            group: .fileSearchIgnorePatterns, "Ignore Patterns",
             keywords: ["exclude", "glob", "node_modules", "skip"])
     ]
 
     private static let notes: [SettingsSearchEntry] = [
-        .init(tab: .notes, title: "Notes", keywords: ["markdown", "scratchpad", "floating"]),
+        .init(pane: .notes, keywords: ["markdown", "scratchpad", "floating"]),
         .init(
-            tab: .notes, section: "Notes", title: "Enable Notes",
+            .notesNotes, "Enable Notes",
             keywords: ["markdown", "scratchpad"]),
         .init(
-            tab: .notes, section: "Commands", title: "Notes commands",
+            group: .notesCommands, "Notes commands",
             keywords: ["shortcut", "new note", "search notes"])
     ]
 
     private static let snippets: [SettingsSearchEntry] = [
         .init(
-            tab: .snippets, title: "Snippets",
+            pane: .snippets,
             keywords: ["expansion", "keyword", "text replacement", "template"]),
         .init(
-            tab: .snippets, section: "Snippets", title: "Enable snippets",
+            .snippetsSnippets, "Enable snippets",
             keywords: ["expansion", "keystrokes", "accessibility"]),
         .init(
-            tab: .snippets, section: "Global Shortcut", title: "Search Snippets",
+            .snippetsGlobalShortcut, "Search Snippets",
             keywords: ["hotkey", "browser"]),
         .init(
-            tab: .snippets, section: "Library", title: "New Snippet",
+            .snippetsLibrary, "New Snippet",
             keywords: ["add", "keyword", "expansion"]),
         .init(
-            tab: .snippets, section: "Library", title: "Snippets Folder",
+            .snippetsLibrary, "Snippets Folder",
             keywords: ["reveal", "finder", "markdown", "files"])
     ]
 
     private static let windowManagement: [SettingsSearchEntry] = [
         .init(
-            tab: .windowManagement, title: "Window Management",
+            pane: .windowManagement,
             keywords: ["tile", "halves", "thirds", "maximize", "snap"]),
         .init(
-            tab: .windowManagement, section: "Window Management",
-            title: "Enable window management", keywords: ["tile", "accessibility"]),
+            .windowManagementWindowManagement, "Enable window management",
+            keywords: ["tile", "accessibility"]),
         .init(
-            tab: .windowManagement, section: "Options", title: "Cycle sizes on repeat",
+            .windowManagementOptions, "Cycle sizes on repeat",
             keywords: ["repeat", "thirds", "halves"]),
         .init(
-            tab: .windowManagement, section: "Options", title: "Gap between windows",
+            .windowManagementOptions, "Gap between windows",
             keywords: ["padding", "spacing", "margin", "points"]),
         .init(
-            tab: .windowManagement, section: "Options", title: "Window commands",
+            group: .windowManagementOptions, "Window commands",
             keywords: ["shortcut", "left half", "maximize", "center"])
     ]
 
     private static let clipboard: [SettingsSearchEntry] = [
         .init(
-            tab: .clipboard, title: "Clipboard",
+            pane: .clipboard,
             keywords: ["paste", "history", "copy", "pasteboard"]),
         .init(
-            tab: .clipboard, section: "Global Shortcuts", title: "Clipboard History",
+            .clipboardGlobalShortcuts, "Clipboard History",
             keywords: ["hotkey", "paste", "browser"]),
         .init(
-            tab: .clipboard, section: "History", title: "Keep history for",
+            .clipboardHistory, "Keep history for",
             keywords: ["retention", "delete", "privacy", "expire"]),
         .init(
-            tab: .clipboard, section: "Disabled Applications", title: "Disabled Applications",
+            group: .clipboardDisabledApplications, "Disabled Applications",
             keywords: ["exclude", "password manager", "ignore", "privacy"]),
         .init(
-            tab: .clipboard, section: "Disabled Applications", title: "Clear history",
+            .clipboardDisabledApplications, "Clear history",
             keywords: ["delete", "erase", "wipe"])
     ]
 
     private static let emoji: [SettingsSearchEntry] = [
         .init(
-            tab: .emoji, title: "Emoji & Symbols",
+            pane: .emoji,
             keywords: ["picker", "character", "unicode", "smiley"]),
         .init(
-            tab: .emoji, section: "Global Shortcuts", title: "Emoji & Symbols",
+            .emojiGlobalShortcuts, "Emoji & Symbols",
             keywords: ["hotkey", "picker"]),
         .init(
-            tab: .emoji, section: "Appearance", title: "Emoji Skin Tone",
+            .emojiAppearance, "Emoji Skin Tone",
             keywords: ["colour", "color", "fitzpatrick", "default"])
     ]
 
     private static let calendar: [SettingsSearchEntry] = [
         .init(
-            tab: .calendar, title: "Calendar",
+            pane: .calendar,
             keywords: ["meetings", "events", "zoom", "join", "schedule"]),
         .init(
-            tab: .calendar, section: "Calendar", title: "Join meetings from Tinycast",
+            .calendarCalendar, "Join meetings from Tinycast",
             keywords: ["zoom", "meet", "teams", "permission"]),
         .init(
-            tab: .calendar, section: "Schedule", title: "Upcoming meetings in launcher",
+            .calendarSchedule, "Upcoming meetings in launcher",
             keywords: ["count", "limit", "events"]),
         .init(
-            tab: .calendar, section: "Schedule", title: "Include Tomorrow's Events",
+            .calendarSchedule, "Include Tomorrow's Events",
             keywords: ["next day", "range"]),
         .init(
-            tab: .calendar, section: "Joining", title: "Show the join card",
+            .calendarJoining, "Show the join card",
             keywords: ["hud", "timing", "early", "reminder"]),
         .init(
-            tab: .calendar, section: "Joining", title: "Auto Join Meetings",
+            .calendarJoining, "Auto Join Meetings",
             keywords: ["automatic", "start"]),
         .init(
-            tab: .calendar, section: "Joining", title: "Confirm before joining",
+            .calendarJoining, "Confirm before joining",
             keywords: ["ask", "prompt"]),
         .init(
-            tab: .calendar, section: "Joining", title: "Camera Preview",
+            .calendarJoining, "Camera Preview",
             keywords: ["webcam", "mirror", "video", "check"]),
         .init(
-            tab: .calendar, section: "Menu Bar", title: "Calendar in Menu Bar",
+            .calendarMenuBar, "Calendar in Menu Bar",
             keywords: ["status item", "menubar", "date"]),
         .init(
-            tab: .calendar, section: "Menu Bar", title: "Show Upcoming Events",
+            .calendarMenuBar, "Show Upcoming Events",
             keywords: ["menubar", "next event", "title"]),
         .init(
-            tab: .calendar, section: "Menu Bar", title: "Only show events with meetings",
+            .calendarMenuBar, "Only show events with meetings",
             keywords: ["links", "filter", "menubar"]),
         .init(
-            tab: .calendar, section: "Menu Bar", title: "Hide Current Event",
+            .calendarMenuBar, "Hide Current Event",
             keywords: ["started", "time left", "menubar"]),
         .init(
-            tab: .calendar, section: "Calendars", title: "Calendars",
+            group: .calendarCalendars, "Calendars",
             keywords: ["accounts", "sources", "choose", "icloud", "google"])
     ]
 
     private static let extensions: [SettingsSearchEntry] = [
         .init(
-            tab: .extensions, title: "Extensions",
+            pane: .extensions,
             keywords: ["raycast", "plugins", "store", "javascript"]),
         .init(
-            tab: .extensions, section: "Extensions", title: "Enable extensions",
+            .extensionsExtensions, "Enable extensions",
             keywords: ["raycast", "third party", "javascript"]),
         .init(
-            tab: .extensions, section: "Compatibility", title: "Compatibility",
+            group: .extensionsCompatibility, "Compatibility",
             keywords: ["supported", "unsupported", "raycast api"]),
         .init(
-            tab: .extensions, section: "Installed", title: "Installed extensions",
+            group: .extensionsInstalled, "Installed extensions",
             keywords: ["library", "uninstall", "preferences", "appearance"]),
         .init(
-            tab: .extensions, section: "Install", title: "Search extensions",
+            .extensionsInstall, "Search extensions",
             keywords: ["store", "browse", "install", "registry"]),
         .init(
-            tab: .extensions, section: "Install", title: "Registries",
+            group: .extensionsInstall, "Registries",
             keywords: ["github", "source", "store"]),
         .init(
-            tab: .extensions, section: "Install", title: "Import from Raycast",
+            .extensionsInstall, "Import from Raycast",
             keywords: ["migrate", "existing"]),
         .init(
-            tab: .extensions, section: "Install", title: "Add from folder",
+            .extensionsInstall, "Add from folder",
             keywords: ["local", "develop", "sideload"]),
         .init(
-            tab: .extensions, section: "Storage", title: "Leftover files",
+            .extensionsStorage, "Leftover files",
             keywords: ["clean up", "disk", "reclaim", "cache"])
     ]
 
     private static let permissions: [SettingsSearchEntry] = [
         .init(
-            tab: .permissions, title: "Permissions",
+            pane: .permissions,
             keywords: ["privacy", "tcc", "access", "grant"]),
         .init(
-            tab: .permissions, section: "Accessibility", title: "Accessibility",
+            .permissionsAccessibility, "Accessibility",
             keywords: ["paste", "keystrokes", "privacy", "grant"]),
         .init(
-            tab: .permissions, section: "Calendars", title: "Calendars",
+            .permissionsCalendars, "Calendars",
             keywords: ["events", "privacy", "grant", "eventkit"])
     ]
 
     private static let backup: [SettingsSearchEntry] = [
         .init(
-            tab: .backup, title: "Backup",
+            pane: .backup,
             keywords: ["export", "import", "restore", "migrate", "raycast"]),
         .init(
-            tab: .backup, section: "Export", title: "Export Backup",
+            .backupExport, "Export Backup",
             keywords: ["save", "tinycast file", "archive"]),
         .init(
-            tab: .backup, section: "Import", title: "Backup File",
+            .backupImport, "Backup File",
             keywords: ["restore", "choose", "tinycast file"]),
         .init(
-            tab: .backup, section: "Import from Raycast", title: "Raycast Export",
+            .backupImportFromRaycast, "Raycast Export",
             keywords: ["migrate", "rayconfig", "passphrase"])
     ]
 
     private static let about: [SettingsSearchEntry] = [
         .init(
-            tab: .about, title: "About",
+            pane: .about,
             keywords: ["version", "licence", "license", "credits"]),
         .init(
-            tab: .about, section: "About", title: "Check for Updates",
+            .aboutAbout, "Check for Updates",
             keywords: ["version", "upgrade", "release"]),
         .init(
-            tab: .about, section: "Links", title: "Links",
+            group: .aboutLinks, "Links",
             keywords: ["github", "source", "issues", "website"]),
         .init(
-            tab: .about, section: "Links", title: "Support",
+            .aboutLinks, "Support",
             keywords: ["donate", "sponsor", "funding"])
     ]
 }

--- a/Tinycast/Features/Settings/SettingsSearchField.swift
+++ b/Tinycast/Features/Settings/SettingsSearchField.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// The sidebar's search field. Not `SettingsFilterField`: that one is borderless because it sits
+/// inside a `Form` row, where a bezel would read as a control the section owns.
+struct SettingsSearchField: View {
+    @Binding var query: String
+    @FocusState.Binding var focused: Bool
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("", text: $query, prompt: Text("Search"))
+                .textFieldStyle(.plain)
+                .labelsHidden()
+                .focused($focused)
+                .pointerStyle(.horizontalText)
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .frame(height: Theme.Size.settingsSearchField)
+        // Glass on a layer of its own: `frosted` ends in `.tint(.clear)`, which would erase the caret.
+        .background { Color.clear.frosted(in: Capsule()) }
+        .contentShape(.rect)
+        .onTapGesture { focused = true }
+        .accessibilityLabel("Search settings")
+    }
+}

--- a/Tinycast/Features/Settings/SettingsSidebarView.swift
+++ b/Tinycast/Features/Settings/SettingsSidebarView.swift
@@ -55,7 +55,7 @@ struct SettingsSidebarView: View {
             // Arrowing through results moves the pane with the selection, as System Settings does.
             .onChange(of: highlighted) { _, id in
                 guard let entry = results.first(where: { $0.id == id }) else { return }
-                navigation.select(entry.tab)
+                navigation.select(entry.tab, revealing: entry.target)
             }
         }
     }

--- a/Tinycast/Features/Settings/SettingsSidebarView.swift
+++ b/Tinycast/Features/Settings/SettingsSidebarView.swift
@@ -3,8 +3,30 @@ import SwiftUI
 /// Stock `.sidebar` styling throughout: headers, capsule and tint are all system-supplied.
 struct SettingsSidebarView: View {
     @Environment(SettingsNavigationState.self) private var navigation
+    @State private var query = ""
+    @State private var highlighted: SettingsSearchEntry.ID?
+    @FocusState private var searchFocused: Bool
+
+    private var results: [SettingsSearchEntry] { SettingsSearchCatalog.results(for: query) }
 
     var body: some View {
+        VStack(spacing: 0) {
+            SettingsSearchField(query: $query, focused: $searchFocused)
+                .padding(.horizontal, Theme.Spacing.lg)
+                .padding(.bottom, Theme.Spacing.md)
+            if query.isEmpty {
+                browse
+            } else {
+                found
+            }
+        }
+        // The field sits under the toolbar's material, so it needs its own clearance from the top.
+        .padding(.top, Theme.Spacing.md)
+        .onExitCommand { query = "" }
+        .background(focusShortcut)
+    }
+
+    private var browse: some View {
         List(selection: selection) {
             ForEach(SettingsSection.allCases) { section in
                 Section(section.title) {
@@ -17,11 +39,61 @@ struct SettingsSidebarView: View {
         .listStyle(.sidebar)
     }
 
+    @ViewBuilder private var found: some View {
+        if results.isEmpty {
+            ContentUnavailableView.search(text: query)
+        } else {
+            // A second `List`, so result IDs and `SettingsTab` never share a selection namespace.
+            List(selection: $highlighted) {
+                Section("Results") {
+                    ForEach(results) { entry in
+                        SettingsSearchResultRow(entry: entry).tag(entry.id)
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+            // Arrowing through results moves the pane with the selection, as System Settings does.
+            .onChange(of: highlighted) { _, id in
+                guard let entry = results.first(where: { $0.id == id }) else { return }
+                navigation.select(entry.tab)
+            }
+        }
+    }
+
+    /// ⌘F with no menu item to hang it on; zero-sized so it only ever contributes the shortcut.
+    private var focusShortcut: some View {
+        Button("Search Settings") { searchFocused = true }
+            .keyboardShortcut("f", modifiers: .command)
+            .buttonStyle(.plain)
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
+    }
+
     /// `List` hands back an optional selection; routing it through `select` records history.
     private var selection: Binding<SettingsTab?> {
         Binding(
             get: { navigation.tab },
             set: { if let tab = $0 { navigation.select(tab) } }
         )
+    }
+}
+
+private struct SettingsSearchResultRow: View {
+    let entry: SettingsSearchEntry
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                Text(entry.title).lineLimit(1)
+                Text(entry.breadcrumb)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        } icon: {
+            Image(systemName: entry.tab.systemImage)
+        }
     }
 }

--- a/Tinycast/Features/Settings/SettingsToolbarController.swift
+++ b/Tinycast/Features/Settings/SettingsToolbarController.swift
@@ -32,6 +32,10 @@ final class SettingsToolbarController: NSObject, WindowChrome, NSToolbarDelegate
         window.toolbarStyle = .unified
         // `.automatic` draws a hairline once content scrolls under the bar, splitting the surface.
         window.titlebarSeparatorStyle = .none
+        // Transparent opts the titlebar out of the system's glass band; Settings wants it drawn.
+        window.titlebarAppearsTransparent = false
+        // Stock Settings isn't dragged by its content — a drag on a `Form` shouldn't move the window.
+        window.isMovableByWindowBackground = false
 
         let toolbar = NSToolbar(identifier: "SettingsToolbar")
         toolbar.delegate = self

--- a/Tinycast/Features/Snippets/Settings/SnippetsSettingsView.swift
+++ b/Tinycast/Features/Snippets/Settings/SnippetsSettingsView.swift
@@ -12,7 +12,7 @@ struct SnippetsSettingsView: View {
         @Bindable var core = core
         return Form {
             FeatureSwitchSection(
-                header: "Snippets",
+                anchor: .snippetsSnippets,
                 enableTitle: "Enable snippets",
                 enableSubtitle:
                     "Reusable Markdown templates, expanded from the launcher or a typed keyword.",
@@ -47,6 +47,7 @@ struct SnippetsSettingsView: View {
             .settingsEnabled(settings.snippetsEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.snippets)
         // Presented from the pane, so the browser's Edit and Create rows can open it too.
         .sheet(item: $core.pendingSnippetEdit) { request in
             SnippetEditorSheet(record: request.record)
@@ -65,9 +66,11 @@ struct SnippetsSettingsView: View {
 
     private var shortcuts: some View {
         Section {
-            SettingsRow(title: "Search Snippets") { ShortcutRecorder(action: .command(.searchSnippets)) }
+            SettingsRow(title: "Search Snippets", anchor: .snippetsGlobalShortcut) {
+                ShortcutRecorder(action: .command(.searchSnippets))
+            }
         } header: {
-            Text("Global Shortcut")
+            SettingsSectionHeader(.snippetsGlobalShortcut)
         } footer: {
             Text("Opens the snippets browser, whatever app you are in.")
         }
@@ -90,7 +93,7 @@ struct SnippetsSettingsView: View {
             LabeledContent {
                 Button("Add…") { core.snippetCoordinator.editSnippet(nil) }
             } label: {
-                Text("New Snippet")
+                SettingsRowTitle(.snippetsLibrary, "New Snippet")
                 Text("Give the snippet a searchable name and an optional expansion keyword.")
             }
 
@@ -98,11 +101,11 @@ struct SnippetsSettingsView: View {
                 Button("Open Folder", action: core.snippetCoordinator.revealSnippetsInFinder)
                     .accessibilityHint("Reveals this Tinycast channel’s snippets folder in Finder.")
             } label: {
-                Text("Snippets Folder")
+                SettingsRowTitle(.snippetsLibrary, "Snippets Folder")
                 Text("Plain Markdown files in this channel’s Application Support folder.")
             }
         } header: {
-            Text("Library")
+            SettingsSectionHeader(.snippetsLibrary)
         }
     }
 

--- a/Tinycast/Features/SystemActions/Settings/SystemActionsSettingsView.swift
+++ b/Tinycast/Features/SystemActions/Settings/SystemActionsSettingsView.swift
@@ -5,10 +5,11 @@ struct SystemActionsSettingsView: View {
         Form {
             LauncherItemsSection(
                 kind: .systemAction,
-                header: "System Actions",
+                anchor: .systemActionsSystemActions,
                 searchPrompt: "Search system actions…")
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.systemActions)
         .releasesFocusOnOutsideClick()
     }
 }

--- a/Tinycast/Features/WindowManagement/WindowManagementSettingsView.swift
+++ b/Tinycast/Features/WindowManagement/WindowManagementSettingsView.swift
@@ -7,7 +7,7 @@ struct WindowManagementSettingsView: View {
         @Bindable var settings = settings
         return Form {
             FeatureSwitchSection(
-                header: "Window Management",
+                anchor: .windowManagementWindowManagement,
                 enableTitle: "Enable window management",
                 enableSubtitle:
                     "Moves the window you were last in, using the Accessibility permission Tinycast already uses to paste.",
@@ -22,13 +22,14 @@ struct WindowManagementSettingsView: View {
             .settingsEnabled(settings.windowManagementEnabled)
         }
         .formStyle(.grouped)
+        .settingsScrollTarget(.windowManagement)
     }
 
     private var options: some View {
         @Bindable var settings = settings
         return Section {
             Toggle(isOn: $settings.windowCycleOnRepeat) {
-                Text("Cycle sizes on repeat")
+                SettingsRowTitle(.windowManagementOptions, "Cycle sizes on repeat")
                 Text(
                     "Triggering a half again steps it through a third and two thirds before returning."
                 )
@@ -43,11 +44,11 @@ struct WindowManagementSettingsView: View {
                         .labelsHidden()
                 }
             } label: {
-                Text("Gap between windows")
+                SettingsRowTitle(.windowManagementOptions, "Gap between windows")
                 Text("Points left between tiled windows and around the screen edge.")
             }
         } header: {
-            Text("Options")
+            SettingsSectionHeader(.windowManagementOptions)
         }
     }
 

--- a/Tinycast/Windows/About/AboutView.swift
+++ b/Tinycast/Windows/About/AboutView.swift
@@ -32,10 +32,12 @@ struct AboutView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, Theme.Spacing.lg)
                 }
+                .settingsAnchor(.aboutAbout)
                 links
                 support
             }
             .formStyle(.grouped)
+            .settingsScrollTarget(.about)
 
             // Outside the form, so the copyright stays pinned to the bottom edge.
             footer
@@ -65,9 +67,13 @@ struct AboutView: View {
                     .overlay(
                         Capsule().strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
                     )
-                Button("Check for Updates…") { core.updateCoordinator.checkForUpdates() }
-                    .buttonStyle(.link)
-                    .font(.caption)
+                Button {
+                    core.updateCoordinator.checkForUpdates()
+                } label: {
+                    SettingsRowTitle(.aboutAbout, "Check for Updates")
+                }
+                .buttonStyle(.link)
+                .font(.caption)
             }
 
             Text("A tiny, native macOS launcher.")
@@ -82,7 +88,7 @@ struct AboutView: View {
                 AboutLinkRow(link: link)
             }
         } header: {
-            Text("Links")
+            SettingsSectionHeader(.aboutLinks)
         }
     }
 
@@ -99,7 +105,7 @@ struct AboutView: View {
                             .foregroundStyle(Theme.Colors.brand)
                     )
                 VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
-                    Text("Support \(Bundle.main.appDisplayName)")
+                    SettingsRowTitle(.aboutLinks, "Support")
                         .font(.body.weight(.medium))
                     Text("Free and open source, funded out of pocket.")
                         .font(.caption)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,6 +167,11 @@ SwiftLint owns the rules that catch defects, including the two checkable comment
 formatter, deliberately — the configuration and the measurements behind that are in
 [development.md](development.md#formatting).
 
+The script then runs `Scripts/check-settings-search.js`, one check SwiftLint can't: every
+`SettingsAnchor` must be claimed by a section, and every row in `SettingsSearchCatalog` must be
+marked by a `SettingsRowTitle`. Either gap compiles and reads fine, and fails only at runtime as a
+search result that navigates and then sits there.
+
 ## Performance measurement
 
 `Platform/Signposts.swift` emits eight intervals on the `com.tinycast.perf` subsystem: `AppCore.start`,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -539,17 +539,49 @@ system-drawn and a pane reads exactly as macOS System Settings does.
   swaps it for a flat, ranked result list; each result carries the pane's `systemImage`, the row's
   title and a `Pane › Section` breadcrumb, and arrowing through them moves the pane, as System
   Settings does. Selection runs through `SettingsNavigationState.select`, so a result is an ordinary
-  navigation the Back/Forward chevrons can walk. It is a **second `List`**, keyed by
+  navigation the Back/Forward chevrons can walk. **A row result also reveals its section**: the pane
+  scrolls the matched setting to centre and pulses its own name once (`Colors.searchFlash`) before
+  settling; a result no single row answers pulses the section's header instead.
+  It is a **second `List`**, keyed by
   `SettingsSearchEntry.ID`, so result identities never share a selection namespace with `SettingsTab`.
   ⌘F focuses the field, Escape clears it.
 - **`SettingsSearchCatalog` is hand-written, and that is the only option.** A `Form` cannot be asked
-  what rows it holds, so a new row is searchable only once it is listed there — with its pane, its
-  `Section` header, its title and the keywords the title doesn't contain ("caps lock" for Hyper Key).
+  what rows it holds, so a new row is searchable only once it is listed there — with its anchor, its
+  title and the keywords the title doesn't contain ("caps lock" for Hyper Key).
   Matching reuses `FuzzyMatch` (`Launcher/Model/SearchRelevance.swift`), multi-term like `NoteSearch`:
   every term must hit the title, the breadcrumb or a keyword, a title hit outranks the rest, and a
   pane outranks its own rows so a bare "clipboard" lands on the pane. `Tests/settings-history-test.swift`
   pins that every pane is covered and that identities are unique; row-level drift is caught in review.
   **Match ranges are deliberately not highlighted** — `FuzzyMatch` returns tier and score only.
+- **`SettingsAnchor` names a section once, so the catalog and the pane cannot disagree.** An entry
+  takes its pane *from* the anchor, so a row filed under the wrong pane won't compile.
+  `SettingsSectionHeader(_:)` in a section's `header:` supplies the name and the id a group result
+  scrolls to; `SettingsRowTitle(_:_:)` stands in for the `Text` of a row's own label and does the
+  same for one setting. A section with no header of its own takes `.settingsAnchor(_:)`, an id and
+  nothing else. **A catalog entry is `.init(anchor, title)` for one row and `.init(group:_:)` when
+  no single row answers it** — a list, a section's master switch, a button that lives in another
+  row's trailing edge. The half the compiler can't reach — a target nothing declares, which
+  navigates and then sits there — is caught by `Scripts/check-settings-search.js`, run from
+  `Scripts/lint.sh`. **Add the entry and its marker together, or lint will say so.**
+- **The reveal lives in two modifiers, never in a pane** (`SettingsScrollTarget.swift`).
+  `.settingsScrollTarget()` on a pane's `Form` holds the `ScrollViewReader` and one `.task(id:)` keyed
+  on the request, so a second jump cancels the first mid-pulse and the pane releases the request when
+  it settles; `.settingsAnchor(_:)` on a `Section` supplies the `.id` and paints the wash, reading
+  which anchor is lit from `\.settingsFlash` rather than having it threaded down.
+  `SettingsScrollRequest` carries a token because picking the same result twice has to scroll again
+  rather than compare equal and do nothing.
+- **The pulse is a pill on the name, and nothing around it is touched.** A grouped `Form` applies a
+  `.background` to a row's whole *content* box, so lighting a section — or a row — paints ragged
+  blocks at the width of every label, button and footer paragraph in it. (`.listRowBackground` is a
+  no-op here, at section and at row level, and `.overlay` strokes every row separately.) Putting the
+  pill on the label instead is one fixed shape nothing can render badly, it leaves each row's
+  subtitle and control alone, and it marks exactly the words the result row showed.
+- **The light is the window's, not the pane's** (`SettingsNavigationState.flashing`). Both panes are
+  briefly alive across a swap, so a pane-local `@State` pulse dies with the pane that lit it, and an
+  `@Environment` value doesn't reliably repaint an already-realized `Form` row. Two rules fall out:
+  a cancelled reveal returns *without* ending the pulse, since cancellation means a later jump owns
+  the light now; and `scrollRequest` is released only once the pulse is over, because it keys the
+  pane's `.task(id:)` and clearing it early cancels the very task doing the revealing.
 - **The sidebar's field is not `SettingsFilterField`.** That one is borderless because it lives inside
   a `Form` row; the sidebar's is a glass capsule — `.frosted(in: Capsule())` at
   `Size.settingsSearchField`, lensing the sidebar's own vibrancy — and lives in `Features/Settings/`,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -42,7 +42,7 @@ These are the things that quietly break the look if changed. Preserve them unles
 - **An icon is drawn for a surface *and* a system icon style, and both move under you.** macOS restyles the icons `NSWorkspace` hands out when System Settings → Appearance → **Icon & widget style** changes, so `IconStyleMonitor` and Tinycast's own appearance both call `IconCache.invalidateStyled()`. **The monitor may not invalidate on the notification itself.** AppKit posts `NSWorkspaceIconAppearanceConfigurationDidChange` before IconServices has swapped what `NSWorkspace` vends — measured at 25–120ms behind, jittering run to run — and the images it hands back are live objects macOS restyles in place, so flattening one on the signal freezes the *outgoing* style into a bitmap nothing ever invalidates again. `IconStyleMonitor` therefore polls `IconCache.styleFingerprint()` until the pixels actually move, and only then invalidates. Waiting also sidesteps the cost: re-flattening every icon the instant a restyle begins forces a cold IconServices regeneration, measured at 160× the settled draw cost. That drops the cached bitmaps, bumps every cache key so an in-flight decode cannot repopulate a stale one, and moves `IconCache.style.generation`. **Any view that draws an icon must key its fetch on that generation** — wrap the view's own key in `IconRequest`, or call `IconCache.observeStyle()` where the icon is resolved synchronously in a `body`. It is reached through `IconCache` rather than injected precisely because icons are drawn in menus, popovers and every list, where a missed injection would be a silent staleness bug.
 - **No hard dividers between the list and the bars.** The header and bottom bar are `safeAreaInset` overlays with no background; separation comes from `edgeDissolve()`, nothing else. (One deliberate exception: the vertical hairline between the clipboard list and its preview pane.)
 - **The panel corner is clipped once, at the root.** `RootPaletteView.body` ends with `.background(panelScrim) → .background(VisualEffectView()) → .clipShape(RoundedRectangle(26, .continuous))`. Keep that order; the scrim goes _over_ the vibrancy, and the clip is last.
-- **Don't use the native scroll edge effect.** Inside a transparent panel it renders a hard-bounded rectangle. Use `edgeDissolve()`, or a gradient `mask` where a surface owns its own fade — `scrollEdgeEffectStyle` draws a *material* where a scroll view meets a safe area, so over a panel that already has `panelScrim` + `VisualEffectView` it composites to nothing. Tried and rejected on `QuickActionResultView`, with and without `safeAreaBar`.
+- **Don't use the native scroll edge effect.** Inside a transparent panel it renders a hard-bounded rectangle. Use `edgeDissolve()`, or a gradient `mask` where a surface owns its own fade — `scrollEdgeEffectStyle` draws a *material* where a scroll view meets a safe area, so over a panel that already has `panelScrim` + `VisualEffectView` it composites to nothing. Tried and rejected on `QuickActionResultView`, with and without `safeAreaBar`. This is a rule about the borderless panels; the Settings window is a titled `NSWindow` whose system titlebar draws the band itself (see "Settings").
 - **Test over a light desktop.** Transparency and corner masking bugs only show over bright wallpaper. Dark wallpaper hides them.
 - **No `NSAlert`, no `NSSlider`, no system popovers.** Every confirmation, failure report, value prompt and transient readout is Tinycast's own SwiftUI surface (see "Dialogs & HUD"). An Aqua alert on an alpha-over-vibrancy app reads as a different product, and its `runModal` run loop keeps Carbon hotkeys firing underneath.
 - **A dialog has three independent axes; never let one infer another.** The **icon** (`DialogRequest.symbol`, required) is always the *subject's* own glyph — a command being confirmed uses its `SystemAction.sfSymbol`, so the Restart dialog shows the same icon as the Restart row. Tone never picks an icon. The **tone** (`DialogTone`: `.neutral` / `.success` / `.danger`) tints only that glyph. The **button** takes its color from `DialogAction.Role` (`.standard` white / `.destructive` red / `.cancel` secondary), so a red-glyph security warning can still carry a plain white button — as "Import executable commands?" does.
@@ -522,10 +522,42 @@ system-drawn and a pane reads exactly as macOS System Settings does.
   ride under the last row.
 - **The pane's own title is not in the pane.** `SettingsToolbarController` puts it in the titlebar,
   seated in the detail column by `.sidebarTrackingSeparator`.
+- **Settings is the one window that keeps the system titlebar.** `AppWindowController` builds every
+  window with `titlebarAppearsTransparent = true`, which opts the titlebar out of the system's glass
+  band; `SettingsToolbarController.install(in:)` sets it back to `false`, so the band and its scroll
+  edge effect are drawn by AppKit as a pane's `Form` scrolls under it. `.fullSizeContentView` and
+  `titlebarSeparatorStyle = .none` stay — the content still runs under the bar, and a hairline would
+  split the surface the band unifies. It also clears `isMovableByWindowBackground`: stock Settings
+  isn't dragged by its content. Onboarding, Updates, Support and Command Output keep the transparent
+  titlebar they were tuned for. Never hand-draw a header band; a main surface takes the system's
+  material, not `glassEffect`.
 - `SettingsComponents.swift` holds only what more than one pane needs: **`SettingsRow`**,
   **`FeatureSwitchSection`** (a feature's master switch plus its launcher-visibility companion) and
   **`SettingsFilterField`** (the filter row above a long list). `Onboarding/OnboardingCard.swift`
   keeps the older hand-drawn card, which that window still uses.
+- **The sidebar searches every pane *and* its rows.** `SettingsSearchField` sits above the list and
+  swaps it for a flat, ranked result list; each result carries the pane's `systemImage`, the row's
+  title and a `Pane › Section` breadcrumb, and arrowing through them moves the pane, as System
+  Settings does. Selection runs through `SettingsNavigationState.select`, so a result is an ordinary
+  navigation the Back/Forward chevrons can walk. It is a **second `List`**, keyed by
+  `SettingsSearchEntry.ID`, so result identities never share a selection namespace with `SettingsTab`.
+  ⌘F focuses the field, Escape clears it.
+- **`SettingsSearchCatalog` is hand-written, and that is the only option.** A `Form` cannot be asked
+  what rows it holds, so a new row is searchable only once it is listed there — with its pane, its
+  `Section` header, its title and the keywords the title doesn't contain ("caps lock" for Hyper Key).
+  Matching reuses `FuzzyMatch` (`Launcher/Model/SearchRelevance.swift`), multi-term like `NoteSearch`:
+  every term must hit the title, the breadcrumb or a keyword, a title hit outranks the rest, and a
+  pane outranks its own rows so a bare "clipboard" lands on the pane. `Tests/settings-history-test.swift`
+  pins that every pane is covered and that identities are unique; row-level drift is caught in review.
+  **Match ranges are deliberately not highlighted** — `FuzzyMatch` returns tier and score only.
+- **The sidebar's field is not `SettingsFilterField`.** That one is borderless because it lives inside
+  a `Form` row; the sidebar's is a glass capsule — `.frosted(in: Capsule())` at
+  `Size.settingsSearchField`, lensing the sidebar's own vibrancy — and lives in `Features/Settings/`,
+  having one call site. **The glass goes on a background layer, not on the content**
+  (`.background { Color.clear.frosted(in: Capsule()) }`): `frosted` ends in `.tint(.clear)`, which a
+  `TextField` descendant would inherit as an invisible caret.
+  `.searchable(placement: .sidebar)` renders nothing here — it needs a SwiftUI `NavigationSplitView`,
+  and this sidebar is an `NSHostingController` in a real `NSSplitViewController`.
 - **A `Form` realizes every row it is handed.** `LauncherItemsSection` therefore holds its items in
   a `LazyVStack` inside one Form row — 400 apps cost 55 ms and 69 views that way against 750 ms and
   2040 eager. Any other unbounded list must do the same.


### PR DESCRIPTION
## Related issue

Closes #

## What changed

Two gaps against stock macOS System Settings on macOS 26.

**Settings search.** The sidebar gains a search field above the pane list. Typing swaps the four
groups for a flat, ranked result list: pane icon, the row's title, and a `General › Hyper Key`
breadcrumb. Arrowing through results moves the pane as System Settings does; selection runs through
`SettingsNavigationState.select`, so a result is an ordinary navigation the Back/Forward chevrons can
walk. ⌘F focuses the field, Escape clears it.

- `SettingsSearchCatalog.swift` — ~120 entries (pane, `Section` header, title, keywords), plus the
  matcher. **It is hand-written because a `Form` cannot be asked what rows it holds**, so a new row is
  searchable only once it is listed there. `keywords` carries what the visible title doesn't — "caps
  lock" finds Hyper Key, "startup" finds Launch at login.
- Matching reuses `FuzzyMatch` (`Launcher/Model/SearchRelevance.swift`) rather than adding a second
  matcher, multi-term in the shape of `NoteSearch`: every term must hit the title, the breadcrumb or a
  keyword; a title hit outranks the rest; a pane outranks its own rows, so a bare "clipboard" lands on
  the pane and not on one of its toggles.
- The results list is a **second `List`**, keyed by `SettingsSearchEntry.ID`, so result identities
  never share a selection namespace with `SettingsTab` — the constraint
  `sidebarIdentityNamespacesAreDisjoint()` already pins for the browse list.
- **A result reveals the setting it names.** The pane scrolls it to centre and pulses its own label
  once; a result no single row answers (an editable list, a master switch, a button living in another
  row's trailing edge) pulses the section header instead. `SettingsAnchor` names a section once and
  `SettingsTarget` picks a section or one row inside it — an entry takes its pane *from* the target,
  so a row filed under the wrong pane won't compile, and `Scripts/check-settings-search.js` covers
  what the compiler cannot: a target nothing declares navigates and then sits there.
- **The pulse is a pill on the label, not a wash over the row or the section.** A grouped `Form`
  applies a `.background` to a row's whole *content* box, so lighting the row or the section paints
  ragged blocks at the width of every label, button and footer paragraph in it. `.listRowBackground`
  is a no-op here (at section and at row level) and `.overlay` strokes every row separately.
- **The lit target lives on `SettingsNavigationState`, not on the pane.** Both panes are briefly
  alive across a swap, so a pane-local `@State` pulse dies with the pane that lit it. Two rules fall
  out: a cancelled reveal returns *without* ending the pulse, and `scrollRequest` is released only
  once the pulse is over, because it keys the pane's `.task(id:)`.

**The glassy header.** `AppWindowController.makeWindow` sets `titlebarAppearsTransparent = true` for
every window it builds, which opts the titlebar out of the system's Liquid Glass band. Combined with
`.fullSizeContentView` that left pane content scrolling under a bar painting nothing — legible
straight through it. `SettingsToolbarController.install(in:)` now sets it back to `false`, so AppKit
draws the band and its scroll edge effect. It also clears `isMovableByWindowBackground`: stock
Settings isn't dragged by its content. `.fullSizeContentView` and `titlebarSeparatorStyle = .none`
stay — content still runs under the bar, and a hairline would split the surface the band unifies.
**Settings only**; Onboarding, Updates, Support and Command Output keep the transparent titlebar they
were tuned for.

Non-obvious bits in the diff:

- **The search field's glass is on a background layer, not on the content.** `Theme.frosted(in:)` ends
  in `.tint(.clear)`, which a `TextField` descendant would inherit as an invisible caret.
- **`.searchable(placement: .sidebar)` was tried first and renders nothing here.** The placement needs
  a SwiftUI `NavigationSplitView`; this sidebar is an `NSHostingController` in a real
  `NSSplitViewController` (which the toolbar needs for `.sidebarTrackingSeparator`). Probed, not
  assumed — see below.
- The field is **not** `SettingsFilterField`. That one is deliberately borderless because it sits
  inside a `Form` row; the sidebar's is a glass capsule.

## Memory footprint

The catalog is ~120 immutable structs behind a `static let`, built once on first search and held for
the process; the results list is capped at 50. Nothing here allocates per keystroke beyond the
folded query. No new caches, timers, observers or tasks.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested:

## Demo

Not captured — this shell has no Screen Recording grant, so `screencapture` fails on both window and
display. Needs a before/after clip of the header band as a pane scrolls, and of typing in the sidebar.

## Drawbacks

- **The catalog will drift.** A `Form` can't be introspected, so adding a `Toggle` to a pane without
  adding a catalog entry leaves it unsearchable, and the test can't catch it — it pins that every pane
  is covered and that identities are unique, but not per-row completeness (pinning entry counts would
  need updating on every pane edit). Row-level drift is a review item.
- **15 entries stay group-level and light the section header, not a row.** "Search Scopes",
  "Calendars", "Ignore Patterns", "Installed extensions", "Window commands", "Links" and similar have
  no single row to point at — they are editable lists, or a button in another row's trailing edge.
- **Marking rows touched a lot of panes.** Six `Picker`/`Button` rows moved from a string label to a
  label closure so their title could carry the pill ("Emoji Skin Tone", "Add MCP Server",
  "Add API Connection", "Add Custom Command", "Add Quicklink", "Check for Updates"). Worth a look
  that they still read right.
- **`lint.sh` now needs node**, which it didn't before. `ci.yml` runs it and only `website.yml` sets
  node up, so the lint job likely needs an `actions/setup-node` step.
- **Match ranges in the sidebar are not highlighted.** `FuzzyMatch` returns tier and score only;
  adding index tracking to it is a change to the launcher's hot path and didn't belong here.
- **The pill follows the system accent** (`Color.accentColor.opacity(0.35)`) and has only been seen
  against blue.
- **The header change is unverified by eye.** See below — I could confirm the mechanism but not the
  appearance.

## Tests & validation

`./Scripts/run-tests.sh` — all 54 harnesses pass. Four cases added to `settings-history-test`, which
already owns the Settings taxonomy assertions (`SettingsSearchCatalog.swift` and `SearchRelevance.swift`
added to its compile line):

- `catalogCoversEveryPane` — every `SettingsTab` has at least one entry, so a new pane can't ship
  unsearchable.
- `catalogIdentitiesAreUnique` — a duplicate `id` would make two result rows select as one.
- `catalogFindsKnownRows` — golden queries land on the right pane: `hyper`, `caps lock`,
  `launch at login`, `paste history`, `window manage`, `skin tone`, `mcp`.
- `catalogRanksTitlesFirst` — a pane beats its own rows, and an unmatched query returns nothing.
- `flashOutlivesThePaneThatLitIt` — only a pulse's own owner may end it, and navigating away clears
  a stale one.

`./Scripts/lint.sh` also runs `Scripts/check-settings-search.js`, which fails if any anchor has no
section or any catalog row has no `SettingsRowTitle`.

Debug build compiles with no new warnings; `./Scripts/lint.sh` clean; the `Model/` purity grep returns
nothing. `xcodegen generate` re-run for the two new files, project committed.

**Probed rather than assumed** (throwaway `swiftc` harnesses, not shipped):

- Reproduced the Settings chrome — `NSSplitViewController`, unified `NSToolbar`, hosted SwiftUI
  columns — in two windows differing only in `titlebarAppearsTransparent`, and rendered both. The band
  and its gradient edge appear only with the flag off. That is what confirmed the one-line fix.
- Rendered the real `SettingsSidebarView` (compiling the shipped files) empty and with "hyper" typed,
  to check the field, the result rows and the breadcrumbs.
- Reproduced the reveal across a genuine pane swap (two distinct pane types, as `SettingsDetailView`
  has) and pixel-diffed the pulse against the settled frame: 2379/8988 samples differ, then back to
  baseline. That is what caught both cancellation bugs — before the fix the two frames were
  byte-identical, and a solid-red flash proved it was a repaint failure, not weak contrast.
- Confirmed `ScrollViewReader.scrollTo` works inside `.formStyle(.grouped)` (a 5878pt document
  scrolled to 4564), and that an `.id` on a section's *header* scrolls just as well.
- Compared highlight treatments against toggle, label, button and picker rows before settling on the
  label pill; a full-row band and a section wash were both tried and rejected.
- Injected a one-character typo into a catalog title to confirm `check-settings-search.js` fails on
  it and takes lint down with it.
- `glassEffect` cannot be captured this way — `cacheDisplay` renders backdrop layers as blank, which
  is also why the sidebar's own vibrancy comes out flat in those stills. Confirmed the glass instead
  by dumping the layer tree: an `SDFLayer` → `CABackdropLayer` → `CASDFLayer` stack at the field's
  exact 272×28 frame, sampling the `NSVisualEffectView` behind it.

**Not verified, and worth a look before merge:** how the header band and the field's glass actually
read — in both Light and Dark, over a light desktop. I could confirm the mechanism, not the
appearance.

