### PR TITLE
Stop the Hyper key from announcing itself as fn

### DIFF
--- a/Tinycast/Features/HotKeys/Service/HyperKeyTap.swift
+++ b/Tinycast/Features/HotKeys/Service/HyperKeyTap.swift
@@ -207,6 +207,9 @@ final class HyperKeyTap: HealthCheckable {
         }
     }
 
+    /// F18 carries fn like any function key, and a `flagsChanged` saying so reads as a real fn press.
+    private static let functionKeyFlagRaw = CGEventFlags.maskSecondaryFn.rawValue
+
     private func hyperized(_ flagsRaw: UInt64) -> UInt64 {
         (flagsRaw & ~strippedFlagsRaw) | hyperFlagsRaw
     }
@@ -236,6 +239,7 @@ final class HyperKeyTap: HealthCheckable {
     ) -> Decision {
         if key.tapUsesKeyEvents {
             // F18 arrives as keyDown/keyUp; convert both ends into flagsChanged transitions.
+            let flagsRaw = flagsRaw & ~Self.functionKeyFlagRaw
             switch type {
             case .keyDown:
                 if isAutorepeat { return .suppress }

--- a/docs/features/hotkeys.md
+++ b/docs/features/hotkeys.md
@@ -144,9 +144,13 @@ window — that is un-remapped HID behaviour, not something Tinycast can stop.
 
 Once remapped, Caps Lock arrives as **keyDown/keyUp** rather than `flagsChanged`. Both ends are
 converted into Left Control `flagsChanged` transitions, so everything downstream sees the Hyper chord
-move with the key rather than a swallowed press. A classic `IOHIDSystem` connection reads and drives
-the Caps Lock LED and lock state; it is used only by the explicit Quick Press toggle and the one-time
-unlatch when the remap is installed.
+move with the key rather than a swallowed press. That conversion is also why the **fn bit is scrubbed
+from both ends**: every function key reports `NX_SECONDARYFNMASK`, harmless on a keyDown but read as a
+real fn press once the event is a `flagsChanged`, which fired anything bound to fn on every Hyper
+press. Only the Hyper key's own two events are scrubbed, so Hyper+F-key and Hyper+arrow keep the fn
+bit they are entitled to. A classic `IOHIDSystem` connection reads and drives the Caps Lock LED and
+lock state; it is used only by the explicit Quick Press toggle and the one-time unlatch when the remap
+is installed.
 
 ### Press tracking uses toggle semantics
 


### PR DESCRIPTION
## Related issue

Closes #447

## What changed

While Caps Lock serves as Hyper it is HID-remapped to F18, and the tap converts the
F18 `keyDown`/`keyUp` into Left Control `flagsChanged` transitions so downstream sees
the chord move with the key. That conversion was passing the event's own flags
through untouched — and a real F18 press carries `NX_SECONDARYFNMASK`, because macOS
sets it for every key in the function-key group.

On a plain `keyDown` that bit is inert: no one reads a key event as a modifier change.
Once the event is a `flagsChanged`, it is the only thing that bit can mean — fn just
went down. And the `keyUp` rewrite kept the bit as well, so nothing ever said fn came
back up. Every Hyper tap or hold therefore fired whatever the user has bound to fn;
the reporter's dictation hotkey was the visible symptom, but any fn binding was hit.

`HyperKeyTap` now clears the bit from the incoming flags at the top of the key-event
branch, before either end is composed. The scope is deliberate: only the Hyper key's
own two events are scrubbed. Combos keep going through `hyperized` untouched, so
Hyper+F1 and Hyper+arrow still carry the fn bit they are entitled to — and they need
it, since that bit is part of how those keys are identified.

The right-side modifier keys were never affected. They arrive as `flagsChanged`
already, so there is no type conversion and no function-key residue to leak.

## Memory footprint

Not measured. The change is one `UInt64` mask against a value already in a register
inside the tap callback. It allocates nothing, stores nothing and adds no object to
the graph, so there is no footprint or leak surface to report; figures here would be
invented.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — nothing retained.

## Drawbacks

**No automated regression test.** `HyperKeyTap` is not in a harness — it reaches
`AppSettings`, `HealthTicker` and IOKit — so the flag arithmetic this bug lives in is
only covered by the build. Extracting the arithmetic into `HotKeys/Model/` would make
it testable and is the obvious follow-up, but it is a refactor rather than a fix and
is not in this PR.

**The mechanism is reasoned, not instrumented.** A modifying tap needs Accessibility
and a physical Caps Lock press, so it cannot be exercised from a test process; the
diagnosis rests on Apple's documented behaviour for the function-key group plus the
rewrite path in the diff. Worth one manual confirmation before merge.

The scrub is unconditional inside the Caps Lock branch. If a future Hyper key were
some other function key, it would inherit the same treatment — which is correct for
the same reason, so this is a note rather than a concern.

## Tests & validation

- `./Scripts/run-tests.sh` — all 56 harnesses pass.
- Debug build via `xcodebuild`: succeeds, no new warnings.
- `./Scripts/lint.sh`: clean.
- Pure-layer grep over `Features/*/Model/`: no hits.
- No harness added, for the reason above.

Not verified by hand: Caps Lock as Hyper with an fn-bound app listening, and
Hyper+F-key / Hyper+arrow still reporting fn. Both want a real keyboard.
