### PR TITLE
Raise Raycast payload gunzip cap so large exports import

### DIFF
--- a/Tests/raycast-test.swift
+++ b/Tests/raycast-test.swift
@@ -41,6 +41,7 @@ enum RaycastTests {
         recognition()
         decryption()
         gunzipSlices()
+        gunzipCap()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
@@ -184,5 +185,28 @@ enum RaycastTests {
             "a non-zero-index gzip slice decompresses instead of trapping")
         expect((try? Zlib.gunzip(gzippedJSON)) == plainJSON, "a zero-based gzip still works")
         expect((try? Zlib.gunzip(Data(repeating: 0x00, count: 32))) == nil, "non-gzip throws")
+    }
+
+    /// Built here, never committed: a fixture past the default cap cannot live in the repo.
+    static func gunzipCap() {
+        let oversized = Data(repeating: 0x5a, count: 70 * 1024 * 1024)
+        guard let gzipped = try? Zlib.gzip(oversized) else {
+            failures += 1
+            print("FAIL: the oversized fixture did not gzip")
+            return
+        }
+        do {
+            _ = try Zlib.gunzip(gzipped)
+            failures += 1
+            print("FAIL: a 70 MB payload passed the 64 MB default cap")
+        } catch ZlibError.tooLarge {
+            passes += 1
+        } catch {
+            failures += 1
+            print("FAIL: the default cap threw \(error), expected tooLarge")
+        }
+        expect(
+            (try? Zlib.gunzip(gzipped, maxOutput: 512 * 1024 * 1024))?.count == oversized.count,
+            "the same payload inflates under the 512 MB payload cap")
     }
 }

--- a/Tinycast/Features/Backup/Model/RaycastImportError.swift
+++ b/Tinycast/Features/Backup/Model/RaycastImportError.swift
@@ -4,12 +4,15 @@ enum RaycastImportError: LocalizedError {
     case notRaycastFile
     case incorrectPassphrase
     case corrupt
+    case tooLarge
 
     var errorDescription: String? {
         switch self {
         case .notRaycastFile: return "This doesn't look like a Raycast export (.rayconfig)."
         case .incorrectPassphrase: return "Incorrect passphrase, or the file is corrupted."
         case .corrupt: return "The Raycast export could not be read."
+        case .tooLarge:
+            return "This export is too large to import. Clear some Raycast clipboard history and export again."
         }
     }
 }

--- a/Tinycast/Features/Backup/Service/RaycastDecoder.swift
+++ b/Tinycast/Features/Backup/Service/RaycastDecoder.swift
@@ -53,7 +53,7 @@ enum RaycastDecoder {
             throw RaycastImportError.incorrectPassphrase
         }
 
