### PR TITLE
Import a folder of Raycast script commands

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -213,6 +213,7 @@ run window-layout-test     Tinycast/Features/WindowManagement/Model/WindowComman
                            Tinycast/Features/WindowManagement/Model/WindowLayoutStore.swift
 run custom-command-test    Tinycast/Platform/PseudoTerminal.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift \
+                           Tinycast/Features/CustomCommands/Model/RaycastScriptImport.swift \
                            Tinycast/Features/CustomCommands/Service/ShellCommandRunner.swift \
                            Tinycast/Features/CustomCommands/Service/CustomCommandArgumentSession.swift
 run uninstall-test         Tinycast/Features/Uninstall/Model/UninstallTarget.swift \

--- a/Tests/custom-command-test.swift
+++ b/Tests/custom-command-test.swift
@@ -116,6 +116,134 @@ struct CustomCommandTests {
             "a record written before the enabled flag loads as enabled",
             CustomCommandStore(defaults: defaults).commands.first?.isEnabled == true)
 
+        // MARK: Batch add
+
+        var commits = 0
+        store.onChange = { _ in commits += 1 }
+        let batched = store.add(contentsOf: [
+            CustomCommand(name: "One", command: "/usr/bin/true"),
+            CustomCommand(name: "blanks", command: "/usr/bin/true"),
+            CustomCommand(name: "Two", command: "/usr/bin/true"),
+            CustomCommand(name: "one", command: "/usr/bin/false")
+        ])
+        store.onChange = nil
+        check("a batch add counts only the commands it added", batched == 2)
+        check("a whole batch is one commit", commits == 1)
+        check(
+            "a name colliding with the library or with the batch is dropped",
+            store.commands.map(\.name) == ["Blanks", "One", "Two"])
+
+        // MARK: Raycast script import
+
+        let shellSource = """
+            #!/bin/bash
+
+            # Required parameters:
+            # @raycast.schemaVersion 1
+            # @raycast.title Chrome CDP
+            # @raycast.mode silent
+
+            # Optional parameters:
+            # @raycast.icon 📘
+            # @raycast.needsConfirmation false
+
+            CDP_PORT=9222
+            # @raycast.mode fullOutput
+            """
+        let shellScript = RaycastScriptImport.command(
+            at: URL(fileURLWithPath: "/Users/me/scripts/chrome cdp.sh"), source: shellSource)
+        check("the title becomes the command name", shellScript?.name == "Chrome CDP")
+        check(
+            "the shebang names the interpreter and the path is one quoted word",
+            shellScript?.command == #"/bin/bash '/Users/me/scripts/chrome cdp.sh' "$@""#)
+        check("silent mode opens no output window", shellScript?.showsOutput == false)
+        check("needsConfirmation false stays off", shellScript?.requiresConfirmation == false)
+        check(
+            "a script runs in its own folder",
+            shellScript?.workingDirectory == "/Users/me/scripts")
+
+        let appleSource = """
+            #!/usr/bin/osascript
+
+            # @raycast.schemaVersion 1
+            # @raycast.title Facebook
+            # @raycast.mode fullOutput
+            # @raycast.needsConfirmation true
+            # @raycast.currentDirectoryPath ~/Sites
+            # @raycast.argument1 { "type": "text", "placeholder": "Profile" }
+            # @raycast.argument2 { "type": "text", "placeholder": "Tab", "optional": true }
+
+            tell application id "com.vivaldi.Vivaldi"
+            """
+        let appleScript = RaycastScriptImport.command(
+            at: URL(fileURLWithPath: "/tmp/facebook.applescript"), source: appleSource)
+        check(
+            "osascript comes from the shebang",
+            appleScript?.command == #"/usr/bin/osascript '/tmp/facebook.applescript' "$@""#)
+        check("an output mode opens the window", appleScript?.showsOutput == true)
+        check("needsConfirmation true is carried over", appleScript?.requiresConfirmation == true)
+        check(
+            "a declared directory wins over the script's folder",
+            appleScript?.workingDirectory == "~/Sites")
+        check(
+            "arguments come from their placeholders, in order",
+            appleScript?.arguments == [
+                CustomCommandArgument(name: "Profile"),
+                CustomCommandArgument(name: "Tab", isOptional: true)
+            ])
+
+        check(
+            "a file naming no interpreter is not a script command",
+            RaycastScriptImport.command(
+                at: URL(fileURLWithPath: "/tmp/notes.txt"), source: "# @raycast.title Notes\n")
+                == nil)
+        check(
+            "a script declaring no title is not a script command",
+            RaycastScriptImport.command(
+                at: URL(fileURLWithPath: "/tmp/helper.sh"),
+                source: "#!/bin/bash\n# @raycast.schemaVersion 1\necho hi\n") == nil)
+        check(
+            "the JavaScript template's // directives are read too",
+            RaycastScriptImport.command(
+                at: URL(fileURLWithPath: "/tmp/x.js"),
+                source: "#!/usr/bin/env node\n// @raycast.title Node\n")?.command
+                == #"/usr/bin/env node '/tmp/x.js' "$@""#)
+        check(
+            "a quote in the path cannot break out of the argument",
+            RaycastScriptImport.command(
+                at: URL(fileURLWithPath: "/tmp/it's here.sh"),
+                source: "#!/bin/zsh\n# @raycast.title Quoted\n")?.command
+                == #"/bin/zsh '/tmp/it'\''s here.sh' "$@""#)
+
+        let scriptDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-scripts-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(
+            at: scriptDirectory.appendingPathComponent("nested"), withIntermediateDirectories: true)
+        for (name, source) in [
+            ("b-second.sh", "#!/bin/bash\n# @raycast.title Second\n"),
+            ("a-first.sh", "#!/bin/bash\n# @raycast.title First\n"),
+            ("plain.txt", "just notes\n"),
+            (".hidden.sh", "#!/bin/bash\n# @raycast.title Hidden\n")
+        ] {
+            try? Data(source.utf8).write(to: scriptDirectory.appendingPathComponent(name))
+        }
+        check(
+            "a folder yields its script commands in name order and nothing else",
+            RaycastScriptImport.scan(directory: scriptDirectory).map(\.name) == ["First", "Second"])
+
+        // The whole run, through `"$@"`: an imported script reads its value as data, never as syntax.
+        try? Data("#!/bin/bash\n# @raycast.title Echo\nprintf '%s' \"$1\"\n".utf8).write(
+            to: scriptDirectory.appendingPathComponent("echo.sh"))
+        let imported = RaycastScriptImport.scan(directory: scriptDirectory).first { $0.name == "Echo" }
+        let forwarded = await ShellCommandRunner.run(
+            imported?.command ?? "", arguments: ["; touch /tmp/tinycast-import-should-not-exist"],
+            workingDirectory: imported?.workingDirectory)
+        check(
+            "an imported script receives its argument as one inert word",
+            forwarded.standardOutput == "; touch /tmp/tinycast-import-should-not-exist"
+                && !FileManager.default.fileExists(atPath: "/tmp/tinycast-import-should-not-exist"))
+        try? FileManager.default.removeItem(at: scriptDirectory)
+
         // MARK: Runner
 
         let succeeded = await ShellCommandRunner.run("/usr/bin/true")

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		9BE84B47BCF0DA5552AB3591 /* CameraCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5873BB8728FD8BC5D256A21 /* CameraCoordinator.swift */; };
 		9DB09F96E6F8C226BD9AB1C9 /* SymbolCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387BE675F580496656E72559 /* SymbolCatalog.swift */; };
 		9DB4319C835DCF8C0723356D /* MenuBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2902B904C7BD2FC23856EDB9 /* MenuBarItem.swift */; };
+		9DB73F12214137B60AE00828 /* RaycastScriptImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CF6A57ECFDA17248393EA8 /* RaycastScriptImport.swift */; };
 		9E4497ECAD183E5C2B49475B /* MeetingDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0599199132DAFBE12C59FBD /* MeetingDay.swift */; };
 		9E514EA8EB0408653AC3D1D9 /* BundleSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E30EFA3197FC5EF1E85C21 /* BundleSignature.swift */; };
 		9E5B694969D3F99BF7D0D9E1 /* ExtensionImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D20FAFD9F3CC0E5802A966 /* ExtensionImage.swift */; };
