### PR TITLE
Treat a lone x between operands as multiplication

### DIFF
--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -74,6 +74,19 @@ struct CalcTests {
         expectDisplay("e^2", "7.389056099")
 
         // Implicit multiplication
+        // `x` reads as `*` between operands, attached or spaced, like Raycast
+        expectDisplay("3x3", "9")
+        expectDisplay("3 x 3", "9")
+        expectDisplay("3X3", "9")
+        expectDisplay("3 x -2", "-6")
+        expectDisplay("2xpi", "6.283185307")
+        expectDisplay("6/2x(1+2)", "9")
+        expectDisplay("10 x", "10")  // trailing operator keeps the prefix while typing
+        expectDisplay("$5 x 2", "10.00 USD")
+        expectDisplay("2(3)kg x 2", "12 kg")
+        expectNil("x")
+        expectNil("x3")
+        expectNil("3x")  // half-typed, not an operator yet
         expectDisplay("4(2+3)", "20")
         expectDisplay("(2+3)(2+3)", "25")
         expectDisplay("2pi", "6.283185307")

--- a/Tinycast/Features/Calculator/Model/CalcParser.swift
+++ b/Tinycast/Features/Calculator/Model/CalcParser.swift
@@ -91,6 +91,12 @@ enum CalcTokenizer {
             }
 
             if ch.isLetter || ch == "°" {
+                // A lone `x` between operands is the spoken `*`, never part of a word.
+                if ch == "x" || ch == "X", isStandaloneX(chars, i, previous: tokens.last) {
+                    tokens.append(.op("*"))
+                    i += 1
+                    continue
+                }
                 // Split an attached currency prefix (`USD1K`) before the ident scanner eats it.
                 if ch.isLetter {
                     var letterEnd = i
@@ -171,6 +177,33 @@ enum CalcTokenizer {
             i += 1
         }
         return tokens
+    }
+
+    /// A lone `x` reads as `*` only at a token boundary with a value to its left.
+    private static func isStandaloneX(
+        _ chars: [Character], _ index: Int, previous: CalcToken?
+    ) -> Bool {
+        if index > 0, chars[index - 1].isLetter { return false }
+        guard let previous, endsOperand(previous) else { return false }
+        let attached = !chars[index - 1].isWhitespace
+        var next = index + 1
+        while next < chars.count, chars[next].isWhitespace { next += 1 }
+        // An attached `x` with nothing after it is a half-typed `0x` prefix, not `*`.
+        guard next < chars.count else { return !attached }
+        switch chars[next] {
+        case ")", "!", "%", "^", "/", ",", "=", "*", "×", "÷", "−", "→": return false
+        default: return true
+        }
+    }
+
+    /// Whether a token can end a left operand, so `3 x 3` multiplies but `x 3` stays a search.
+    private static func endsOperand(_ token: CalcToken) -> Bool {
+        switch token {
+        case .number, .compactNumber, .intLiteral: return true
+        case .op(let op): return op == ")" || op == "!" || op == "%"
+        case .ident(let name): return !["to", "in", "of", "mod", "power", "and"].contains(name)
+        case .arrow, .comma: return false
+        }
     }
 
     /// Only a spelling the table resolves, so `6/2(1+2)` keeps dividing.

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -276,6 +276,12 @@ Juxtaposition means `*` at the same binding power as an explicit one (`4(2+3)` �
 with `6/2*(1+2)`. `CalcParser.parseExpression` checks it after `peekBinary()` fails and, unlike a real
 operator, consumes no token before parsing the right operand.
 
+A lone `x` / `X` between operands is the same operator (`3x3`, `3 x 3` → 9, `2xpi`), folded in the
+tokenizer rather than the parser so the typed quantity path agrees (`$5 x 2`). It only fires at a
+token boundary with a value to its left, which is why `x`, `x3`, `max` and `hex` stay searches or
+words; an attached `x` with nothing after it stays silent too, so a half-typed `0x` prefix never
+flashes a card.
+
 The scalar side is deliberately narrow: only `(` or a name in `CalcParser.constants` / `functions`
 starts an implicit product. Adjacent _numbers_ never do — `5 3` stays an app search — and no unit or
 currency name is a constant or function, so `10km` keeps its own path. `QuantityParser.peekBinary`


### PR DESCRIPTION
## Related issue

Closes #

## What changed

- `CalcTokenizer` folds a lone `x` / `X` between operands into `*` (`3x3`, `3 x 3`, `2xpi`, `$5 x 2`), so the scalar and typed-quantity paths agree with no parser change. It only fires at a token boundary with a value on the left, which is why `x`, `x3`, `max`, `hex` and a half-typed `0x` prefix stay as they were.
- `docs/signing.md`: two-step identity creation (`req -new` + `x509 -req`). The one-shot `req -x509` prepends a duplicate `CA:true` basicConstraints on OpenSSL 1.1, producing an identity `codesign` cannot use. Verification is now a trial sign instead of `find-identity`.

## Memory footprint

No new state — a tokenizer-only change plus docs.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | —      |
| Palette open            | —      |
| Feature in use (peak)   | —      |
| Palette closed, settled | —      |

Leak-tested: n/a — no new long-lived objects.

## Drawbacks

- The card echoes what was typed (`3 x 3`, not `3 × 3`).
- An attached trailing `3x` stays silent until the next operand arrives, which is what keeps a half-typed hex prefix card-free.

## Tests & validation

- `calc-test`: new cases for attached / spaced / uppercase `x`, a unary right side, `2xpi`, `6/2x(1+2)`, the trailing partial (`10 x` → `10`), quantity and currency (`2(3)kg x 2`, `$5 x 2`), and nil guards (`x`, `x3`, `3x`).
- Full suite: 58/58 harnesses pass; `lint.sh` is clean.
- By hand: the new two-step identity trial-signed a scratch binary, and a Debug `Tinycast Dev` build signed with it succeeded.