### PR TITLE
Keep focus in the header when Escape or Tab leaves an argument field

### DIFF
--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -18,54 +18,78 @@ struct PaletteEscapeTests {
 
     static func main() {
         expect(
-            PaletteEscapeAction.resolve(menuOpen: true, query: "notes", mode: .launcher),
+            PaletteEscapeAction.resolve(
+                menuOpen: true, argumentFocused: false, query: "notes", mode: .launcher),
             .closeMenu,
             "an open menu closes before anything else")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "notes", mode: .launcher),
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: false, query: "notes", mode: .launcher),
             .clearQuery,
             "a typed launcher query clears before the palette hides")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "notes", mode: .extensionCommand),
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: false, query: "notes", mode: .extensionCommand),
             .clearQuery,
             "a typed extension query clears before the extension screen exits")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .extensionCommand),
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: false, query: "", mode: .extensionCommand),
             .exitExtensionScreen,
             "an empty extension query exits the extension screen")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .launcher),
+            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .launcher),
             .hidePalette,
             "an empty launcher query hides the palette")
         // The two modes where the field is not a search field: an argument answer and a chat draft.
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "blue", mode: .quicklinkArguments),
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: false, query: "blue", mode: .quicklinkArguments),
             .clearQuery,
             "a half-typed argument clears before the pending quicklink is abandoned")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .quicklinkArguments),
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: false, query: "", mode: .quicklinkArguments),
             .hidePalette,
             "an empty argument field hides the palette, which cancels the pending quicklink")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "why is the sky", mode: .ai),
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: false, query: "why is the sky", mode: .ai),
             .clearQuery,
             "an unsent chat draft clears before chat itself is left")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .ai),
+            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .ai),
             .exitToLauncher,
             "an empty composer backs chat out to the launcher rather than hiding the palette")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, query: "", mode: .clipboard),
+            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .clipboard),
             .hidePalette,
             "only chat backs out; an empty clipboard filter still hides the palette")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: true, query: "", mode: .ai),
+            PaletteEscapeAction.resolve(menuOpen: true, argumentFocused: false, query: "", mode: .ai),
             .closeMenu,
             "a menu outranks the chat screen it is drawn over")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: true, query: "", mode: .extensionCommand),
+            PaletteEscapeAction.resolve(
+                menuOpen: true, argumentFocused: false, query: "", mode: .extensionCommand),
             .closeMenu,
             "a menu outranks the extension screen it is drawn over")
