### PR TITLE
Let the notes hotkey put the panel away again

### DIFF
--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -157,7 +157,7 @@ final class LauncherCoordinator {
             calendarCoordinator.createEvent()
         case .showNotes:
             dismissPalette()
-            notesCoordinator.show()
+            notesCoordinator.toggle()
         case .createNote:
             dismissPalette()
             notesCoordinator.createNote()

--- a/Tinycast/Features/Notes/UI/NotesCoordinator.swift
+++ b/Tinycast/Features/Notes/UI/NotesCoordinator.swift
@@ -103,8 +103,13 @@ final class NotesCoordinator {
         await store.flush()
     }
 
-    func show() {
-        request(.editor)
+    /// The command is a toggle, like every other surface: a second press puts the panel away.
+    func toggle() {
+        if windowController.isVisible {
+            hide()
+        } else {
+            request(.editor)
+        }
     }
 
     func createNote() {

--- a/docs/features/notes.md
+++ b/docs/features/notes.md
@@ -82,7 +82,7 @@ failed flush retains the draft for retry.
 
 ## Commands, switcher, and window
 
-- **Show Notes** selects the last active note and shows or focuses the panel without toggling it closed.
+- **Show Notes** toggles the panel: it selects the last active note and shows it, or hides a visible one.
 - **Create Note** creates and selects one unique Untitled note, including from an empty channel.
 - **Search Notes** shows the same panel with the switcher open and its search field focused.
 


### PR DESCRIPTION
## Related issue

Closes #455

## What changed

`NotesCoordinator.show()` became `toggle()`: with the note panel already on screen the command hides it, otherwise it opens as before. Hiding runs through the existing `hide()`, so the switcher closes, pending presentation work is retired and the draft is flushed — the same path Escape and ⌘W already take.

The `.showNotes` case in `LauncherCoordinator.runCommand` is the only caller, so the global hotkey and the palette row share the behaviour.

Non-obvious: `NotesPanel` is a floating panel, so a visible panel is always on top of whatever the user is in. A press from another app therefore hides it rather than focusing it — the same rule the clipboard palette follows.

## Memory footprint

Not measured; the change adds no state, no allocation and no new window — one branch in an existing command.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no — no new ownership, tasks or observers.

## Demo

No visual change: the panel that appears and the panel that hides are the ones already shipped.

## Drawbacks

The palette row is still labelled **Show Notes** while it can now hide. Running it from the palette with the panel visible behind hides the panel, which reads oddly for a row named "Show" — the hotkey is the path the issue asks about, and splitting the row from the shortcut would give one command two meanings.

## Tests & validation

`./Scripts/run-tests.sh` — all 56 harnesses pass. `./Scripts/lint.sh` clean, Debug build with no new warnings. By hand: hotkey opens, hotkey hides, hotkey re-opens the same note; hide with the switcher open closes both; Escape and ⌘W unchanged.