@@ -398,7 +399,6 @@
 		BAD4BEF8041665ACCF1CE460 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F64FC06CB10BDF8CD044D64 /* ScheduleView.swift */; };
 		BB1277D988169C0829374ACC /* QuickActionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E97E59C7338458DB797507 /* QuickActionPanelState.swift */; };
 		BBAB44C0E70AABE70A048889 /* QuicklinkArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */; };
-		B5D92F0C81E3507F02D1C4E3 /* RaycastQuicklinkImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C81E9B70D24F6E91C0B3D2 /* RaycastQuicklinkImport.swift */; };
 		BC755BD99ECA1F2D382D5C94 /* SettingsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */; };
 		BCA7E1C4BCF6F77634E54CA7 /* MeetingClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474E6D9830E336752C79F461 /* MeetingClock.swift */; };
 		BD45A99F26C015BF00AC77D5 /* ApplicationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289FC415E1D1776DD1C4EB9E /* ApplicationsSettingsView.swift */; };
@@ -479,6 +479,7 @@
 		E268D74F0DEFFA598E2D02AA /* OnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6972F177922B1EB8831735 /* OnboardingCard.swift */; };
 		E29056264B57A3F0EC5F5698 /* SupportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97986EE62AE844FFCCD27449 /* SupportCoordinator.swift */; };
 		E29CF7293742DDCAE030682C /* SupportReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE1ED405A53ECA5DED66AA1 /* SupportReminderStore.swift */; };
