### PR TITLE
Focus extension command arguments after Space

### DIFF
--- a/Tests/ext-test.swift
+++ b/Tests/ext-test.swift
@@ -250,6 +250,26 @@ struct ExtensionTests {
         check(
             "provided arguments survive completion",
             manifest.commands[3].completeArguments(["q": "hi"]) == ["q": "hi"])
+        check(
+            "Space after an exact command title focuses its first argument",
+            manifest.commands[3].firstArgumentNameAfterSpace(
+                previousQuery: "Args", newQuery: "Args ") == "q")
+        check(
+            "the exact command title comparison ignores case",
+            manifest.commands[3].firstArgumentNameAfterSpace(
+                previousQuery: "args", newQuery: "args ") == "q")
+        check(
+            "a partial command title keeps filtering",
+            manifest.commands[3].firstArgumentNameAfterSpace(
+                previousQuery: "Arg", newQuery: "Arg ") == nil)
+        check(
+            "ordinary edits do not steal argument focus",
+            manifest.commands[3].firstArgumentNameAfterSpace(
+                previousQuery: "Args", newQuery: "Args!") == nil)
+        check(
+            "a command without arguments keeps search focus",
+            manifest.commands[0].firstArgumentNameAfterSpace(
+                previousQuery: "Search", newQuery: "Search ") == nil)
 
         let prefs = Dictionary(uniqueKeysWithValues: manifest.preferences.map { ($0.name, $0) })
         check("password kind", prefs["token"]?.kind == .password)

--- a/Tinycast/Features/Extensions/Model/ExtensionManifest.swift
+++ b/Tinycast/Features/Extensions/Model/ExtensionManifest.swift
@@ -162,6 +162,16 @@ struct ExtensionCommand: Sendable, Hashable, Identifiable {
         return complete
     }
 
+    /// Raycast hands an exact command-name query to its first argument when Space is appended.
+    func firstArgumentNameAfterSpace(previousQuery: String, newQuery: String) -> String? {
+        guard let first = arguments.first, newQuery.last == " ", newQuery.dropLast() == previousQuery
+        else { return nil }
+        let typedName = previousQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard typedName.compare(title, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        else { return nil }
+        return first.name
+    }
+
     init?(json: Any) {
         guard let dict = json as? [String: Any], let name = dict["name"] as? String,
             let title = dict["title"] as? String

--- a/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
@@ -167,6 +167,16 @@ final class ExtensionCoordinator {
         return command.arguments
     }
 
+    func argumentFocusTarget(
+        for entry: AppEntry?, previousQuery: String, newQuery: String
+    ) -> String? {
+        guard let entry, entry.kind == .extensionCommand,
+            let (_, command) = extensions.resolve(entry)
+        else { return nil }
+        return command.firstArgumentNameAfterSpace(
+            previousQuery: previousQuery, newQuery: newQuery)
+    }
+
     /// Escape past an empty search field: pop the extension's own stack, then leave the command.
     func exitExtensionScreen() {
         Task {

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -156,6 +156,13 @@ struct LauncherScreen: PaletteScreen {
         return app
     }
 
+    func argumentFocusTarget(
+        at selection: Int, previousQuery: String, newQuery: String
+    ) -> String? {
+        core.extensionCoordinator.argumentFocusTarget(
+            for: entry(at: selection), previousQuery: previousQuery, newQuery: newQuery)
+    }
+
     private func isCardSelected(_ selection: Int) -> Bool {
         switch row(at: selection) {
         case .calc, .meeting, .color: return true

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -277,9 +277,15 @@ struct RootPaletteView: View {
             searchFocused = !screen.hidesSearchField
             openMenu = nil
         }
-        .onChange(of: vm.query) {
+        .onChange(of: vm.query) { previousQuery, newQuery in
+            let argumentTarget = (screen as? LauncherScreen)?.argumentFocusTarget(
+                at: selection(in: screen), previousQuery: previousQuery, newQuery: newQuery)
             vm.selection = 0
             scroll = ScrollIntent(kind: .top)
+            if let argumentTarget {
+                argumentFocused = argumentTarget
+                searchFocused = false
+            }
             if vm.mode == .fileSearch { fileSearch.search(vm.query) }
             // A command that took over the search text filters its own list.
             if vm.mode == .extensionCommand, let handler = extensionScreen.searchTextHandler {

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -292,10 +292,11 @@ screens hold (see [palette.md](palette.md)).
   root, which would tear the command down before its `await confirmAlert(…)` ever returns.
 - **Command arguments** — a command declaring `arguments` shows inline fields sized to their
   placeholders, right after the typed text, exactly as Raycast does. Tab walks search field → each
-  argument → back; ↵ from any of them runs the command with the values as `props.arguments`; a blank
-  required argument blocks the launch and focuses the offending field. The fields get their own
-  `FocusState` rather than joining the search field's, so the palette's one always-attached `TextField`
-  (see [palette.md](palette.md)) keeps owning focus.
+  argument → back; typing an exact command title followed by Space hands focus directly to the first
+  field. ↵ from any field runs the command with the values as `props.arguments`; a blank required
+  argument blocks the launch and focuses the offending field. The fields get their own `FocusState`
+  rather than joining the search field's, so the palette's one always-attached `TextField` (see
+  [palette.md](palette.md)) keeps owning focus.
 
   Every declared argument is sent, **empty string when unfilled** (`ExtensionCommand.completeArguments`).
   That is Raycast's contract and extensions depend on it: `Number(args.seconds)` is `0` for `""` but


### PR DESCRIPTION
## Summary

- Focus the first declared argument when a selected extension command's exact title is followed by Space.
- Keep ordinary launcher filtering unchanged for partial titles, non-Space edits, and commands without arguments.
- Reuse the existing inline argument field and submission flow; no new persistent state or UI surface is introduced.

## Motivation

Raycast extension commands frequently require an argument. After locating an exact command, users currently need to press Tab before typing that argument. This change allows one continuous keyboard flow: type the command title, press Space, then enter the first argument.

## Implementation

- Add a pure matcher for the exact-title plus trailing-Space transition.
- Resolve the selected extension command's first argument in `LauncherScreen`.
- Route that focus target through the existing palette query-change path.
- Cover exact, case-insensitive, partial-title, non-Space, and no-argument behavior in the standalone harness.

## Verification

- `./Scripts/run-tests.sh`: 58 harnesses passed.
- `./Scripts/lint.sh`: passed.
- Debug build: succeeded with no new warnings.
- Model-layer import purity check: passed.
- Manual Dev-build smoke test: entering `Ask AI`, pressing Space, and typing `hello` kept the launcher query at `Ask AI` and placed `hello` in the inline `Question` field.
- Physical footprint remained below the documented ceiling: 50 MB idle, 54 MB while exercising the flow, and 53 MB after closing the palette.

Related to #486.