### PR TITLE
Descend through symlinked folders when scanning application scopes

### DIFF
--- a/Tests/scopes-test.swift
+++ b/Tests/scopes-test.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @main
 struct ScopesTest {
-    static func main() {
+    static func main() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
             .appendingPathComponent("tinycast-scopes-\(UUID().uuidString)")
@@ -33,13 +33,39 @@ struct ScopesTest {
         let deep = vendor.appendingPathComponent("Deeper")
         makeDir(deep.appendingPathComponent("TooDeep.app"))
 
-        let found = SearchScopes.appBundles(in: [apps.path]).map(\.lastPathComponent)
+        let managedApps = root.appendingPathComponent("Managed Apps")
+        makeDir(managedApps.appendingPathComponent("Managed.app"))
+        let managedAppsLink = apps.appendingPathComponent("Home Manager Apps")
+        try fm.createSymbolicLink(at: managedAppsLink, withDestinationURL: managedApps)
+        let managedAppLink = root.appendingPathComponent("Managed Link.app")
+        try fm.createSymbolicLink(
+            at: managedAppLink,
+            withDestinationURL: managedApps.appendingPathComponent("Managed.app"))
+        let brokenAppLink = apps.appendingPathComponent("Broken.app")
+        try fm.createSymbolicLink(
+            at: brokenAppLink,
+            withDestinationURL: root.appendingPathComponent("Missing.app"))
+
+        let foundURLs = SearchScopes.appBundles(in: [apps.path])
+        let found = foundURLs.map(\.lastPathComponent)
         check(
-            "direct and one-level-nested .app children are indexed",
-            Set(found) == ["Alpha.app", "Beta.app", "Nested.app"])
+            "direct, nested, and symlinked .app children are indexed",
+            Set(found) == ["Alpha.app", "Beta.app", "Managed.app", "Nested.app"])
         check("non-app children are skipped", !found.contains("Notes.txt"))
         check("hidden bundles are skipped", !found.contains(".Hidden.app"))
         check("bundles nested two levels deep are not indexed", !found.contains("TooDeep.app"))
+        let logicalManagedApp = managedAppsLink.appendingPathComponent("Managed.app")
+        let physicalManagedApp = managedApps.appendingPathComponent("Managed.app")
+        check(
+            "apps under a symlink keep their logical paths",
+            foundURLs.contains(logicalManagedApp) && !foundURLs.contains(physicalManagedApp))
+        check("broken .app symlinks are skipped", !foundURLs.contains(brokenAppLink))
+        check(
+            "a symlinked directory works as its own scope",
+            SearchScopes.appBundles(in: [managedAppsLink.path]) == [logicalManagedApp])
+        check(
+            "an .app symlink works as its own scope",
+            SearchScopes.appBundles(in: [managedAppLink.path]) == [managedAppLink])
         check(
             "a deeply nested folder works as its own scope",
             SearchScopes.appBundles(in: [deep.path]).map(\.lastPathComponent) == ["TooDeep.app"])

--- a/Tinycast/Features/Launcher/Model/SearchScopes.swift
+++ b/Tinycast/Features/Launcher/Model/SearchScopes.swift
@@ -47,37 +47,46 @@ enum SearchScopes {
         return result
     }
 
+    private static let scanKeys: [URLResourceKey] = [.isDirectoryKey, .isSymbolicLinkKey]
+    private static let scanKeySet: Set<URLResourceKey> = [.isDirectoryKey, .isSymbolicLinkKey]
+
     /// `.app` is a leaf here — never descended into.
     private static func appBundles(under url: URL, subfolderDepth: Int) -> [URL] {
+        let fm = FileManager.default
         guard
-            let items = try? FileManager.default.contentsOfDirectory(
-                at: url.resolvingSymlinksInPath(),
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )
+            let items = (try? fm.contentsOfDirectory(
+                at: url, includingPropertiesForKeys: scanKeys, options: [.skipsHiddenFiles]))
+                ?? (try? fm.contentsOfDirectory(
+                    at: url.resolvingSymlinksInPath(),
+                    includingPropertiesForKeys: scanKeys,
+                    options: [.skipsHiddenFiles]))
         else { return [] }
 
         var result: [URL] = []
         for item in items {
-            let logicalURL = url.appendingPathComponent(item.lastPathComponent)
-            if logicalURL.pathExtension == "app" {
-                if FileManager.default.fileExists(atPath: logicalURL.path) {
-                    result.append(logicalURL)
+            let logicalItem = url.appendingPathComponent(item.lastPathComponent)
+            let isApp = logicalItem.pathExtension == "app"
+            let values = try? item.resourceValues(forKeys: scanKeySet)
+            let isSymlink = values?.isSymbolicLink == true
+
+            if isApp {
+                if !isSymlink || fm.fileExists(atPath: logicalItem.path) {
+                    result.append(logicalItem)
                 }
-            } else if subfolderDepth > 0, isDirectory(at: logicalURL) {
-                result.append(
-                    contentsOf: appBundles(
-                        under: logicalURL,
-                        subfolderDepth: subfolderDepth - 1))
+            } else if subfolderDepth > 0 {
+                if values?.isDirectory == true {
+                    result.append(
+                        contentsOf: appBundles(under: logicalItem, subfolderDepth: subfolderDepth - 1))
+                } else if isSymlink,
+                    (try? logicalItem.resolvingSymlinksInPath().resourceValues(forKeys: [.isDirectoryKey]))?
+                        .isDirectory == true
+                {
+                    result.append(
+                        contentsOf: appBundles(under: logicalItem, subfolderDepth: subfolderDepth - 1))
+                }
             }
         }
         return result
-    }
-
-    private static func isDirectory(at url: URL) -> Bool {
-        var isDir: ObjCBool = false
-        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
-            && isDir.boolValue
     }
 
     private static func trimTrailingSlash(_ path: String) -> String {

--- a/Tinycast/Features/Launcher/Model/SearchScopes.swift
+++ b/Tinycast/Features/Launcher/Model/SearchScopes.swift
@@ -47,25 +47,37 @@ enum SearchScopes {
         return result
     }
 
-    /// `.app` is a leaf here — never descended into, only real subfolders recurse.
+    /// `.app` is a leaf here — never descended into.
     private static func appBundles(under url: URL, subfolderDepth: Int) -> [URL] {
         guard
             let items = try? FileManager.default.contentsOfDirectory(
-                at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+                at: url.resolvingSymlinksInPath(),
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
             )
         else { return [] }
 
         var result: [URL] = []
         for item in items {
-            if item.pathExtension == "app" {
-                result.append(item)
-            } else if subfolderDepth > 0,
-                (try? item.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            {
-                result.append(contentsOf: appBundles(under: item, subfolderDepth: subfolderDepth - 1))
+            let logicalURL = url.appendingPathComponent(item.lastPathComponent)
+            if logicalURL.pathExtension == "app" {
+                if FileManager.default.fileExists(atPath: logicalURL.path) {
+                    result.append(logicalURL)
+                }
+            } else if subfolderDepth > 0, isDirectory(at: logicalURL) {
+                result.append(
+                    contentsOf: appBundles(
+                        under: logicalURL,
+                        subfolderDepth: subfolderDepth - 1))
             }
         }
         return result
+    }
+
+    private static func isDirectory(at url: URL) -> Bool {
+        var isDir: ObjCBool = false
+        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+            && isDir.boolValue
     }
 
     private static func trimTrailingSlash(_ path: String) -> String {


### PR DESCRIPTION
## Related issue

Follow-up to #256 (PR #268)

## What changed

PR #268 enabled one-level-deep descent to discover apps located inside vendor subfolders. However, if a subfolder or scope is a symbolic link, `FileManager.default.contentsOfDirectory` throws POSIX error 20 (`ENOTDIR`) and `item.resourceValues.isDirectory` returns `false`.

- **First choice (fast path)**: Retains batched attribute prefetching (`includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey]`). Normal directories and bundles follow the original path with zero extra stat calls.
- **Fallback**: When `contentsOfDirectory(at: url)` fails with `ENOTDIR` (e.g. `url` is a symlinked directory), it falls back to `url.resolvingSymlinksInPath()`. During enumeration, symlinks are checked to see if their destination is a directory.
- **Logical paths**: Reconstructs items using `url.appendingPathComponent(item.lastPathComponent)` so indexed app paths remain stable under their configured scope rather than leaking transient physical targets.
- Prunes broken `.app` symlinks so dead targets are not indexed.

## Memory footprint

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Not profiled. The change only performs a bounded directory traversal returning temporary `[URL]` arrays dropped immediately after enumeration. No cache, no long-lived state, and no background tasks.

Leak-tested: no — allocations are local to the function call.

## Drawbacks

None. Bounded depth of 1 and leaf treatment of `.app` bundles remain strictly unchanged.

## Tests & validation

- Extended `Tests/scopes-test.swift` with assertions for symlinked directories, logical path preservation, and broken symlink pruning.
- Passed `./Scripts/run-tests.sh scopes-test`.
- Passed `./Scripts/run-tests.sh` (all 54 harnesses pass).
- Passed `./Scripts/lint.sh`.
- Verified on macOS that `SearchScopes.appBundles(in: ["~/Applications"])` discovers apps under symlinked subfolders with logical paths preserved.