+		E448C90CF3076440A4FA2CE4 /* RaycastQuicklinkImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25EA21DCF61666DB736D5B82 /* RaycastQuicklinkImport.swift */; };
 		E457BC709D195B8F5D0C2A79 /* UninstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6DAC3B9FF387367C3FAB4 /* UninstallSession.swift */; };
 		E4B18EBFFD009B2CAFF4BA9B /* PanelTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E25B87C692D5FEE1FBF994 /* PanelTransition.swift */; };
 		E4C40AC649B871B08B7F1B6E /* QuickActionPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEF20B209EEEAB7ED97DF36 /* QuickActionPanel.swift */; };
@@ -538,6 +539,7 @@
 
 /* Begin PBXFileReference section */
 		00B475B5929CC0478EFAC7D8 /* UpdateFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFailure.swift; sourceTree = "<group>"; };
+		00CF6A57ECFDA17248393EA8 /* RaycastScriptImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastScriptImport.swift; sourceTree = "<group>"; };
 		00ECBD55353C83A7F4E93592 /* MCPSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPSettingsSection.swift; sourceTree = "<group>"; };
 		025D7D760DE2FD02C0D7D9D2 /* ColorFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorFormat.swift; sourceTree = "<group>"; };
 		0266BAF4643A4B5C41B600DE /* ExtensionColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionColors.swift; sourceTree = "<group>"; };
@@ -604,6 +606,7 @@
 		23F7C8CBD0AA75D016DBFC06 /* SettingsPaneScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScanner.swift; sourceTree = "<group>"; };
 		2438C33DEAF16B26E4F195EB /* ExecutableLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecutableLocator.swift; sourceTree = "<group>"; };
 		2575583134BE03EA9FA719CD /* ActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicy.swift; sourceTree = "<group>"; };
+		25EA21DCF61666DB736D5B82 /* RaycastQuicklinkImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastQuicklinkImport.swift; sourceTree = "<group>"; };
 		264B68DBB21C3752E39ECC29 /* NoteTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTitle.swift; sourceTree = "<group>"; };
 		26AD346C8FD5F2D4F00FF2B6 /* HotKeyCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyCenter.swift; sourceTree = "<group>"; };
 		27021D72339800AA6DA3D3FF /* AIScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIScreen.swift; sourceTree = "<group>"; };
@@ -1054,7 +1057,6 @@
 		F524FA7B33C0F861995EB1E6 /* QuicklinkArgumentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsScreen.swift; sourceTree = "<group>"; };
 		F58E564E6181EB15497E51CD /* SnippetTemplateEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplateEngine.swift; sourceTree = "<group>"; };
 		F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArchive.swift; sourceTree = "<group>"; };
-		A4C81E9B70D24F6E91C0B3D2 /* RaycastQuicklinkImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastQuicklinkImport.swift; sourceTree = "<group>"; };
 		F6C8B2F6592B65CB6576D247 /* ExtensionAppearancePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAppearancePicker.swift; sourceTree = "<group>"; };
 		F7420F642776452B469182D0 /* FileSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchResult.swift; sourceTree = "<group>"; };
 		F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClick.swift; sourceTree = "<group>"; };
@@ -1268,7 +1270,7 @@
 				F616D2EE62AEC6782E77364D /* QuicklinkArchive.swift */,
 				61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */,
 				685FB7FD7E4E5BE6606440D0 /* QuicklinkStore.swift */,
