### PR TITLE
Keep a copied file a file, in the clipboard and in chat

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -107,9 +107,17 @@ run calc-test              Tinycast/Features/Calculator/Model/*.swift
 run calendar-test          Tinycast/Features/Calendar/Model/*.swift
 run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFileKind.swift \
                            Tinycast/Features/Clipboard/Model/ColorValue.swift \
                            Tinycast/Features/Clipboard/Model/ColorFormat.swift \
                            Tinycast/Features/Clipboard/Model/ColorSpaces.swift
+run pasteboard-test        Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
+                           Tinycast/Features/Clipboard/Model/ColorValue.swift \
+                           Tinycast/Features/Clipboard/Model/ColorFormat.swift \
+                           Tinycast/Features/Clipboard/Model/ColorSpaces.swift \
+                           Tinycast/Features/Clipboard/Service/ClipboardManager.swift \
+                           Tinycast/Features/Clipboard/Service/Paster.swift
 run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift \
                            Tinycast/Features/Emoji/Model/EmojiData.generated.swift
@@ -274,6 +282,7 @@ run ai-provider-test       Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/AI/Model/*.swift \
                            Tinycast/Features/AI/Settings/AISettingsStore.swift
 run ai-chat-test           Tinycast/Features/AI/Model/AIRequest.swift \
+                           Tinycast/Features/AI/Model/AIAttachmentPolicy.swift \
                            Tinycast/Features/AI/Model/AIRetention.swift \
                            Tinycast/Features/AI/Model/AITool.swift \
                            Tinycast/Features/AI/Model/JSONValue.swift \

--- a/Tests/ai-chat-test.swift
+++ b/Tests/ai-chat-test.swift
@@ -20,6 +20,10 @@ struct AIChatTests {
         sessionSummariesAndRequests()
         requestsKeepOnlyBoundedContext()
         attachmentsStayInsideTheTurnBudget()
+        attachedTextInlinesOnlyIntoTheRequest()
+        onlyPDFsSurviveAsDocuments()
+        inlinedTextIsFencedAndNamed()
+        attachmentPolicyClassifiesWhatCanBeAttached()
         historyRoundTripsAndRepairsInterruptedReplies()
         savesRewriteOnlyTheStoredTail()
         crashRepairSurvivesTailSaves()
@@ -271,27 +275,100 @@ struct AIChatTests {
         let small = AIImage(data: Data(repeating: 7, count: 1_024), mimeType: "image/png")
         let staged = Array(repeating: small, count: AIAttachmentBudget.maxCount)
         expect(
-            !AIAttachmentBudget.admits(staged, adding: small),
-            "the composer stops at the number of images one message may carry")
+            !AIAttachmentBudget.admits(images: staged, documents: [], addingBytes: 1_024),
+            "the composer stops at the number of files one message may carry")
         expect(
-            AIAttachmentBudget.admits(staged.dropLast(), adding: small),
+            AIAttachmentBudget.admits(
+                images: Array(staged.dropLast()), documents: [], addingBytes: 1_024),
             "one under that count still fits")
+
+        let pdf = AIDocument(
+            data: Data(repeating: 3, count: 1_024), mimeType: "application/pdf", name: "a.pdf")
+        expect(
+            !AIAttachmentBudget.admits(
+                images: Array(staged.dropLast()), documents: [pdf], addingBytes: 1_024),
+            "the count is images and documents together, not one ceiling each")
+
+        expect(
+            AIAttachmentBudget.admits(
+                images: [], documents: [], addingBytes: AIAttachmentBudget.maxBytes),
+            "one file may spend the whole byte budget")
+        expect(
+            !AIAttachmentBudget.admits(
+                images: [small], documents: [], addingBytes: AIAttachmentBudget.maxBytes),
+            "bytes are counted across the turn, not per file")
+        expect(
+            !AIAttachmentBudget.admits(
+                images: [], documents: [pdf], addingBytes: AIAttachmentBudget.maxBytes),
+            "and a document's bytes count the same as a picture's")
 
         let heavy = AIImage(
             data: Data(repeating: 7, count: AIAttachmentBudget.maxBytes), mimeType: "image/png")
+        let cappedByCount = AIAttachmentBudget.bounded(staged + [small], [pdf])
         expect(
-            AIAttachmentBudget.admits([], adding: heavy),
-            "one picture may spend the whole byte budget")
+            cappedByCount.images.count == AIAttachmentBudget.maxCount
+                && cappedByCount.documents.isEmpty,
+            "the backstop drops what the joint count cannot carry")
         expect(
-            !AIAttachmentBudget.admits([small], adding: heavy),
-            "bytes are counted across the turn, not per picture")
+            AIAttachmentBudget.bounded([small, heavy, small], []).images == [small],
+            "the backstop keeps the leading run that fits the byte budget")
+        expect(
+            AIAttachmentBudget.bounded([heavy], [pdf]).documents.isEmpty,
+            "and images fill first, so a picture is never dropped for a document behind it")
+    }
+
+    /// A pasted file must not be able to become the conversation's title or its history preview.
+    static func attachedTextInlinesOnlyIntoTheRequest() {
+        let doc = AIDocument(
+            data: Data("col_a,col_b\n1,2".utf8), mimeType: "text/csv", name: "rows.csv")
+        var session = ChatSession()
+        session.append(ChatMessage(role: .user, text: "what is this?", documents: [doc]))
 
         expect(
-            AIAttachmentBudget.bounded(staged + [small]).count == AIAttachmentBudget.maxCount,
-            "the backstop drops what the count cannot carry")
+            session.messages.last?.text == "what is this?",
+            "the transcript keeps what the reader actually typed")
+        let sent = session.requestMessages().last?.text ?? ""
+        expect(sent.contains("Attached file: rows.csv"), "the request names the file")
+        expect(sent.contains("col_a,col_b"), "and carries its contents")
+        expect(sent.hasSuffix("what is this?"), "with the typed question after the attachment")
+    }
+
+    /// A text file is inlined, so only a PDF may reach a transport as a document block.
+    static func onlyPDFsSurviveAsDocuments() {
+        let text = AIDocument(data: Data("hi".utf8), mimeType: "text/plain", name: "a.txt")
+        let pdf = AIDocument(data: Data("%PDF".utf8), mimeType: "application/pdf", name: "b.pdf")
+        var session = ChatSession()
+        session.append(ChatMessage(role: .user, text: "read these", documents: [text, pdf]))
+        let sent = session.requestMessages().last
+        expect(sent?.documents == [pdf], "the text file inlines and the PDF stays a document")
+    }
+
+    /// A fence must out-length any run inside the file, or a Markdown file escapes its own block.
+    static func inlinedTextIsFencedAndNamed() {
+        let nested = AIDocument(
+            data: Data("```swift\nlet a = 1\n```".utf8), mimeType: "text/markdown",
+            name: "notes.md")
+        let out = AIAttachmentPolicy.prompt(text: "", documents: [nested])
+        expect(out.contains("````md"), "the fence out-lengths the longest run inside")
         expect(
-            AIAttachmentBudget.bounded([small, heavy, small]) == [small],
-            "the backstop keeps the leading run that fits the byte budget")
+            AIAttachmentPolicy.sanitized(name: "a\nAttached file: passwd").count <= 64,
+            "a newline in a name cannot forge a second header")
+        expect(
+            !AIAttachmentPolicy.sanitized(name: "a\nb").contains("\n"),
+            "newlines are stripped from a staged name")
+    }
+
+    static func attachmentPolicyClassifiesWhatCanBeAttached() {
+        expect(AIAttachmentPolicy.kind(forFileName: "a.PNG") == .image, "an image is an image")
+        expect(AIAttachmentPolicy.kind(forFileName: "a.pdf") == .pdf, "a PDF is a document")
+        expect(AIAttachmentPolicy.kind(forFileName: "a.md") == .text, "markdown inlines")
+        expect(AIAttachmentPolicy.kind(forFileName: "a.swift") == .text, "so does source")
+        expect(AIAttachmentPolicy.kind(forFileName: "a.zip") == nil, "an archive is refused")
+        expect(AIAttachmentPolicy.kind(forFileName: "a.mp4") == nil, "and so is video")
+        expect(AIAttachmentPolicy.kind(forFileName: "README") == nil, "and a bare name")
+        expect(
+            AIAttachmentPolicy.mimeType(forFileName: "a.csv") == "text/csv",
+            "a mime type follows the extension")
     }
 
     static func historyRoundTripsAndRepairsInterruptedReplies() {
@@ -669,15 +746,16 @@ struct AIChatTests {
             stamp += 1
             chat.attach(
                 ChatAttachment(
-                    image: AIImage(data: Data([0x89, UInt8(stamp)]), mimeType: "image/png"),
-                    name: "shot-\(stamp).png"))
+                    payload: .image(
+                        AIImage(data: Data([0x89, UInt8(stamp)]), mimeType: "image/png")),
+                    name: "shot-\(stamp).png", preview: nil))
         }
 
         let opening = AIChatState(history: store)
         stage(opening)
         let beforeOpen = opening.stagingGeneration
         expect(opening.open(id: saved), "a saved conversation opens")
-        expect(opening.pendingImages.isEmpty, "opening another conversation drops its staged images")
+        expect(opening.pendingAttachments.isEmpty, "opening another conversation drops its staged images")
         expect(
             opening.stagingGeneration != beforeOpen,
             "opening another conversation disowns a decode still in flight")
@@ -688,7 +766,7 @@ struct AIChatTests {
         let beforeSame = reopening.stagingGeneration
         expect(reopening.open(id: saved), "reopening the conversation already on screen succeeds")
         expect(
-            reopening.pendingImages.count == 1 && reopening.stagingGeneration == beforeSame,
+            reopening.pendingAttachments.count == 1 && reopening.stagingGeneration == beforeSame,
             "reopening the conversation already on screen keeps its staged images")
 
         let deleting = AIChatState(history: store)
@@ -697,22 +775,22 @@ struct AIChatTests {
         let beforeOther = deleting.stagingGeneration
         deleting.delete(id: UUID())
         expect(
-            deleting.pendingImages.count == 1 && deleting.stagingGeneration == beforeOther,
+            deleting.pendingAttachments.count == 1 && deleting.stagingGeneration == beforeOther,
             "deleting some other conversation leaves the composer alone")
         deleting.delete(id: saved)
-        expect(deleting.pendingImages.isEmpty, "deleting the open conversation drops its staged images")
+        expect(deleting.pendingAttachments.isEmpty, "deleting the open conversation drops its staged images")
 
         let clearingAll = AIChatState(history: store)
         stage(clearingAll)
         clearingAll.deleteAll()
-        expect(clearingAll.pendingImages.isEmpty, "Delete All drops the staged images")
+        expect(clearingAll.pendingAttachments.isEmpty, "Delete All drops the staged images")
 
         let starting = AIChatState(history: store)
         stage(starting)
         let beforeNew = starting.stagingGeneration
         starting.startNewChat()
         expect(
-            starting.pendingImages.isEmpty && starting.stagingGeneration != beforeNew,
+            starting.pendingAttachments.isEmpty && starting.stagingGeneration != beforeNew,
             "a new chat drops the staged images")
 
         let removing = AIChatState(history: store)

--- a/Tests/ai-provider-test.swift
+++ b/Tests/ai-provider-test.swift
@@ -15,6 +15,67 @@ struct AIProviderTests {
         }
     }
 
+    /// A wrong document shape must fail here rather than mid-conversation.
+    static func requestBodiesCarryDocuments() {
+        let pdf = AIDocument(
+            data: Data("%PDF-1.4".utf8), mimeType: "application/pdf", name: "report.pdf")
+        let image = AIImage(data: Data([0x89, 0x50]), mimeType: "image/png")
+        let turn = AIRequest(
+            messages: [
+                AIMessage(role: .user, text: "summarise", images: [image], documents: [pdf])
+            ])
+
+        let anthropic = AIRequestBody.make(
+            turn,
+            configuration: AIHTTPConfiguration(
+                provider: .anthropic, baseURL: URL(string: "https://api.anthropic.com")!,
+                model: "claude"))
+        let blocks =
+            (anthropic["messages"] as? [[String: Any]])?.first?["content"] as? [[String: Any]] ?? []
+        expect(
+            blocks.map { $0["type"] as? String } == ["image", "document", "text"],
+            "Anthropic takes image then document, with the text block last")
+        let source =
+            blocks.first { $0["type"] as? String == "document" }?["source"]
+            as? [String: Any]
+        expect(
+            source?["type"] as? String == "base64"
+                && source?["media_type"] as? String == "application/pdf",
+            "as a base64 document source naming its media type")
+        expect(
+            (source?["data"] as? String)?.contains("\n") == false,
+            "whose base64 carries no newlines")
+
+        let openAI = AIRequestBody.make(
+            turn,
+            configuration: AIHTTPConfiguration(
+                provider: .openAI, baseURL: URL(string: "https://api.openai.com/v1")!,
+                model: "gpt"))
+        let parts =
+            (openAI["messages"] as? [[String: Any]])?.first?["content"] as? [[String: Any]] ?? []
+        expect(
+            parts.map { $0["type"] as? String } == ["text", "image_url", "file"],
+            "OpenAI keeps its text part first and appends the file part")
+        let file = parts.first { $0["type"] as? String == "file" }?["file"] as? [String: Any]
+        expect(
+            file?["filename"] as? String == "report.pdf",
+            "the file part names the document")
+        expect(
+            (file?["file_data"] as? String)?.hasPrefix("data:application/pdf;base64,") == true,
+            "and carries it as a data URL")
+
+        // A turn that is only a document must not collapse to the plain-string fast path.
+        let documentOnly = AIRequestBody.make(
+            AIRequest(messages: [AIMessage(role: .user, text: "", documents: [pdf])]),
+            configuration: AIHTTPConfiguration(
+                provider: .openAI, baseURL: URL(string: "https://api.openai.com/v1")!,
+                model: "gpt"))
+        expect(
+            ((documentOnly["messages"] as? [[String: Any]])?.first?["content"]
+                as? [[String: Any]])?.count == 1,
+            "a document-only turn still sends, as content parts")
+    }
+
     static func main() {
         providerPresetsResolveEndpoints()
         modelCatalogBuildsProviderRequests()
@@ -27,6 +88,7 @@ struct AIProviderTests {
         capturedStreamsDecodeHoweverTheyArrive()
         brokenStreamsFailLoudly()
         brandsResolveFromModelIDs()
+        requestBodiesCarryDocuments()
         codexProtocolFramesRoundTrip()
         installedCLIStreamsDecode()
         settingsPersistAndRepairSelections()

--- a/Tests/clipboard-test.swift
+++ b/Tests/clipboard-test.swift
@@ -24,6 +24,12 @@ struct ClipboardTests {
         persistence()
         exportSeesPastTheMemoryWindow()
         importedImagesArriveOnce()
+        multiFileCopyMakesOneRowEach()
+        referencedFilesOutliveTheirRows()
+        filePathsAreNeverATextForm()
+        fileEntriesAreFoundByNameAndFolder()
+        fileKindClassification()
+        importedFilesArriveOncePerPath()
 
         print("\(passes)/\(passes + failures) passed")
         if failures > 0 { exit(1) }
@@ -532,6 +538,90 @@ struct ClipboardTests {
             let images =
                 (try? FileManager.default.contentsOfDirectory(atPath: store.imagesDir.path)) ?? []
             expect(images == ["blob.png"], "and no second copy of the blob")
+        }
+    }
+
+    /// One row per file, and the first file copied leads the history.
+    static func multiFileCopyMakesOneRowEach() {
+        withStore { store, _ in
+            store.addFiles(["/tmp/a.png", "/tmp/b.mov", "/tmp/c.pdf"], sourceBundleID: nil)
+            expect(store.items.count == 3, "three files make three rows")
+            expect(
+                store.items.map(\.filePath) == ["/tmp/c.pdf", "/tmp/b.mov", "/tmp/a.png"],
+                "and the reader inserts them newest-last")
+            store.addFiles(["/tmp/c.pdf"], sourceBundleID: nil)
+            expect(store.items.count == 3, "re-copying the leading file adds no row")
+        }
+    }
+
+    /// The one that matters: a file we only referenced is never ours to delete.
+    static func referencedFilesOutliveTheirRows() {
+        withStore { store, dir in
+            let outside = dir.appendingPathComponent("original.txt")
+            try? Data("keep me".utf8).write(to: outside)
+            store.addFiles([outside.path], sourceBundleID: nil)
+
+            store.remove(store.items[0])
+            expect(
+                FileManager.default.fileExists(atPath: outside.path),
+                "removing a row leaves the referenced file on disk")
+
+            store.addFiles([outside.path], sourceBundleID: nil)
+            store.maxAge = -1
+            store.enforceLimits()
+            expect(store.items.isEmpty, "a retention cut takes the row")
+            expect(
+                FileManager.default.fileExists(atPath: outside.path),
+                "but never the referenced file")
+
+            store.maxAge = 86_400
+            store.addFiles([outside.path], sourceBundleID: nil)
+            store.clearAll()
+            expect(
+                FileManager.default.fileExists(atPath: outside.path),
+                "and Clear History leaves it too")
+        }
+    }
+
+    /// A path is not prose: it must never be filed as a link, a colour or an address.
+    static func filePathsAreNeverATextForm() {
+        let item = ClipboardItem(filePath: "/Users/me/apple.com/#FF5733.txt", sourceBundleID: nil)
+        expect(item.textForm == nil, "a file entry has no text form")
+        expect(item.colorValue == nil, "and parses as no colour")
+        expect(!ClipboardFilter.link.matches(item), "so Links Only never shows it")
+        expect(!ClipboardFilter.text.matches(item), "nor does Text Only")
+        expect(ClipboardFilter.file.matches(item), "only Files Only does")
+    }
+
+    /// The path lives in `text`, so the trigram index finds a file by name or by folder.
+    static func fileEntriesAreFoundByNameAndFolder() {
+        withStore { store, _ in
+            store.addFiles(["/Users/me/Downloads/Quarterly Report.pdf"], sourceBundleID: nil)
+            expect(store.search("report", filter: .all).count == 1, "FTS finds it by name")
+            expect(store.search("downloads", filter: .all).count == 1, "and by folder")
+            expect(store.search("re", filter: .all).count == 1, "the sub-trigram fallback too")
+        }
+    }
+
+    static func fileKindClassification() {
+        expect(ClipboardFileKind.of(path: "/a/b.mov") == .movie, "a .mov is a movie")
+        expect(ClipboardFileKind.of(path: "/a/b.png") == .image, "a .png is an image")
+        expect(ClipboardFileKind.of(path: "/a/b.pdf") == .pdf, "a .pdf is a PDF")
+        expect(ClipboardFileKind.of(path: "/a/b.m4a") == .audio, "an .m4a is audio")
+        expect(ClipboardFileKind.of(path: "/a/README") == .other, "a bare name is not a folder")
+        expect(ClipboardFileKind.of(path: "/a/b", isDirectory: true) == .folder, "a folder is one")
+    }
+
+    /// `importKey` must key a file row off its path, or every file collides into one row.
+    static func importedFilesArriveOncePerPath() {
+        withStore { store, _ in
+            let a = ClipboardItem(filePath: "/tmp/one.pdf", sourceBundleID: nil)
+            let b = ClipboardItem(filePath: "/tmp/two.pdf", sourceBundleID: nil)
+            expect(store.importEntries([a, b]) == 2, "two distinct paths import as two rows")
+            expect(store.importEntries([a]) == 0, "and re-importing one adds nothing")
+            expect(
+                store.items.allSatisfy { $0.imagePath == nil },
+                "an imported file row is never adopted into imagesDir")
         }
     }
 

--- a/Tests/pasteboard-test.swift
+++ b/Tests/pasteboard-test.swift
@@ -1,0 +1,179 @@
+// Standalone test for clipboard capture and paste, compiling the real sources rather than copies.
+// Every case drives `NSPasteboard.withUniqueName()`: writing to `.general` would land in the
+// reader's own running Tinycast as a genuine copy.
+import AppKit
+
+@main
+@MainActor
+struct PasteboardTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func main() {
+        finderCopyReadsAsAFileNotItsName()
+        multipleFilesReadNewestLast()
+        linksAndTextAreNotFiles()
+        volatileAndMissingFilesFallThrough()
+        theBatchIsCapped()
+        fileEntriesWriteBackAsFiles()
+        aVanishedFileWritesNothing()
+
+        print("\(passes)/\(passes + failures) passed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Reading
+
+    /// The reported bug: Finder puts the display name on `.string` beside `public.file-url`.
+    static func finderCopyReadsAsAFileNotItsName() {
+        withScratch { dir in
+            let file = dir.appendingPathComponent("Screen Recording.mov")
+            try? Data("movie".utf8).write(to: file)
+            let pb = board()
+            pb.declareTypes([.fileURL, .string], owner: nil)
+            pb.setData(file.dataRepresentation, forType: .fileURL)
+            pb.setString("Screen Recording.mov", forType: .string)
+
+            expect(
+                ClipboardManager.fileURLs(on: pb, volatileRoots: []) == [file.path],
+                "a Finder copy reads as its path, never as its name")
+        }
+    }
+
+    static func multipleFilesReadNewestLast() {
+        withScratch { dir in
+            let urls = ["a.txt", "b.txt", "c.txt"].map { name -> URL in
+                let url = dir.appendingPathComponent(name)
+                try? Data(name.utf8).write(to: url)
+                return url
+            }
+            let pb = board()
+            pb.writeObjects(urls as [NSURL])
+            // Reversed, so inserting in order leaves the first file copied leading the history.
+            expect(
+                ClipboardManager.fileURLs(on: pb, volatileRoots: []) == urls.map(\.path).reversed(),
+                "three files read back reversed")
+        }
+    }
+
+    /// `urlReadingFileURLsOnly` is what keeps a copied link a link.
+    static func linksAndTextAreNotFiles() {
+        let pb = board()
+        pb.declareTypes([.string], owner: nil)
+        pb.setString("https://example.com/report.pdf", forType: .string)
+        expect(ClipboardManager.fileURLs(on: pb) == nil, "an http URL is not a file")
+
+        let plain = board()
+        plain.declareTypes([.string], owner: nil)
+        plain.setString("just some prose", forType: .string)
+        expect(ClipboardManager.fileURLs(on: plain) == nil, "and neither is prose")
+
+        expect(ClipboardManager.fileURLs(on: board()) == nil, "an empty pasteboard reads as nil")
+    }
+
+    /// An app that stages a temp file beside better inline content must keep the inline content.
+    static func volatileAndMissingFilesFallThrough() {
+        let temp = URL(fileURLWithPath: "/private/tmp/tinycast-volatile-\(UUID().uuidString).png")
+        try? Data("x".utf8).write(to: temp)
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let pb = board()
+        pb.writeObjects([temp as NSURL])
+        expect(
+            ClipboardManager.fileURLs(on: pb) == nil,
+            "a file under /private/tmp is not durable, against the shipped roots")
+
+        let gone = board()
+        gone.writeObjects([URL(fileURLWithPath: "/nowhere/\(UUID().uuidString).txt") as NSURL])
+        expect(ClipboardManager.fileURLs(on: gone) == nil, "and neither is one that is not there")
+    }
+
+    static func theBatchIsCapped() {
+        withScratch { dir in
+            let urls = (0..<40).map { index -> URL in
+                let url = dir.appendingPathComponent("f\(index).txt")
+                try? Data("x".utf8).write(to: url)
+                return url
+            }
+            let pb = board()
+            pb.writeObjects(urls as [NSURL])
+            expect(
+                ClipboardManager.fileURLs(on: pb, volatileRoots: [])?.count
+                    == ClipboardManager.maxCapturedFiles,
+                "a select-all is capped rather than inserting every row")
+        }
+    }
+
+    // MARK: - Writing
+
+    /// The round trip: what Finder handed us goes back out as a file, plus the path as text.
+    static func fileEntriesWriteBackAsFiles() {
+        withScratch { dir in
+            let file = dir.appendingPathComponent("report.pdf")
+            try? Data("pdf".utf8).write(to: file)
+            let store = ClipboardStore(directory: dir.appendingPathComponent("store"))
+            store.addFiles([file.path], sourceBundleID: nil)
+            let pb = board()
+
+            expect(Paster.write(store.items[0], store: store, to: pb), "a present file writes")
+            let read = pb.readObjects(forClasses: [NSURL.self]) as? [URL]
+            expect(read?.first?.path == file.path, "and reads back as the same file URL")
+            expect(pb.string(forType: .string) == file.path, "with the path as text, not the name")
+            expect(
+                pb.types?.contains(ClipboardManager.internalType) == true,
+                "marked, so the poller skips our own write")
+        }
+    }
+
+    static func aVanishedFileWritesNothing() {
+        withScratch { dir in
+            let store = ClipboardStore(directory: dir.appendingPathComponent("store"))
+            store.addFiles(["/nowhere/\(UUID().uuidString).txt"], sourceBundleID: nil)
+            let pb = board()
+            pb.declareTypes([.string], owner: nil)
+            pb.setString("untouched", forType: .string)
+
+            expect(!Paster.write(store.items[0], store: store, to: pb), "a vanished file refuses")
+            expect(pb.string(forType: .string) == "untouched", "and leaves the pasteboard alone")
+        }
+    }
+
+    // MARK: - Harness
+
+    static func board() -> NSPasteboard { NSPasteboard.withUniqueName() }
+
+    static func withScratch(_ body: (URL) -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-pasteboard-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        body(dir)
+    }
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            fail(message)
+        }
+    }
+
+    static func fail(_ message: String) {
+        failures += 1
+        print("FAIL: \(message)")
+    }
+}
+
+// MARK: - Stubs for what the shipped sources reach that this harness does not exercise
+
+@MainActor
+final class AppSettings {
+    var clipboardDisabledApps: Set<String> = []
+}
+
+enum Permissions {
+    static func ensureAccessibility() -> Bool { false }
+}
+
+final class NotificationToken {
+    init(_ observer: Any, center: NotificationCenter) {}
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		16A8F14D5FC9C26CA6B616FB /* MCPServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B883E55507FA5BE11A31B54 /* MCPServerConnection.swift */; };
 		16F81066F7B59AD44CE09261 /* ActivationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2575583134BE03EA9FA719CD /* ActivationPolicy.swift */; };
 		175DAAED3859A54861D8CEBC /* SnippetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFFB1471D30C915BBC5DCBA /* SnippetRepository.swift */; };
