### PR TITLE
Add Mac keyboard keys and Apple logo to the emoji picker

### DIFF
--- a/Scripts/gen-emoji.js
+++ b/Scripts/gen-emoji.js
@@ -188,6 +188,19 @@ const SHAPES = [
   ["№", "numero sign", "number"],
   ["¡", "inverted exclamation mark", "spanish punctuation"],
   ["¿", "inverted question mark", "spanish punctuation"],
+  ["◉", "fisheye", "bullseye target circle dot"],
+  ["◎", "bullseye", "target circle ring"],
+  ["#", "number sign", "hash pound sharp"],
+  ["*", "asterisk", "star multiply wildcard"],
+  ["@", "at sign", "at arobase email"],
+  ["&", "ampersand", "and"],
+  ["%", "percent sign", "percent modulo"],
+  ["⁉", "exclamation question mark", "interrobang surprise"],
+  ["‼", "double exclamation mark", "bang emphasis"],
+  ["℗", "sound recording copyright", "phonogram copyright publishing"],
+  ["℠", "service mark", "servicemark trademark"],
+  ["ª", "feminine ordinal indicator", "feminine ordinal spanish"],
+  ["º", "masculine ordinal indicator", "masculine ordinal spanish portuguese"],
 ];
 // Everyday CJK punctuation — not Unicode emoji, so the upstream data never carries it.
 const CJK = [
@@ -238,12 +251,40 @@ const CJK = [
   ["﹃", "vertical left white corner bracket", "tategaki quote open"],
   ["﹄", "vertical right white corner bracket", "tategaki quote close"],
 ];
+// Mac keyboard keys and everyday technicals, all listed by the macOS character viewer.
+//  is Apple private-use (U+F8FF), so it never appears in Unicode data and is curated here.
+const KEYS = [
+  ["⌘", "command key", "cmd looped square place of interest"],
+  ["⌥", "option key", "opt alt"],
+  ["⌃", "control key", "ctrl caret up arrowhead"],
+  ["⎋", "escape key", "esc"],
+  ["⏎", "return key", "enter newline carriage"],
+  ["⌤", "enter key", "enter numpad"],
+  ["⌫", "delete key", "backspace erase backward"],
+  ["⌦", "forward delete key", "delete forward fn"],
+  ["⇥", "tab key", "tab right"],
+  ["⇤", "backtab key", "shift tab left"],
+  ["⇱", "home key", "home corner"],
+  ["⇲", "end key", "end corner"],
+  ["⇞", "page up key", "pgup page up"],
+  ["⇟", "page down key", "pgdn page down"],
+  ["⏏", "eject key", "eject media disk"],
+  ["⌧", "clear key", "clear numpad"],
+  ["⎙", "print screen key", "print screen sysrq"],
+  ["␣", "space symbol", "space blank open box"],
+  ["⌀", "diameter sign", "diameter engineering average"],
+  ["⌂", "house", "home house"],
+  ["⌨", "keyboard", "keyboard"],
+  ["⚙", "gear", "settings cog preferences"],
+  ["", "apple logo", "apple logo private"],
+];
 const SYMBOL_SECTIONS = [
   ["xa", ARROWS],
   ["xc", CURRENCY],
   ["xm", MATH],
   ["xs", SHAPES],
   ["xj", CJK],
+  ["xk", KEYS],
 ];
 
 const LINE_RE =

--- a/Tests/emoji-test.swift
+++ b/Tests/emoji-test.swift
@@ -31,6 +31,10 @@ struct EmojiTests {
         expect(euro?.category == .currency, "€ landed in Currency")
         let reference = entries.first { $0.glyph == "※" }
         expect(reference?.category == .cjk, "※ landed in CJK Symbols")
+        let command = entries.first { $0.glyph == "⌘" }
+        expect(command?.category == .keysAndTechnical, "⌘ landed in Keys & Technical")
+        let apple = entries.first { $0.glyph == "\u{F8FF}" }
+        expect(apple?.keywords.contains("apple") == true, " is searchable as apple")
 
         // Skin tone application
         expect(EmojiCatalog.applyTone(.dark, to: "👋") == "👋🏿", "modifier appended")

--- a/Tinycast/Features/Emoji/Model/EmojiCatalog.swift
+++ b/Tinycast/Features/Emoji/Model/EmojiCatalog.swift
@@ -15,6 +15,7 @@ enum EmojiCategory: String, CaseIterable, Sendable {
     case math = "xm"
     case shapesAndPunctuation = "xs"
     case cjk = "xj"
+    case keysAndTechnical = "xk"
 
     var title: String {
         switch self {
@@ -31,6 +32,7 @@ enum EmojiCategory: String, CaseIterable, Sendable {
         case .math: return "Math"
         case .shapesAndPunctuation: return "Shapes & Punctuation"
         case .cjk: return "CJK Symbols"
+        case .keysAndTechnical: return "Keys & Technical"
         }
     }
 }

--- a/Tinycast/Features/Emoji/Model/EmojiData.generated.swift
+++ b/Tinycast/Features/Emoji/Model/EmojiData.generated.swift
@@ -2056,6 +2056,19 @@ $|dollar sign|xc|0|usd money currency
 №|numero sign|xs|0|number
 ¡|inverted exclamation mark|xs|0|spanish punctuation
 ¿|inverted question mark|xs|0|spanish punctuation
+◉|fisheye|xs|0|bullseye target circle dot
+◎|bullseye|xs|0|target circle ring
+#|number sign|xs|0|hash pound sharp
+*|asterisk|xs|0|star multiply wildcard
+@|at sign|xs|0|at arobase email
+&|ampersand|xs|0|and
+%|percent sign|xs|0|percent modulo
+⁉|exclamation question mark|xs|0|interrobang surprise
+‼|double exclamation mark|xs|0|bang emphasis
+℗|sound recording copyright|xs|0|phonogram copyright publishing
+℠|service mark|xs|0|servicemark trademark
+ª|feminine ordinal indicator|xs|0|feminine ordinal spanish
+º|masculine ordinal indicator|xs|0|masculine ordinal spanish portuguese
 ※|reference mark|xj|0|kome komejirushi note footnote annotation
 〃|ditto mark|xj|0|same repeat above
 〄|japanese industrial standard symbol|xj|0|jis
@@ -2102,5 +2115,28 @@ $|dollar sign|xc|0|usd money currency
 ﹂|vertical right corner bracket|xj|0|tategaki kagi quote close
 ﹃|vertical left white corner bracket|xj|0|tategaki quote open
 ﹄|vertical right white corner bracket|xj|0|tategaki quote close
+⌘|command key|xk|0|cmd looped square place of interest
+⌥|option key|xk|0|opt alt
+⌃|control key|xk|0|ctrl caret up arrowhead
+⎋|escape key|xk|0|esc
+⏎|return key|xk|0|enter newline carriage
+⌤|enter key|xk|0|enter numpad
+⌫|delete key|xk|0|backspace erase backward
+⌦|forward delete key|xk|0|delete forward fn
+⇥|tab key|xk|0|tab right
+⇤|backtab key|xk|0|shift tab left
+⇱|home key|xk|0|home corner
+⇲|end key|xk|0|end corner
+⇞|page up key|xk|0|pgup page up
+⇟|page down key|xk|0|pgdn page down
+⏏|eject key|xk|0|eject media disk
+⌧|clear key|xk|0|clear numpad
+⎙|print screen key|xk|0|print screen sysrq
+␣|space symbol|xk|0|space blank open box
+⌀|diameter sign|xk|0|diameter engineering average
+⌂|house|xk|0|home house
+⌨|keyboard|xk|0|keyboard
+⚙|gear|xk|0|settings cog preferences
+|apple logo|xk|0|apple logo private
 """
 }


### PR DESCRIPTION
## Related issue

Closes #

## What changed

- New **Keys & Technical** catalog section (`xk`): `⌘ ⌥ ⌃ ⎋ ⏎ ⌤ ⌫ ⌦ ⇥ ⇤ ⇱ ⇲ ⇞ ⇟ ⏏ ⌧ ⎙ ␣ ⌀ ⌂ ⌨ ⚙` plus `` (U+F8FF, Apple private-use, so it can never come from Unicode data and is curated with `apple logo` keywords).
- 13 complements to **Shapes & Punctuation**: `◉ ◎ # * @ & % ⁉ ‼ ℗ ℠ ª º` (e.g. searching `hash`, `arobase`, `numero` now resolves).
- Every added glyph was checked against the macOS Character Viewer lists (renderable, no tofu) and against the existing dataset (no duplicates — `gen-emoji.js` also throws on collision).
- Dataset regenerated via `node Scripts/gen-emoji.js` (2100 → 2136 records, append-only, upstream emoji data unchanged); `EmojiData.generated.swift` never hand-edited.

## Memory footprint

36 static records parsed once at index load; no new caches, observers, or long-lived state. Search stays a single memoized fuzzy pass.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | ~159 MB RSS (Dev build, whole app — unchanged by this diff) |
| Palette open            | Not measured headlessly |
| Feature in use (peak)   | Not measured headlessly |
| Palette closed, settled | Not measured headlessly |

Leak-tested: No — nothing new to leak (static dataset rows only).

## Demo

No clip recorded from here (headless session). Repro: summon the palette → emoji picker → type `command`, `eject`, `apple`, or `arobase`; a Keys & Technical section appears. Happy to attach a capture if wanted.

## Drawbacks

- Hand-picked essentials (~36), not full Unicode coverage — a deliberate scope choice; the script is ready to take more curated rows.
- Media keys (`⏵ ⏸ ⏯`) and `⏻` excluded on purpose: absent from the macOS Character Viewer lists, so rendering isn't guaranteed.

## Tests & validation

- `./Scripts/run-tests.sh`: 58/58 harnesses pass, including `emoji-test` with 2 new asserts (`⌘` lands in Keys & Technical, `` searchable as `apple`).
- `./Scripts/lint.sh`: clean (only pre-existing warnings in unrelated files).
- Debug `xcodebuild` succeeds with no new warnings; `Model/` still Foundation-only.
- Ran the fresh `Tinycast Dev.app` build locally in place of the previous Debug build.