### PR TITLE
Let the clipboard be switched off, like every other feature

### DIFF
--- a/Tests/palette-tab-test.swift
+++ b/Tests/palette-tab-test.swift
@@ -18,25 +18,25 @@ struct PaletteTabTests {
 
     static func main() {
         expect(
-            PaletteTabAction.resolve(mode: .launcher, aiEnabled: true),
+            PaletteTabAction.resolve(mode: .launcher, aiEnabled: true, clipboardEnabled: true),
             .ask,
             "the launcher hands the typed text to chat as the question, not as a draft")
         expect(
-            PaletteTabAction.resolve(mode: .ai, aiEnabled: true),
+            PaletteTabAction.resolve(mode: .ai, aiEnabled: true, clipboardEnabled: true),
             .freshScreen(.clipboard),
             "chat hands on to the clipboard without carrying the unsent draft into the filter")
         expect(
-            PaletteTabAction.resolve(mode: .clipboard, aiEnabled: true),
+            PaletteTabAction.resolve(mode: .clipboard, aiEnabled: true, clipboardEnabled: true),
             .carryQuery(.launcher),
             "the clipboard closes the ring, and one search narrows both lists")
 
         // Off, chat has no launcher command and no hotkey; the ring must not strand a reader there.
         expect(
-            PaletteTabAction.resolve(mode: .launcher, aiEnabled: false),
+            PaletteTabAction.resolve(mode: .launcher, aiEnabled: false, clipboardEnabled: true),
             .carryQuery(.clipboard),
             "turned off, chat is skipped and the launcher flips straight to the clipboard")
         expect(
-            PaletteTabAction.resolve(mode: .clipboard, aiEnabled: false),
+            PaletteTabAction.resolve(mode: .clipboard, aiEnabled: false, clipboardEnabled: true),
             .carryQuery(.launcher),
             "turned off, the clipboard still returns to the launcher")
 
@@ -45,21 +45,33 @@ struct PaletteTabTests {
             PaletteMode.aiHistory, .emoji, .fileSearch, .calculatorHistory, .quicklinks, .snippets
         ] {
             expect(
-                PaletteTabAction.resolve(mode: mode, aiEnabled: true),
+                PaletteTabAction.resolve(mode: mode, aiEnabled: true, clipboardEnabled: true),
                 .carryQuery(.launcher),
                 "\(mode.rawValue) is a sub-screen, so Tab exits to the launcher")
         }
 
         expect(
-            PaletteTabAction.resolve(mode: .extensionCommand, aiEnabled: true),
+            PaletteTabAction.resolve(
+                mode: .extensionCommand, aiEnabled: true, clipboardEnabled: true),
             .carryQuery(.launcher),
             "an extension command exits to the launcher rather than joining the ring")
+
+        // Both stops off, so Tab has nowhere to ring on to and must leave the launcher standing.
+        expect(
+            PaletteTabAction.resolve(
+                mode: .launcher, aiEnabled: false, clipboardEnabled: false),
+            .carryQuery(.launcher),
+            "with the clipboard off too, the launcher rings back onto itself")
+        expect(
+            PaletteTabAction.resolve(mode: .ai, aiEnabled: true, clipboardEnabled: false),
+            .carryQuery(.launcher),
+            "turned off, the clipboard is skipped and chat returns to the launcher")
 
         // Three presses from the launcher have to land back on it, or the ring is a dead end.
         var mode = PaletteMode.launcher
         var visited: [PaletteMode] = []
         for _ in 0..<3 {
-            switch PaletteTabAction.resolve(mode: mode, aiEnabled: true) {
+            switch PaletteTabAction.resolve(mode: mode, aiEnabled: true, clipboardEnabled: true) {
             case .carryQuery(let next), .freshScreen(let next): mode = next
             // Asking opens chat, so the ring still steps onto it.
             case .ask: mode = .ai
@@ -76,7 +88,9 @@ struct PaletteTabTests {
         var offMode = PaletteMode.launcher
         var offVisited: [PaletteMode] = []
         for _ in 0..<2 {
-            switch PaletteTabAction.resolve(mode: offMode, aiEnabled: false) {
+            switch PaletteTabAction.resolve(
+                mode: offMode, aiEnabled: false, clipboardEnabled: true)
+            {
             case .carryQuery(let next), .freshScreen(let next): offMode = next
             case .ask: offMode = .ai
             }

--- a/Tests/settings-backup-test.swift
+++ b/Tests/settings-backup-test.swift
@@ -53,6 +53,9 @@ struct SettingsBackupTest {
             "user ignore patterns ride the settings backup",
             mirrored["fileSearchIgnorePatterns"] == .fileSearchIgnorePatterns)
         check("notes enablement rides the settings backup", mirrored["notesEnabled"] == .notesEnabled)
+        check(
+            "clipboard enablement rides the settings backup",
+            mirrored["clipboardEnabled"] == .clipboardEnabled)
 
         // Named one by one: a backup now carries content, so it is far likelier to be sent on.
         for key: AppSettingsKey in [

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -122,7 +122,8 @@ final class AppCore {
     @ObservationIgnored private(set) lazy var fallbackCoordinator = FallbackCoordinator(
         store: fallbacks, quicklinks: quicklinks, settings: settings, core: self)
     @ObservationIgnored private(set) lazy var clipboardCoordinator = ClipboardCoordinator(
-        clipboardStore: clipboardStore, palette: palette, windowController: windowController,
+        clipboardStore: clipboardStore, clipboardManager: clipboardManager, settings: settings,
+        appIndex: appIndex, palette: palette, windowController: windowController,
         paletteCoordinator: paletteCoordinator, core: self)
     @ObservationIgnored private(set) lazy var emojiCoordinator = EmojiCoordinator(
         frequentEmoji: frequentEmoji, settings: settings, windowController: windowController,
@@ -190,12 +191,8 @@ final class AppCore {
             applyAppearance()
             observeEffectiveAppearance()
 
-            clipboardStore.maxAge = settings.clipboardRetention.maxAge
-            // Defer the SQLite read + prune off the launch path; the palette fills in later.
-            Task { clipboardStore.load() }
-            clipboardManager.start()
-
             appIndex.start(settings: settings)
+            clipboardCoordinator.applyEnabled()
             extensions.start(appIndex: appIndex, coordinator: extensionCoordinator)
             extensionCoordinator.applyEnabled()
             fileSearchCoordinator.applyEnabled()
@@ -405,6 +402,8 @@ final class AppCore {
                 _ = $0.quicklinksEnabled
                 _ = $0.quicklinksShowInLauncher
             }, reproject: { $0.quicklinkCoordinator.applyQuicklinksPresence() })
+        track(
+            { _ = $0.clipboardEnabled }, reproject: { $0.clipboardCoordinator.applyEnabled() })
         track({ _ = $0.fileSearchEnabled }, reproject: { $0.fileSearchCoordinator.applyEnabled() })
         track({ _ = $0.notesEnabled }, reproject: { $0.notesCoordinator.applyEnabled() })
         track({ _ = $0.aiEnabled }, reproject: { $0.aiChatCoordinator.applyEnabled() })

--- a/Tinycast/App/MenuBarItem.swift
+++ b/Tinycast/App/MenuBarItem.swift
@@ -17,8 +17,11 @@ struct MenuBarMenu: View {
         Button("Open \(appName)") {
             AppCore.shared.paletteCoordinator.showPalette(mode: .launcher)
         }
-        Button("Clipboard History") {
-            AppCore.shared.paletteCoordinator.showPalette(mode: .clipboard)
+        // Read through Observation, so switching the feature off takes the row with it.
+        if AppCore.shared.settings.clipboardEnabled {
+            Button("Clipboard History") {
+                AppCore.shared.paletteCoordinator.showPalette(mode: .clipboard)
+            }
         }
         Divider()
         Button("Check for Updates...") { AppCore.shared.updateCoordinator.checkForUpdates() }

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -15,6 +15,8 @@ struct SettingsBackup: Codable {
     /// Enums store by raw value, so an unknown one is ignored rather than failing.
     struct SettingsData: Codable {
         // Adding a field here means adding it to SettingsBackupCoverage too, or the harness fails.
+        // Carried, unlike the consent flags: recording your own copies grants no permission class.
+        var clipboardEnabled: Bool?
         var clipboardRetentionDays: Int?
         var clipboardDisabledApps: [String]?
         var launchAtLogin: Bool?
@@ -100,6 +102,7 @@ extension SettingsBackup {
         let s = core.settings
         var backup = SettingsBackup()
         backup.settings = SettingsData(
+            clipboardEnabled: s.clipboardEnabled,
             clipboardRetentionDays: s.clipboardRetention.rawValue,
             clipboardDisabledApps: s.clipboardDisabledApps,
             launchAtLogin: s.launchAtLogin,
@@ -219,6 +222,10 @@ extension SettingsBackup {
     private func applySettings(_ s: SettingsData, to core: AppCore) -> Int {
         let settings = core.settings
         var count = 0
+        if let flag = s.clipboardEnabled {
+            settings.clipboardEnabled = flag
+            count += 1
+        }
         if let days = s.clipboardRetentionDays, let retention = ClipboardRetention(rawValue: days) {
             settings.clipboardRetention = retention
             core.clipboardCoordinator.applyRetention(retention)

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -4,6 +4,7 @@ import Foundation
 enum SettingsBackupCoverage {
     /// Each `SettingsData` field paired with the `AppSettings` key it mirrors.
     static let mirrored: [String: AppSettingsKey] = [
+        "clipboardEnabled": .clipboardEnabled,
         "clipboardRetentionDays": .clipboardRetention,
         "clipboardDisabledApps": .clipboardDisabledApps,
         "hyperKey": .hyperKey,

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -156,14 +156,25 @@ final class ClipboardStore {
         imagesDir = base.appendingPathComponent("images", isDirectory: true)
         dbURL = base.appendingPathComponent("clipboard.sqlite3")
         try? FileManager.default.createDirectory(at: imagesDir, withIntermediateDirectories: true)
-        if !openDatabase() {
-            // Captured, not authored: discard a corrupt or outdated database and start over.
-            closeDatabase()
-            for suffix in ["", "-wal", "-shm"] {
-                try? FileManager.default.removeItem(atPath: dbURL.path + suffix)
-            }
-            if !openDatabase() { closeDatabase() }
+        open()
+    }
+
+    /// Idempotent, so the coordinator can re-open the file when the feature is switched back on.
+    func open() {
+        guard db == nil else { return }
+        if openDatabase() { return }
+        // Captured, not authored: discard a corrupt or outdated database and start over.
+        closeDatabase()
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: dbURL.path + suffix)
         }
+        if !openDatabase() { closeDatabase() }
+    }
+
+    /// Every accessor is statement-guarded, so a closed store answers as an empty history.
+    func close() {
+        closeDatabase()
+        items = []
     }
 
     /// Application Support, not Caches: a history the OS may reclaim is not a history.

--- a/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
+++ b/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
@@ -20,6 +20,7 @@ final class ClipboardManager {
     private var timer: Timer?
     private var sessionTokens: [NotificationToken] = []
     private var lastChangeCount = 0
+    private var isCapturing = false
 
     init(store: ClipboardStore, settings: AppSettings) {
         self.store = store
@@ -32,8 +33,17 @@ final class ClipboardManager {
     }
 
     func start() {
+        guard !isCapturing else { return }
+        isCapturing = true
         installSessionObservers()
         startPolling()
+    }
+
+    /// Turning the feature off: the poller, the observers and the drain all go with it.
+    func stop() {
+        isCapturing = false
+        sessionTokens = []
+        stopPolling()
     }
 
     // Fast user switching: another session's clipboard isn't ours, so stop waking up for it.
@@ -60,7 +70,7 @@ final class ClipboardManager {
 
     // Re-baselining first is what stops a clip made in another session reading as new on resume.
     private func startPolling() {
-        guard timer == nil else { return }
+        guard isCapturing, timer == nil else { return }
         lastChangeCount = NSPasteboard.general.changeCount
         let timer = Timer(timeInterval: 0.5, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated { self?.poll() }
@@ -77,6 +87,7 @@ final class ClipboardManager {
 
     // Drain first: the real copy must reach history before we overwrite the pasteboard.
     func prepareForTinycastPasteboardMutation() {
+        guard isCapturing else { return }
         poll()
     }
 

--- a/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
@@ -11,6 +11,15 @@ struct ClipboardSettingsView: View {
         @Bindable var settings = settings
         return Form {
             Section {
+                Toggle(isOn: $settings.clipboardEnabled) {
+                    SettingsRowTitle(.clipboardClipboard, "Enable Clipboard History")
+                    Text("Record what you copy, so you can paste anything back from the browser.")
+                }
+            } header: {
+                SettingsSectionHeader(.clipboardClipboard)
+            }
+
+            Section {
                 SettingsRow(title: "Clipboard History", anchor: .clipboardGlobalShortcuts) {
                     ShortcutRecorder(action: .command(.clipboardHistory))
                 }
@@ -21,6 +30,7 @@ struct ClipboardSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .settingsEnabled(settings.clipboardEnabled)
 
             Section {
                 Picker(selection: $settings.clipboardRetention) {
@@ -37,6 +47,7 @@ struct ClipboardSettingsView: View {
             } header: {
                 SettingsSectionHeader(.clipboardHistory)
             }
+            .settingsEnabled(settings.clipboardEnabled)
 
             Section {
                 ForEach(settings.clipboardDisabledApps, id: \.self) { bundleID in
@@ -59,6 +70,7 @@ struct ClipboardSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .settingsEnabled(settings.clipboardEnabled)
 
             Section {
                 LabeledContent {
@@ -77,7 +89,7 @@ struct ClipboardSettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Clear History", role: .destructive) {
-                core.clipboardStore.clearAll()
+                core.clipboardCoordinator.clearHistory()
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -4,6 +4,9 @@ import AppKit
 @MainActor
 final class ClipboardCoordinator {
     private let clipboardStore: ClipboardStore
+    private let clipboardManager: ClipboardManager
+    private let settings: AppSettings
+    private let appIndex: AppIndex
     private let palette: PaletteState
     private let windowController: PaletteWindowController
     private let paletteCoordinator: PaletteCoordinator
@@ -12,16 +15,38 @@ final class ClipboardCoordinator {
 
     init(
         clipboardStore: ClipboardStore,
+        clipboardManager: ClipboardManager,
+        settings: AppSettings,
+        appIndex: AppIndex,
         palette: PaletteState,
         windowController: PaletteWindowController,
         paletteCoordinator: PaletteCoordinator,
         core: AppCore
     ) {
         self.clipboardStore = clipboardStore
+        self.clipboardManager = clipboardManager
+        self.settings = settings
+        self.appIndex = appIndex
         self.palette = palette
         self.windowController = windowController
         self.paletteCoordinator = paletteCoordinator
         self.core = core
+    }
+
+    /// Off means the poller stops, the database closes and nothing new is ever recorded.
+    func applyEnabled() {
+        appIndex.setCommandsVisible([.clipboardHistory], settings.clipboardEnabled)
+        guard settings.clipboardEnabled else {
+            clipboardManager.stop()
+            if palette.mode == .clipboard { palette.prepare(mode: .launcher) }
+            clipboardStore.close()
+            return
+        }
+        clipboardStore.open()
+        clipboardStore.maxAge = settings.clipboardRetention.maxAge
+        clipboardManager.start()
+        // Deferred off the launch path: the palette fills in behind the SQLite read and prune.
+        Task { clipboardStore.load() }
     }
 
     /// The setting names an age, the store enforces it; a shortened window culls straight away.
@@ -53,7 +78,14 @@ final class ClipboardCoordinator {
                 message: "Every entry goes, pinned ones included. This can't be undone.",
                 symbol: PaletteMode.clipboard.systemImage, confirmTitle: "Clear History")
         else { return }
+        clearHistory()
+    }
+
+    /// Reachable with the feature off, so what was kept before can still be erased afterwards.
+    func clearHistory() {
+        clipboardStore.open()
         clipboardStore.clearAll()
+        if !settings.clipboardEnabled { clipboardStore.close() }
     }
 
     func copyToClipboard(_ item: ClipboardItem) {

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -123,6 +123,11 @@ final class AppSettings {
         didSet { defaults.set(searchScopes, forKey: Key.searchScopes.rawValue) }
     }
 
+    /// Ships on, unlike every other feature switch: a launcher is expected to keep history.
+    var clipboardEnabled: Bool {
+        didSet { defaults.set(clipboardEnabled, forKey: Key.clipboardEnabled.rawValue) }
+    }
+
     var clipboardRetention: ClipboardRetention {
         didSet {
             defaults.set(clipboardRetention.rawValue, forKey: Key.clipboardRetention.rawValue)
@@ -433,6 +438,10 @@ final class AppSettings {
     }
 
     init() {
+        // The only feature switch that defaults on, so absence has to outrank a stored `false`.
+        clipboardEnabled =
+            defaults.object(forKey: Key.clipboardEnabled.rawValue) == nil
+            || defaults.bool(forKey: Key.clipboardEnabled.rawValue)
         // `integer(forKey:)` returns 0 when unset, which no case matches.
         clipboardRetention =
             ClipboardRetention(rawValue: defaults.integer(forKey: Key.clipboardRetention.rawValue))

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -3,6 +3,7 @@ import Foundation
 /// The UserDefaults keys `AppSettings` owns; `CaseIterable` so the backup harness enumerates them.
 enum AppSettingsKey: String, CaseIterable {
     // Every raw value is spelled out so renaming a case can never rename a persisted key.
+    case clipboardEnabled = "clipboardEnabled"
     case clipboardRetention = "clipboardRetentionDays"
     case clipboardDisabledApps = "clipboardDisabledApps"
     case hyperKey = "hyperKeyPhysicalKey"

--- a/Tinycast/Features/Settings/SettingsAnchor.swift
+++ b/Tinycast/Features/Settings/SettingsAnchor.swift
@@ -62,6 +62,7 @@ extension SettingsAnchor {
         tab: .windowManagement, title: "Window Management")
     static let windowManagementOptions = Self(tab: .windowManagement, title: "Options")
 
+    static let clipboardClipboard = Self(tab: .clipboard, title: "Clipboard")
     static let clipboardGlobalShortcuts = Self(tab: .clipboard, title: "Global Shortcuts")
     static let clipboardHistory = Self(tab: .clipboard, title: "History")
     static let clipboardDisabledApplications = Self(

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -358,6 +358,9 @@ enum SettingsSearchCatalog {
             pane: .clipboard,
             keywords: ["paste", "history", "copy", "pasteboard"]),
         .init(
+            .clipboardClipboard, "Enable Clipboard History",
+            keywords: ["disable", "turn off", "monitor", "record", "privacy"]),
+        .init(
             .clipboardGlobalShortcuts, "Clipboard History",
             keywords: ["hotkey", "paste", "browser"]),
         .init(

--- a/Tinycast/Palette/PaletteTabAction.swift
+++ b/Tinycast/Palette/PaletteTabAction.swift
@@ -9,11 +9,14 @@ enum PaletteTabAction: Equatable {
     /// The typed text is the question, so chat opens on the answer rather than an empty composer.
     case ask
 
-    static func resolve(mode: PaletteMode, aiEnabled: Bool) -> Self {
+    static func resolve(mode: PaletteMode, aiEnabled: Bool, clipboardEnabled: Bool) -> Self {
         switch mode {
-        // Turned off, chat is not a stop on the ring, which leaves the launcher ↔ clipboard flip.
-        case .launcher: return aiEnabled ? .ask : .carryQuery(.clipboard)
-        case .ai: return .freshScreen(.clipboard)
+        // A stop that is off leaves the ring, so Tab skips it rather than opening nothing.
+        case .launcher:
+            if aiEnabled { return .ask }
+            return clipboardEnabled ? .carryQuery(.clipboard) : .carryQuery(.launcher)
+        case .ai:
+            return clipboardEnabled ? .freshScreen(.clipboard) : .carryQuery(.launcher)
         case .clipboard: return .carryQuery(.launcher)
         default: return .carryQuery(.launcher)
         }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -605,7 +605,9 @@ struct RootPaletteView: View {
     /// Resolved through `PaletteTabAction`, so the hint cannot promise the wrong destination.
     private var tabOpensChat: Bool {
         guard !isCollapsed, headerAccessory?.fieldNames.isEmpty ?? true else { return false }
-        return PaletteTabAction.resolve(mode: vm.mode, aiEnabled: settings.aiEnabled) == .ask
+        return PaletteTabAction.resolve(
+            mode: vm.mode, aiEnabled: settings.aiEnabled,
+            clipboardEnabled: settings.clipboardEnabled) == .ask
     }
 
     /// The typed text's width, floored for the caret and capped so the strip stays on screen.
@@ -920,7 +922,10 @@ struct RootPaletteView: View {
 
     /// Crossing chat's edge opens a fresh screen, so a draft never lands in a list.
     private func cycleMode() {
-        switch PaletteTabAction.resolve(mode: vm.mode, aiEnabled: settings.aiEnabled) {
+        switch PaletteTabAction.resolve(
+            mode: vm.mode, aiEnabled: settings.aiEnabled,
+            clipboardEnabled: settings.clipboardEnabled)
+        {
         case .carryQuery(let mode): vm.mode = mode
         case .freshScreen(let mode): vm.prepare(mode: mode)
         case .ask: core.aiChatCoordinator.ask(vm.query)

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -2,6 +2,10 @@
 
 ## Invariants
 
+- **`clipboardEnabled` ships on — the only feature switch that does.** Absence of the key therefore
+  has to outrank a stored `false` in `AppSettings.init`, and off means fully off: the poller stops,
+  the SQLite file closes, the launcher command and its shortcut go, and Tab skips the screen.
+  `ClipboardCoordinator.applyEnabled()` is the single place that applies it.
 - **Clipboard writes stamp a private `internalType` marker** so the poller skips Tinycast's own writes.
   If the writer and the poller ever disagree, the app re-captures its own pastes in a loop.
 - **`Model/ClipboardStore.swift` keeps to Foundation plus SQLite3 and no other app source**, so
@@ -22,6 +26,15 @@
 `ClipboardManager` runs a 0.5s `Timer` watching `NSPasteboard.general.changeCount`. To avoid
 re-capturing Tinycast's own writes, every write stamps a private `internalType` marker on the
 pasteboard and the poller skips anything carrying it.
+
+`stop()` is the off switch: it drops the timer and the fast-user-switching observers, and clears the
+`isCapturing` flag that `prepareForTinycastPasteboardMutation` reads — so a paste Tinycast performs
+itself no longer drains the pasteboard into history either.
+
+Existing clips survive being switched off, since a history is captured rather than authored and
+nothing else can put it back. **Clear history stays live with the feature off** —
+`ClipboardCoordinator.clearHistory()` reopens the file, empties it and closes it again — so a reader
+who turns the feature off can still erase what it kept.
 
 ## Store
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -263,6 +263,9 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - ↵ pastes into the previous app; ⌥↵ pastes without closing the palette
 - A copy from an excluded app (Settings ▸ Clipboard ▸ Disabled Applications) is **not** recorded
 - Password-manager copies are still not recorded
+- Off (Settings ▸ Clipboard ▸ Enable Clipboard History): nothing new is recorded, the launcher row
+  and its shortcut are gone, the menu-bar row is gone, and Tab rings straight past the screen
+- Off then on again: existing clips come back; Clear history erases them while it is still off
 
 ### Launcher and icons
 


### PR DESCRIPTION
## Related issue

Closes #444

## What changed

Clipboard history was the one feature with no off switch. `clipboardEnabled` adds one, and it is the
only feature switch that ships **on** — so absence of the key has to outrank a stored `false` in
`AppSettings.init`, the way the other default-on preferences already do.

`ClipboardCoordinator.applyEnabled()` is the single place that applies it, driven from `AppCore.start()`
and from an `observeFeatureSwitches` track like every other switch. Off means fully off:

- `ClipboardManager.stop()` drops the 0.5s timer and the fast-user-switching observers, and clears the
  `isCapturing` flag that `prepareForTinycastPasteboardMutation` reads — so a paste Tinycast performs
  itself no longer drains the pasteboard into history either.
- `ClipboardStore.close()` releases the SQLite handle and the resident window. Every accessor was
  already statement-guarded, so a closed store simply answers as an empty history; `open()` is
  idempotent and keeps the existing delete-and-recreate recovery for a file that will not open.
- `appIndex.setCommandsVisible([.clipboardHistory], …)` takes the launcher row down, and `allowsAction`
  already drops the shortcut of a hidden command with it.
- An open clipboard screen goes back to the launcher, `PaletteTabAction` skips the stop so Tab cannot
  ring onto a screen that is off, and the menu-bar row goes too.

Clips already recorded survive being switched off — a history is captured rather than authored, and
nothing else can put it back. **Clear history stays live while the feature is off**:
`ClipboardCoordinator.clearHistory()` reopens the file, empties it and closes it again, so a reader who
turns the feature off can still erase what it kept.

`clipboardEnabled` rides a settings backup, unlike `snippetsEnabled` and its siblings: recording your
own copies grants no permission class, so it belongs with `notesEnabled` and `fileSearchEnabled` rather
than with the consent flags.

## Memory footprint

Not measured — this change only removes work (a timer, an open SQLite handle and the resident 1000-row
window) when the feature is off, and is byte-for-byte the previous behaviour when it is on.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no. No new long-lived object — the coordinator gained three existing `AppCore`-owned
references, and `ClipboardManager.stop()` releases its `NotificationToken`s.

## Demo

No visual change while the feature is on. With it off, the Clipboard pane greys out below the new
toggle and the launcher/menu-bar rows disappear.

## Drawbacks

- The menu-bar menu now reads one piece of feature state (`AppCore.shared.settings.clipboardEnabled`).
  The "carries no feature state" note there is on `MenuBarLabel`, which is untouched, but the menu is
  no longer entirely state-free. The alternative was a dead row that opens nothing.
- With the store closed, `{clipboard offset=N}` in a snippet falls back to the live pasteboard alone.
  That is the honest result of having no history, not a regression to paper over.
- The clipboard slice of a backup is still exportable and importable with the feature off, matching how
  snippets and notes behave.

## Tests & validation

- `./Scripts/run-tests.sh` — all 55 harnesses pass.
- `palette-tab-test`: `resolve` takes `clipboardEnabled`; new cases cover chat ringing past a
  disabled clipboard, and both stops off leaving the launcher standing.
- `settings-backup-test`: new check that `clipboardEnabled` is mirrored, plus the existing coverage
  rule that every `AppSettingsKey` is either backed up or deliberately excluded.
- Debug build compiles with no new warnings; `./Scripts/lint.sh` is clean.
- Docs: `docs/features/clipboard.md` gains the invariant and the switch-off behaviour;
  `docs/testing.md` gains the manual checks.
