### PR TITLE
Add clipboard default action setting (paste or copy)

### DIFF
--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -19,6 +19,7 @@ struct SettingsBackup: Codable {
         // Carried, unlike the consent flags: recording your own copies grants no permission class.
         var clipboardEnabled: Bool?
         var clipboardRetentionDays: Int?
+        var clipboardDefaultAction: String?
         var clipboardDisabledApps: [String]?
         var launchAtLogin: Bool?
         var hyperKey: String?
@@ -108,6 +109,7 @@ extension SettingsBackup {
         backup.settings = SettingsData(
             clipboardEnabled: s.clipboardEnabled,
             clipboardRetentionDays: s.clipboardRetention.rawValue,
+            clipboardDefaultAction: s.clipboardDefaultAction.rawValue,
             clipboardDisabledApps: s.clipboardDisabledApps,
             launchAtLogin: s.launchAtLogin,
             hyperKey: s.hyperKey.rawValue,
@@ -248,6 +250,10 @@ extension SettingsBackup {
         }
         if let apps = s.clipboardDisabledApps {
             settings.clipboardDisabledApps = apps
+            count += 1
+        }
+        if let raw = s.clipboardDefaultAction, let action = ClipboardDefaultAction(rawValue: raw) {
+            settings.clipboardDefaultAction = action
             count += 1
         }
         if let launch = s.launchAtLogin {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -6,6 +6,7 @@ enum SettingsBackupCoverage {
     static let mirrored: [String: AppSettingsKey] = [
         "clipboardEnabled": .clipboardEnabled,
         "clipboardRetentionDays": .clipboardRetention,
+        "clipboardDefaultAction": .clipboardDefaultAction,
         "clipboardDisabledApps": .clipboardDisabledApps,
         "hyperKey": .hyperKey,
         "hyperKeyIncludesShift": .hyperKeyIncludesShift,

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -99,6 +99,21 @@ enum ClipboardRetention: Int, CaseIterable, Identifiable, Sendable {
     }
 }
 
+/// What ↵ does on a clipboard entry; ⌘↵ always does the other one.
+enum ClipboardDefaultAction: String, CaseIterable, Identifiable, Sendable {
+    case paste
+    case copy
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .paste: return "Paste"
+        case .copy: return "Copy to Clipboard"
+        }
+    }
+}
+
 /// SQLite-backed clipboard history. See docs/features/clipboard.md#store.
 @MainActor
 @Observable

--- a/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
+++ b/Tinycast/Features/Clipboard/Settings/ClipboardSettingsView.swift
@@ -44,6 +44,14 @@ struct ClipboardSettingsView: View {
                 .onChange(of: settings.clipboardRetention) {
                     core.clipboardCoordinator.applyRetention(settings.clipboardRetention)
                 }
+                Picker(selection: $settings.clipboardDefaultAction) {
+                    ForEach(ClipboardDefaultAction.allCases) { action in
+                        Text(action.title).tag(action)
+                    }
+                } label: {
+                    SettingsRowTitle(.clipboardHistory, "Default action")
+                    Text("What ↵ does on an entry; ⌘↵ does the other one.")
+                }
             } header: {
                 SettingsSectionHeader(.clipboardHistory)
             }

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -55,6 +55,15 @@ final class ClipboardCoordinator {
         clipboardStore.enforceLimits()
     }
 
+    /// ↵ runs the configured default; ⌘↵ the other one, so the two chords stay a swapped pair.
+    func activate(_ item: ClipboardItem, inverted: Bool = false) {
+        if (settings.clipboardDefaultAction == .copy) != inverted {
+            copyToClipboard(item)
+        } else {
+            paste(item)
+        }
+    }
+
     func paste(_ item: ClipboardItem) {
         let previous = windowController.previousApp
         paletteCoordinator.hidePalette(restoreFocus: false)

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -10,7 +10,11 @@ struct ClipboardScreen: PaletteScreen {
 
     var rows: [ClipboardItem] { store.search(vm.query, filter: vm.clipboardFilter) }
 
-    var primaryActionTitle: String { vm.pasteTarget?.pasteTitle ?? "Paste" }
+    var primaryActionTitle: String {
+        core.settings.clipboardDefaultAction == .copy
+            ? ClipboardDefaultAction.copy.title
+            : vm.pasteTarget?.pasteTitle ?? ClipboardDefaultAction.paste.title
+    }
 
     private func item(at selection: Int) -> ClipboardItem? {
         let rows = rows
@@ -25,22 +29,22 @@ struct ClipboardScreen: PaletteScreen {
 
     func activate(at selection: Int) {
         guard let item = item(at: selection) else { return }
-        core.clipboardCoordinator.paste(item)
+        core.clipboardCoordinator.activate(item)
     }
 
-    /// ⌘1…⌘0 — paste the Nth visible pinned entry (Pinned section order), if present.
+    /// ⌘1…⌘0 — the Nth visible pinned entry (Pinned section order), like ↵.
     func activatePinned(at index: Int) -> Bool {
         guard let item = store.pinnedItem(at: index, in: vm.query, filter: vm.clipboardFilter) else {
             return false
         }
-        core.clipboardCoordinator.paste(item)
+        core.clipboardCoordinator.activate(item)
         return true
     }
 
-    /// ⌘↵ — copy without pasting, leaving the frontmost app's own clipboard use alone.
+    /// ⌘↵ — the action ↵ is not set to.
     func secondary(at selection: Int) -> Bool {
         guard let item = item(at: selection) else { return false }
-        core.clipboardCoordinator.copyToClipboard(item)
+        core.clipboardCoordinator.activate(item, inverted: true)
         return true
     }
 
@@ -135,23 +139,28 @@ enum ClipboardActionsMenu {
     static func content(
         item: ClipboardItem, core: AppCore, store: ClipboardStore, target: PasteTarget?
     ) -> PopoverMenuContent {
-        var items: [PopoverMenuItem] = [
-            PopoverMenuItem(
-                title: target?.pasteTitle ?? "Paste",
-                icon: .paste(target, fallback: "doc.on.clipboard"), shortcut: "↵"
-            ) {
-                core.clipboardCoordinator.paste(item)
-            },
-            PopoverMenuItem(title: "Copy to Clipboard", systemImage: "doc.on.doc", shortcut: "⌘↵") {
-                core.clipboardCoordinator.copyToClipboard(item)
-            },
-            PopoverMenuItem(
-                title: "Paste and Keep Window Open", icon: .paste(target, fallback: "macwindow"),
-                shortcut: "⌥↵"
-            ) {
-                core.clipboardCoordinator.pasteKeepingWindowOpen(item)
-            }
-        ]
+        let copyFirst = core.settings.clipboardDefaultAction == .copy
+        let pasteItem = PopoverMenuItem(
+            title: target?.pasteTitle ?? ClipboardDefaultAction.paste.title,
+            icon: .paste(target, fallback: "doc.on.clipboard"), shortcut: copyFirst ? "⌘↵" : "↵"
+        ) {
+            core.clipboardCoordinator.paste(item)
+        }
+        let copyItem = PopoverMenuItem(
+            title: ClipboardDefaultAction.copy.title, systemImage: "doc.on.doc",
+            shortcut: copyFirst ? "↵" : "⌘↵"
+        ) {
+            core.clipboardCoordinator.copyToClipboard(item)
+        }
+        var items: [PopoverMenuItem] =
+            (copyFirst ? [copyItem, pasteItem] : [pasteItem, copyItem]) + [
+                PopoverMenuItem(
+                    title: "Paste and Keep Window Open", icon: .paste(target, fallback: "macwindow"),
+                    shortcut: "⌥↵"
+                ) {
+                    core.clipboardCoordinator.pasteKeepingWindowOpen(item)
+                }
+            ]
         if item.isPinned {
             items.append(
                 PopoverMenuItem(title: "Unpin Entry", systemImage: "pin.slash", shortcut: "⌘.") {

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -139,6 +139,14 @@ final class AppSettings {
         didSet { defaults.set(clipboardDisabledApps, forKey: Key.clipboardDisabledApps.rawValue) }
     }
 
+    /// What ↵ does on a clipboard entry; ⌘↵ always does the other one.
+    var clipboardDefaultAction: ClipboardDefaultAction {
+        didSet {
+            defaults.set(
+                clipboardDefaultAction.rawValue, forKey: Key.clipboardDefaultAction.rawValue)
+        }
+    }
+
     var launchAtLogin: Bool {
         didSet { LaunchAtLogin.set(launchAtLogin) }
     }
@@ -458,6 +466,9 @@ final class AppSettings {
         clipboardDisabledApps =
             defaults.stringArray(forKey: Key.clipboardDisabledApps.rawValue)
             ?? ["com.apple.keychainaccess", "com.apple.Passwords"]
+        clipboardDefaultAction =
+            defaults.string(forKey: Key.clipboardDefaultAction.rawValue)
+            .flatMap(ClipboardDefaultAction.init) ?? .paste
         launchAtLogin = LaunchAtLogin.isEnabled
         hyperKey =
             defaults.string(forKey: Key.hyperKey.rawValue).flatMap(HyperKeyPhysicalKey.init)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -5,6 +5,7 @@ enum AppSettingsKey: String, CaseIterable {
     // Every raw value is spelled out so renaming a case can never rename a persisted key.
     case clipboardEnabled = "clipboardEnabled"
     case clipboardRetention = "clipboardRetentionDays"
+    case clipboardDefaultAction = "clipboardDefaultAction"
     case clipboardDisabledApps = "clipboardDisabledApps"
     case hyperKey = "hyperKeyPhysicalKey"
     case hyperKeyIncludesShift = "hyperKeyIncludesShift"

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -382,6 +382,9 @@ enum SettingsSearchCatalog {
             .clipboardHistory, "Keep history for",
             keywords: ["retention", "delete", "privacy", "expire"]),
         .init(
+            .clipboardHistory, "Default action",
+            keywords: ["enter", "return", "paste", "copy", "primary"]),
+        .init(
             group: .clipboardDisabledApplications, "Disabled Applications",
             keywords: ["exclude", "password manager", "ignore", "privacy"]),
         .init(

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -6,6 +6,11 @@
   has to outrank a stored `false` in `AppSettings.init`, and off means fully off: the poller stops,
   the SQLite file closes, the launcher command and its shortcut go, and Tab skips the screen.
   `ClipboardCoordinator.applyEnabled()` is the single place that applies it.
+- **↵ and ⌘↵ are one swapped pair, and `ClipboardCoordinator.activate(_:inverted:)` is the only
+  place that reads which way round they sit.** `clipboardDefaultAction` names what ↵ does — paste
+  (the default) or copy — and ⌘↵ always does the other. ⌘1…⌘0 on a pin and a double-click go
+  through the same call, so no surface can drift from the setting; ⌥↵ pastes regardless, since
+  keeping the window open is a paste-only idea. The ⌘K menu puts the default first with the ↵ chip.
 - **Clipboard writes stamp a private `internalType` marker** so the poller skips Tinycast's own writes.
   If the writer and the poller ever disagree, the app re-captures its own pastes in a loop.
 - **`Model/ClipboardStore.swift` keeps to Foundation plus SQLite3 and no other app source**, so


### PR DESCRIPTION
## Related issue

None.

## What changed

New Clipboard setting "Default action" (Settings → Clipboard → History): Paste (default, current behavior) or Copy to Clipboard.

When Copy is the default, ⏎ and ⌘⏎ swap: ⏎ copies, ⌘⏎ pastes — including ⌘1…⌘0 pinned shortcuts and double-click. The ⌘K menu puts the default action first with the ⏎ shortcut, and the footer pill shows the default action title. The setting persists in UserDefaults (`clipboardDefaultAction`, defaults to paste) and rides the settings backup/restore like the other clipboard settings.

Non-obvious: `ClipboardDefaultAction` lives in `ClipboardStore.swift` next to `ClipboardRetention` rather than its own Model file, so no `xcodegen` regen is needed.

## Memory footprint

No new allocations on any path: one enum read per activation plus a settings Picker. No new windows, tasks, or observers.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | —      |
| Palette open            | —      |
| Feature in use (peak)   | —      |
| Palette closed, settled | —      |

Leak-tested: N/A — no objects introduced.

## Drawbacks

None known. Unknown raw values from a future backup fall back to Paste.

## Tests & validation

- `./Scripts/run-tests.sh`: all 58 harnesses passed (incl. `settings-backup-test`).
- Debug build succeeds with no new warnings; `./Scripts/lint.sh` clean; no AppKit/SwiftUI imports under `Model/`.
- Exercised by hand in Tinycast Dev: picker switches ⏎/⌘⏎ behavior, menu order/shortcuts, and footer pill.