### PR TITLE
Lend the paste board only the expansion, never the old clipboard's flavours

### DIFF
--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -562,7 +562,7 @@ struct SnippetsTests {
         let injector = TextInjector(clipboardManager: ClipboardManager(), settings: AppSettings())
         let backing = NSPasteboard(name: .init("tinycast-copy-tests-\(UUID().uuidString)"))
         defer { backing.releaseGlobally() }
-        let pasteboard = CountingPasteboard(backing: backing)
+        let pasteboard = StubPasteboard(backing: backing)
 
         func seed(_ text: String) {
             let item = NSPasteboardItem()
@@ -736,7 +736,7 @@ struct SnippetsTests {
 
         let backingPasteboard = NSPasteboard(
             name: .init("tinycast-snippets-tests-\(UUID().uuidString)"))
-        let pasteboard = CountingPasteboard(backing: backingPasteboard)
+        let pasteboard = StubPasteboard(backing: backingPasteboard)
         defer { backingPasteboard.releaseGlobally() }
         let customType = NSPasteboard.PasteboardType("com.example.custom")
         let firstItem = NSPasteboardItem()
@@ -753,17 +753,13 @@ struct SnippetsTests {
             text: "Temporary",
             pasteboard: pasteboard)
         check(
-            "temporary pasteboard ownership preserves the original item shape",
+            "the lent pasteboard carries the text and no representation of the original",
             lease?.isOwned == true
                 && pasteboard.string(forType: .string) == "Temporary"
-                && pasteboard.pasteboardItems?.count == 2
-                && pasteboard.pasteboardItems?[0].data(forType: customType)
-                    == Data([0, 1, 2, 3])
-                && pasteboard.pasteboardItems?[1].data(forType: secondType)
-                    == Data([4, 5, 6])
+                && pasteboard.pasteboardItems?.count == 1
+                && pasteboard.pasteboardItems?[0].data(forType: customType) == nil
+                && pasteboard.pasteboardItems?[0].data(forType: secondType) == nil
         )
-        let clearCountBeforeRestore = pasteboard.clearCount
-        let writeCountBeforeRestore = pasteboard.writeCount
         let restoreResult = lease?.restoreIfOwned()
         let restoredItems = pasteboard.pasteboardItems
         check(
@@ -774,9 +770,10 @@ struct SnippetsTests {
                 && restoredItems?[0].data(forType: customType) == Data([0, 1, 2, 3])
                 && restoredItems?[1].data(forType: secondType) == Data([4, 5, 6]))
         check(
-            "pasteboard restoration does not clear before a fallible write",
-            pasteboard.clearCount == clearCountBeforeRestore
-                && pasteboard.writeCount == writeCountBeforeRestore)
+            "pasteboard restoration leaves no Tinycast marker on the restored clipboard",
+            restoredItems?.allSatisfy {
+                !$0.types.contains(ClipboardManager.internalType)
+            } == true)
 
         pasteboard.writeFailuresRemaining = 1
         var recoveredMutationCount: Int?
@@ -1759,10 +1756,8 @@ struct SnippetsTests {
 }
 
 @MainActor
-private final class CountingPasteboard: PasteboardAccess {
+private final class StubPasteboard: PasteboardAccess {
     let backing: NSPasteboard
-    private(set) var clearCount = 0
-    private(set) var writeCount = 0
     var writeFailuresRemaining = 0
 
     init(backing: NSPasteboard) {
@@ -1774,12 +1769,10 @@ private final class CountingPasteboard: PasteboardAccess {
 
     @discardableResult
     func clearContents() -> Int {
-        clearCount += 1
-        return backing.clearContents()
+        backing.clearContents()
     }
 
     func writeObjects(_ objects: [any NSPasteboardWriting]) -> Bool {
-        writeCount += 1
         if writeFailuresRemaining > 0 {
             writeFailuresRemaining -= 1
             return false

--- a/Tinycast/Features/TextInjection/Service/TextInjector.swift
+++ b/Tinycast/Features/TextInjection/Service/TextInjector.swift
@@ -994,8 +994,6 @@ final class TemporaryPasteboardLease {
     private let pasteboard: any PasteboardAccess
     private let ownedChangeCount: Int
     private let original: PasteboardSnapshot
-    /// Set only when the clipboard already held a string, which restores in place at no cost.
-    private let temporaryItem: NSPasteboardItem?
     private var isFinished = false
 
     var isOwned: Bool {
@@ -1005,13 +1003,11 @@ final class TemporaryPasteboardLease {
     private init(
         pasteboard: any PasteboardAccess,
         ownedChangeCount: Int,
-        original: PasteboardSnapshot,
-        temporaryItem: NSPasteboardItem?
+        original: PasteboardSnapshot
     ) {
         self.pasteboard = pasteboard
         self.ownedChangeCount = ownedChangeCount
         self.original = original
-        self.temporaryItem = temporaryItem
     }
 
     static func begin(
@@ -1020,13 +1016,13 @@ final class TemporaryPasteboardLease {
         onMutation: (Int) -> Void = { _ in }
     ) -> TemporaryPasteboardLease? {
         guard let snapshot = PasteboardSnapshot(pasteboard: pasteboard),
-            let temporaryItems = snapshot.items(borrowingFor: text),
+            let temporaryItem = PasteboardSnapshot.temporaryItem(carrying: text),
             let originalItems = snapshot.pasteboardItems(),
             pasteboard.changeCount == snapshot.changeCount
         else { return nil }
 
         pasteboard.clearContents()
-        guard pasteboard.writeObjects(temporaryItems) else {
+        guard pasteboard.writeObjects([temporaryItem]) else {
             if originalItems.isEmpty || pasteboard.writeObjects(originalItems) {
                 onMutation(pasteboard.changeCount)
             }
@@ -1037,36 +1033,16 @@ final class TemporaryPasteboardLease {
         return TemporaryPasteboardLease(
             pasteboard: pasteboard,
             ownedChangeCount: ownedChangeCount,
-            original: snapshot,
-            temporaryItem: snapshot.firstStringData == nil ? nil : temporaryItems.first)
+            original: snapshot)
     }
 
+    /// The lent board holds nothing of the original, so restoring rewrites the snapshot whole.
     func restoreIfOwned() -> RestoreResult {
         guard !isFinished else { return .superseded }
         guard pasteboard.changeCount == ownedChangeCount else {
             isFinished = true
             return .superseded
         }
-        guard let temporaryItem, let originalStringData = original.firstStringData else {
-            return rewriteOriginal()
-        }
-        guard temporaryItem.setData(originalStringData, forType: .string) else {
-            if pasteboard.changeCount != ownedChangeCount {
-                isFinished = true
-                return .superseded
-            }
-            return .failed
-        }
-        guard pasteboard.changeCount == ownedChangeCount else {
-            isFinished = true
-            return .superseded
-        }
-        isFinished = true
-        return .restored(changeCount: ownedChangeCount)
-    }
-
-    /// A borrowed board has no original string to write back into, so the whole board is rewritten.
-    private func rewriteOriginal() -> RestoreResult {
         guard let items = original.pasteboardItems() else { return .failed }
         pasteboard.clearContents()
         isFinished = true
@@ -1104,33 +1080,21 @@ struct PasteboardSnapshot {
         self.changeCount = changeCount
     }
 
+    /// A kept `public.html` is the flavour a Chromium editor prefers, so we lend the text alone.
+    static func temporaryItem(carrying text: String) -> NSPasteboardItem? {
+        let item = NSPasteboardItem()
+        guard item.setString(text, forType: .string),
+            item.setData(Data(), forType: ClipboardManager.internalType)
+        else { return nil }
+        return item
+    }
+
     func pasteboardItems() -> [NSPasteboardItem]? {
-        makePasteboardItems(firstString: nil)
-    }
-
-    /// A board with no string of its own lends a fresh item instead of declining the loan.
-    func items(borrowingFor text: String) -> [NSPasteboardItem]? {
-        guard firstStringData != nil else {
-            let item = NSPasteboardItem()
-            guard item.setString(text, forType: .string),
-                item.setData(Data(), forType: ClipboardManager.internalType)
-            else { return nil }
-            return [item]
-        }
-        return makePasteboardItems(firstString: text)
-    }
-
-    private func makePasteboardItems(firstString: String?) -> [NSPasteboardItem]? {
         var pasteboardItems: [NSPasteboardItem] = []
         pasteboardItems.reserveCapacity(items.count)
-        for (index, item) in items.enumerated() {
+        for item in items {
             let pasteboardItem = NSPasteboardItem()
-            if index == 0, let firstString {
-                guard pasteboardItem.setString(firstString, forType: .string),
-                    pasteboardItem.setData(Data(), forType: ClipboardManager.internalType)
-                else { return nil }
-            }
-            for value in item.values where index != 0 || firstString == nil || value.type != .string {
+            for value in item.values {
                 guard pasteboardItem.setData(value.data, forType: value.type) else { return nil }
             }
             pasteboardItems.append(pasteboardItem)

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -279,15 +279,25 @@ text and a scalar never exceeds four units on its own. The chunks post through t
 re-gated loop the deletions use, so a target that goes away mid-word stops the rest.
 
 Longer or multiline fallback text uses a temporary paste. Tinycast snapshots every item, type and data
-payload, takes temporary ownership with the same item shape, and changes only the first plain-text
-payload; restoration mutates that owned item back in place, never clearing the clipboard before a
-fallible restore. A pasteboard with no string of its own — empty, or image-first — **borrows** instead:
-Tinycast writes a single string item and restores by rewriting the snapshot, which is the one path that
-clears first, because there is no original string item left to write back into. Declining the loan
-there would have sent a long multiline expansion down the keystroke path a character at a time. The
-pasteboard change count is checked before restoration, so a newer copy is never overwritten, and the
-clipboard poller synchronizes to Tinycast's ownership changes so temporary or restored text is not
-added as new history.
+payload, then **lends a board holding nothing but the expansion** — one item carrying the plain text
+and Tinycast's own marker type — and restores by rewriting the snapshot whole.
+
+**The loan carries no other flavour of the old clipboard.** Keeping the original item's shape and
+swapping only its `.string` would leave `public.html`, `public.rtf` and the rest describing the
+*previous* copy, and a rich-text editor prefers those: ChatGPT's ProseMirror composer takes Chromium's
+`text/html` over its `text/plain`, so a snippet pasted over an HTML-bearing clipboard inserted the
+previous copy instead. A representation Tinycast cannot rewrite to mean the expansion is one it must
+not lend, and the whitelist of text-bearing UTIs it *could* rewrite would never be complete. Rewriting
+the snapshot therefore clears before a fallible write — the risk a same-shape loan bought off — which
+is the trade a correct paste is worth, and the items are built from the in-memory snapshot before the
+clear so the write has nothing left to fail on.
+
+An empty or image-only clipboard lends the same single item; declining the loan there would have sent
+a long multiline expansion down the keystroke path a character at a time. The pasteboard change count
+is checked before restoration, so a newer copy is never overwritten, and the clipboard poller
+synchronizes to Tinycast's ownership changes so temporary or restored text is not added as new history.
+Because the marker type lives only on the lent item, a restored clipboard carries none of it, and the
+poller keeps seeing the user's own copy.
 
 When Accessibility text state is readable, a long paste waits for evidence that the target changed.
 If the editor cannot expose post-paste text state, a successfully posted paste is accepted only after


### PR DESCRIPTION
## Related issue

Closes #427

## What changed

A snippet expanded into the ChatGPT composer pasted the **previous clipboard entry** instead of the snippet.

`TemporaryPasteboardLease` built its temporary item by copying every type off the original item 0 and replacing only `.string`. Captured on a live board mid-lease:

```
public.utf8-plain-text    ← swapped for the snippet
public.html               ← still the previous copy
org.chromium.source-url   ← ditto
com.tinycast.internal
```

Chromium hands both flavours to the page, and ProseMirror — ChatGPT's composer — prefers `text/html`. So it inserted the stale HTML and never read the plain text we wrote. Any rich-text web editor over an HTML-bearing clipboard hits this; a plain-text clipboard hides it entirely, which is why the manual sweep never caught it. Only the paste tier is affected, so short single-line snippets (≤ 100 chars, typed as four-unit Unicode keystrokes) always worked — the reported snippet is 300 chars and multiline.

The lease now lends **one item carrying the expansion and Tinycast's marker type, and nothing else**, and restores by rewriting the snapshot whole. `PasteboardSnapshot.items(borrowingFor:)` and `makePasteboardItems(firstString:)` collapse into `temporaryItem(carrying:)` plus a plain `pasteboardItems()`; the in-place restore branch and its `temporaryItem` field are gone, so every clipboard shape now takes the one path the empty and image-only boards already took.

Second bug fixed by the same change: the in-place restore left `com.tinycast.internal` on the item it handed back, so `ClipboardManager.poll()` skipped that entry from then on. A rewritten snapshot carries no marker.

## Memory footprint

Not measured — the change is a few pasteboard items on an existing transient path, allocates strictly less than before (one item instead of a full copy of the original board), and adds no retained state; `TemporaryPasteboardLease` loses a stored property.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no.

## Drawbacks

**Restoration now clears before a fallible write.** The same-shape loan's in-place `setData` was the only thing buying "never clear the clipboard before a restore that can fail", and it was buyable only by lending representations of the old copy. Rewriting each text-bearing UTI to mean the expansion instead — `public.html`, `public.rtf`, flat-RTFD — is a whitelist that would never be complete, and one missed type is this bug again. The restore items are built from the in-memory snapshot *before* the clear, so the write has nothing left to fail on, and the change-count guard still refuses to overwrite a newer copy.

**A target that wanted rich text now gets plain text.** It was already getting plain text on any clipboard without an HTML payload; it just also got a stale one when there was.

## Tests & validation

`./Scripts/run-tests.sh` — all 55 harnesses pass. Debug build clean, `./Scripts/lint.sh` clean.

`snippets-test` assertions updated to the new contract:

- "the lent pasteboard carries the text and no representation of the original" — replaces the old item-shape check, and is the assertion that fails on the pre-fix code.
- "pasteboard restoration leaves no Tinycast marker on the restored clipboard" — replaces "restoration does not clear before a fallible write", which asserted the behaviour this PR deliberately drops.
- Restoration, superseded-copy, failed-write, empty-board and image-only cases are unchanged and still pass.

`CountingPasteboard` → `StubPasteboard`; its `clearCount`/`writeCount` had no readers left.

**Manual — not yet run.** Which tier a target takes is not harness-testable, so the sweep in `docs/features/snippets.md` still needs a pass by hand: copy rich text from a web page, then type the keyword in the ChatGPT composer in a Chromium browser. Also worth re-checking VSCodium, Notes and Mail, since the restore path changed for every clipboard shape, not just HTML-bearing ones.

`docs/features/snippets.md` § Text delivery and pasteboard safety rewritten to describe the loan and state the trade.
