### PR TITLE
Make the Raycast import passphrase field visible in Settings

### DIFF
--- a/Tinycast/Features/Backup/Settings/BackupSettingsView.swift
+++ b/Tinycast/Features/Backup/Settings/BackupSettingsView.swift
@@ -89,9 +89,15 @@ struct BackupSettingsView: View {
                     Text(raycastFileSubtitle)
                 }
                 LabeledContent {
-                    SecureField("Passphrase", text: $passphrase)
-                        .frame(width: 160)
-                        .onSubmit(runRaycastImport)
+                    SecureField(
+                        "Passphrase", text: $passphrase, prompt: Text("Export password")
+                    )
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    // LabeledContent right-aligns its value text, caret and all; a field reads left.
+                    .multilineTextAlignment(.leading)
+                    .frame(width: 160)
+                    .onSubmit(runRaycastImport)
                 } label: {
                     Text("Passphrase")
                     Text("The password you set when exporting from Raycast.")


### PR DESCRIPTION
### What

**Settings → Backup → Import from Raycast** rendered its Passphrase row as two
lines of label text with grey text on the right — the grey text *was* the field.
`BackupSettingsView` was the only view under `Features/*/Settings/` that rendered
a text input without ever calling `.textFieldStyle`, so a grouped `Form` drew it
without a bezel. Its `SecureField` title was also `"Passphrase"`, repeating the
row label, and `LabeledContent` right-aligns its value — text and caret alike —
so the placeholder read as a duplicated caption rather than an empty field.
With `Import` gated on `!passphrase.isEmpty`, the button stayed disabled the whole
time, reinforcing the impression that the import was unsupported.

### How

- `.textFieldStyle(.roundedBorder)`, matching the same row in onboarding.
- A prompt distinct from the row label (`Export password`), with `.labelsHidden()`
  so the title stops rendering beside it — the shape `AISettingsView` already uses.
- `.multilineTextAlignment(.leading)` so the text and caret start on the left.

### Verification

Rendered the row before and after in a throwaway host, dark appearance:

Before — no boundary, placeholder repeats the label, caret at the far right.
After — bordered field, distinct placeholder, text and caret on the left.

`./Scripts/run-tests.sh` — all 58 harnesses pass. Debug build succeeds with no
new warnings. `./Scripts/lint.sh` clean.

Closes #479