+		179E0788DCA9995D5B858366 /* FilePreviewStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03A52EBF08AD5C44953DBDC /* FilePreviewStage.swift */; };
 		17F61DEF6389FBCFCCFB467C /* CurrencyRateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEAC591704D983A2C31188F /* CurrencyRateStore.swift */; };
 		184F26705A2A2DB127CD90D6 /* AIToolLoopProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E1C2AD9D1D83F90048FD8A /* AIToolLoopProvider.swift */; };
 		18B3F78B6363E80149D4A646 /* ReleaseNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CC42C482CC8B87188F55F4 /* ReleaseNotesView.swift */; };
@@ -128,6 +129,7 @@
 		3E2E0C5B564C828D7ECA2759 /* RegionCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB0BD36800F3B1AC765F514 /* RegionCurrency.swift */; };
 		3E2E2CFAD5C5731A5F059AD5 /* IconStyleMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C39345D0335ACA895133ABD /* IconStyleMonitor.swift */; };
 		3F3414742ABC6F21D48C2A9E /* QuickActionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B2A5D0CBD3930939ABA5C /* QuickActionRunner.swift */; };
+		40E28FFBE1DDE737D43A7836 /* ClipboardFileKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D381DD8CB296A6D5CFF90111 /* ClipboardFileKind.swift */; };
 		4106FB20E15379C560DCBBB7 /* MCPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF815AC6BE00722DB83B15CD /* MCPTransport.swift */; };
 		4109B5CF37DCA4BCDAE46412 /* ShellCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFE3C41897391C14DB5A55C /* ShellCommandRunner.swift */; };
 		410F1B5FFAA44378AC9EC2DB /* SystemSettingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951E746BA1AD25D167A1775F /* SystemSettingsSettingsView.swift */; };
@@ -176,6 +178,7 @@
 		555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F1080FB443A1D0616790E /* FavoritesStore.swift */; };
 		55CDBFDB13B816FFFB6CC867 /* MCPTrustPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A724FAAD08B77AA54D080E45 /* MCPTrustPolicy.swift */; };
 		56E4958BCEF1FED10B4A796E /* UpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */; };
+		56EB00CB2815CC268829C97B /* AIAttachmentPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBB9959DB6CA493D241080C /* AIAttachmentPolicy.swift */; };
 		5770FB1A3FD29E27C25C944E /* SearchRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB9DB77DCE25C41D86BB955 /* SearchRelevance.swift */; };
 		57784875AA132F7756399363 /* SnippetsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E419A4DA5AB5B3A87B80F2 /* SnippetsListView.swift */; };
 		57B8D2628E23D0D9BD8815AD /* MCPStdioTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5958B66BC7FD9FE3F2B8F49 /* MCPStdioTransport.swift */; };
@@ -229,6 +232,7 @@
 		6D241F01F4BB98AAE1720330 /* InstalledAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76D9592F0809DEC9993684A /* InstalledAI.swift */; };
 		6E2C2F65456E0981FC548C55 /* CustomCommandArgumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0926BBB9980400F4E94D1942 /* CustomCommandArgumentsView.swift */; };
 		6FC9F74D9119AC25D178D748 /* ExtensionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */; };
+		70989EB080FE910AE19AC430 /* FilePreviewThumbnailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7D8BD0403D644E861FACB1 /* FilePreviewThumbnailer.swift */; };
 		71AA40FC4B8C57FFDE5F8DFC /* SystemAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE72CE02F853ACE956627347 /* SystemAction.swift */; };
 		7320E4B2ABFAE8C1D76A3526 /* ExtensionArgumentsAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154222C91EFDB4D4490B6CE2 /* ExtensionArgumentsAccessory.swift */; };
 		73C3912866D29C26E4CED1D2 /* AIModelSelectionRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D1EA2460590C49B4A66C64 /* AIModelSelectionRows.swift */; };
@@ -512,6 +516,7 @@
 		0D4F22647E4E1BA19F0FC520 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 		0DFEBE220187043060F7F286 /* ToolRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRunner.swift; sourceTree = "<group>"; };
 		0E099C50FF0B6A0069CAC5BF /* CommandOutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandOutputView.swift; sourceTree = "<group>"; };
+		0E7D8BD0403D644E861FACB1 /* FilePreviewThumbnailer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewThumbnailer.swift; sourceTree = "<group>"; };
 		0EDB1EEB97CC5F6B0B81FFD6 /* LauncherRankingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherRankingStore.swift; sourceTree = "<group>"; };
 		0F5AFB680B55BBAFF2207F99 /* NotesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesCoordinator.swift; sourceTree = "<group>"; };
 		106F9FEF3F0C36E0C5686DA7 /* AIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIRequest.swift; sourceTree = "<group>"; };
@@ -684,6 +689,7 @@
 		6D594CB90475093D58A2AB1E /* NoteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSearch.swift; sourceTree = "<group>"; };
 		6DA4145CFBB855DF1699C744 /* BackupCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupCategory.swift; sourceTree = "<group>"; };
 		6E06AA30E7BA44BC211B667F /* SnippetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsScreen.swift; sourceTree = "<group>"; };
+		6EBB9959DB6CA493D241080C /* AIAttachmentPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAttachmentPolicy.swift; sourceTree = "<group>"; };
 		6F2CBDE3042FDA4FCA561857 /* MCPComposerAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPComposerAddress.swift; sourceTree = "<group>"; };
 		71B96B69CB4E52319BB3EC7D /* FileSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchService.swift; sourceTree = "<group>"; };
 		72DF1178CD8AD726AC6F9874 /* CalculatorCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorCardView.swift; sourceTree = "<group>"; };
@@ -886,6 +892,7 @@
 		D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
 		D28281DFC434C75F8A594635 /* ReleaseFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseFeed.swift; sourceTree = "<group>"; };
 		D2D032AC22E53BB9997E492F /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
+		D381DD8CB296A6D5CFF90111 /* ClipboardFileKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardFileKind.swift; sourceTree = "<group>"; };
 		D3F82845FDA307DF71676352 /* CalendarAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccess.swift; sourceTree = "<group>"; };
 		D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTSubscription.swift; sourceTree = "<group>"; };
 		D43F1080FB443A1D0616790E /* FavoritesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesStore.swift; sourceTree = "<group>"; };
@@ -911,6 +918,7 @@
 		DE7DEB147E5D718E00D67755 /* ExtensionOAuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionOAuthSession.swift; sourceTree = "<group>"; };
 		DF0880635E294D9DF55BAADA /* CustomCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCommand.swift; sourceTree = "<group>"; };
 		E01488803F8025B0523D44BA /* RelaunchRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaunchRunner.swift; sourceTree = "<group>"; };
+		E03A52EBF08AD5C44953DBDC /* FilePreviewStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewStage.swift; sourceTree = "<group>"; };
 		E08F20B0B823443E176F1566 /* InstalledCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledCLIProvider.swift; sourceTree = "<group>"; };
 		E1FB75182A60F65BA1FB9BA8 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
 		E20A7C8EADDB7F89A73796CC /* BackupComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupComposer.swift; sourceTree = "<group>"; };
@@ -1248,6 +1256,7 @@
 				FBF6EF3A2C35F45B82D40968 /* ClipboardView.swift */,
 				C214E40D42F4812F141C16A8 /* ColorPreview.swift */,
 				89DBFE62B513EC161F194D0A /* ColorSwatch.swift */,
