### PR TITLE
Find an app by its Chinese name, not only its English one

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -101,7 +101,9 @@ run file-search-session-test Tinycast/Platform/Signposts.swift \
                              Tinycast/Features/FileSearch/Service/*.swift
 run ranking-test           $L/SearchRelevance.swift $L/LauncherRankingStore.swift
 run scopes-test            $L/SearchScopes.swift
-run app-name-test          Tinycast/Platform/AppDisplayName.swift
+run app-name-test          Tinycast/Platform/AppDisplayName.swift \
+                           Tinycast/Platform/BundleLocalization.swift \
+                           $L/SearchRelevance.swift
 run favorites-test         $L/FavoriteSlots.swift
 run calc-test              Tinycast/Features/Calculator/Model/*.swift
 run calendar-test          Tinycast/Features/Calendar/Model/*.swift

--- a/Tests/app-name-test.swift
+++ b/Tests/app-name-test.swift
@@ -92,6 +92,52 @@ struct AppNameTest {
             "two blank keys still fall back to the filename",
             blankBoth?.installedAppName == "Ghost")
 
+        func codes(_ preferred: [String]) -> [String] {
+            BundleLocalization.indexedLanguages(preferred)
+        }
+        check(
+            "a Simplified Chinese Mac looks up the zh_CN Apple actually keys by",
+            codes(["zh-Hans-CN"]).contains("zh_CN"))
+        check(
+            "a script-only tag maximizes to reach the same key",
+            codes(["zh-Hans"]).contains("zh_CN"))
+        check(
+            "Traditional Chinese resolves to its own region, not the mainland's",
+            codes(["zh-Hant-TW"]).contains("zh_TW") && !codes(["zh-Hant-TW"]).contains("zh_CN"))
+        check(
+            "English stays last so a Chinese reader still types \"Calendar\"",
+            codes(["zh-Hans-CN"]).last == "en")
+        check(
+            "a tag carrying no script is left exactly as it was",
+            codes(["pt-BR"]) == ["pt-BR", "pt_BR", "pt", "en"])
+
+        /// The whole path: a bundle translated only in its loctable, read as the scan reads it.
+        func makeLocalizedApp(_ fileName: String, table: [String: Any]) -> URL {
+            let url = root.appendingPathComponent(fileName)
+            let resources = url.appendingPathComponent("Contents/Resources")
+            try? fm.createDirectory(at: resources, withIntermediateDirectories: true)
+            let data = try? PropertyListSerialization.data(
+                fromPropertyList: table, format: .xml, options: 0)
+            try? data?.write(to: resources.appendingPathComponent("InfoPlist.loctable"))
+            return url
+        }
+
+        let monitor = makeLocalizedApp(
+            "Activity Monitor.app",
+            table: [
+                "zh_CN": ["CFBundleName": "活动监视器"],
+                "zh_TW": ["CFBundleName": "活動監視器"],
+                "en": ["CFBundleName": "Activity Monitor"]
+            ])
+        check(
+            "a loctable app is found by its Chinese name, English still indexed",
+            BundleLocalization.names(for: monitor, languages: codes(["zh-Hans-CN"]))
+                == ["活动监视器", "Activity Monitor"])
+        check(
+            "an English Mac indexes only the English name",
+            BundleLocalization.names(for: monitor, languages: codes(["en-US"]))
+                == ["Activity Monitor"])
+
         try? fm.removeItem(at: root)
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)

--- a/Tinycast/Platform/BundleLocalization.swift
+++ b/Tinycast/Platform/BundleLocalization.swift
@@ -7,14 +7,30 @@ enum BundleLocalization {
         var codes: [String] = []
         var seen = Set<String>()
         for tag in preferred + ["en"] {
-            // loctable keys and .lproj folders both use underscores where a language tag uses "-".
-            let underscored = tag.replacingOccurrences(of: "-", with: "_")
             let bare = tag.split(separator: "-").first.map(String.init) ?? tag
-            for code in [tag, underscored, bare] where !code.isEmpty && seen.insert(code).inserted {
-                codes.append(code)
+            for form in [tag, regionForm(tag), bare].compactMap({ $0 }) {
+                // loctable keys and .lproj folders use underscores where a language tag uses "-".
+                let underscored = form.replacingOccurrences(of: "-", with: "_")
+                for code in [form, underscored]
+                where !code.isEmpty && seen.insert(code).inserted {
+                    codes.append(code)
+                }
             }
         }
         return codes
+    }
+
+    /// Apple keys a script-bearing tag by region alone, so a `zh-Hans-CN` Mac wants `zh_CN`.
+    private static func regionForm(_ tag: String) -> String? {
+        let subtags = tag.split(separator: "-")
+        guard subtags.contains(where: { $0.count == 4 && $0.allSatisfy(\.isLetter) })
+        else { return nil }
+        let language = Locale.Language(identifier: tag)
+        guard let code = language.languageCode?.identifier,
+            let region = language.region
+                ?? Locale.Language(identifier: language.maximalIdentifier).region
+        else { return nil }
+        return "\(code)-\(region.identifier)"
     }
 
     /// Every localized name the bundle carries, most preferred language first.


### PR DESCRIPTION
## Related issue

Closes #463

## What changed

`BundleLocalization.indexedLanguages` expanded a preferred language tag into three
candidates: the tag, its underscored spelling and its bare language. That set never
reaches Chinese. macOS reports `zh-Hans-CN`, but Apple keys both `InfoPlist.loctable`
and the `.lproj` folder as `zh_CN` — the script rides in the tag and the region rides
in the key, so `zh-Hans-CN`, `zh_Hans_CN` and `zh` all miss. A Simplified Chinese Mac
indexed only the English name, and 活动监视器 found nothing.

It now derives the region-only form too. The non-obvious part is the gate: it fires
only when the tag literally carries a four-letter script subtag, so `fr`, `pt-BR` and
`en-US` emit byte-identical code lists and pay nothing. A script-bearing tag with no
region (`zh-Hans`) maximizes to recover one. `sr-Latn-RS` picks up `sr_RS` for free.

English still lands last, so a Chinese reader who types "Calendar" still finds it.

This is only the app-name half of the issue. **Simplified Chinese localization of
Tinycast's own interface is not in scope here and is not planned for now** — there is
no string catalog in the project and every string is a Swift literal, so that is a
separate piece of work rather than a follow-on to this one.

Worth knowing for triage: on a Chinese Mac the launcher probably already finds 微信
today, because `SpotlightNames` reads `kMDItemDisplayName`, which macOS resolves to
the current locale. This fix repairs the loctable path, which exists precisely so
localized search does not depend on Spotlight having indexed the bundle.

## Memory footprint

Not measured. The change is a pure `[String] -> [String]` function that adds at most
two short strings to a per-scan array; it allocates nothing new that outlives the
scan, holds no state and touches no long-lived object graph, so there is no plausible
footprint or leak surface to report. Claiming figures here would be inventing them.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no — nothing retained.

## Drawbacks

A Chinese Mac now probes six language codes per uncached bundle instead of four, so a
cold scan makes two extra `InfoPlist.strings` reads per app against the ~0.2 ms
budget `BundleNameCache` documents. That is the cost of not depending on Spotlight,
and it is confined to users whose tag carries a script — everyone else is unchanged.

The script gate is a subtag-shape test rather than a full BCP 47 parse. That is
deliberate: it keeps a malformed tag from silently acquiring a region it never asked
for, at the price of ignoring exotic spellings no macOS locale produces.

I could not exercise this on a machine actually set to Simplified Chinese — this Mac
is `en-US`, so the language plumbing is covered by passing tags explicitly rather than
by reading real `Locale.preferredLanguages`.

## Tests & validation

`./Scripts/run-tests.sh` — all 56 harnesses pass. Debug build succeeds with no new
warnings; `./Scripts/lint.sh` is clean and flags nothing in the touched files.

`app-name-test` now compiles `BundleLocalization.swift` and `SearchRelevance.swift`
and gains six cases: `zh_CN` reached from `zh-Hans-CN` and from a region-less
`zh-Hans`, `zh-Hant-TW` resolving to `zh_TW` and *not* `zh_CN`, English staying last,
`pt-BR` unchanged, and an end-to-end fixture bundle translated only in its loctable
that resolves to `["活动监视器", "Activity Monitor"]` for a Chinese Mac and to
`["Activity Monitor"]` for an English one.

I checked these tests actually bite: compiled against `HEAD`'s `BundleLocalization.swift`,
four of them fail; against the new one, all pass. By hand, I read the real
`/System/Applications/Utilities/Activity Monitor.app` loctable and confirmed the new
code list resolves 活动监视器 (`zh_CN`), 活動監視器 (`zh_TW`, `zh_HK`) where the old
list matched nothing but `en`.
