### PR TITLE
Stop a fruitless settings search from collapsing the window

### DIFF
--- a/Tinycast/Features/Settings/SettingsSidebarView.swift
+++ b/Tinycast/Features/Settings/SettingsSidebarView.swift
@@ -41,7 +41,9 @@ struct SettingsSidebarView: View {
 
     @ViewBuilder private var found: some View {
         if results.isEmpty {
+            // Greedy: a finite max height here becomes a constraint that shrinks the whole window.
             ContentUnavailableView.search(text: query)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             // A second `List`, so result IDs and `SettingsTab` never share a selection namespace.
             List(selection: $highlighted) {


### PR DESCRIPTION
## Related issue

Closes #457

## What changed

Searching Settings for something with no matches shrank the window to a third of
its height, and the edge could not be dragged back out until the query was
cleared.

`NSHostingController` defaults to sizing options that include `.maxSize`, so the
hosted column's largest sensible height becomes a *required* constraint on the
split view, and through it on the window. Every other sidebar state is a `List`,
which is greedy and so has no finite maximum. `ContentUnavailableView` is not,
and it was the one view that pinned the window to its own ideal height — which
is also why the window would not grow again while the query stood.

The empty state now fills the column, the way `SettingsDetailView`'s root
already does, leaving the sidebar greedy in all three of its states. One line.

Measured on a standalone probe that mirrors the split controller — a fixed 215pt
sidebar item, a 420pt-minimum detail item, and a window opened at 860×700:

| | on the empty state | after a regrow to 1100×900 |
| --- | --- | --- |
| before | 860×**261** | 1100×**195** |
| after | 860×700 | 1100×900 |

The "before" row is the report exactly: it collapses, and asking for more height
gives less. Note that `contentMinSize` stayed 860×700 throughout — the content
constraint outranks it, so the window's own minimum never entered into it.

## Memory footprint

Not measured. A layout modifier on a view that already exists allocates nothing
new and creates no ownership, so there is nothing here that a profile would
speak to.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — no new object, task, observer or timer.

## Demo

No before/after recording. The regression is a window *size*, so the numbers in
the table above are the measurement a side-by-side clip would be showing, taken
under identical conditions. Flagging it rather than posting an "after"-only clip
that would not count.

## Drawbacks

The trap itself is still there: any future sidebar content that is not
vertically greedy will shrink the window the same way, and nothing warns you.
`SettingsSplitViewController` could neutralise the whole class by setting
`sizingOptions = []` on both hosting controllers — which is what
`AppWindowController` already does on its own SwiftUI path, for this exact
reason ("Keep the window's size authoritative"), and that asymmetry is what let
the bug exist. I left it out because it would also mask a future layout mistake
as silent clipping instead of a visible wrong size, and because the diff belongs
at the defect. Worth deciding separately.

This is the only `ContentUnavailableView` in the app, so no other surface
carries the bug today.

## Tests & validation

- `./Scripts/run-tests.sh` — all 56 harnesses pass.
- Debug build via `xcodebuild`, no new warnings.
- `./Scripts/lint.sh` clean.
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` returns nothing.
- The probe above, run against both variants, which is where the numbers come from.

No harness added: `Tests/` compiles model sources and cannot import SwiftUI, so
a hosting-controller constraint is out of its reach by design.