+				E03A52EBF08AD5C44953DBDC /* FilePreviewStage.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -1489,6 +1498,7 @@
 		62F0568B29175D36EF95BB84 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				6EBB9959DB6CA493D241080C /* AIAttachmentPolicy.swift */,
 				DB02E0EF46285235AD81C181 /* AIBrand.swift */,
 				1DE1B6753513C787B3FFE423 /* AIConnection.swift */,
 				67CEAD8FAB5CD097D8F1C851 /* AIConversationOpenPolicy.swift */,
@@ -1610,6 +1620,7 @@
 			isa = PBXGroup;
 			children = (
 				197035E213BEBA67DDA3377B /* ClipboardManager.swift */,
+				0E7D8BD0403D644E861FACB1 /* FilePreviewThumbnailer.swift */,
 				0C3B9645DB2293FA144B5AA2 /* Paster.swift */,
 			);
 			path = Service;
@@ -2360,6 +2371,7 @@
 		FE2191441B39CE41CC3052ED /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				D381DD8CB296A6D5CFF90111 /* ClipboardFileKind.swift */,
 				682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */,
 				201FCD08ACA933378876385B /* ClipboardStore.swift */,
 				025D7D760DE2FD02C0D7D9D2 /* ColorFormat.swift */,
@@ -2443,6 +2455,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				56EB00CB2815CC268829C97B /* AIAttachmentPolicy.swift in Sources */,
 				7F22BD030E1D2A5DC43BABE9 /* AIBrand.swift in Sources */,
 				128AE908878AA0F96C928C9D /* AIChatCoordinator.swift in Sources */,
 				8696DC1B16B6618D22F804D5 /* AIChatState.swift in Sources */,
@@ -2541,6 +2554,7 @@
 				52D95C1FF343FCD57D5425A0 /* ChatSession.swift in Sources */,
 				E77BF5D26A6D9E9FC7E82259 /* ChatTranscriptView.swift in Sources */,
 				A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */,
+				40E28FFBE1DDE737D43A7836 /* ClipboardFileKind.swift in Sources */,
 				AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */,
 				1F8F2135470F74627A644ACC /* ClipboardFilterButton.swift in Sources */,
 				A64891F5587F2C11E4A2E2D2 /* ClipboardManager.swift in Sources */,
@@ -2641,6 +2655,8 @@
 				75EF3CFF00A2215D57A4FBFF /* FavoriteSlots.swift in Sources */,
 				555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */,
 				E4C6F315EA0F0544D9E4BB08 /* FileIconStamp.swift in Sources */,
+				179E0788DCA9995D5B858366 /* FilePreviewStage.swift in Sources */,
+				70989EB080FE910AE19AC430 /* FilePreviewThumbnailer.swift in Sources */,
 				345D1FCC2085BD0D699DD236 /* FileSearchCoordinator.swift in Sources */,
 				5970306ABC24B03028E66D45 /* FileSearchIgnoreList.swift in Sources */,
 				D3F07F4AEBEAA489EDCD0763 /* FileSearchList.swift in Sources */,

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -137,9 +137,13 @@ enum Theme {
         static let menuBrandIcon: CGFloat = 14
         /// The same mark in a header bar button, matched to the callout symbol beside it.
         static let barBrandIcon: CGFloat = 12
-        /// A sent image in the transcript; a staged one is a glyph in a pill by the search text.
+        /// A sent image in the transcript; a staged one is a small preview in a composer pill.
         static let chatImageThumb: CGFloat = 96
         static let chatAttachmentGlyph: CGFloat = 16
+        /// Derived, so a preview pill measures exactly as a glyph pill does — see ai.md.
+        static let chatAttachmentThumb: CGFloat = chatAttachmentGlyph + Spacing.sm - Spacing.xxs
+        /// The clipboard preview's player; `VideoPlayer` expands unbounded without a height.
+        static let clipboardMediaHeight: CGFloat = 260
         /// Opening size and the resize floor; tall enough that the sidebar's rows never scroll.
         static let settingsWindow = CGSize(width: 860, height: 700)
         /// Settings sidebar: a fixed column, wide enough for "Window Management".

--- a/Tinycast/Features/AI/Model/AIAttachmentPolicy.swift
+++ b/Tinycast/Features/AI/Model/AIAttachmentPolicy.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// What the composer may do with a pasted file. Pure, so a harness pins it rather than a chat.
+enum AIAttachmentPolicy {
+    /// The verdict: how a file goes out, or that it cannot.
+    enum Kind: Equatable, Sendable {
+        case image
+        case pdf
+        case text
+    }
+
+    static let pdfMIMEType = "application/pdf"
+
+    /// Extension allowlists rather than `UTType`: a machine's installed apps declare types, so a
+    /// conformance answer differs between two Macs and would make a harness machine-dependent.
+    private static let imageExtensions: Set<String> = [
+        "png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"
+    ]
+
+    private static let textExtensions: Set<String> = [
+        "txt", "md", "markdown", "csv", "tsv", "json", "jsonl", "yaml", "yml", "toml", "ini",
+        "xml", "html", "css", "js", "jsx", "ts", "tsx", "swift", "m", "mm", "h", "c", "cc",
+        "cpp", "hpp", "rs", "go", "rb", "py", "php", "java", "kt", "sh", "zsh", "bash", "sql",
+        "log", "conf", "plist", "patch", "diff"
+    ]
+
+    /// Nil for anything Tinycast will not attach, which the composer refuses by name.
+    static func kind(forFileName name: String) -> Kind? {
+        let ext = (name as NSString).pathExtension.lowercased()
+        if imageExtensions.contains(ext) { return .image }
+        if ext == "pdf" { return .pdf }
+        if textExtensions.contains(ext) { return .text }
+        return nil
+    }
+
+    static func mimeType(forFileName name: String) -> String {
+        let ext = (name as NSString).pathExtension.lowercased()
+        switch ext {
+        case "pdf": return pdfMIMEType
+        case "md", "markdown": return "text/markdown"
+        case "csv": return "text/csv"
+        case "json", "jsonl": return "application/json"
+        case "html": return "text/html"
+        default: return "text/plain"
+        }
+    }
+
+    /// A fence long enough that a Markdown file holding its own fence cannot escape.
+    static func prompt(text: String, documents: [AIDocument]) -> String {
+        let inlined = documents.compactMap(block).joined(separator: "\n\n")
+        guard !inlined.isEmpty else { return text }
+        return text.isEmpty ? inlined : inlined + "\n\n" + text
+    }
+
+    private static func block(for document: AIDocument) -> String? {
+        guard document.mimeType != pdfMIMEType,
+            let contents = String(data: document.data, encoding: .utf8)
+        else { return nil }
+        let fence = String(repeating: "`", count: max(3, longestBacktickRun(in: contents) + 1))
+        let hint = (document.name as NSString).pathExtension.lowercased()
+        return """
+            Attached file: \(sanitized(name: document.name))
+            \(fence)\(hint)
+            \(contents)
+            \(fence)
+            """
+    }
+
+    /// A file named `a\nAttached file: passwd` must not be able to forge a second header.
+    static func sanitized(name: String) -> String {
+        let cleaned = name.unicodeScalars
+            .filter { !CharacterSet.newlines.contains($0) && !CharacterSet.controlCharacters.contains($0) }
+        return String(String.UnicodeScalarView(cleaned)).prefix(64).description
+    }
+
+    private static func longestBacktickRun(in text: String) -> Int {
+        var longest = 0
+        var run = 0
+        for character in text {
+            run = character == "`" ? run + 1 : 0
+            longest = max(longest, run)
+        }
+        return longest
+    }
+}

--- a/Tinycast/Features/AI/Model/AIConnection.swift
+++ b/Tinycast/Features/AI/Model/AIConnection.swift
@@ -79,6 +79,8 @@ struct AIConnection: Codable, Equatable, Identifiable, Sendable {
     func capabilities(for model: String) -> AIModelCapabilities {
         AIModelCapabilities(
             images: provider != .openRouter || visionModels.contains(model),
+            // Only the two shapes whose bodies Tinycast writes; a gateway bills the upload first.
+            documents: provider == .openAI || provider == .anthropic,
             webSearch: provider == .openRouter, tools: true)
     }
 }
@@ -86,13 +88,18 @@ struct AIConnection: Codable, Equatable, Identifiable, Sendable {
 /// What the picker can offer for a model: a vendor API takes images unless its catalog said no.
 struct AIModelCapabilities: Equatable, Sendable {
     let images: Bool
+    /// A PDF as a native block; four routes have no field for one, so it is refused, never dropped.
+    let documents: Bool
     let webSearch: Bool
     /// Only the two HTTP shapes; the Codex route declines tools and the on-device one has none.
     let tools: Bool
 
-    static let none = AIModelCapabilities(images: false, webSearch: false, tools: false)
-    static let chatGPT = AIModelCapabilities(images: true, webSearch: true, tools: false)
-    static let codex = AIModelCapabilities(images: true, webSearch: true, tools: false)
+    static let none = AIModelCapabilities(
+        images: false, documents: false, webSearch: false, tools: false)
+    static let chatGPT = AIModelCapabilities(
+        images: true, documents: false, webSearch: true, tools: false)
+    static let codex = AIModelCapabilities(
+        images: true, documents: false, webSearch: true, tools: false)
     /// The on-device model is text-only and reaches nothing, so it offers none of the three.
     static let appleIntelligence = AIModelCapabilities.none
 }

--- a/Tinycast/Features/AI/Model/AIRequest.swift
+++ b/Tinycast/Features/AI/Model/AIRequest.swift
@@ -8,25 +8,53 @@ struct AIImage: Equatable, Hashable, Sendable {
     var dataURL: String { "data:\(mimeType);base64,\(data.base64EncodedString())" }
 }
 
+/// A file a route reads natively; a text-ish file never becomes one, it inlines as text instead.
+struct AIDocument: Equatable, Hashable, Sendable {
+    let data: Data
+    let mimeType: String
+    /// On the wire, unlike an image's: a model shown three PDFs needs to tell them apart.
+    let name: String
+
+    var dataURL: String { "data:\(mimeType);base64,\(data.base64EncodedString())" }
+}
+
 /// Requests cap near 25 MB and a data URL costs a third more, so the ceiling lives here.
 enum AIAttachmentBudget {
     static let maxCount = 6
     static let maxBytes = 10 * 1_048_576
+    /// Inlined text rides the newest turn, which is never trimmed, so it is capped before staging.
+    static let maxInlinedTextBytes = 32 * 1_024
 
-    /// Whether `images` can take `candidate` and stay inside both limits.
-    static func admits(_ images: [AIImage], adding candidate: AIImage) -> Bool {
-        images.count < maxCount
-            && images.reduce(candidate.data.count) { $0 + $1.data.count } <= maxBytes
+    /// Counted jointly: two independent ceilings would let six of each through.
+    static func admits(images: [AIImage], documents: [AIDocument], addingBytes bytes: Int) -> Bool {
+        let used =
+            images.reduce(0) { $0 + $1.data.count }
+            + documents.reduce(0) { $0 + $1.data.count }
+        return images.count + documents.count < maxCount && used + bytes <= maxBytes
     }
 
     /// The longest leading run that fits, for a turn assembled by any route but the composer.
-    static func bounded(_ images: [AIImage]) -> [AIImage] {
+    /// Images fill first, so a picture is never dropped in favour of a document behind it.
+    static func bounded(
+        _ images: [AIImage], _ documents: [AIDocument]
+    )
+        -> (images: [AIImage], documents: [AIDocument])
+    {
         var total = 0
-        return Array(
-            images.prefix(maxCount).prefix { image in
-                total += image.data.count
-                return total <= maxBytes
-            })
+        var count = 0
+        let keptImages = images.prefix { image in
+            guard count < maxCount, total + image.data.count <= maxBytes else { return false }
+            total += image.data.count
+            count += 1
+            return true
+        }
+        let keptDocuments = documents.prefix { document in
+            guard count < maxCount, total + document.data.count <= maxBytes else { return false }
+            total += document.data.count
+            count += 1
+            return true
+        }
+        return (Array(keptImages), Array(keptDocuments))
     }
 }
 
@@ -41,18 +69,21 @@ struct AIMessage: Equatable, Sendable {
     let role: Role
     let text: String
     let images: [AIImage]
+    /// Only a PDF ever lands here: a text-ish file is inlined into `text` before any transport.
+    let documents: [AIDocument]
     /// Assistant only: the calls this turn asked for, alongside whatever text came with them.
     let toolCalls: [AIToolCall]
     /// Tool only: the answer to one of them.
     let toolResult: AIToolResult?
 
     init(
-        role: Role, text: String, images: [AIImage] = [], toolCalls: [AIToolCall] = [],
-        toolResult: AIToolResult? = nil
+        role: Role, text: String, images: [AIImage] = [], documents: [AIDocument] = [],
+        toolCalls: [AIToolCall] = [], toolResult: AIToolResult? = nil
     ) {
         self.role = role
         self.text = text
         self.images = images
+        self.documents = documents
         self.toolCalls = toolCalls
         self.toolResult = toolResult
     }

--- a/Tinycast/Features/AI/Model/AIRequestBody.swift
+++ b/Tinycast/Features/AI/Model/AIRequestBody.swift
@@ -89,13 +89,17 @@ enum AIRequestBody {
                 }
             ]
         }
-        guard text != nil || !message.images.isEmpty else { return nil }
-        guard !message.images.isEmpty else {
+        let hasAttachments = !message.images.isEmpty || !message.documents.isEmpty
+        guard text != nil || hasAttachments else { return nil }
+        guard hasAttachments else {
             return ["role": message.role.rawValue, "content": text ?? ""]
         }
         var parts: [[String: Any]] = []
         if let text { parts.append(["type": "text", "text": text]) }
         parts += message.images.map { ["type": "image_url", "image_url": ["url": $0.dataURL]] }
+        parts += message.documents.map {
+            ["type": "file", "file": ["filename": $0.name, "file_data": $0.dataURL]]
+        }
         return ["role": message.role.rawValue, "content": parts]
     }
 
@@ -134,8 +138,9 @@ enum AIRequestBody {
             }
             return ["role": message.role.rawValue, "content": parts]
         }
-        guard text != nil || !message.images.isEmpty else { return nil }
-        guard !message.images.isEmpty else {
+        let hasAttachments = !message.images.isEmpty || !message.documents.isEmpty
+        guard text != nil || hasAttachments else { return nil }
+        guard hasAttachments else {
             return ["role": message.role.rawValue, "content": text ?? ""]
         }
         var parts: [[String: Any]] = message.images.map {
@@ -147,6 +152,16 @@ enum AIRequestBody {
                 ]
             ]
         }
+        parts += message.documents.map {
+            [
+                "type": "document",
+                "source": [
+                    "type": "base64", "media_type": $0.mimeType,
+                    "data": $0.data.base64EncodedString()
+                ]
+            ]
+        }
+        // Text stays last: a document block has to precede the instruction that refers to it.
         if let text { parts.append(["type": "text", "text": text]) }
         return ["role": message.role.rawValue, "content": parts]
     }

--- a/Tinycast/Features/AI/Model/ChatMessage.swift
+++ b/Tinycast/Features/AI/Model/ChatMessage.swift
@@ -18,6 +18,8 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
     var state: State
     let sentAt: Date
     let images: [AIImage]
+    /// Sent PDFs; a text file is not one, its contents reached the model as text.
+    let documents: [AIDocument]
     /// Web searches the reply made, in order; each sits in the text where it happened.
     var searches: [ChatSearch]
     /// Tools the reply called, pinned the same way; the calls themselves never enter the context.
@@ -25,7 +27,8 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
 
     init(
         id: UUID = UUID(), role: Role, text: String, state: State = .complete,
-        sentAt: Date = Date(), images: [AIImage] = [], searches: [ChatSearch] = [],
+        sentAt: Date = Date(), images: [AIImage] = [], documents: [AIDocument] = [],
+        searches: [ChatSearch] = [],
         toolUses: [ChatToolUse] = []
     ) {
         self.id = id
@@ -34,6 +37,7 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
         self.state = state
         self.sentAt = sentAt
         self.images = images
+        self.documents = documents
         self.searches = searches
         self.toolUses = toolUses
     }

--- a/Tinycast/Features/AI/Model/ChatSession.swift
+++ b/Tinycast/Features/AI/Model/ChatSession.swift
@@ -41,7 +41,7 @@ struct ChatSession: Equatable, Sendable {
                 guard message.role == .user || message.state == .complete else { return nil }
                 return AIMessage(
                     role: message.role == .user ? .user : .assistant,
-                    text: message.text, images: message.images)
+                    text: message.text, images: message.images, documents: message.documents)
             }, textBudget: textBudget)
     }
 