+        // An inline argument field is deeper than the query that found the command.
+        expect(
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: true, query: "search", mode: .launcher),
+            .leaveArgumentField,
+            "an argument field hands focus back before the query that found it clears")
+        expect(
+            PaletteEscapeAction.resolve(
+                menuOpen: false, argumentFocused: true, query: "", mode: .launcher),
+            .leaveArgumentField,
+            "an empty query does not let the argument field skip its own step")
+        expect(
+            PaletteEscapeAction.resolve(
+                menuOpen: true, argumentFocused: true, query: "search", mode: .launcher),
+            .closeMenu,
+            "a menu still outranks the argument field beneath it")
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -3,13 +3,18 @@ import Foundation
 /// Ordered like a bare backspace: a screen is only left once the search field is empty.
 enum PaletteEscapeAction: Equatable {
     case closeMenu
+    case leaveArgumentField
     case clearQuery
     case exitExtensionScreen
     case exitToLauncher
     case hidePalette
 
-    static func resolve(menuOpen: Bool, query: String, mode: PaletteMode) -> Self {
+    static func resolve(
+        menuOpen: Bool, argumentFocused: Bool, query: String, mode: PaletteMode
+    ) -> Self {
         if menuOpen { return .closeMenu }
+        // An argument field is a step deeper than the query, so it is left before anything clears.
+        if argumentFocused { return .leaveArgumentField }
         if !query.isEmpty { return .clearQuery }
         // An extension pops its own navigation stack before the command is left.
         if mode == .extensionCommand { return .exitExtensionScreen }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -396,9 +396,14 @@ struct RootPaletteView: View {
         .onKeyPress(.escape) {
             // An open list closes itself first, exactly as the ⌘K menu does.
             if vm.isControlListOpen { return .ignored }
-            switch PaletteEscapeAction.resolve(menuOpen: menuOpen, query: vm.query, mode: vm.mode) {
+            switch PaletteEscapeAction.resolve(
+                menuOpen: menuOpen, argumentFocused: argumentFocused != nil, query: vm.query,
+                mode: vm.mode)
+            {
             case .closeMenu:
                 closeMenus()
+            case .leaveArgumentField:
+                returnFocusToSearchField()
             case .clearQuery:
                 vm.query = ""
             case .exitExtensionScreen:
@@ -930,10 +935,7 @@ struct RootPaletteView: View {
         // A control editing with ↑/↓ keeps them; only ⇥ leaves it.
         guard !screen.ownsVerticalKeys(at: selection(in: screen)) else { return .ignored }
         // Moving off a command takes its argument fields with it, so hand focus back first.
-        if argumentFocused != nil {
-            argumentFocused = nil
-            searchFocused = true
-        }
+        if argumentFocused != nil { returnFocusToSearchField() }
         guard let next = screen.move(delta, axis: .vertical, from: selection(in: screen)) else {
             move(delta, in: screen)
             return .handled
@@ -1025,8 +1027,16 @@ struct RootPaletteView: View {
         guard let accessory = headerAccessory, !accessory.fieldNames.isEmpty else {
             return cycleMode()
         }
-        argumentFocused = accessory.fieldAfter(argumentFocused)
-        searchFocused = argumentFocused == nil
+        // Read from the local value: a `@FocusState` set in this tick still reads back stale.
+        let next = accessory.fieldAfter(argumentFocused)
+        argumentFocused = next
+        searchFocused = next == nil
+    }
+
+    /// AppKit selects the whole query as the field editor comes back, which is the wanted reset.
+    private func returnFocusToSearchField() {
+        argumentFocused = nil
+        searchFocused = true
     }
 
     private func navigateBack() {

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -94,7 +94,9 @@ to the launcher rather than joining the ring, and is reached by a command or a g
 Uninstall only from a launcher app's Actions menu, scoped to that app. Chat is skipped whole when
 `aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced. **Escape clears a
 non-empty query before it leaves the screen**, so one press clears and the next leaves: chat backs
-out to the launcher, an extension screen exits itself, and anywhere else the palette hides.
+out to the launcher, an extension screen exits itself, and anywhere else the palette hides. A focused
+inline argument field is a rung above the query, so Escape hands focus back to the search field
+first — the query that found the command is still there to be cleared by the next press.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
 pairing of a label with its key. It is drawn only when Tab really would open chat, a condition read
@@ -128,9 +130,17 @@ invariants:
   flipping the branch tears down its field editor, which drops first responder mid-navigation. Only
   its *width* changes — it shrinks to the width of the typed text so the argument chips sit right
   after it, as they do in Raycast.
-- Argument focus is its own `@FocusState`, `argumentFocused`, keyed by argument name. Moving the
-  selection hands focus back to the search field first, because the row that owned those fields is
-  about to stop being selected. ↵ on a blank required argument focuses it instead of launching.
+- Argument focus is its own `@FocusState`, `argumentFocused`, keyed by argument name. Every way out
+  — moving the selection, Escape, Tab past the last field — goes through
+  `returnFocusToSearchField()`, because the row that owned those fields is about to stop being
+  selected and a field that unmounts while focused leaves the panel with no first responder at all.
+  ↵ on a blank required argument focuses it instead of launching.
+- **Never read a `@FocusState` back in the tick that writes it.** It still reports the old field, so
+  `searchFocused = argumentFocused == nil` resolved to `false` and Tab out of the last argument
+  focused nothing; AppKit's key-view loop then answered the next presses instead. Both writes come
+  from one local value.
+- Returning focus this way leaves the query selected, because AppKit selects the whole string as the
+  field editor comes back — here that is the wanted reset rather than the hazard it is under ↵.
 
 The typed values live on `PaletteState.commandArguments`, keyed by
 `PaletteState.argumentKey(entryID, name)`, and are cleared with the rest of the screen.


### PR DESCRIPTION
## Related issue

Closes #

## What changed

Two defects stranded first responder once an inline command argument was focused — typing the argument for a command like Brew's Search, then pressing Escape, left the palette with nothing focused and no way to type.

**Tab out of the last argument focused nothing.** `advanceTabFocus` wrote `argumentFocused` and then read it back in the same tick:

```swift
argumentFocused = accessory.fieldAfter(argumentFocused)
searchFocused = argumentFocused == nil   // still reports the OLD field -> false
```

A `@FocusState` set in a tick still reports the previous field for the rest of it, so `searchFocused` was set to `false` and focus landed on the window. With no focused view inside the SwiftUI tree, later presses never reached `onKeyPress` at all and AppKit's key-view loop answered them instead — which is why the *third* press, not the first, landed on the search field with its text selected. Both writes now come from one local value.

**Escape had no rung for a focused argument field**, so it ran `.clearQuery`; that reset the selection, the command row stopped being selected, and the field unmounted while focused. `PaletteEscapeAction` gains `.leaveArgumentField` above `.clearQuery`, so the ladder reads: leave the field → clear the query → leave the screen. AppKit selects the whole string as the field editor comes back, so one press hands focus back with the query selected and the next clears it — no select-all machinery needed.

`moveVertically`'s existing hand-back and the new Escape case share `returnFocusToSearchField()`.

## Memory footprint

Not measured. Nothing is allocated, retained or observed that was not before — the change is two assignments and one enum case on an existing key handler, with no new objects, timers or subscriptions.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | n/a    |
| Palette open            | n/a    |
| Feature in use (peak)   | n/a    |
| Palette closed, settled | n/a    |

Leak-tested: no — no ownership change to test.

## Demo

Focus behaviour, not a visual change; nothing renders differently. Verified by hand in the app (see below).

## Drawbacks

⇧⇥ inside the argument strip still walks *forward*: `PaletteHeaderAccessory.fieldAfter` has no backwards direction, and `advanceTabFocus` passes `backwards` only to `screen.tabTarget`. That gap predates this change and only shows with two or more arguments, so it is left for its own commit rather than widened into this one.

## Tests & validation

- `./Scripts/run-tests.sh` — all 58 harnesses pass.
- `Tests/palette-escape-test.swift` — three cases added for the new rung: an argument field outranks a non-empty query, an empty query does not let it skip its step, and an open menu still outranks it. Every existing case gained `argumentFocused: false`.
- Debug build clean, no new warnings; `./Scripts/lint.sh` clean.
- Both mechanisms were reproduced in a standalone SwiftUI probe before the fix — the stale `@FocusState` read-back and the unmount-while-focused — and the probe confirmed the corrected handoff lands on the search field with the query selected.
- By hand: type `search`, Tab into Brew's argument, then Escape (query selected), Escape (query cleared), Escape (palette hides); Tab now rings search ↔ argument in one press each way.