-        guard let payload = try? Zlib.gunzip(payloadGzip) else {
+        guard let payload = try? Zlib.gunzip(payloadGzip, maxOutput: maximumPayloadLength) else {
             throw RaycastImportError.corrupt
         }
         return payload
@@ -63,6 +63,8 @@ enum RaycastDecoder {
     private static let containerSchemaVersion = 3
     private static let fixedHeaderLength = 12
     private static let maximumHeaderLength = 1024 * 1024
+    // AES already authenticated this stream; the cap is only a memory bound.
+    private static let maximumPayloadLength = 512 * 1024 * 1024
     private static let authenticationTagLength = 16
     private static let ivLength = 16
     private static let saltLength = 16

--- a/Tinycast/Features/Backup/Service/RaycastDecoder.swift
+++ b/Tinycast/Features/Backup/Service/RaycastDecoder.swift
@@ -53,10 +53,13 @@ enum RaycastDecoder {
             throw RaycastImportError.incorrectPassphrase
         }
 
-        guard let payload = try? Zlib.gunzip(payloadGzip, maxOutput: maximumPayloadLength) else {
+        do {
+            return try Zlib.gunzip(payloadGzip, maxOutput: maximumPayloadLength)
+        } catch ZlibError.tooLarge {
+            throw RaycastImportError.tooLarge
+        } catch {
             throw RaycastImportError.corrupt
         }
-        return payload
     }
 
     private static let magic = Data("RAYCFG3\n".utf8)

--- a/docs/features/raycast-import.md
+++ b/docs/features/raycast-import.md
@@ -16,6 +16,9 @@ between them are both gone, deleted rather than carried.
 - **Every scrypt derive costs seconds in the unoptimized harness.** `raycast-test` derives once for its
   fixture and keeps the cases that reach key derivation to the few that need it; anything testing the
   container's framing is written to fail before it.
+- **The payload gunzip cap is a memory bound, not a zip-bomb guard.** AES-GCM has already authenticated
+  those bytes. The unauthenticated header stays at 1 MB. A clipboard-heavy export decompresses past
+  64 MB, so the payload cap is 512 MB.
 
 ## Wire format
 


### PR DESCRIPTION
## Related issue

Closes #481

## What changed

A clipboard-heavy Raycast 2.x `.rayconfig` decrypts fine, then `Zlib.gunzip` of the authenticated payload hits the default 64 MB cap and is reported as `The Raycast export could not be read.` (`RaycastImportError.corrupt`). Wrong passphrase is a different string.

The payload is AES-256-GCM opened first. That 64 MB default is a zip-bomb guard for *unauthenticated* inflate (the header already has its own 1 MB cap; extension `gunzip` still uses 64 MB). This change passes an explicit 512 MB cap on the authenticated payload only, and reports going past it as its own `tooLarge` error rather than `corrupt`, so the message names the cause instead of sending the user back to a passphrase that was already right.

One export that failed: 14.8 MB on disk, 108,971,846 bytes after gunzip.

## Memory footprint

Not measured in Instruments on this machine (no signed local Debug identity). Import already runs off
the main actor in an autoreleasepool (`BackupActions.importRaycast`).

**The cap bounds the inflated `Data`, not the peak.** `RaycastImportReader.map` hands that blob straight
to `JSONSerialization.jsonObject`, which builds a Foundation object graph several times the byte size
for clipboard data — many short strings, each carrying per-object overhead. On the 104 MB sample the
real peak is plausibly a few hundred MB, and the 512 MB cap does not bound that at all. Instruments on
that file would settle the multiplier.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | unchanged |
| Palette open            | unchanged |
| Feature in use (peak)   | one-shot import; ~104 MB inflated on the failing file, plus the JSON object graph built from it |
| Palette closed, settled | unchanged; import tree is discarded |

Leak-tested: no. This is two constants and one `maxOutput:` argument; no new retain cycle.

**Why 512 MB and not 1 GB.** Clipboard images are exported as file paths, not inline bytes
(`mapClipboard`), so the payload is all text. 104 MB is roughly 300,000 entries; 512 MB is roughly
1.5 million, or a ~70 MB `.rayconfig` on disk. A bigger cap buys headroom no real export uses, and
moves the failure from an error message to an OOM.

## Demo

Nothing visual changed.

## Drawbacks

- CONTRIBUTING asks for a green-lit issue before merge. #481 is filed with this PR; maintainers can still close the issue as "won't raise the cap" if they want a streaming reader instead.
- A still-larger export fails with the new `tooLarge` copy, which asks the user to trim clipboard history. Past 512 MB the real fix is a streaming reader, not a bigger cap.
- The `ZlibError.tooLarge` → `RaycastImportError.tooLarge` mapping is not covered end-to-end: proving it needs a real 512 MB encrypted payload, which cannot be built cheaply or committed. `gunzipCap` covers the `Zlib` half.

## Tests & validation

- `./Scripts/run-tests.sh raycast-test` — pass, with a new `gunzipCap` case: it gzips 70 MB in memory,
  asserts the default cap throws `tooLarge`, and asserts the same bytes inflate under the 512 MB cap.
  The fixture is built at runtime, so nothing oversized is committed (see the raycast-import invariant).
- Hand: decrypted a real RAYCFG3 export with the same decoder after the cap change (`decrypt_ok`, payload 108,971,846 bytes, top-level JSON object).
- Header path and extension `gunzip` still use the old caps.