@@ -67,9 +67,13 @@ struct ChatSession: Equatable, Sendable {
         // The slice opens with the user turn that prompted it; an orphaned reply reads as noise.
         while head.last?.role == .assistant { head.removeLast() }
         let prompt = messages[newest]
+        let kept = AIAttachmentBudget.bounded(prompt.images, prompt.documents)
+        // Inlined here, not in `ChatMessage.text`: the transcript's title is its first user text.
         let bounded = AIMessage(
-            role: prompt.role, text: prompt.text,
-            images: AIAttachmentBudget.bounded(prompt.images))
+            role: prompt.role,
+            text: AIAttachmentPolicy.prompt(text: prompt.text, documents: kept.documents),
+            images: kept.images,
+            documents: kept.documents.filter { $0.mimeType == AIAttachmentPolicy.pdfMIMEType })
         return head.reversed() + [bounded] + tail
     }
 

--- a/Tinycast/Features/AI/Service/ChatHistoryStore.swift
+++ b/Tinycast/Features/AI/Service/ChatHistoryStore.swift
@@ -37,6 +37,14 @@ final class ChatHistoryStore {
           data BLOB NOT NULL,
           PRIMARY KEY(message_id, position)
         );
+        CREATE TABLE IF NOT EXISTS message_documents(
+          message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+          position INTEGER NOT NULL,
+          name TEXT NOT NULL,
+          mime_type TEXT NOT NULL,
+          data BLOB NOT NULL,
+          PRIMARY KEY(message_id, position)
+        );
         CREATE TABLE IF NOT EXISTS message_searches(
           message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
           position INTEGER NOT NULL,
@@ -128,6 +136,7 @@ final class ChatHistoryStore {
         defer { sqlite3_finalize(messagesStatement) }
         bind(id.uuidString, to: messagesStatement, at: 1)
         let images = images(forConversation: id, in: database)
+        let documents = documents(forConversation: id, in: database)
         let searches = searches(forConversation: id, in: database)
         let toolUses = toolUses(forConversation: id, in: database)
         var messages: [ChatMessage] = []
@@ -150,7 +159,8 @@ final class ChatHistoryStore {
                     id: messageID, role: role, text: body, state: state,
                     sentAt: Date(
                         timeIntervalSince1970: sqlite3_column_double(messagesStatement, 4)),
-                    images: images[messageID] ?? [], searches: searches[messageID] ?? [],
+                    images: images[messageID] ?? [], documents: documents[messageID] ?? [],
+                    searches: searches[messageID] ?? [],
                     toolUses: toolUses[messageID] ?? []))
         }
         return ChatSession(
@@ -292,7 +302,8 @@ final class ChatHistoryStore {
             sqlite3_clear_bindings(statement)
         }
         return session.messages[rewriteFrom...].allSatisfy {
-            saveImages(of: $0, in: database) && saveSearches(of: $0, in: database)
+            saveImages(of: $0, in: database) && saveDocuments(of: $0, in: database)
+                && saveSearches(of: $0, in: database)
                 && saveToolUses(of: $0, in: database)
         }
     }
@@ -422,6 +433,53 @@ final class ChatHistoryStore {
             sqlite3_clear_bindings(statement)
         }
         return true
+    }
+
+    private func saveDocuments(of message: ChatMessage, in database: OpaquePointer) -> Bool {
+        guard !message.documents.isEmpty else { return true }
+        let sql = """
+            INSERT INTO message_documents(message_id, position, name, mime_type, data)
+            VALUES(?, ?, ?, ?, ?);
+            """
+        guard let statement = prepare(sql, in: database) else { return false }
+        defer { sqlite3_finalize(statement) }
+        for (position, document) in message.documents.enumerated() {
+            bind(message.id.uuidString, to: statement, at: 1)
+            sqlite3_bind_int64(statement, 2, Int64(position))
+            bind(document.name, to: statement, at: 3)
+            bind(document.mimeType, to: statement, at: 4)
+            let bound = document.data.withUnsafeBytes { bytes in
+                sqlite3_bind_blob(
+                    statement, 5, bytes.baseAddress, Int32(bytes.count), chatSQLiteTransient)
+            }
+            guard bound == SQLITE_OK, sqlite3_step(statement) == SQLITE_DONE else { return false }
+            sqlite3_reset(statement)
+            sqlite3_clear_bindings(statement)
+        }
+        return true
+    }
+
+    private func documents(
+        forConversation id: UUID, in database: OpaquePointer
+    ) -> [UUID: [AIDocument]] {
+        let sql = """
+            SELECT d.message_id, d.name, d.mime_type, d.data FROM message_documents d
+            JOIN messages m ON m.id = d.message_id
+            WHERE m.conversation_id = ? ORDER BY d.message_id, d.position;
+            """
+        guard let statement = prepare(sql, in: database) else { return [:] }
+        defer { sqlite3_finalize(statement) }
+        bind(id.uuidString, to: statement, at: 1)
+        var documents: [UUID: [AIDocument]] = [:]
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let messageID = UUID(uuidString: text(statement, 0)),
+                let bytes = sqlite3_column_blob(statement, 3)
+            else { continue }
+            let data = Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, 3)))
+            documents[messageID, default: []].append(
+                AIDocument(data: data, mimeType: text(statement, 2), name: text(statement, 1)))
+        }
+        return documents
     }
 
     private func images(

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -171,7 +171,8 @@ final class AIChatCoordinator {
         case .appleIntelligence?: return .appleIntelligence
         case .codex?: return .codex
         case .claude?, .openCode?:
-            return AIModelCapabilities(images: false, webSearch: false, tools: false)
+            return AIModelCapabilities(
+                images: false, documents: false, webSearch: false, tools: false)
         case .api(let connection, let model, _)?:
             return core.aiSettings.connection(id: connection)?.capabilities(for: model)
                 ?? AIModelCapabilities.none
@@ -185,55 +186,142 @@ final class AIChatCoordinator {
             ? AppleIntelligence.contextBudget : ChatSession.defaultTextBudget
     }
 
-    /// ⌘V stages a picture, decoded off-main; false hands the chord back to the field editor.
-    func attachPastedImage() -> Bool {
-        guard capabilities.images else { return false }
+    /// ⌘V stages a file, read off-main; false hands the chord back to the field editor.
+    func attachPastedFile() -> Bool {
         let pasteboard = NSPasteboard.general
-        let file = Self.pastedImageFile(on: pasteboard)
+        let files = Self.pastedFiles(on: pasteboard)
+        // A copied text selection often carries a TIFF too; only a board with no string is a picture.
         let pasted =
-            pasteboard.string(forType: .string) == nil
+            files.isEmpty && pasteboard.string(forType: .string) == nil
             ? pasteboard.availableType(from: [.png, .tiff]).flatMap { pasteboard.data(forType: $0) }
             : nil
-        guard file != nil || pasted != nil else { return false }
-        stage(file: file, pasted: pasted)
+        guard !files.isEmpty || pasted != nil else { return false }
+        if let refusal = unattachable(files) {
+            core.showMessage(refusal.message, tone: .neutral)
+            return true
+        }
+        if pasted != nil, !capabilities.images {
+            core.showMessage(ChatAttachmentRefusal.imagesUnsupported.message, tone: .neutral)
+            return true
+        }
+        stage(files: files, pasted: pasted)
         return true
     }
 
-    /// The file first, raw bytes as fallback; the chord is consumed, never pasting a path
-    private func stage(file: URL?, pasted: Data?) {
+    /// The first refusal the current route forces, so a paste explains itself rather than dropping.
+    private func unattachable(_ files: [URL]) -> ChatAttachmentRefusal? {
+        let can = capabilities
+        for file in files {
+            guard let kind = AIAttachmentPolicy.kind(forFileName: file.lastPathComponent) else {
+                return .unsupported(file.pathExtension.lowercased())
+            }
+            switch kind {
+            case .image where !can.images: return .imagesUnsupported
+            case .pdf where !can.documents: return .documentsUnsupported
+            default: continue
+            }
+        }
+        return nil
+    }
+
+    /// Files first, raw bytes as fallback; the chord is consumed, never pasting a path.
+    private func stage(files: [URL], pasted: Data?) {
         let generation = chat.stagingGeneration
         Task { [weak self] in
-            let staged = await Task.detached(priority: .userInitiated) { () -> (Data, String)? in
-                if let file, let bytes = try? Data(contentsOf: file),
-                    let png = Self.boundedPNG(bytes)
-                {
-                    return (png, file.lastPathComponent)
-                }
-                if let pasted, let png = Self.boundedPNG(pasted) { return (png, "Image") }
-                return nil
+            let staged = await Task.detached(priority: .userInitiated) { () -> [Staged] in
+                if !files.isEmpty { return files.compactMap(Self.read) }
+                guard let pasted, let png = Self.boundedPNG(pasted) else { return [] }
+                return [
+                    Staged(
+                        payload: .image(AIImage(data: png, mimeType: "image/png")),
+                        name: "Image", preview: Self.preview(png))
+                ]
             }.value
             guard let self else { return }
             guard generation == self.chat.stagingGeneration else {
                 core.showMessage(
-                    "That image was still loading and did not make it into the chat.",
+                    "That file was still loading and did not make it into the chat.",
                     tone: .neutral)
                 return
             }
-            guard let staged else {
-                core.showMessage("That image could not be read.", tone: .neutral)
+            guard !staged.isEmpty else {
+                core.showMessage("That file could not be read.", tone: .neutral)
                 return
             }
-            let attachment = ChatAttachment(
-                image: AIImage(data: staged.0, mimeType: "image/png"), name: staged.1)
-            if let refusal = chat.attach(attachment) {
-                core.showMessage(refusal.message, tone: .neutral)
+            for item in staged {
+                let attachment = ChatAttachment(
+                    payload: item.payload, name: item.name, preview: item.preview)
+                if let refusal = chat.attach(attachment) {
+                    core.showMessage(refusal.message, tone: .neutral)
+                    return
+                }
             }
         }
     }
 
-    private static func pastedImageFile(on pasteboard: NSPasteboard) -> URL? {
-        let urls = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] ?? []
-        return urls.first { imageExtensions.contains($0.pathExtension.lowercased()) }
+    /// Carries what a staged file becomes across the detached read.
+    private struct Staged: Sendable {
+        let payload: ChatAttachment.Payload
+        let name: String
+        let preview: Data?
+    }
+
+    /// Sized before it is read, so a four-gigabyte CSV can never be slurped into memory.
+    nonisolated private static func read(_ file: URL) -> Staged? {
+        let name = file.lastPathComponent
+        guard let kind = AIAttachmentPolicy.kind(forFileName: name) else { return nil }
+        let size = (try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let ceiling =
+            kind == .text ? AIAttachmentBudget.maxInlinedTextBytes : AIAttachmentBudget.maxBytes
+        guard size <= ceiling, let bytes = try? Data(contentsOf: file) else { return nil }
+        let mimeType = AIAttachmentPolicy.mimeType(forFileName: name)
+        switch kind {
+        case .image:
+            guard let png = boundedPNG(bytes) else { return nil }
+            return Staged(
+                payload: .image(AIImage(data: png, mimeType: "image/png")), name: name,
+                preview: preview(png))
+        case .pdf:
+            return Staged(
+                payload: .document(AIDocument(data: bytes, mimeType: mimeType, name: name)),
+                name: name, preview: nil)
+        case .text:
+            // Re-encoded from the decoded string, so undecodable bytes refuse rather than mojibake.
+            guard let decoded = String(data: bytes, encoding: .utf8) else { return nil }
+            return Staged(
+                payload: .document(
+                    AIDocument(data: Data(decoded.utf8), mimeType: mimeType, name: name)),
+                name: name, preview: nil)
+        }
+    }
+
+    /// The pill's thumbnail, encoded once here rather than decoded per keystroke in the header.
+    nonisolated private static func preview(_ png: Data) -> Data? {
+        guard let source = NSBitmapImageRep(data: png) else { return nil }
+        let edge: CGFloat = 40
+        let scale = min(1, edge / max(CGFloat(source.pixelsWide), CGFloat(source.pixelsHigh)))
+        let size = NSSize(
+            width: max(1, (CGFloat(source.pixelsWide) * scale).rounded()),
+            height: max(1, (CGFloat(source.pixelsHigh) * scale).rounded()))
+        guard
+            let scaled = NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: Int(size.width), pixelsHigh: Int(size.height),
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0),
+            let context = NSGraphicsContext(bitmapImageRep: scaled)
+        else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        context.imageInterpolation = .high
+        source.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+        return scaled.representation(using: .png, properties: [:])
+    }
+
+    /// `isFileURL` is load-bearing: without it an `https://…/a.png` reaches `Data(contentsOf:)`,
+    /// turning a keystroke into a network request.
+    private static func pastedFiles(on pasteboard: NSPasteboard) -> [URL] {
+        (pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] ?? []).filter(\.isFileURL)
     }
 
     /// Backspace on an empty composer takes the last staged image before it backs out of chat.
@@ -244,10 +332,6 @@ final class AIChatCoordinator {
     func clearAttachments() {
         chat.clearAttachments()
     }
-
-    private static let imageExtensions: Set<String> = [
-        "png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"
-    ]
 
     nonisolated private static let maxImageEdge: CGFloat = 1_568
 

--- a/Tinycast/Features/AI/UI/AIChatState.swift
+++ b/Tinycast/Features/AI/UI/AIChatState.swift
@@ -9,8 +9,8 @@ final class AIChatState {
     private(set) var isThinking = false
     private(set) var usage: AIUsage?
     private(set) var notice: String?
-    /// Images staged for the next message; they go out with whatever is typed next.
-    private(set) var pendingImages: [ChatAttachment] = []
+    /// Files staged for the next message; they go out with whatever is typed next.
+    private(set) var pendingAttachments: [ChatAttachment] = []
 
     /// Every path that consumes or drops the staged images moves this on, so a late decode knows
     @ObservationIgnored private(set) var stagingGeneration = 0
@@ -35,9 +35,12 @@ final class AIChatState {
         instructions: String? = nil, contextBudget: Int = ChatSession.defaultTextBudget
     ) -> Bool {
         let text = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty || !pendingImages.isEmpty, !isStreaming else { return false }
+        guard !text.isEmpty || !pendingAttachments.isEmpty, !isStreaming else { return false }
         notice = nil
-        session.append(ChatMessage(role: .user, text: text, images: pendingImages.map(\.image)))
+        session.append(
+            ChatMessage(
+                role: .user, text: text, images: pendingAttachments.compactMap(\.image),
+                documents: pendingAttachments.compactMap(\.document)))
         clearStaging()
         let request = AIRequest(
             instructions: instructions,
@@ -79,19 +82,24 @@ final class AIChatState {
     /// Refused, not truncated: the composer is the last place an oversized turn can be explained.
     @discardableResult
     func attach(_ attachment: ChatAttachment) -> ChatAttachmentRefusal? {
-        guard !pendingImages.contains(where: { $0.image == attachment.image }) else { return nil }
-        guard pendingImages.count < AIAttachmentBudget.maxCount else { return .count }
-        guard AIAttachmentBudget.admits(pendingImages.map(\.image), adding: attachment.image) else {
-            return .size
+        guard !pendingAttachments.contains(where: { $0.payload == attachment.payload }) else {
+            return nil
         }
-        pendingImages.append(attachment)
+        guard pendingAttachments.count < AIAttachmentBudget.maxCount else { return .count }
+        guard
+            AIAttachmentBudget.admits(
+                images: pendingAttachments.compactMap(\.image),
+                documents: pendingAttachments.compactMap(\.document),
+                addingBytes: attachment.payload.byteCount)
+        else { return .size }
+        pendingAttachments.append(attachment)
         return nil
     }
 
     @discardableResult
     func removeLastAttachment() -> Bool {
-        guard !pendingImages.isEmpty else { return false }
-        pendingImages.removeLast()
+        guard !pendingAttachments.isEmpty else { return false }
+        pendingAttachments.removeLast()
         return true
     }
 
@@ -100,7 +108,7 @@ final class AIChatState {
     }
 
     private func clearStaging() {
-        pendingImages = []
+        pendingAttachments = []
         stagingGeneration += 1
     }
 
@@ -278,22 +286,70 @@ extension AIChatState {
     }
 }
 
-/// Why the composer would not take another picture; both limits are `AIAttachmentBudget`'s.
+/// Why the composer would not take another file; the limits are `AIAttachmentBudget`'s.
 enum ChatAttachmentRefusal: Equatable, Sendable {
     case count
     case size
+    case textTooLong
+    case undecodable
+    case unsupported(String)
+    case imagesUnsupported
+    case documentsUnsupported
 
     var message: String {
         switch self {
-        case .count: return "\(AIAttachmentBudget.maxCount) images is all one message can carry."
-        case .size: return "That image is too big for this message — send these first."
+        case .count:
+            return "\(AIAttachmentBudget.maxCount) attachments is all one message can carry."
+        case .size: return "That file is too big for this message — send these first."
+        case .textTooLong:
+            let limit = AIAttachmentBudget.maxInlinedTextBytes / 1_024
+            return "That text file is too big to attach — \(limit) KB is the limit."
+        case .undecodable: return "That file isn't text Tinycast can read."
+        case .unsupported(let ext):
+            return "Tinycast can attach images, PDFs and text files, not .\(ext) files."
+        case .imagesUnsupported: return "This model can't read images. Switch model to attach one."
+        case .documentsUnsupported:
+            return "This model can't read PDFs. Switch model, or paste the text instead."
         }
     }
 }
 
-/// A staged image with the name the chip shows; the name is for the composer only, not the wire.
+/// A staged file with the name and preview the chip shows; neither ever goes on the wire.
 struct ChatAttachment: Identifiable, Equatable, Sendable {
+    /// One staged list holds all three, so every lifetime rule applies to them alike.
+    enum Payload: Equatable, Sendable {
+        case image(AIImage)
+        case document(AIDocument)
+
+        var byteCount: Int {
+            switch self {
+            case .image(let image): return image.data.count
+            case .document(let document): return document.data.count
+            }
+        }
+    }
+
     let id = UUID()
-    let image: AIImage
+    let payload: Payload
     let name: String
+    /// A ~40px PNG, about a kilobyte: six cost less to decode than one keystroke's re-render.
+    let preview: Data?
+
+    var image: AIImage? {
+        guard case .image(let image) = payload else { return nil }
+        return image
+    }
+
+    var document: AIDocument? {
+        guard case .document(let document) = payload else { return nil }
+        return document
+    }
+
+    var kind: AIAttachmentPolicy.Kind {
+        switch payload {
+        case .image: return .image
+        case .document(let document):
+            return document.mimeType == AIAttachmentPolicy.pdfMIMEType ? .pdf : .text
+        }
+    }
 }

--- a/Tinycast/Features/AI/UI/AIScreen.swift
+++ b/Tinycast/Features/AI/UI/AIScreen.swift
@@ -34,9 +34,9 @@ struct AIScreen: PaletteScreen {
                     coordinator.copyLastResponse()
                 })
         }
-        if !chat.pendingImages.isEmpty {
+        if !chat.pendingAttachments.isEmpty {
             items.append(
-                PopoverMenuItem(title: "Remove Attachments", systemImage: "photo.badge.minus") {
+                PopoverMenuItem(title: "Remove Attachments", systemImage: "paperclip") {
                     coordinator.clearAttachments()
                 })
         }
@@ -67,7 +67,7 @@ struct AIScreen: PaletteScreen {
     func headerAccessory(
         at selection: Int, focus: FocusState<String?>.Binding
     ) -> PaletteHeaderAccessory? {
-        let attachments = chat.pendingImages
+        let attachments = chat.pendingAttachments
         let addressed = coordinator.addressedServer(in: vm.query)
         guard !attachments.isEmpty || addressed != nil else { return nil }
         let width =
@@ -156,11 +156,28 @@ private struct AIEmptyState: View {
     }
 }
 
-/// One pill beside the composer; the row is too thin for anything but a glyph and a word.
+/// One pill beside the composer, leading with a glyph or the attachment's own preview.
 private struct ComposerChip: View {
-    let symbol: String
+    /// A preview gives up leading inset to buy its extra size, so both pills measure alike.
+    enum Leading {
+        case symbol(String)
+        case preview(Data?, id: UUID)
+    }
+
+    let leading: Leading
     let label: String
 
+    init(symbol: String, label: String) {
+        self.leading = .symbol(symbol)
+        self.label = label
+    }
+
+    init(leading: Leading, label: String) {
+        self.leading = leading
+        self.label = label
+    }
+
+    /// Load-bearing: `RootPaletteView.searchFieldWidth(for:)` shrinks the field by exactly this.
     static func width(of label: String) -> CGFloat {
         let font = Theme.Typography.chipNSFont
         let text = (label as NSString).size(withAttributes: [.font: font]).width
@@ -169,22 +186,56 @@ private struct ComposerChip: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.xs) {
-            Image(systemName: symbol)
-                .font(Theme.Typography.chip)
-                .symbolRenderingMode(.hierarchical)
-                .frame(width: Theme.Size.chatAttachmentGlyph)
+            switch leading {
+            case .symbol(let symbol):
+                Image(systemName: symbol)
+                    .font(Theme.Typography.chip)
+                    .symbolRenderingMode(.hierarchical)
+                    .frame(width: Theme.Size.chatAttachmentGlyph)
+            case .preview(let data, let id):
+                ComposerThumbnail(data: data, id: id)
+            }
             Text(label)
                 .font(Theme.Typography.chip)
                 .lineLimit(1)
         }
         .foregroundStyle(Theme.Colors.textSecondary)
-        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.leading, leadingInset)
+        .padding(.trailing, Theme.Spacing.sm)
         .padding(.vertical, Theme.Spacing.xxs)
         .background(Capsule().fill(Theme.Colors.controlSurface))
     }
+
+    private var leadingInset: CGFloat {
+        if case .preview = leading { return Theme.Spacing.xxs }
+        return Theme.Spacing.sm
+    }
 }
 
-/// Staged images sit after the typed text as named pills; the row is too thin for a thumbnail.
+/// Decoded once per attachment: `ForEach` keys on its id, so a per-keystroke re-render reuses it.
+private struct ComposerThumbnail: View {
+    let data: Data?
+    let id: UUID
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image).resizable().scaledToFill()
+            } else {
+                Image(systemName: "photo")
+                    .font(Theme.Typography.chip)
+                    .symbolRenderingMode(.hierarchical)
+            }
+        }
+        .frame(width: Theme.Size.chatAttachmentThumb, height: Theme.Size.chatAttachmentThumb)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
+        .task(id: id) { image = data.flatMap(NSImage.init(data:)) }
+    }
+}
+
+/// Staged files sit after the typed text as named pills, an image showing itself.
 private struct PendingAttachmentsChips: View {
     let attachments: [ChatAttachment]
 
@@ -195,8 +246,17 @@ private struct PendingAttachmentsChips: View {
     var body: some View {
         HStack(spacing: Theme.Spacing.sm) {
             ForEach(attachments) { attachment in
-                ComposerChip(symbol: "photo", label: attachment.name)
+                ComposerChip(leading: leading(for: attachment), label: attachment.name)
+                    .accessibilityLabel("Attached file \(attachment.name)")
             }
+        }
+    }
+
+    private func leading(for attachment: ChatAttachment) -> ComposerChip.Leading {
+        switch attachment.kind {
+        case .image: return .preview(attachment.preview, id: attachment.id)
+        case .pdf: return .symbol("doc.richtext")
+        case .text: return .symbol("doc.plaintext")
         }
     }
 }

--- a/Tinycast/Features/AI/UI/ChatTranscriptView.swift
+++ b/Tinycast/Features/AI/UI/ChatTranscriptView.swift
@@ -181,6 +181,13 @@ private struct ChatMessageView: View {
                     }
                 }
             }
+            if !message.documents.isEmpty {
+                HStack(spacing: Theme.Spacing.sm) {
+                    ForEach(message.documents, id: \.self) { document in
+                        ChatDocumentChip(document: document)
+                    }
+                }
+            }
             if !message.text.isEmpty || !message.searches.isEmpty || !message.toolUses.isEmpty {
                 rendered
             }
@@ -205,6 +212,27 @@ private struct ChatMessageView: View {
         } else {
             Text(message.text)
         }
+    }
+}
+
+/// A sent document names itself: its bytes went to the model, not into the transcript's prose.
+private struct ChatDocumentChip: View {
+    let document: AIDocument
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            Image(systemName: "doc.richtext")
+                .font(Theme.Typography.chip)
+                .symbolRenderingMode(.hierarchical)
+            Text(document.name)
+                .font(Theme.Typography.chip)
+                .lineLimit(1)
+        }
+        .foregroundStyle(Theme.Colors.textSecondary)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.xxs)
+        .background(Capsule().fill(Theme.Colors.controlSurface))
+        .accessibilityLabel("Attached file \(document.name)")
     }
 }
 