-				A4C81E9B70D24F6E91C0B3D2 /* RaycastQuicklinkImport.swift */,
+				25EA21DCF61666DB736D5B82 /* RaycastQuicklinkImport.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2493,6 +2495,7 @@
 			isa = PBXGroup;
 			children = (
 				DF0880635E294D9DF55BAADA /* CustomCommand.swift */,
+				00CF6A57ECFDA17248393EA8 /* RaycastScriptImport.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3029,7 +3032,6 @@
 				3C23AEA2FDDB7BD61278BD77 /* QuickActionsSettingsView.swift in Sources */,
 				EBCDF88CD59A4B6F21F945C6 /* Quicklink.swift in Sources */,
 				BBAB44C0E70AABE70A048889 /* QuicklinkArchive.swift in Sources */,
-				B5D92F0C81E3507F02D1C4E3 /* RaycastQuicklinkImport.swift in Sources */,
 				DA1EE0A8933EADD357FCE32C /* QuicklinkArgumentSession.swift in Sources */,
 				244668334681070EB823FF13 /* QuicklinkArgumentsScreen.swift in Sources */,
 				A7CEBFBFBB46554ACAD73CFB /* QuicklinkArgumentsView.swift in Sources */,
@@ -3046,6 +3048,8 @@
 				A79B7385C6B6E6C67FDFB152 /* RaycastImportError.swift in Sources */,
 				46F5D522E6F5470D3694A218 /* RaycastImportReader.swift in Sources */,
 				22420E8A41685143315904F5 /* RaycastImportSelection.swift in Sources */,
+				E448C90CF3076440A4FA2CE4 /* RaycastQuicklinkImport.swift in Sources */,
+				9DB73F12214137B60AE00828 /* RaycastScriptImport.swift in Sources */,
 				478500C6465327947EBD9D61 /* RaycastSnippetImport.swift in Sources */,
 				F801D00F877421DC7045C5F3 /* RedactedPlaceholder.swift in Sources */,
 				E1A4472391E5AD3EE828202E /* RedactedText.swift in Sources */,