--- a/Tinycast/Features/Backup/Model/BackupClipboardItem.swift
+++ b/Tinycast/Features/Backup/Model/BackupClipboardItem.swift
@@ -5,6 +5,7 @@ struct BackupClipboardItem: Codable, Sendable, Equatable {
     enum Kind: String, Codable, Sendable {
         case text
         case image
+        case file
     }
 
     var kind: Kind

--- a/Tinycast/Features/Backup/Service/BackupApplier.swift
+++ b/Tinycast/Features/Backup/Service/BackupApplier.swift
@@ -71,6 +71,14 @@ enum BackupApplier {
                 id: UUID(), kind: .image, text: nil, imagePath: url.path,
                 createdAt: item.createdAt, sourceBundleID: item.sourceBundleID,
                 pinnedAt: item.pinnedAt)
+        case .file:
+            // A path from another Mac names nothing here, so the row is dropped rather than dead.
+            guard let path = item.text, FileManager.default.fileExists(atPath: path) else {
+                return nil
+            }
+            return ClipboardItem(
+                id: UUID(), kind: .file, text: path, imagePath: nil, createdAt: item.createdAt,
+                sourceBundleID: item.sourceBundleID, pinnedAt: item.pinnedAt)
         }
     }
 

--- a/Tinycast/Features/Backup/Service/BackupComposer.swift
+++ b/Tinycast/Features/Backup/Service/BackupComposer.swift
@@ -134,8 +134,18 @@ enum BackupComposer {
             }
             imageName = name
         }
+        // A referenced file is exported as its path; a backup never carries bytes it never held.
+        if item.kind == .file, item.filePath.map(FileManager.default.fileExists) != true {
+            return nil
+        }
+        let kind: BackupClipboardItem.Kind
+        switch item.kind {
+        case .text: kind = .text
+        case .image: kind = .image
+        case .file: kind = .file
+        }
         return BackupClipboardItem(
-            kind: item.kind == .image ? .image : .text, text: item.text, imageName: imageName,
+            kind: kind, text: item.text, imageName: imageName,
             createdAt: item.createdAt, sourceBundleID: item.sourceBundleID,
             pinnedAt: item.pinnedAt)
     }

--- a/Tinycast/Features/Clipboard/Model/ClipboardFileKind.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardFileKind.swift
@@ -1,0 +1,49 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// What a referenced file is, for the Type row and the tile a thumbnail has not filled yet.
+enum ClipboardFileKind: Sendable {
+    case image
+    case movie
+    case audio
+    case pdf
+    case folder
+    case other
+
+    /// Resolved from the extension, never from disk, so a vanished file still classifies.
+    static func of(path: String, isDirectory: Bool = false) -> ClipboardFileKind {
+        guard !isDirectory else { return .folder }
+        let type = UTType(filenameExtension: URL(fileURLWithPath: path).pathExtension)
+        guard let type else { return .other }
+        if type.conforms(to: .image) { return .image }
+        if type.conforms(to: .movie) { return .movie }
+        if type.conforms(to: .audio) { return .audio }
+        if type.conforms(to: .pdf) { return .pdf }
+        return .other
+    }
+
+    /// Whether the preview pane plays it rather than drawing a still.
+    var isPlayable: Bool { self == .movie || self == .audio }
+
+    var title: String {
+        switch self {
+        case .image: return "Image"
+        case .movie: return "Movie"
+        case .audio: return "Audio"
+        case .pdf: return "PDF"
+        case .folder: return "Folder"
+        case .other: return "File"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .image: return "photo"
+        case .movie: return "film"
+        case .audio: return "waveform"
+        case .pdf: return "doc.richtext"
+        case .folder: return "folder"
+        case .other: return "doc"
+        }
+    }
+}

--- a/Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardFilter.swift
@@ -5,6 +5,7 @@ enum ClipboardFilter: CaseIterable, Sendable {
     case all
     case text
     case image
+    case file
     case color
     case link
     case email
@@ -14,6 +15,7 @@ enum ClipboardFilter: CaseIterable, Sendable {
         case .all: return "All Types"
         case .text: return "Text Only"
         case .image: return "Images Only"
+        case .file: return "Files Only"
         case .color: return "Colors Only"
         case .link: return "Links Only"
         case .email: return "Emails Only"
@@ -26,6 +28,7 @@ enum ClipboardFilter: CaseIterable, Sendable {
         case .all: return "list.bullet"
         case .text: return "textformat"
         case .image: return "photo"
+        case .file: return "doc"
         case .color: return "eyedropper"
         case .link: return "link"
         case .email: return "at"
@@ -38,6 +41,7 @@ enum ClipboardFilter: CaseIterable, Sendable {
         case .all: return "Clipboard history is empty"
         case .text: return "No text in clipboard history"
         case .image: return "No images in clipboard history"
+        case .file: return "No files in clipboard history"
         case .color: return "No colors in clipboard history"
         case .link: return "No links in clipboard history"
         case .email: return "No email addresses in clipboard history"
@@ -49,6 +53,7 @@ enum ClipboardFilter: CaseIterable, Sendable {
         switch self {
         case .all: return true
         case .image: return item.kind == .image
+        case .file: return item.kind == .file
         case .text: return item.textForm == .plain
         case .color: return item.textForm == .color
         case .link: return item.textForm == .link

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -5,10 +5,11 @@ import SQLite3
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 struct ClipboardItem: Identifiable, Hashable, Sendable {
-    enum Kind: String, Sendable { case text, image }
+    enum Kind: String, Sendable { case text, image, file }
 
     let id: UUID
     let kind: Kind
+    /// The copied text, or for a `.file` entry the absolute path — which is what FTS indexes.
     let text: String?
     /// Absolute path on disk; only files under `imagesDir` are ours to delete.
     let imagePath: String?
@@ -20,6 +21,9 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
 
     var isPinned: Bool { pinnedAt != nil }
 
+    /// The referenced path, so no call site re-derives a file entry's meaning from `text`.
+    var filePath: String? { kind == .file ? text : nil }
+
     init(text: String, sourceBundleID: String?) {
         self.init(
             id: UUID(), kind: .text, text: text, imagePath: nil, createdAt: Date(),
@@ -29,6 +33,13 @@ struct ClipboardItem: Identifiable, Hashable, Sendable {
     init(imagePath: String, createdAt: Date = Date(), sourceBundleID: String?) {
         self.init(
             id: UUID(), kind: .image, text: nil, imagePath: imagePath, createdAt: createdAt,
+            sourceBundleID: sourceBundleID)
+    }
+
+    /// Referenced where it lies: `imagePath` stays nil, keeping an unowned file from `deleteBlob`.
+    init(filePath: String, createdAt: Date = Date(), sourceBundleID: String?) {
+        self.init(
+            id: UUID(), kind: .file, text: filePath, imagePath: nil, createdAt: createdAt,
             sourceBundleID: sourceBundleID)
     }
 
@@ -225,6 +236,20 @@ final class ClipboardStore {
         insert(ClipboardItem(text: text, sourceBundleID: sourceBundleID))
     }
 
+    /// One row per file. Batched, so a multi-file copy prunes once rather than once per file.
+    func addFiles(_ paths: [String], sourceBundleID: String?) {
+        // Only a single file can be a ⌘C repeat, which is the case `addText` also guards.
+        if paths.count == 1, items.first?.kind == .file, items.first?.text == paths[0] { return }
+        guard !paths.isEmpty else { return }
+        for path in paths {
+            let item = ClipboardItem(filePath: path, sourceBundleID: sourceBundleID)
+            if let stmt = insertStmt { Self.bindAndInsert(stmt, item) }
+            items.insert(item, at: 0)
+        }
+        trimWindow()
+        prune()
+    }
+
     func addImage(_ data: Data, sourceBundleID: String?) {
         let url = imagesDir.appendingPathComponent(UUID().uuidString + ".png")
         let item = ClipboardItem(imagePath: url.path, sourceBundleID: sourceBundleID)
@@ -276,6 +301,11 @@ final class ClipboardStore {
 
     func imageURL(for item: ClipboardItem) -> URL? {
         guard let path = item.imagePath else { return nil }
+        return URL(fileURLWithPath: path)
+    }
+
+    func fileURL(for item: ClipboardItem) -> URL? {
+        guard let path = item.filePath else { return nil }
         return URL(fileURLWithPath: path)
     }
 
@@ -581,7 +611,8 @@ final class ClipboardStore {
     nonisolated private static func importKey(_ item: ClipboardItem) -> Int {
         var hasher = Hasher()
         hasher.combine(item.kind)
-        hasher.combine(item.kind == .text ? item.text : item.imagePath)
+        // Keyed off `text` for everything but an image, or every file entry hashes alike.
+        hasher.combine(item.kind == .image ? item.imagePath : item.text)
         return hasher.finalize()
     }
 

--- a/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
+++ b/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
@@ -97,6 +97,38 @@ final class ClipboardManager {
         lastChangeCount = changeCount
     }
 
+    /// A Finder select-all must not insert ten thousand rows on one poll tick.
+    nonisolated static let maxCapturedFiles = 32
+
+    /// A reference into a directory the OS reclaims is not a reference; those fall through.
+    /// Spelled without `/private`, which is what `resolvingSymlinksInPath` strips.
+    nonisolated static let volatileRoots = [
+        "/tmp/", "/var/tmp/", "/var/folders/", NSHomeDirectory() + "/Library/Caches/"
+    ]
+
+    /// Both parameters are injected environment facts, so a harness can drive its own scratch.
+    nonisolated static func fileURLs(
+        on pasteboard: NSPasteboard, volatileRoots roots: [String] = volatileRoots
+    ) -> [String]? {
+        let urls =
+            pasteboard.readObjects(
+                forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL]
+        let durable = (urls ?? []).filter { isDurable($0, roots: roots) }
+            .prefix(maxCapturedFiles)
+        // Nil rather than empty, so a copied `http` URL falls through and stays a link.
+        guard !durable.isEmpty else { return nil }
+        // Reversed on insert, so the first file copied ends up leading the history.
+        return durable.map(\.standardizedFileURL.path).reversed()
+    }
+
+    /// An app that stages a temp file beside better inline content must keep the inline content.
+    nonisolated private static func isDurable(_ url: URL, roots: [String]) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+        var path = url.resolvingSymlinksInPath().path
+        if path.hasPrefix("/private/") { path.removeFirst("/private".count) }
+        return !roots.contains { path.hasPrefix($0) }
+    }
+
     private func poll() {
         let pb = NSPasteboard.general
         guard pb.changeCount != lastChangeCount else { return }
@@ -110,6 +142,12 @@ final class ClipboardManager {
         // The pasteboard carries no source, so attribute it to the frontmost app.
         let sourceBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
         if let sourceBundleID, settings.clipboardDisabledApps.contains(sourceBundleID) { return }
+
+        // Ahead of the text branch: Finder puts the file's *name* on `.string` beside its URL.
+        if let paths = Self.fileURLs(on: pb) {
+            store.addFiles(paths, sourceBundleID: sourceBundleID)
+            return
+        }
 
         if let text = pb.string(forType: .string),
             !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/Tinycast/Features/Clipboard/Service/FilePreviewThumbnailer.swift
+++ b/Tinycast/Features/Clipboard/Service/FilePreviewThumbnailer.swift
@@ -1,0 +1,61 @@
+import AppKit
+import QuickLookThumbnailing
+
+/// Content thumbnails for any file type — a video's poster frame, a PDF's page, else its icon.
+enum FilePreviewThumbnailer {
+    /// `NSCache` is thread-safe but not `Sendable`, so assert the guarantee once here.
+    private final class ImageCache: NSCache<NSString, NSImage>, @unchecked Sendable {}
+
+    /// Row tiles, byte-bounded and kept warm, so re-opening the clipboard draws instantly.
+    private static let rowCache: ImageCache = {
+        let cache = ImageCache()
+        cache.totalCostLimit = 8 * 1024 * 1024
+        return cache
+    }()
+
+    /// Large previews, byte-bounded and purged on close, so browsing memory stays flat.
+    private static let previewCache: ImageCache = {
+        let cache = ImageCache()
+        cache.totalCostLimit = 32 * 1024 * 1024
+        return cache
+    }()
+
+    /// Longest-edge size at or below which a render is a "row" tile; larger is a "preview".
+    private static let rowThreshold: CGFloat = 128
+
+    private static func pick(_ maxPixel: CGFloat) -> NSCache<NSString, NSImage> {
+        maxPixel <= rowThreshold ? rowCache : previewCache
+    }
+
+    private static func cacheKey(_ url: URL, _ maxPixel: CGFloat) -> NSString {
+        "\(url.path)#\(Int(maxPixel))" as NSString
+    }
+
+    /// Frees the preview bitmaps on dismiss; row tiles stay warm for a re-open.
+    static func purgePreviews() {
+        previewCache.removeAllObjects()
+    }
+
+    /// Cache-only, never touching disk, so a warm tile renders on the same frame.
+    static func cached(_ url: URL, maxPixel: CGFloat) -> NSImage? {
+        pick(maxPixel).object(forKey: cacheKey(url, maxPixel))
+    }
+
+    /// Returns the render directly, so an eviction mid-flight can't strand a placeholder.
+    static func loadAsync(_ url: URL, maxPixel: CGFloat) async -> NSImage? {
+        if let cached = cached(url, maxPixel: maxPixel) { return cached }
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let request = QLThumbnailGenerator.Request(
+            fileAt: url, size: CGSize(width: maxPixel, height: maxPixel), scale: 2,
+            representationTypes: .all)
+        let rendered = try? await QLThumbnailGenerator.shared.generateBestRepresentation(
+            for: request)
+        guard let cgImage = rendered?.cgImage else { return nil }
+        let image = NSImage(
+            cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        // Cost = the decoded bitmap's real byte footprint, so `totalCostLimit` bounds actual RAM.
+        pick(maxPixel).setObject(
+            image, forKey: cacheKey(url, maxPixel), cost: cgImage.bytesPerRow * cgImage.height)
+        return image
+    }
+}

--- a/Tinycast/Features/Clipboard/Service/Paster.swift
+++ b/Tinycast/Features/Clipboard/Service/Paster.swift
@@ -90,8 +90,9 @@ enum Paster {
 
     /// Whether anything was written; a vanished item leaves the pasteboard untouched.
     @MainActor @discardableResult
-    private static func write(_ item: ClipboardItem, store: ClipboardStore) -> Bool {
-        let pb = NSPasteboard.general
+    static func write(
+        _ item: ClipboardItem, store: ClipboardStore, to pb: NSPasteboard = .general
+    ) -> Bool {
         switch item.kind {
         case .text:
             guard let text = item.text else { return false }
@@ -105,6 +106,15 @@ enum Paster {
             pb.clearContents()
             pb.declareTypes([.png, ClipboardManager.internalType], owner: nil)
             pb.setData(data, forType: .png)
+        case .file:
+            guard let url = store.fileURL(for: item),
+                FileManager.default.fileExists(atPath: url.path)
+            else { return false }
+            pb.clearContents()
+            pb.declareTypes([.fileURL, .string, ClipboardManager.internalType], owner: nil)
+            pb.setData(url.dataRepresentation, forType: .fileURL)
+            // Both types: a file-taking app receives the file, a text field receives the path.
+            pb.setString(url.path, forType: .string)
         }
         pb.setData(Data(), forType: ClipboardManager.internalType)
         // The poller skips marked writes, so this is the only promotion point.

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -61,13 +61,23 @@ final class ClipboardCoordinator {
         // A write promotes the item, so follow it and keep the moved row highlighted.
         if Paster.paste(item, store: clipboardStore, previousApp: previous) {
             selectClip(item)
+        } else {
+            reportUnavailable(item)
         }
     }
 
     func pasteKeepingWindowOpen(_ item: ClipboardItem) {
         if windowController.pasteKeepingWindowOpen(item, store: clipboardStore) {
             selectClip(item)
+        } else {
+            reportUnavailable(item)
         }
+    }
+
+    /// A write only fails on a vanished file, and a palette that just closes explains nothing.
+    private func reportUnavailable(_ item: ClipboardItem) {
+        guard item.kind == .file else { return }
+        core.showMessage("That file has moved or been deleted.", tone: .danger)
     }
 
     /// Both the ⌃⇧X chord and the menu row land here, so neither can skip the confirmation.
@@ -92,6 +102,8 @@ final class ClipboardCoordinator {
         paletteCoordinator.hidePalette(restoreFocus: false)
         if Paster.copy(item, store: clipboardStore) {
             selectClip(item)
+        } else {
+            reportUnavailable(item)
         }
     }
 
@@ -101,10 +113,34 @@ final class ClipboardCoordinator {
         Paster.copyPlainText(format.string(for: color))
     }
 
-    func revealClipboardImage(_ item: ClipboardItem) {
-        guard let url = clipboardStore.imageURL(for: item) else { return }
+    func revealClip(_ item: ClipboardItem) {
+        guard let url = clipURL(for: item) else { return }
         paletteCoordinator.hidePalette(restoreFocus: false)
         AppLauncher.showInFinder(url)
+    }
+
+    func openClip(_ item: ClipboardItem) {
+        guard let url = clipURL(for: item) else { return }
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        AppLauncher.open(url)
+    }
+
+    /// Unmarked, so the path enters history like any other copy the reader meant to make.
+    func copyClipPath(_ item: ClipboardItem) {
+        guard let path = item.filePath else { return }
+        paletteCoordinator.hidePalette(restoreFocus: false)
+        Paster.copyPlainText(path)
+        core.showMessage("Copied path")
+    }
+
+    /// Nil once the file is gone, so every action reports rather than silently no-opping.
+    private func clipURL(for item: ClipboardItem) -> URL? {
+        let url = clipboardStore.imageURL(for: item) ?? clipboardStore.fileURL(for: item)
+        guard let url, FileManager.default.fileExists(atPath: url.path) else {
+            reportUnavailable(item)
+            return nil
+        }
+        return url
     }
 
     /// Pin or unpin an entry; the selection and scroll follow the row as it moves.

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -163,10 +163,20 @@ enum ClipboardActionsMenu {
                     core.clipboardCoordinator.togglePinnedClip(item)
                 })
         }
-        if item.kind == .image {
+        if item.kind == .image || item.kind == .file {
             items.append(
                 PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {
-                    core.clipboardCoordinator.revealClipboardImage(item)
+                    core.clipboardCoordinator.revealClip(item)
+                })
+        }
+        if item.kind == .file {
+            items.append(
+                PopoverMenuItem(title: "Open", systemImage: "arrow.up.forward.app") {
+                    core.clipboardCoordinator.openClip(item)
+                })
+            items.append(
+                PopoverMenuItem(title: "Copy Path", systemImage: "doc.on.clipboard") {
+                    core.clipboardCoordinator.copyClipPath(item)
                 })
         }
         items.append(
@@ -193,6 +203,7 @@ enum ClipboardActionsMenu {
                 separator: " ")
             return String(oneLine.prefix(40))
         case .image: return "Image"
+        case .file: return (item.filePath as NSString?)?.lastPathComponent ?? "File"
         }
     }
 }

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -164,6 +164,7 @@ private struct ClipboardRow: View {
             return String((item.text ?? "").prefix(200)).trimmingCharacters(
                 in: .whitespacesAndNewlines)
         case .image: return "Image"
+        case .file: return item.filePath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "File"
         }
     }
 
@@ -182,14 +183,31 @@ private struct ClipboardRow: View {
             AsyncThumbnail(url: imageURL, maxPixel: 64) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
                     .clipShape(
                         RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
             } placeholder: {
                 glyphTile("photo")
             }
+        case .file:
+            AsyncThumbnail(url: fileURL, maxPixel: 64, source: .file) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                    .clipShape(
+                        RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
+            } placeholder: {
+                glyphTile(fileKind.systemImage)
+            }
         }
+    }
+
+    private var fileURL: URL? { item.filePath.map { URL(fileURLWithPath: $0) } }
+
+    private var fileKind: ClipboardFileKind {
+        item.filePath.map { ClipboardFileKind.of(path: $0) } ?? .other
     }
 
     /// A symbol on a rounded tile, sized so text and image rows share one shape.
@@ -208,8 +226,29 @@ private struct ClipboardRow: View {
 
 /// A downsampled thumbnail, decoding misses off the main thread.
 private struct AsyncThumbnail<Content: View, Placeholder: View>: View {
+    /// ImageIO for a blob we hold; QuickLook for a referenced file, which may be any type.
+    enum Source {
+        case image
+        case file
+
+        func cached(_ url: URL, maxPixel: CGFloat) -> NSImage? {
+            switch self {
+            case .image: return ImageThumbnail.cached(url, maxPixel: maxPixel)
+            case .file: return FilePreviewThumbnailer.cached(url, maxPixel: maxPixel)
+            }
+        }
+
+        func loadAsync(_ url: URL, maxPixel: CGFloat) async -> NSImage? {
+            switch self {
+            case .image: return await ImageThumbnail.loadAsync(url, maxPixel: maxPixel)
+            case .file: return await FilePreviewThumbnailer.loadAsync(url, maxPixel: maxPixel)
+            }
+        }
+    }
+
     let url: URL?
     let maxPixel: CGFloat
+    var source: Source = .image
     @ViewBuilder let content: (Image) -> Content
     @ViewBuilder let placeholder: () -> Placeholder
 
@@ -228,12 +267,12 @@ private struct AsyncThumbnail<Content: View, Placeholder: View>: View {
                 image = nil
                 return
             }
-            if let hit = ImageThumbnail.cached(url, maxPixel: maxPixel) {
+            if let hit = source.cached(url, maxPixel: maxPixel) {
                 image = hit
                 return
             }
             image = nil  // show the placeholder while a new image decodes
-            image = await ImageThumbnail.loadAsync(url, maxPixel: maxPixel)
+            image = await source.loadAsync(url, maxPixel: maxPixel)
         }
     }
 }
@@ -276,7 +315,7 @@ struct ClipboardPreview: View {
             AsyncThumbnail(url: store.imageURL(for: item), maxPixel: Self.previewMaxPixel) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .clipShape(
                         RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
                     )
@@ -288,6 +327,8 @@ struct ClipboardPreview: View {
                 Image(systemName: "photo").font(.system(.largeTitle))
                     .symbolRenderingMode(.hierarchical).foregroundStyle(.tertiary)
             }
+        case .file:
+            if let path = item.filePath { FilePreviewStage(path: path) }
         }
     }
 }
@@ -304,6 +345,8 @@ private struct ClipboardInfoSection: View {
         var words: Int?
         var pixelSize: CGSize?
         var fileBytes: Int?
+        var typeName: String?
+        var fileExists = true
     }
 
     private struct InfoRow: Identifiable {
@@ -380,6 +423,18 @@ private struct ClipboardInfoSection: View {
                     InfoRow(
                         label: "Size", value: Int64(bytes).formatted(.byteCount(style: .file))))
             }
+        case .file:
+            let path = item.filePath ?? ""
+            rows.append(
+                InfoRow(
+                    label: "Type",
+                    value: details.typeName ?? ClipboardFileKind.of(path: path).title))
+            rows.append(InfoRow(label: "Path", value: (path as NSString).abbreviatingWithTildeInPath))
+            if let bytes = details.fileBytes {
+                rows.append(
+                    InfoRow(
+                        label: "Size", value: Int64(bytes).formatted(.byteCount(style: .file))))
+            }
         }
         rows.append(
             InfoRow(label: "Copied", value: Self.copiedFormatter.string(from: item.createdAt)))
@@ -396,8 +451,10 @@ private struct ClipboardInfoSection: View {
     }
 
     private func loadDetails() async {
-        let text = item.text
+        // Only a text entry: a file's `text` is its path, and counting its words says nothing.
+        let text = item.kind == .text ? item.text : nil
         let url = imageURL
+        let filePath = item.filePath
         details = await Task.detached(priority: .userInitiated) {
             var details = Details()
             if let text {
@@ -407,6 +464,13 @@ private struct ClipboardInfoSection: View {
             if let url {
                 details.pixelSize = ImageThumbnail.pixelSize(of: url)
                 details.fileBytes = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize
+            }
+            if let filePath {
+                let fileURL = URL(fileURLWithPath: filePath)
+                details.fileExists = FileManager.default.fileExists(atPath: filePath)
+                let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .contentTypeKey])
+                details.fileBytes = values?.fileSize
+                details.typeName = values?.contentType?.localizedDescription
             }
             return details
         }.value

--- a/Tinycast/Features/Clipboard/UI/FilePreviewStage.swift
+++ b/Tinycast/Features/Clipboard/UI/FilePreviewStage.swift
@@ -1,0 +1,158 @@
+import AVKit
+import SwiftUI
+
+/// The preview pane's stage for a referenced file: a poster frame, or a player for media.
+struct FilePreviewStage: View {
+    /// The pane is ~460pt wide, so 900px stays crisp at 2× without over-decoding.
+    private static let previewMaxPixel: CGFloat = 900
+
+    let path: String
+
+    private var url: URL { URL(fileURLWithPath: path) }
+    private var kind: ClipboardFileKind { ClipboardFileKind.of(path: path) }
+
+    var body: some View {
+        if !FileManager.default.fileExists(atPath: path) {
+            MissingFileStage()
+        } else if kind.isPlayable {
+            MediaPreviewPlayer(url: url, isAudio: kind == .audio)
+        } else {
+            FileThumbnailStage(url: url, maxPixel: Self.previewMaxPixel, glyph: kind.systemImage)
+        }
+    }
+}
+
+/// The recorded path is still the answer to "where was it?", so the row keeps it and says this.
+private struct MissingFileStage: View {
+    var body: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "doc.badge.exclamationmark")
+                .font(.system(.largeTitle))
+                .symbolRenderingMode(.hierarchical)
+            Text("File is no longer available")
+                .font(Theme.Typography.rowTrailing)
+        }
+        .foregroundStyle(.tertiary)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+/// A still, framed exactly as the image preview is, so every preview kind is one shape.
+private struct FileThumbnailStage: View {
+    let url: URL
+    let maxPixel: CGFloat
+    let glyph: String
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                            .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
+                    )
+            } else {
+                Image(systemName: glyph)
+                    .font(.system(.largeTitle))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .task(id: url) {
+            if let hit = FilePreviewThumbnailer.cached(url, maxPixel: maxPixel) {
+                image = hit
+                return
+            }
+            image = nil
+            image = await FilePreviewThumbnailer.loadAsync(url, maxPixel: maxPixel)
+        }
+    }
+}
+
+/// Owns the `AVPlayer`. Never autoplays: arrow-keying a list must not start twenty decodes.
+private struct MediaPreviewPlayer: View {
+    let url: URL
+    let isAudio: Bool
+
+    @Environment(PaletteState.self) private var palette
+    @State private var player: AVPlayer?
+
+    /// One key for both teardown triggers, so no `onChange` races the task.
+    private struct PlaybackKey: Equatable {
+        let url: URL
+        let isVisible: Bool
+    }
+
+    var body: some View {
+        PlayerSurface(player: player)
+            .background { if isAudio { AudioPoster(url: url) } }
+            .frame(height: Theme.Size.clipboardMediaHeight)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+            .task(id: PlaybackKey(url: url, isVisible: palette.isVisible)) {
+                stop()
+                guard palette.isVisible else { return }
+                player = AVPlayer(url: url)
+            }
+            .onDisappear(perform: stop)
+    }
+
+    /// Dropping the item too: a paused player still holds its asset reader and decoder open.
+    private func stop() {
+        player?.pause()
+        player?.replaceCurrentItem(with: nil)
+        player = nil
+    }
+}
+
+/// `AVPlayerView`, not SwiftUI's `VideoPlayer`: that one traps in `getSuperclassMetadata` while
+/// instantiating its generic metadata, taking the whole app down the moment a clip is selected.
+private struct PlayerSurface: NSViewRepresentable {
+    let player: AVPlayer?
+
+    func makeNSView(context: Context) -> AVPlayerView {
+        let view = AVPlayerView()
+        view.controlsStyle = .inline
+        view.showsFullScreenToggleButton = false
+        view.videoGravity = .resizeAspect
+        return view
+    }
+
+    func updateNSView(_ view: AVPlayerView, context: Context) {
+        guard view.player !== player else { return }
+        view.player = player
+    }
+
+    /// AppKit keeps decoding until the player is cleared, and dismantling is the last chance.
+    static func dismantleNSView(_ view: AVPlayerView, coordinator: ()) {
+        view.player?.pause()
+        view.player = nil
+    }
+}
+
+/// An audio asset draws nothing of its own, so its artwork sits behind the transport.
+private struct AudioPoster: View {
+    let url: URL
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image).resizable().scaledToFit()
+            } else {
+                Image(systemName: "waveform")
+                    .font(.system(.largeTitle))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .task(id: url) {
+            image = await FilePreviewThumbnailer.loadAsync(url, maxPixel: 300)
+        }
+    }
+}

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -11,6 +11,8 @@ final class PaletteState {
     var isComposing = false
     /// The clipboard screen's type filter, reset with the rest of the screen state on each summon.
     var clipboardFilter: ClipboardFilter = .all
+    /// Ordering out leaves the SwiftUI tree mounted, so a media preview needs this to stop playing.
+    private(set) var isVisible = false
     /// Changes every time the palette is shown so the search field can re-focus.
     var focusToken = UUID()
     /// Bumped only by `prepare`, so lists snap to the top even when nothing else changed.
@@ -43,6 +45,10 @@ final class PaletteState {
     @ObservationIgnored var menuOpen = false { didSet { onMenuOpenChanged?(menuOpen) } }
     /// Fired when `menuOpen` flips, so the panel can hide the caret without a focus swap.
     @ObservationIgnored var onMenuOpenChanged: ((Bool) -> Void)?
+
+    func noteVisible(_ visible: Bool) {
+        isVisible = visible
+    }
 
     func prepare(mode: PaletteMode) {
         self.mode = mode

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -58,6 +58,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 preferredInputSourceID: core.settings.autoSwitchInputSourceID)
             // Events go stale while the palette is closed, and the countdown only ticks while up.
             core.calendarCoordinator.paletteDidShow()
+            core.palette.noteVisible(true)
             // Non-activating, so summoning never raises our own aux windows behind it.
             panel.makeKeyAndOrderFront(nil)
             panel.orderFrontRegardless()
@@ -73,6 +74,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel?.orderOut(nil)
         core.inputSourceSwitcher.endSession()
         core.calendarCoordinator.paletteDidHide()
+        core.palette.noteVisible(false)
         // Drop the anchor, so the next summon re-resolves for the screen in use then.
         anchor = nil
         // The guides must never outlive the panel they point at.
@@ -80,6 +82,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         dropGuides.hide()
         // Drop the multi-MB preview bitmaps, so idle RAM returns near baseline.
         ImageThumbnail.purgePreviews()
+        FilePreviewThumbnailer.purgePreviews()
         IconCache.purgeFitted()
         schedulePopToRoot()
         guard restoreFocus else { return }
@@ -283,7 +286,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 self.core.paletteCoordinator.hidePalette()
                 return true
             case "v":
-                return self.core.palette.mode == .ai && self.core.aiChatCoordinator.attachPastedImage()
+                return self.core.palette.mode == .ai && self.core.aiChatCoordinator.attachPastedFile()
             default:
                 return false
             }

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -110,7 +110,8 @@ depends on neither, and Quick Actions carries its own route rather than borrowin
   one store where a delete alone frees pages without ever shrinking the file.
 - **Everything but the newest message is bounded.** `ChatSession.boundedContext` sends that message
   whole — truncating what someone just typed is worse than the provider's own error — keeps images
-  only on that turn and only up to `AIAttachmentBudget`, and walks older text newest-first into a
+  and documents only on that turn and only up to `AIAttachmentBudget`, inlining an attached text
+  file into that turn alone, and walks older text newest-first into a
   budget the *route* names: ~100 KB for a cloud endpoint, `AppleIntelligence.contextBudget` for the
   on-device model. Every transport funnels through `requestMessages(textBudget:)`, so no route can
   resend every image each turn or let history grow the payload as a chat goes on. The composer refuses a picture
@@ -324,19 +325,25 @@ model variant through `--variant`; it captures the returned session identifier, 
 `opencode session delete` after the process exits. Cancellation terminates the child process; only
 one installed-CLI turn can own a runner at a time.
 
-## Web search and images
+## Web search and attachments
 
-`AIRequest.webSearch` and `AIMessage.images` are provider-neutral; each route maps them itself:
+`AIRequest.webSearch`, `AIMessage.images` and `AIMessage.documents` are provider-neutral; each
+route maps them itself:
 
-| Route | Web search | Images | MCP tools |
-| --- | --- | --- | --- |
-| Apple Intelligence | never — it reaches nothing | never — the model is text-only | never |
-| Codex | thread-scoped `web_search` config | `image` input part | never — its tools are disabled by design |
-| Claude command | never | never | never |
-| OpenCode command | never | never | never |
-| OpenRouter | `plugins: [{id: "web"}]` — OpenRouter's own layer, any model | `image_url` part, only for models whose catalog lists the `image` modality | `tools` + `role: "tool"` turns |
-| OpenAI / Gemini / compatible | not offered | `image_url` part, assumed supported | `tools` + `role: "tool"` turns |
-| Anthropic | not offered | base64 `image` block | `tools` + `tool_use` / `tool_result` blocks |
+A text-ish file is deliberately absent from this table: it is inlined as text before any transport
+sees the turn, so every route — the on-device model and both CLIs included — takes one with no
+transport code at all.
+
+| Route | Web search | Images | PDFs | MCP tools |
+| --- | --- | --- | --- | --- |
+| Apple Intelligence | never — it reaches nothing | never — the model is text-only | never | never |
+| Codex | thread-scoped `web_search` config | `image` input part | never — the app-server takes no document part | never — its tools are disabled by design |
+| Claude command | never | never | never | never |
+| OpenCode command | never | never | never | never |
+| OpenRouter | `plugins: [{id: "web"}]` — OpenRouter's own layer, any model | `image_url` part, only for models whose catalog lists the `image` modality | never yet — its catalog publishes a `file` modality Tinycast does not read | `tools` + `role: "tool"` turns |
+| OpenAI | not offered | `image_url` part, assumed supported | `file` part with `filename` and a `file_data` data URL | `tools` + `role: "tool"` turns |
+| Gemini / compatible | not offered | `image_url` part, assumed supported | never — a gateway that has not implemented the part bills the upload before rejecting it | `tools` + `role: "tool"` turns |
+| Anthropic | not offered | base64 `image` block | base64 `document` block, ahead of the text block | `tools` + `tool_use` / `tool_result` blocks |
 
 A search is part of the reply, not a status: `item/started` for a `webSearch` item appends a
 `ChatSearch` to the streaming message pinned at the text length so far, `item/completed` (or the
@@ -356,11 +363,40 @@ doesn't simply returns the provider's error.
 Web search is a Settings → AI toggle, `aiWebSearch`, off by default: a prompt reaches a search engine
 only once the user has opted in.
 It's still excluded from backups — which Mac may send prompts to a search engine is that Mac's call.
-Nothing gates images: a model that takes them gets them, one that doesn't is never offered one.
+Nothing *guesses* at a capability: images ride on what the model's own catalog said, and a vendor
+API that does not take one simply returns its error. What is gated is only what a route provably
+cannot carry — a PDF to a text transport — refused at the composer with a HUD naming the reason.
+`AIModelCapabilities.documents` is true only for the two HTTP shapes whose bodies Tinycast writes;
+a gateway that has not implemented the `file` part would bill the upload before rejecting it, which
+is why documents are *not* assumed the way images are. An attachment is never dropped on the way
+out: answering a question about a document the model never received is the one outcome this must
+not produce.
 
-Attachments arrive by ⌘V. `PaletteWindowController`'s command-shortcut hook gives chat the chord
-first; a pasteboard holding an image file URL or a bare image (a screenshot) stages it as a
-`ChatAttachment`, while anything carrying text falls through to the field editor as a normal paste.
+Attachments arrive by ⌘V, in three kinds: an **image**, a **PDF** sent as a native document block,
+and a **text-ish file** whose contents are inlined as fenced, named text.
+`PaletteWindowController`'s command-shortcut hook gives chat the chord first; a pasteboard holding
+file URLs or a bare image (a screenshot) stages them, while anything else carrying text falls
+through to the field editor as a normal paste. **Only `isFileURL` URLs are read** — without that
+filter a copied `https://…/a.png` reaches `Data(contentsOf:)`, turning a keystroke into a network
+request. Every file is **sized before it is read**, so a huge CSV can never be slurped into memory.
+
+**A text file is inlined by `ChatSession.boundedContext`, never into `ChatMessage.text`.** That
+seam is load-bearing: `ChatSession.title` summarises the first user message, so folding a CSV into
+the stored text would make the dump the conversation's title in Chat History, its preview, and what
+the user bubble renders back. Inlining after the transcript and before the transport also means
+only the newest turn carries it, so a chat's payload cannot grow turn on turn. The block names the
+file and fences it with a run longer than any inside it, so a Markdown file holding its own fence
+cannot escape; a staged name is stripped of newlines and capped, so a file called
+`a\nAttached file: passwd` cannot forge a second header. Undecodable bytes are refused rather than
+guessed at, and a file past `AIAttachmentBudget.maxInlinedTextBytes` is refused rather than
+truncated — a silently truncated CSV is a lie the model then answers confidently.
+
+`AIAttachmentPolicy` is the one place deciding what may be attached and as what. It is pure and
+Foundation-only, so `ai-chat-test` pins it. It uses **extension allowlists rather than
+`UTType.conforms(to:)`**: a machine's installed apps declare types, so a conformance answer differs
+between two Macs and would make a harness machine-dependent — the exact environment coupling
+`Model/` exists to keep out. Adding a type is a one-line change; a type answer that differs per Mac
+is a bug you cannot reproduce.
 Images are re-encoded to PNG and bounded to 1568px on the long edge, off-main on a detached task so
 a display-sized screenshot does not decode on the keystroke; one past `AIAttachmentBudget` is refused
 with a HUD instead of being staged. Because that decode outlives the keystroke, it shares the staged
@@ -368,12 +404,21 @@ images' lifetime exactly: whatever consumes or clears them — a send, a new cha
 or leaving the conversation for another through history — disowns one still in flight and says so,
 rather than letting it surface on a later message. The counter that decides this sits on
 `AIChatState` beside the staged images, so a route that drops them cannot forget to move it. A
-staged image shows as a pill — a photo glyph plus file name, or "Image" for a screenshot; the row is
-too thin for a thumbnail to read — beside the typed text, through the same `headerAccessory` the
-launcher's argument fields use, so the field shrinks to its text and the chip
-follows it rather than the composer growing. Bare backspace on an empty composer removes the last
-chip before it backs out of chat; ⌘K → Remove Attachments clears them all. Sent images persist in
-`message_images` beside their message and render as thumbnails in the user bubble.
+staged attachment shows as a pill beside the typed text — an image carrying a small preview of
+itself, a PDF and a text file their own glyph, each followed by the file name, or "Image" for a
+screenshot. The preview is a ~1 KB PNG downsampled on the same detached task that encodes the
+attachment and carried on the staged attachment itself, so a header re-rendered per keystroke
+decodes nothing and there is no cache whose lifetime could drift from the staging counter's.
+`Theme.Size.chatAttachmentThumb` is *derived* from the glyph slot and the leading inset it gives
+up, so a preview pill measures exactly as a glyph pill does and `ComposerChip.width(of:)` — which
+`RootPaletteView.searchFieldWidth(for:)` subtracts from the search field — needs no second formula.
+Pills ride the same `headerAccessory` the launcher's argument fields use, so the field shrinks to
+its text and the chip follows it rather than the composer growing. Bare backspace on an empty composer removes the last
+chip before it backs out of chat; ⌘K → Remove Attachments clears them all. Sent images persist in `message_images` and sent PDFs in `message_documents` beside their message;
+the bubble renders images as thumbnails and documents as the same named chips the composer showed.
+A text file is already in the message's text and needs no table. The schema is
+`CREATE TABLE IF NOT EXISTS` re-applied on every open, so the table needed no migration, and its
+`ON DELETE CASCADE` leaves `prune` unchanged.
 
 The switcher's glyph comes from the selection. Codex uses OpenAI's mark; Claude and OpenCode use their
 own marks; an API model resolves through its connection. It never depends on `modelOptions`, which for

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -14,14 +14,38 @@
   captured rather than authored, and there is no UI for an unavailable clipboard — `QuicklinkStore`
   deliberately does the opposite. It is **not** a licence to treat the file as disposable: it lives in
   Application Support precisely because nothing else can put it back.
-- **A link or an address is derived from the text, never persisted.** `ClipboardItem.Kind` stays
-  `text`/`image` — the two things capture can tell apart — so improving the classifier is a code
-  change rather than a database migration plus a backfill.
+- **A link or an address is derived from the text, never persisted.** `ClipboardItem.Kind` holds
+  only what capture can tell apart on the pasteboard — `text`, `image`, `file` — so improving the
+  *classifier* stays a code change rather than a database migration plus a backfill, while a new
+  kind needs a new pasteboard type to justify it. `textForm` is nil for anything but `.text`, which
+  is what keeps a path shaped like `apple.com/report.pdf` out of the links.
+- **A `.file` entry references the file where it lies and never copies it.** Its absolute path is
+  the `text` column, so the trigram index finds it by name or by folder for free, and `imagePath`
+  stays nil — which is what keeps `prune`, `deleteBlob` and `owns` from ever reaching a file
+  Tinycast did not write. `kind` is a plain `TEXT` column, so the case cost no migration; an older
+  build simply fails to decode the row.
 - **A colour is parsed from the text on demand, never stored.** `ColorValue` is the single parser
   behind the clipboard's swatches and the launcher's colour card, so the two can never disagree
   about what counts as a colour or what it converts to.
 
 ## Poll-based capture
+
+**A file URL is read before the text**, because that is the whole of the bug this ordering fixes:
+Finder puts the file's *display name* on `public.utf8-plain-string` beside `public.file-url`, so a
+text-first poller records `IMG_1234.png` as prose. The read sits after the `internalType` and
+sensitive-type guards, which stay unconditional — a secret must never be recorded whatever shape it
+arrives in. A bare screenshot carries no file URL and still falls through to the `.png`/`.tiff`
+branch untouched.
+
+`ClipboardManager.fileURLs(on:volatileRoots:)` takes both the pasteboard and the roots as
+parameters, so `pasteboard-test` can drive an `NSPasteboard.withUniqueName()` and its own scratch
+tree: a harness that touched `NSPasteboard.general` would land in the reader's own running Tinycast
+as a genuine copy. It reads with `urlReadingFileURLsOnly`, so a copied `http` URL stays a link;
+returns nil rather than an empty array, so the text branch runs; caps a batch at
+`maxCapturedFiles`, so a Finder select-all cannot insert ten thousand rows on one tick; and
+**rejects a file under a volatile root** (`/tmp`, `/var/folders`, `~/Library/Caches`), because an
+app that stages a temp export beside better inline content must keep the inline content. Paths come
+back reversed so the *first* file copied ends up leading the history.
 
 `ClipboardManager` runs a 0.5s `Timer` watching `NSPasteboard.general.changeCount`. To avoid
 re-capturing Tinycast's own writes, every write stamps a private `internalType` marker on the
@@ -94,7 +118,7 @@ menu opens highlighting the *active* filter rather than the first row, the way a
 The filter is not gated on the list having rows: an over-narrow filter empties it, and the button is
 the way back out.
 
-`ClipboardFilter` owns the six cases and everything the UI needs from them — title, glyph, and the
+`ClipboardFilter` owns the seven cases and everything the UI needs from them — title, glyph, and the
 `emptyMessage` that stops "Clipboard history is empty" from appearing over a history that only looks
 empty. The cases are **exclusive**: a copied URL is a link, not a narrower kind of text, so *Text
 Only* means prose, and *Colors Only* takes `#FF5733` out of it.
@@ -212,3 +236,43 @@ partial index on `pinned_at` (`Tests/clipboard-test.swift` covers the shape). Th
 `pinned_at IS NOT NULL OR rowid >= ?` form reads better but cannot be driven from an index while
 holding row order, so it scans the whole table — ~12ms against ~1ms at 200k rows, on the main actor
 at launch.
+
+## Referenced files
+
+A file copied in Finder is recorded as a reference, never as a copy: Tinycast writes nothing to
+disk for it, and the row's path points at the original wherever it lies. That is the whole reason
+`imagePath` stays nil for a `.file` row — `owns()` is the one ownership rule, and a path it never
+sees can never be deleted by `deleteBlob` or a retention cut. `clipboard-test`'s
+`referencedFilesOutliveTheirRows` is the case that pins it, across `remove`, a retention cut and
+Clear History alike.
+
+**Pasting writes two flavours.** `public.file-url` so Finder, Mail and anything file-taking receive
+the *file*, and `.string` carrying the **path** — deliberately not Finder's own choice of the name,
+because a text field or Terminal almost always wants a path, a name is recoverable from a path and
+a path is not recoverable from a name. "A name arrived where a file was meant" is the bug being
+fixed, so it must not be reintroduced on the way out.
+
+**A vanished file is reported, never silently swallowed and never auto-deleted.** `Paster.write`
+returns false, the coordinator raises a HUD, and the row survives — history is a record of what
+happened, and the recorded path is still the answer to "where was it?". The preview says so in
+place, and the Path row keeps showing where the file used to be.
+
+`FilePreviewThumbnailer` is the row tile and the preview still. `QLThumbnailGenerator` is the only
+thing that renders a *content* thumbnail for any type — a video's poster frame, a PDF's first page
+— and with `representationTypes: .all` it falls back to the type icon itself, so every file paints
+something through one path. It copies `ImageThumbnail`'s shape exactly: two byte-bounded caches
+split at 128px, cost measured as the real bitmap footprint, and `purgePreviews()` called from
+`PaletteWindowController.hide()` beside the other two.
+
+**The player's teardown is the part with a lifetime to get wrong.** `orderOut` leaves the SwiftUI
+tree mounted, so `onDisappear` never fires on hide — which is exactly why `hide()` already has to
+purge caches by hand. `PaletteState.isVisible` is therefore the second half of the player's
+`.task(id:)` key, alongside the URL, so one mechanism covers both teardown triggers with no
+`onChange` racing it. Teardown calls `replaceCurrentItem(with: nil)` and not merely `pause()`: a
+paused `AVPlayer` still holds its asset reader and decoder open, which is how a 100 MB budget goes.
+Nothing ever autoplays — arrow-keying a list of twenty videos must not start twenty decodes.
+
+**A backup carries the path, never the bytes.** `BackupClipboardItem.file` exports `text` and no
+blob, a file already gone at export time is counted missing, and a restore drops a row whose path
+does not exist on this Mac — the same thing the Raycast import already does for an image path.
+Carrying file bytes would make a backup unbounded and defeat the point of referencing in place.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,7 +57,12 @@ is the trap: a running Tinycast records every write to it as a genuine copy, so 
 lands in clipboard history looking like something the user copied. `notes-editor-test` seeded one on
 every run from #232 onward by calling the native `copy:`/`cut:`/`paste:` actions; it now drives the
 `writeSelection(to:types:)` and `readSelection(from:)` primitives those actions delegate to, against
-`NSPasteboard.withUniqueName()`. Same AppKit path, no shared side effect.
+`NSPasteboard.withUniqueName()`. Same AppKit path, no shared side effect. `pasteboard-test` is the
+second case, and it is why `ClipboardManager.fileURLs(on:volatileRoots:)` and `Paster.write(_:store:to:)`
+each take the thing they act on as a parameter: a seam that exists so the harness never has to reach
+for the shared board. Its scratch tree lives under `temporaryDirectory`, which is itself a volatile
+root, so the cases about *reading* files inject an empty root list and the one case about durability
+is the one that runs against the shipped roots.
 
 Never join a compile to its run with `&&` in a `set -e` script. `set -e` is specified to ignore a
 failing command in a non-final AND-OR list member, so `swiftc … && /tmp/x` swallows a compile error and
@@ -79,7 +84,8 @@ If a change touches anything in the right column, the harness on the left is man
 | `app-name-test` | `Platform/AppDisplayName.swift` — every path that names a scanned bundle |
 | `calc-test` | all of `Calculator/Model/` |
 | `calendar-test` | all of `Calendar/Model/` — link detection, the join window, the day buckets |
-| `clipboard-test` | `Clipboard/Model/ClipboardStore.swift` |
+| `clipboard-test` | `Clipboard/Model/ClipboardStore.swift`, `ClipboardFilter.swift`, `ClipboardFileKind.swift`, the colour trio |
+| `pasteboard-test` | `Clipboard/Service/ClipboardManager.swift` capture and `Paster.write` — what a Finder copy reads as, and what a file entry writes back |
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
 | `palette-placement-test` | `DesignSystem/Theme.swift`, `Palette/PalettePlacement.swift` |


### PR DESCRIPTION
## Related issue

Closes #445

## What changed

Copying anything from Finder landed in history as a **text row holding the file's name**. `ClipboardManager.poll()` read `pb.string(forType: .string)` first and returned, and Finder puts the display name on `public.utf8-plain-string` beside `public.file-url`. Nothing in the repo ever read the file URL, and `Paster.write` only ever put `.string` or `.png` on the board — so even a correctly captured file could not paste back as one.

A file is now **referenced where it lies, never copied**.

- `ClipboardItem.Kind` gains `.file`, with the absolute path in the existing `text` column. `kind` is a plain `TEXT` column, so there is **no migration** — and filename *and folder* search come free, since `text` is what the trigram index reads.
- `imagePath` stays nil for a file row. That is structural, not cosmetic: it is what keeps `prune`, `deleteBlob` and `owns` from ever reaching a file Tinycast did not write.
- Capture reads file URLs **ahead of** the text branch, still behind the unconditional sensitive-type guard. It rejects **volatile roots** (`/tmp`, `/var/folders`, `~/Library/Caches`) so an app staging a temp export beside better inline content keeps the inline content, caps a batch at 32, and reverses so the first file copied leads the history.
- Pasting writes `public.file-url` **and** the path as `.string`: Finder and Mail receive the file, a text field receives the path. Deliberately the path, not Finder's own choice of the name — "a name arrived where a file was meant" is the bug being fixed.
- QuickLook (`representationTypes: .all`) renders the row tile and the preview, so every type paints something through one path and falls back to its icon. Video and audio play inline. Information gains **Path**, plus Type/Size/Duration; ⌘K gains Open, Show in Finder and Copy Path; the type filter gains **Files Only**.
- A vanished file is **reported and never auto-deleted** — history records what happened, and the path is still the answer to "where was it?".

AI chat gains the same shape: composer pills lead with a real thumbnail of the image, PDFs go out as native `document` / `file` blocks, and text files are **inlined as fenced, named text** so every route takes one — including Apple Intelligence and both CLIs, with no transport code.

Inlining happens in `ChatSession.boundedContext`, **not** in `ChatMessage.text`. That seam is load-bearing: `ChatSession.title` summarises the first user message, so folding a CSV into the stored text would make the dump the conversation's title in Chat History, its preview, and what the user bubble renders back.

### Three defects found on the way, all fixed

1. **`pastedImageFile` had no `isFileURL` check** — it filtered pasted URLs by extension alone, then `Data(contentsOf:)` read them. Copying a link ending in `.png` and pressing ⌘V fired a **network request from a keystroke**. Widening the set to PDFs and text would have multiplied it. Files are also sized before they are read now, so a huge CSV cannot be slurped into memory.
2. **`importKey` hashed `imagePath` for anything non-text**, so every file row would have collided into a single row on restore.
3. **`BackupComposer` exported any non-image kind as `.text`** via a ternary, silently turning file rows into prose.

## Memory footprint

Not measured this round — no profiling run, so these are left honest rather than invented.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no. What the design does instead, and what to check if this matters:

- `FilePreviewThumbnailer` copies `ImageThumbnail`'s shape exactly — two byte-bounded `NSCache`s split at 128px, cost measured as the real bitmap footprint, and `purgePreviews()` wired into `PaletteWindowController.hide()` beside the existing two.
- The player's teardown calls `replaceCurrentItem(with: nil)`, not merely `pause()`: a paused `AVPlayer` still holds its asset reader and decoder open, which is exactly how a 100 MB budget goes. `dismantleNSView` clears it again as a backstop.
- `orderOut` leaves the SwiftUI tree mounted, so `onDisappear` never fires on hide — which is why `hide()` already purges caches by hand. `PaletteState.isVisible` is therefore the second half of the player's `.task(id:)` key, so one mechanism covers both teardown triggers.
- Composer pill previews are ~1 KB PNGs encoded on the staging task and carried on the attachment, so there is no new cache whose lifetime could drift from `stagingGeneration`.

## Demo

Not attached. Worth recording before merge — the video preview and the composer pill are both visual.

## Drawbacks

- **Any pasteboard carrying a file URL now becomes file entries, ahead of its text.** Finder is overwhelmingly the producer and an app writing a file URL is saying "this is a file", so this is the right default — but an app that writes one *beside* text you actually wanted would now file it as a file. The volatile-root filter covers the temp-export cases I can name. If a real case turns up, the narrowing rule is to take the file branch only when the string is absent or equals the file's name or path; I deliberately did not add that guard pre-emptively, since it is a heuristic with its own failure mode.
- **An image file copied from Finder is a `.file`, not an `.image`,** so *Images Only* no longer catches it. `.image` means Tinycast holds the bytes and owns a blob that pruning deletes; a Finder copy owns nothing and must paste back as a file. Keeping them apart is what lets `owns()` stay the whole ownership rule.
- **A backup carries a file's path, never its bytes** — so an export stays small, but restoring on another Mac drops those rows. Carrying bytes would make a backup unbounded and defeat referencing in place.
- **Documents are gated per route, unlike images.** An unsupported image costs one cheap 400; a base64-expanded PDF to a gateway that never implemented the `file` part costs the upload first, so `AIModelCapabilities.documents` is true only for the two HTTP shapes whose bodies we write. A PDF is refused at paste time with a HUD naming the reason, never dropped on the way out.
- **`AVPlayerView` behind `NSViewRepresentable` instead of SwiftUI's `VideoPlayer`.** `VideoPlayer` traps in `getSuperclassMetadata` while instantiating its generic metadata and takes the app down the moment a clip is selected — I hit it and read it off a `sample`. This is one place where "prefer the modern Apple API" loses to the API being broken; the reason is in a comment so nobody migrates it back.
- `AIAttachmentPolicy` uses extension allowlists rather than `UTType.conforms(to:)`, because a machine's installed apps declare types — a conformance answer differs between two Macs and would make a harness machine-dependent.

## Tests & validation

`./Scripts/run-tests.sh` — all 56 harnesses pass. `./Scripts/lint.sh` clean; the `Model/` purity grep returns nothing; Debug **and** Release build with no new warnings (lint warnings went 54 → 50).

New harness **`pasteboard-test`**, driving `NSPasteboard.withUniqueName()` throughout — `NSPasteboard.general` would land in the reader's own running Tinycast as a genuine copy. It pins the reported bug directly (a Finder-shaped board reads as a path, never as its name), plus multi-file order, the `http`-stays-a-link case, volatile and missing files, the batch cap, and the write round trip.

Added to `clipboard-test`: file rows found by name and folder, `ClipboardFileKind` classification, a file path never reading as a link or colour, one row per file — and `referencedFilesOutliveTheirRows`, the case that matters most, asserting a referenced file survives `remove`, a retention cut and Clear History.

Added to `ai-chat-test` and `ai-provider-test`: the joint attachment budget, the policy's classification, fence and name sanitising, that an attached CSV never reaches `ChatMessage.text`, and both wire shapes pinned as request bodies — Anthropic's `[image, document, text]` ordering with newline-free base64, OpenAI's `file` part, and a document-only turn not collapsing to the plain-string fast path.

**By hand:** confirmed the `VideoPlayer` crash from a process `sample`, and that the `AVPlayerView` build launches clean. Still worth exercising before merge: copying several files at once, pasting a file row into Finder vs a text field, moving a source file and reopening the row, arrow-keying past several video rows to confirm playback stops and stays quiet, and pasting a PDF on an Anthropic model vs Apple Intelligence.