--- a/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+++ b/Tinycast/Features/CustomCommands/Model/CustomCommand.swift
@@ -153,14 +153,27 @@ final class CustomCommandStore {
     // Takes a whole draft, so adding an option doesn't churn every call site.
     @discardableResult
     func add(_ draft: CustomCommand) throws -> CustomCommand {
-        let value = try validated(draft)
+        let value = try validated(draft, against: commands)
         commit(commands + [value])
         return value
     }
 
+    /// One commit for a whole import, and it returns how many of the drafts were new.
+    @discardableResult
+    func add(contentsOf drafts: [CustomCommand]) -> Int {
+        var updated = commands
+        let existing = commands.count
+        for draft in drafts {
+            guard let value = try? validated(draft, against: updated) else { continue }
+            updated.append(value)
+        }
+        commit(updated)
+        return updated.count - existing
+    }
+
     func update(_ draft: CustomCommand) throws {
         guard let index = commands.firstIndex(where: { $0.id == draft.id }) else { return }
-        let value = try validated(draft)
+        let value = try validated(draft, against: commands)
         var updated = commands
         updated[index] = value
         commit(updated)
@@ -192,7 +205,10 @@ final class CustomCommandStore {
         return updated.count
     }
 
-    private func validated(_ draft: CustomCommand) throws -> CustomCommand {
+    /// `existing` is what the name must be unique against: the library, or a batch in progress.
+    private func validated(
+        _ draft: CustomCommand, against existing: [CustomCommand]
+    ) throws -> CustomCommand {
         var value = draft
         value.name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         value.command = draft.command.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -205,7 +221,7 @@ final class CustomCommandStore {
             throw CustomCommandValidationError.invalidCharacter
         }
         guard
-            !commands.contains(where: {
+            !existing.contains(where: {
                 $0.id != value.id
                     && $0.name.compare(value.name, options: .caseInsensitive) == .orderedSame
             })

--- a/Tinycast/Features/CustomCommands/Model/RaycastScriptImport.swift
+++ b/Tinycast/Features/CustomCommands/Model/RaycastScriptImport.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Reads a folder of Raycast script commands into drafts. See docs/features/custom-commands.md.
+enum RaycastScriptImport {
+    private static let headSize = 8 * 1024
+    private static let directivePrefix = "@raycast."
+    /// `#` for the shell templates, `//` for JavaScript and Swift, `--` for AppleScript.
+    private static let commentMarkers = ["#", "//", "--"]
+
+    /// Non-recursive, like Raycast's own script directories; a non-command file is skipped.
+    nonisolated static func scan(
+        directory: URL, fileManager: FileManager = .default
+    ) -> [CustomCommand] {
+        let contents =
+            (try? fileManager.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])) ?? []
+        return
+            contents
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .compactMap { url in
+                guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true,
+                    let source = head(of: url)
+                else { return nil }
+                return command(at: url, source: source)
+            }
+    }
+
+    /// A file is a script command when it names an interpreter and declares a title.
+    nonisolated static func command(at url: URL, source: String) -> CustomCommand? {
+        guard let interpreter = shebang(in: source) else { return nil }
+        let directives = directives(in: source)
+        guard let title = directives["title"] else { return nil }
+        // The runner's values land on zsh's positional list; unforwarded, the script sees none.
+        return CustomCommand(
+            name: title,
+            command: "\(interpreter) \(shellQuoted(url.path)) \"$@\"",
+            requiresConfirmation: directives["needsConfirmation"] == "true",
+            arguments: arguments(in: directives),
+            showsOutput: showsOutput(mode: directives["mode"]),
+            workingDirectory: workingDirectory(directives["currentDirectoryPath"], script: url))
+    }
+
+    /// Raycast requires one, and naming it rather than relying on the exec bit leaves the file be.
+    private static func shebang(in source: String) -> String? {
+        let first = source.prefix { !$0.isNewline }
+        guard first.hasPrefix("#!") else { return nil }
+        let interpreter = first.dropFirst(2).trimmingCharacters(in: .whitespacesAndNewlines)
+        return interpreter.isEmpty ? nil : interpreter
+    }
+
+    /// The block ends where the code starts; past that, `@raycast.` is the script's own text.
+    private static func directives(in source: String) -> [String: String] {
+        var values: [String: String] = [:]
+        for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            guard let body = commentBody(trimmed) else { break }
+            guard body.hasPrefix(directivePrefix) else { continue }
+            let field = body.dropFirst(directivePrefix.count)
+            guard let separator = field.firstIndex(where: \.isWhitespace) else { continue }
+            let key = String(field[..<separator])
+            let value = field[separator...].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty, !value.isEmpty else { continue }
+            values[key] = value
+        }
+        return values
+    }
+
+    private static func commentBody(_ line: String) -> String? {
+        guard let marker = commentMarkers.first(where: line.hasPrefix) else { return nil }
+        return line.dropFirst(marker.count).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// `silent` and `inline` have nothing to show; the two output modes open the window.
+    private static func showsOutput(mode: String?) -> Bool {
+        mode == "compact" || mode == "fullOutput"
+    }
+
+    /// Raycast allows three, each a JSON object whose placeholder is what we prompt with.
+    private static func arguments(in directives: [String: String]) -> [CustomCommandArgument] {
+        (1...3).compactMap { index in
+            guard let json = directives["argument\(index)"]?.data(using: .utf8),
+                let object = (try? JSONSerialization.jsonObject(with: json)) as? [String: Any],
+                let placeholder = object["placeholder"] as? String, !placeholder.isEmpty
+            else { return nil }
+            return CustomCommandArgument(
+                name: placeholder, isOptional: object["optional"] as? Bool ?? false)
+        }
+    }
+
+    /// The script's own folder unless it says otherwise, which is what its relative paths mean.
+    private static func workingDirectory(_ declared: String?, script: URL) -> String {
+        let path = declared ?? script.deletingLastPathComponent().path
+        return (path as NSString).abbreviatingWithTildeInPath
+    }
+
+    /// Single-quoted, so a path holding a space, a `$` or a quote is still one word to zsh.
+    private static func shellQuoted(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// The shebang and the directives are at the top, and a body running to megabytes is not.
+    private static func head(of url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard var data = try? handle.read(upToCount: headSize), !data.isEmpty else { return nil }
+        // Cut at a newline, which no multi-byte character contains: a full read lands mid-line.
+        if data.count == headSize, let end = data.lastIndex(of: UInt8(ascii: "\n")) {
+            data = data[..<end]
+        }
+        return String(bytes: data, encoding: .utf8)
+    }
+}

--- a/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
+++ b/Tinycast/Features/CustomCommands/Settings/CommandsSettingsView.swift
@@ -48,10 +48,18 @@ struct CommandsSettingsView: View {
                 } label: {
                     SettingsRowTitle(.commandsCustomCommands, "Add Custom Command")
                 }
+                Button {
+                    Task { await core.customCommandCoordinator.importScriptDirectory() }
+                } label: {
+                    SettingsRowTitle(.commandsCustomCommands, "Import Raycast Scripts")
+                }
             } footer: {
-                Text("Name it, then give it a shortcut if you want one.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Text(
+                    "Name it, then give it a shortcut if you want one. Importing reads a folder of "
+                        + "Raycast script commands, one command per script."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
             .settingsEnabled(settings.customCommandsEnabled)
         }

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandCoordinator.swift
@@ -98,6 +98,66 @@ final class CustomCommandCoordinator {
         return count
     }
 
+    // MARK: - Importing
+
+    /// Adds a folder of Raycast script commands, skipping any name already in the library.
+    func importScriptDirectory() async {
+        guard let directory = chooseScriptDirectory() else { return }
+        let drafts = await Task.detached(priority: .userInitiated) {
+            RaycastScriptImport.scan(directory: directory)
+        }.value
+        guard !drafts.isEmpty else {
+            await core.showNotice(
+                title: "Nothing to Import",
+                message: "No Raycast script commands were found in this folder.",
+                symbol: CustomCommand.sfSymbol, tone: .neutral)
+            return
+        }
+        guard await confirmScriptImport(count: drafts.count) else { return }
+        let added = store.add(contentsOf: drafts)
+        // Everything offered was already here, so say so rather than "0 imported".
+        guard added > 0 else {
+            await core.showNotice(
+                title: "Nothing to Import",
+                message: "Every script in this folder is already in your library.",
+                symbol: CustomCommand.sfSymbol, tone: .neutral)
+            return
+        }
+        await core.showNotice(
+            title: "Scripts Imported",
+            message: importSummary(added: added, offered: drafts.count),
+            symbol: CustomCommand.sfSymbol, tone: .success)
+    }
+
+    /// An accessory app must activate first, or the panel opens behind the frontmost app.
+    private func chooseScriptDirectory() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Import"
+        panel.message = "Choose a folder of Raycast script commands."
+        NSApp.activate(ignoringOtherApps: true)
+        guard panel.runModal() == .OK else { return nil }
+        return panel.url
+    }
+
+    /// Scripts run arbitrary code, so this warns the way a backup of custom commands does.
+    private func confirmScriptImport(count: Int) async -> Bool {
+        await core.confirm(
+            title: count == 1 ? "Import 1 script?" : "Import \(count) scripts?",
+            message:
+                "Imported commands run these files with your user account. Only import scripts you "
+                + "trust.",
+            symbol: CustomCommand.sfSymbol, confirmTitle: "Import", confirmRole: .standard)
+    }
+
+    private func importSummary(added: Int, offered: Int) -> String {
+        let imported = added == 1 ? "Imported 1 command." : "Imported \(added) commands."
+        guard offered > added else { return imported }
+        return imported + " Skipped \(offered - added) already in your library."
+    }
+
     // MARK: - Running
 
     /// The one funnel for palette and hotkey, so neither form nor confirmation is bypassed.

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -202,7 +202,10 @@ enum SettingsSearchCatalog {
             keywords: ["script", "shell"]),
         .init(
             .commandsCustomCommands, "Add Custom Command",
-            keywords: ["new", "script", "shell", "shortcut"])
+            keywords: ["new", "script", "shell", "shortcut"]),
+        .init(
+            .commandsCustomCommands, "Import Raycast Scripts",
+            keywords: ["raycast", "script", "folder", "directory", "migrate"])
     ]
 
     private static let quicklinks: [SettingsSearchEntry] = [

--- a/docs/features/custom-commands.md
+++ b/docs/features/custom-commands.md
@@ -251,3 +251,57 @@ Foundation-only harness. Verify by hand:
 12. **Run Again clears the log before the new run prints.** The view draws deltas, so it keys what
     it has drawn on the run's id as well as the trim counter — a fresh run starts back at revision
     zero, and keying on the counter alone left the previous run's output on screen.
+13. **Import Raycast Scripts** opens a folder chooser, then a warning dialog; Cancel there imports
+    nothing. A folder holding no script commands says so instead of reporting zero.
+14. Re-importing the same folder says nothing was left to import, rather than reporting zero.
+15. An imported command with arguments asks for them and the script receives them — the `"$@"`
+    forwarding has no harness coverage of the palette form that fills it.
+
+## Importing Raycast scripts
+
+**Settings → Commands → Import Raycast Scripts** reads a folder of
+[Raycast script commands](https://github.com/raycast/script-commands) and adds one custom command per
+script. It is a one-shot import, not a watched folder: the drafts become ordinary commands, editable
+and deletable like any other, and nothing keeps pointing back at the folder afterwards.
+
+`Model/RaycastScriptImport.swift` does the parsing, and stays Foundation-only like the rest of
+`Model/`. The scan is non-recursive and skips hidden files, matching Raycast's own script directories,
+and runs on a detached task because it opens every file in the folder.
+
+A file becomes a command only when it has **both** a shebang and an `@raycast.title`. Both are
+mandatory in Raycast's own format, so anything failing either is a helper script the user keeps
+alongside their commands, not a command — leaving them out is what lets one folder hold both. Only the
+first 8 KiB of a file is read: the shebang and the metadata block are always at the top, and a
+script's body can run to megabytes.
+
+| Directive | Becomes |
+| --- | --- |
+| `@raycast.title` | the command name, and the only thing fuzzy search matches |
+| `@raycast.mode` | `compact` / `fullOutput` turn **Show output** on; `silent` and `inline` leave it off |
+| `@raycast.needsConfirmation` | **Needs confirmation** |
+| `@raycast.argument1…3` | the [arguments](#arguments), named by each one's `placeholder` |
+| `@raycast.currentDirectoryPath` | **Run In**, otherwise the script's own folder |
+
+`@raycast.icon` is deliberately **not** imported. Raycast's icon is an emoji or an `.icns` path, and
+`iconSymbol` holds an SF Symbol name; there is nothing to map one onto the other, and rendering
+either would mean a second icon field on every surface that draws a command. Imported commands take
+the shared terminal glyph, and the editor's picker is there to change it.
+`@raycast.description`, `@raycast.packageName` and the authorship keys have nowhere to go and are
+dropped.
+
+The generated command text is the shebang's interpreter, the script's path single-quoted, and
+`"$@"`:
+
+```
+/bin/bash '/Users/me/scripts/chrome cdp.sh' "$@"
+```
+
+Naming the interpreter rather than executing the file means the import never has to `chmod` a user's
+script. The `"$@"` matters: [the runner](#execution-contract) puts argument values on **zsh's**
+positional list, so without forwarding them the script would see none — and forwarding them quoted is
+what keeps the [never-spliced invariant](#invariants) true across the extra hop.
+
+An import warns before it applies, the same as a backup carrying custom commands, and it goes in as
+one `CustomCommandStore.add(contentsOf:)` — one persist and one launcher rebuild for the whole folder
+rather than one per script. A name already in the library is skipped and counted, so re-importing a
+folder after adding one script to it adds only that script.

--- a/docs/features/raycast-import.md
+++ b/docs/features/raycast-import.md
@@ -52,6 +52,10 @@ hotkeys do. Raycast's ULID is discarded — each imported row gets a fresh UUID,
 import already does. Importing at least one quicklink turns `quicklinksEnabled` on: opening a link
 grants no permission class.
 
+Script commands are not in a `.rayconfig` — they are files in a folder Raycast points at — so they
+have their own importer, described in
+[custom-commands.md](custom-commands.md#importing-raycast-scripts).
+
 ## Layout
 
 `RaycastDecoder` unwraps the container and returns Raycast's own values; `RaycastImportReader` turns


### PR DESCRIPTION
## Related issue

Closes #478

## What changed

**Settings → Commands → Import Raycast Scripts** reads a folder of [Raycast script
commands](https://github.com/raycast/script-commands) and adds one custom command per script.

It is a one-shot import, not a watched folder. The drafts become ordinary custom commands —
editable, deletable, aliasable, shortcut-able — and nothing keeps pointing back at the folder
afterwards. That was the narrower reading of the issue: the reporter's actual pain is recreating
scripts by hand, and aliases and per-command shortcuts already exist for every launcher entry.

Nothing existing changes. `CustomCommand` gains no field, no persisted key, no migration.

### What a script has to look like

A file becomes a command only when it has **both** a shebang and an `@raycast.title`. Both are
mandatory in Raycast's own format, so anything failing either is a helper script the user keeps
beside their commands, not a command — leaving those out is what lets one folder hold both. The scan
is non-recursive and skips hidden files, matching Raycast's own script directories.

| Directive | Becomes |
| --- | --- |
| `@raycast.title` | the command name |
| `@raycast.mode` | `compact` / `fullOutput` turn **Show output** on; `silent` and `inline` leave it off |
| `@raycast.needsConfirmation` | **Needs confirmation** |
| `@raycast.argument1…3` | arguments, named by each one's `placeholder` |
| `@raycast.currentDirectoryPath` | **Run In**, otherwise the script's own folder |

### Non-obvious bits of the diff

**`@raycast.icon` is deliberately dropped.** Raycast's icon is an emoji or an `.icns` path;
`iconSymbol` holds an SF Symbol name. There is nothing to map one onto the other, and rendering
either would mean a second icon field on every surface that draws a command. Imported commands take
the shared terminal glyph and the editor's picker is there to change it.

**The command text is the interpreter, the quoted path, and `"$@"`:**

```
/bin/bash '/Users/me/scripts/chrome cdp.sh' "$@"
```

Naming the shebang's interpreter rather than executing the file means the import never has to
`chmod` a user's script. The `"$@"` is the part worth reviewing: `ShellCommandRunner` puts argument
values on **zsh's** positional list, so without forwarding them the script would see none — a probe
against the issue's own `greet`-style script printed `Hello  from …` before this was added.
Forwarding them *quoted* is what keeps the never-spliced invariant true across the extra hop, and
there is a harness case that runs an imported script with `; touch …` as its value and checks
nothing was created.

**`CustomCommandStore.add(contentsOf:)`** lands the whole folder in one commit — one persist and one
launcher rebuild for the import, not one per script. This meant giving `validated` an explicit
`existing:` array to check names against, so a batch also dedupes within itself.

The import warns before it applies, the same as a backup carrying custom commands.

## Memory footprint

Not measured — the change adds no long-lived state. `RaycastScriptImport` reads at most 8 KiB per
file (the shebang and metadata are always at the top; a script body can run to megabytes), on a
detached task, and holds only the resulting drafts. The imported commands sit in the array
`CustomCommandStore` already owns.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no.

## Demo

The visible change is one Settings row and the dialogs it raises; there is no palette surface to
show side by side.

## Drawbacks

- **Strict recognition cuts both ways.** A `.sh` with no shebang, or a Raycast script missing its
  title, is silently skipped rather than imported under its filename. The success notice reports
  what was added and what was a duplicate, but not what was ignored — the alternative was slurping
  a folder of helper scripts into the launcher.
- **No icons.** Reasoned above, but it does mean an imported command looks less distinct than it did
  in Raycast.
- **One-shot, so it drifts.** Add a script to the folder and you re-import; already-imported names
  are skipped, which makes that idempotent, but a renamed or deleted script leaves the old command
  behind. A watched directory would fix this and is a much larger change: it needs sync and removal
  semantics and a "managed command" concept the store does not have.
- **Arguments are named by `placeholder`,** which is a hint string in Raycast and a label in
  Tinycast. Usually fine, occasionally reads oddly.

## Tests & validation

`./Scripts/run-tests.sh` — all 58 harnesses pass. `./Scripts/lint.sh` clean, `./Scripts/format.sh`
run, Debug build with no new warnings.

16 cases added to `Tests/custom-command-test.swift`:

- title → name; the shebang's interpreter with the path as one quoted word; `silent` vs `fullOutput`;
  `needsConfirmation` both ways; the script's own folder vs a declared `currentDirectoryPath`;
  arguments and their optionality from `argument1…3`
- a directive *below* the first line of code is the script's own text, not metadata
- no shebang → not a command; no title → not a command
- the JavaScript template's `//` directives parse too
- a `'` in the path cannot break out of the quoted argument
- a folder yields its commands in name order and skips a plain file, a hidden script and a subdirectory
- end to end: an imported script receives `; touch /tmp/…` as one inert word and the file is not created
- `add(contentsOf:)` counts only new commands, fires one commit, and drops a name colliding with the
  library *or* with the batch

By hand: built a folder from the issue's own `chrome-cdp.sh` and `messenger.applescript` plus an
argument-taking script, none of them `chmod +x`, and ran each generated command through
`ShellCommandRunner` — all three exit 0, arguments arrive, and the space in `chrome cdp.sh` survives.

Still worth a human pass (added to the doc's manual checks, since they need AppKit):

1. The folder chooser then the warning dialog; Cancel there imports nothing.
2. A folder with no script commands says so rather than reporting zero.
3. Re-importing the same folder says nothing was left to import.
4. An imported command with arguments asks for them in the palette and the script receives them.
