### PR TITLE
Make Escape walk back through the screens it opened

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -138,6 +138,7 @@ run ai-instructions-test   Tinycast/Features/AI/Model/AIInstructions.swift \
                            Tinycast/Features/AI/Model/AIPreamble.swift
 run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Palette/PaletteState.swift \
+                           Tinycast/Palette/PaletteNavigationStack.swift \
                            Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
@@ -149,6 +150,19 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run palette-escape-test    Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteEscapeAction.swift \
+                           Tinycast/Features/Settings/EscapeKeyBehavior.swift \
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift \
+                           Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+run palette-navigation-test Tinycast/Palette/PaletteNavigationStack.swift \
+                           Tinycast/Palette/PaletteState.swift \
+                           Tinycast/Palette/HoverArming.swift \
+                           Tinycast/Palette/PaletteMode.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
+                           Tinycast/Features/Clipboard/Model/ColorValue.swift \
+                           Tinycast/Features/Clipboard/Model/ColorFormat.swift \
+                           Tinycast/Features/Clipboard/Model/ColorSpaces.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift
@@ -248,6 +262,7 @@ run notes-editor-test      Tinycast/Platform/Signposts.swift \
                            Tinycast/Features/Notes/UI/NoteTextView.swift \
                            Tinycast/Features/Notes/UI/NoteEditorView.swift
 run slow -O raycast-test   Tinycast/Features/Backup/Model/RaycastImportError.swift \
+                           Tinycast/Features/Settings/EscapeKeyBehavior.swift \
                            Tinycast/Features/Backup/Service/RaycastDecoder.swift \
                            Tinycast/Features/Backup/Service/Scrypt.swift \
                            Tinycast/Platform/Compression/Zlib.swift

--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -16,81 +16,94 @@ struct PaletteEscapeTests {
         }
     }
 
+    /// The default behaviour, where Escape is the back key.
+    static func back(
+        menuOpen: Bool = false, argumentFocused: Bool = false, query: String = "",
+        mode: PaletteMode, canGoBack: Bool = false
+    ) -> PaletteEscapeAction {
+        PaletteEscapeAction.resolve(
+            menuOpen: menuOpen, argumentFocused: argumentFocused, query: query, mode: mode,
+            canGoBack: canGoBack, behavior: .popBackOrClose)
+    }
+
+    /// The opt-in behaviour, where Escape always closes and Backspace carries the back step.
+    static func close(
+        menuOpen: Bool = false, argumentFocused: Bool = false, query: String = "",
+        mode: PaletteMode, canGoBack: Bool = false
+    ) -> PaletteEscapeAction {
+        PaletteEscapeAction.resolve(
+            menuOpen: menuOpen, argumentFocused: argumentFocused, query: query, mode: mode,
+            canGoBack: canGoBack, behavior: .closeAndPopToRoot)
+    }
+
+    /// Every screen Escape can land on, so a new mode cannot quietly skip the table below.
+    static let screens: [PaletteMode] = [
+        .launcher, .clipboard, .ai, .aiHistory, .uninstall, .extensionCommand,
+        .customCommandArguments
+    ]
+
     static func main() {
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: true, argumentFocused: false, query: "notes", mode: .launcher),
-            .closeMenu,
-            "an open menu closes before anything else")
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "notes", mode: .launcher),
-            .clearQuery,
-            "a typed launcher query clears before the palette hides")
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "notes", mode: .extensionCommand),
-            .clearQuery,
-            "a typed extension query clears before the extension screen exits")
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "", mode: .extensionCommand),
-            .exitExtensionScreen,
-            "an empty extension query exits the extension screen")
-        expect(
-            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .launcher),
-            .hidePalette,
-            "an empty launcher query hides the palette")
-        // The two surfaces where the field is not a search field: an argument answer, a chat draft.
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "blue",
-                mode: .customCommandArguments),
-            .clearQuery,
-            "a half-typed argument clears before the pending command is abandoned")
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "", mode: .customCommandArguments),
-            .hidePalette,
-            "an empty argument field hides the palette, which cancels the pending command")
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "why is the sky", mode: .ai),
-            .clearQuery,
-            "an unsent chat draft clears before chat itself is left")
-        expect(
-            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .ai),
-            .exitToLauncher,
-            "an empty composer backs chat out to the launcher rather than hiding the palette")
-        expect(
-            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .clipboard),
-            .hidePalette,
-            "only chat backs out; an empty clipboard filter still hides the palette")
-        expect(
-            PaletteEscapeAction.resolve(menuOpen: true, argumentFocused: false, query: "", mode: .ai),
-            .closeMenu,
-            "a menu outranks the chat screen it is drawn over")
-        expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: true, argumentFocused: false, query: "", mode: .extensionCommand),
-            .closeMenu,
-            "a menu outranks the extension screen it is drawn over")
+        // The inner handlers outrank navigation, under either setting.
+        for mode in screens {
+            expect(back(menuOpen: true, mode: mode), .closeMenu, "a menu outranks \(mode)")
+            expect(close(menuOpen: true, mode: mode), .closeMenu, "a menu outranks \(mode) when closing")
+            expect(
+                back(menuOpen: true, query: "typed", mode: mode, canGoBack: true), .closeMenu,
+                "a menu outranks even a typed query on \(mode)")
+        }
+
         // An inline argument field is deeper than the query that found the command.
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: true, query: "search", mode: .launcher),
-            .leaveArgumentField,
+            back(argumentFocused: true, query: "search", mode: .launcher), .leaveArgumentField,
             "an argument field hands focus back before the query that found it clears")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: true, query: "", mode: .launcher),
-            .leaveArgumentField,
+            back(argumentFocused: true, mode: .launcher), .leaveArgumentField,
             "an empty query does not let the argument field skip its own step")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: true, argumentFocused: true, query: "search", mode: .launcher),
-            .closeMenu,
+            close(argumentFocused: true, mode: .launcher, canGoBack: true), .leaveArgumentField,
+            "the argument field is an inner handler, so closing never outranks it")
+        expect(
+            back(menuOpen: true, argumentFocused: true, query: "search", mode: .launcher), .closeMenu,
             "a menu still outranks the argument field beneath it")
+
+        // A typed field clears first, whatever is underneath and whichever setting is on.
+        for mode in screens {
+            for canGoBack in [false, true] {
+                expect(
+                    back(query: "typed", mode: mode, canGoBack: canGoBack), .clearQuery,
+                    "a typed query on \(mode) clears before the screen is left")
+                expect(
+                    close(query: "typed", mode: mode, canGoBack: canGoBack), .clearQuery,
+                    "a typed query on \(mode) clears before the palette closes")
+            }
+        }
+
+        // Pop back or close: an empty field pops one screen, or closes at the bottom.
+        for mode in screens where mode != .extensionCommand {
+            expect(
+                back(mode: mode, canGoBack: false), .hidePalette,
+                "\(mode) reached by its own hotkey has nothing under it, so Escape closes")
+            expect(
+                back(mode: mode, canGoBack: true), .goBack,
+                "\(mode) reached from another screen goes back to it")
+        }
+
+        // An extension leaves through its own coordinator, which pops its inner stack first.
+        expect(
+            back(mode: .extensionCommand, canGoBack: false), .exitExtensionScreen,
+            "an extension screen exits through the extension, not the palette's stack")
+        expect(
+            back(mode: .extensionCommand, canGoBack: true), .exitExtensionScreen,
+            "a row-opened extension still exits through the extension, which then pops the stack")
+
+        // Close and pop to root: Escape stops navigating entirely, extensions included.
+        for mode in screens {
+            for canGoBack in [false, true] {
+                expect(
+                    close(mode: mode, canGoBack: canGoBack), .hidePalette,
+                    "\(mode) closes rather than going back when Escape is set to close")
+            }
+        }
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tests/palette-navigation-test.swift
+++ b/Tests/palette-navigation-test.swift
@@ -1,0 +1,103 @@
+import CoreGraphics
+import Foundation
+
+/// Going back must land on the screen the user last saw, with what they had typed still there.
+@main
+@MainActor
+struct PaletteNavigationTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    /// A launcher part-way through a search: what every push below is expected to restore.
+    static func searching() -> PaletteState {
+        let state = PaletteState()
+        state.prepare(mode: .launcher)
+        state.query = "clipboard"
+        state.selection = 3
+        return state
+    }
+
+    static func main() {
+        var stack = PaletteNavigationStack()
+        expect(!stack.canGoBack, "a fresh stack has nothing under it")
+        expect(stack.pop() == nil, "popping an empty stack yields no frame")
+
+        let frame = PaletteFrame(
+            mode: .launcher, query: "clipboard", selection: 3, clipboardFilter: .all)
+        stack.push(frame)
+        expect(stack.canGoBack, "a pushed frame is a screen to go back to")
+        expect(stack.pop() == frame, "a popped frame is the one that was pushed")
+        expect(!stack.canGoBack, "the last pop empties the stack")
+
+        stack.push(frame)
+        stack.push(PaletteFrame(mode: .ai, query: "", selection: 0, clipboardFilter: .all))
+        stack.reset()
+        expect(!stack.canGoBack, "reset drops every frame, however deep")
+
+        // A summon is a root: Escape on it closes rather than going back.
+        let root = searching()
+        expect(!root.canGoBack, "a prepared screen is the bottom of the stack")
+        expect(!root.pop(), "popping the root reports there was nowhere to go")
+
+        // The round-trip the whole feature exists for: launcher → clipboard → back.
+        let state = searching()
+        state.push(mode: .clipboard)
+        expect(state.mode == .clipboard, "a push lands on the new screen")
+        expect(state.query.isEmpty, "a pushed screen starts with an empty field")
+        expect(state.selection == 0, "a pushed screen starts at its first row")
+        expect(state.canGoBack, "the screen underneath is still there")
+
+        state.clipboardFilter = .image
+        let followed = state.followToken
+        expect(state.pop(), "going back from a pushed screen succeeds")
+        expect(state.mode == .launcher, "back lands on the screen that was pushed over")
+        expect(state.query == "clipboard", "back restores the query that was typed")
+        expect(state.selection == 3, "back restores the row that was selected")
+        expect(state.clipboardFilter == .all, "back restores the filter the screen had")
+        expect(state.followToken != followed, "back scrolls the restored row into view")
+        expect(!state.canGoBack, "the stack is empty once the last screen is restored")
+
+        // Depth: each push is its own frame, and each pop undoes exactly one.
+        let deep = searching()
+        deep.push(mode: .ai)
+        deep.query = "why is the sky blue"
+        deep.push(mode: .aiHistory)
+        expect(deep.pop(), "history goes back to the chat it was opened from")
+        expect(deep.mode == .ai, "the chat is the screen under history")
+        expect(deep.query == "why is the sky blue", "the unsent draft survives the round trip")
+        expect(deep.pop(), "the chat goes back to the launcher under it")
+        expect(deep.mode == .launcher && deep.query == "clipboard", "the launcher comes back whole")
+        expect(!deep.pop(), "the launcher is the root, so the next Escape closes instead")
+
+        // Replacing a screen is lateral: one extension command fired over another must not stack,
+        // or Escape would restore a frame whose command has already been stopped.
+        let lateral = searching()
+        lateral.push(mode: .extensionCommand)
+        lateral.replace(mode: .extensionCommand)
+        expect(lateral.mode == .extensionCommand, "replace lands on the new screen")
+        expect(lateral.canGoBack, "replace keeps whatever was underneath")
+        expect(lateral.pop(), "one pop is enough to leave a replaced screen")
+        expect(lateral.mode == .launcher, "the screen under the replaced one is the original")
+        expect(!lateral.canGoBack, "replacing never added a second frame")
+
+        // Pop to root from any depth, which is what ⌘⎋ and the timeout both do.
+        let reset = searching()
+        reset.push(mode: .ai)
+        reset.push(mode: .aiHistory)
+        reset.prepare(mode: .launcher)
+        expect(!reset.canGoBack, "becoming the root drops every screen underneath")
+        expect(reset.query.isEmpty, "the root search starts empty")
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tests/raycast-test.swift
+++ b/Tests/raycast-test.swift
@@ -42,9 +42,31 @@ enum RaycastTests {
         decryption()
         gunzipSlices()
         gunzipCap()
+        escapeKeyBehavior()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Settings mapping
+
+    /// A `.rayconfig` carries Raycast's own spelling, and only its own spelling.
+    static func escapeKeyBehavior() {
+        expect(
+            EscapeKeyBehavior(raycastValue: "pop-back-or-close") == .popBackOrClose,
+            "Raycast's default maps to going back")
+        expect(
+            EscapeKeyBehavior(raycastValue: "close-and-pop-to-root") == .closeAndPopToRoot,
+            "Raycast's other option maps to closing")
+        expect(
+            EscapeKeyBehavior(raycastValue: "popBackOrClose") == nil,
+            "our own raw value is not Raycast's spelling, so it is skipped")
+        expect(
+            EscapeKeyBehavior(raycastValue: "sometimes") == nil,
+            "an unknown behaviour is skipped rather than guessed at")
+        expect(
+            EscapeKeyBehavior(raycastValue: "") == nil,
+            "an empty behaviour is skipped rather than defaulted")
     }
 
     // MARK: - Fixtures

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		2C9B845C83930B9EEA188C0C /* WindowLayoutInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A29ED24604BE67E562B07D /* WindowLayoutInspector.swift */; };
 		2D51D92BE8EAB5440F4C8517 /* ExtensionPaletteModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0FB3A9CA762A7A8DB99BA6 /* ExtensionPaletteModifiers.swift */; };
 		2E0957985928EC32511A5969 /* MCPServerEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0814A6707E67A3BD3772E119 /* MCPServerEditor.swift */; };
+		2E9641057A7B1FE1446BD14D /* EscapeKeyBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */; };
 		2E9CDC24A175FE8AAE4F03D9 /* InstalledAIStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817AF0E23DDCC95147B5AFB /* InstalledAIStream.swift */; };
 		2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C7F0C39D24F068A8F84864 /* CurrencyData.generated.swift */; };
 		2F2360730BE4992D5745FAD3 /* ExtensionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471E1C3C250FD0A89E2C6430 /* ExtensionListView.swift */; };
@@ -156,6 +157,7 @@
 		47A443F25878A27DE6DF24AA /* NoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAFF79E9897975CAC5EAC0E /* NoteEditorView.swift */; };
 		47C7E1E33C5D70C3DBED15D5 /* CustomCommandArgumentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7F0F7172895889F1AF069 /* CustomCommandArgumentsScreen.swift */; };
 		47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */; };
+		484D72C59BA15A56CF0C7715 /* PaletteNavigationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1525DCB0E6BD68E752CBA453 /* PaletteNavigationStack.swift */; };
 		48AE2C9989F8FA2AA99D2D61 /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B4495E56754B05B5F3551D /* CalcPercent.swift */; };
 		4A09D85BDD4A75B1FF1BABA5 /* CameraSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD42AFBAB42DB5BF5FE1BCE /* CameraSession.swift */; };
 		4C1787D99E49A84C0647C5D8 /* BackupCategorySelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7945C129A685FC29FBA70EE4 /* BackupCategorySelection.swift */; };
@@ -579,6 +581,7 @@
 		132FBA3F0A0B4F6C796B901B /* NoteSwitcherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSwitcherView.swift; sourceTree = "<group>"; };
 		140D704D2B8F12F7D623DB8F /* CameraStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraStage.swift; sourceTree = "<group>"; };
 		14F474B4E9FD7738D97AB65E /* RaycastImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaycastImport.swift; sourceTree = "<group>"; };
+		1525DCB0E6BD68E752CBA453 /* PaletteNavigationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteNavigationStack.swift; sourceTree = "<group>"; };
 		1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteMode.swift; sourceTree = "<group>"; };
 		154222C91EFDB4D4490B6CE2 /* ExtensionArgumentsAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionArgumentsAccessory.swift; sourceTree = "<group>"; };
 		1590A8769EF787763DE189B7 /* CommandArgumentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandArgumentsRow.swift; sourceTree = "<group>"; };
@@ -836,6 +839,7 @@
 		91151402A1A4586B2496BF35 /* NotesPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesPanel.swift; sourceTree = "<group>"; };
 		9188FA8A06EAE3E55FFCBC70 /* UpdateInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInstaller.swift; sourceTree = "<group>"; };
 		91D0784E49BC5899A585F285 /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
+		920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeKeyBehavior.swift; sourceTree = "<group>"; };
 		92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutShape.swift; sourceTree = "<group>"; };
 		92B4495E56754B05B5F3551D /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
 		934DBE501F116131DC1BF5CE /* CalcExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcExpressionParser.swift; sourceTree = "<group>"; };
@@ -2243,6 +2247,7 @@
 				524404EF88622426B0AA4E33 /* PaletteEnvironment.swift */,
 				53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
+				1525DCB0E6BD68E752CBA453 /* PaletteNavigationStack.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
 				445B0374FD5D74DBE23243CD /* PaletteScreen.swift */,
@@ -2415,6 +2420,7 @@
 				A5A8F78D3F1BFA8E86F9CB47 /* AppAppearance.swift */,
 				7F64F4362989516482853CDB /* AppSettings.swift */,
 				384485BD1794D25503534525 /* AppSettingsKey.swift */,
+				920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */,
 				C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */,
 				8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */,
 				C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */,
@@ -2829,6 +2835,7 @@
 				0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */,
 				017FB0EDDC9AF28ED81EA6A8 /* EntryIconView.swift in Sources */,
 				0FD2528627DE63DC9C6B8793 /* EntryNaming.swift in Sources */,
+				2E9641057A7B1FE1446BD14D /* EscapeKeyBehavior.swift in Sources */,
 				7D027F24478DAB019076CA10 /* EventDraft.swift in Sources */,
 				A33EA048BC22D7313F4D480C /* EventDraftFields.swift in Sources */,
 				A6200866E3416744A6E8B6E5 /* ExecutableLocator.swift in Sources */,
@@ -3000,6 +3007,7 @@
 				695898F8FF98200F180FC2CA /* PaletteEnvironment.swift in Sources */,
 				8E30C461429C894907FAD94D /* PaletteEscapeAction.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
+				484D72C59BA15A56CF0C7715 /* PaletteNavigationStack.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
 				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,
 				9F8806D46EBAF7058FC2EAEC /* PaletteRowIndex.swift in Sources */,

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -142,18 +142,20 @@ final class AIChatCoordinator {
             .flatMap { core.mcpCoordinator.server(slug: $0) }
     }
 
+    /// A new chat replaces the screen, so whatever opened the old one is still there to go back to.
     func startNewChat() {
         chat.startNewChat()
-        palette.prepare(mode: .ai)
+        palette.replace(mode: .ai)
     }
 
     func showHistory() {
-        palette.prepare(mode: .aiHistory)
+        palette.push(mode: .aiHistory)
     }
 
+    /// History was pushed from chat, so opening one comes back up rather than descending again.
     func openChat(id: UUID) {
         guard chat.open(id: id) else { return }
-        palette.prepare(mode: .ai)
+        if !palette.pop() { palette.prepare(mode: .ai) }
     }
 
     func deleteChat(id: UUID) {

--- a/Tinycast/Features/Backup/Model/RaycastImport.swift
+++ b/Tinycast/Features/Backup/Model/RaycastImport.swift
@@ -55,6 +55,10 @@ enum RaycastImport {
                 settings.popToRootSeconds = secs
                 hasSettings = true
             }
+            if options.contains(.popToRoot), let behavior = backup.settings?.escapeKeyBehavior {
+                settings.escapeKeyBehavior = behavior
+                hasSettings = true
+            }
             if options.contains(.compactMode) {
                 if let compact = backup.settings?.compactMode {
                     settings.compactMode = compact

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -28,6 +28,7 @@ struct SettingsBackup: Codable {
         var emojiSkinTone: String?
         var showInMenuBar: Bool?
         var popToRootSeconds: Int?
+        var escapeKeyBehavior: String?
         var appearance: String?
         var compactMode: Bool?
         var showFavoritesInCompactMode: Bool?
@@ -119,6 +120,7 @@ extension SettingsBackup {
             showInMenuBar: UserDefaults.standard.object(forKey: SettingsKey.showInMenuBar) as? Bool
                 ?? true,
             popToRootSeconds: s.popToRootTimeout.rawValue,
+            escapeKeyBehavior: s.escapeKeyBehavior.rawValue,
             appearance: s.appearance.rawValue,
             compactMode: s.compactMode,
             showFavoritesInCompactMode: s.showFavoritesInCompactMode,
@@ -282,6 +284,10 @@ extension SettingsBackup {
         }
         if let secs = s.popToRootSeconds, let timeout = PopToRootTimeout(rawValue: secs) {
             settings.popToRootTimeout = timeout
+            count += 1
+        }
+        if let raw = s.escapeKeyBehavior, let behavior = EscapeKeyBehavior(rawValue: raw) {
+            settings.escapeKeyBehavior = behavior
             count += 1
         }
         if let raw = s.appearance, let appearance = AppAppearance(rawValue: raw) {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -13,6 +13,7 @@ enum SettingsBackupCoverage {
         "hyperKeyQuickPress": .hyperKeyQuickPress,
         "emojiSkinTone": .emojiSkinTone,
         "popToRootSeconds": .popToRootTimeout,
+        "escapeKeyBehavior": .escapeKeyBehavior,
         "appearance": .appearance,
         "compactMode": .compactMode,
         "showFavoritesInCompactMode": .showFavoritesInCompactMode,

--- a/Tinycast/Features/Backup/Service/RaycastImportReader.swift
+++ b/Tinycast/Features/Backup/Service/RaycastImportReader.swift
@@ -69,6 +69,12 @@ enum RaycastImportReader {
             data.popToRootSeconds = timeout.rawValue
             mapped = true
         }
+        if let raw = general?["escapeKeyBehavior"] as? String,
+            let behavior = EscapeKeyBehavior(raycastValue: raw)
+        {
+            data.escapeKeyBehavior = behavior.rawValue
+            mapped = true
+        }
         // Raycast's window mode is a string; we only have the compact toggle.
         if let mode = general?["windowMode"] as? String {
             data.compactMode = (mode == "compact")

--- a/Tinycast/Features/Backup/Settings/RaycastImportSelection.swift
+++ b/Tinycast/Features/Backup/Settings/RaycastImportSelection.swift
@@ -21,7 +21,7 @@ struct RaycastImportSelection: View {
         .init(option: .clipboardHistory, symbol: "doc.on.clipboard", label: "Clipboard history"),
         .init(option: .snippets, symbol: "curlybraces", label: "Snippets"),
         .init(option: .quicklinks, symbol: Quicklink.sfSymbol, label: "Quicklinks"),
-        .init(option: .popToRoot, symbol: "arrow.uturn.backward", label: "Pop to root"),
+        .init(option: .popToRoot, symbol: "arrow.uturn.backward", label: "Pop to root & Escape"),
         .init(option: .compactMode, symbol: "macwindow", label: "Compact mode")
     ]
 

--- a/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
@@ -145,11 +145,14 @@ final class ExtensionCoordinator {
         guard let (owner, command) = extensions.resolve(app) else { return }
         switch command.mode {
         case .view:
-            // Switch the palette over first, so the launching state is what the user sees.
-            palette.prepare(mode: .extensionCommand)
-            // A shortcut fires while hidden, where a view command has nowhere to render.
+            // A hidden palette has nowhere to render, so a shortcut-fired command summons a root.
             if !paletteCoordinator.isVisible {
                 paletteCoordinator.showPalette(mode: .extensionCommand)
+            } else if palette.mode == .extensionCommand {
+                // Stacking one command's screen on another would strand the stopped one on Escape.
+                palette.replace(mode: .extensionCommand)
+            } else {
+                palette.push(mode: .extensionCommand)
             }
             Task { await extensions.run(owner, command: command, arguments: arguments) }
         case .noView, .menuBar:
@@ -172,7 +175,8 @@ final class ExtensionCoordinator {
         Task {
             if await extensions.popNavigation() { return }
             await extensions.stop()
-            palette.prepare(mode: .launcher)
+            // A row-opened command has a screen underneath; one opened by its own hotkey does not.
+            if !palette.pop() { paletteCoordinator.hidePalette() }
         }
     }
 

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -177,6 +177,11 @@ final class AppSettings {
         didSet { defaults.set(popToRootTimeout.rawValue, forKey: Key.popToRootTimeout.rawValue) }
     }
 
+    /// What Escape does on an empty search field: pop one screen, or always close.
+    var escapeKeyBehavior: EscapeKeyBehavior {
+        didSet { defaults.set(escapeKeyBehavior.rawValue, forKey: Key.escapeKeyBehavior.rawValue) }
+    }
+
     /// Follow macOS, or pin Tinycast to one appearance. Applied by `AppCore.applyAppearance()`.
     var appearance: AppAppearance {
         didSet { defaults.set(appearance.rawValue, forKey: Key.appearance.rawValue) }
@@ -486,6 +491,9 @@ final class AppSettings {
         popToRootTimeout =
             PopToRootTimeout(rawValue: defaults.integer(forKey: Key.popToRootTimeout.rawValue))
             ?? .immediately
+        escapeKeyBehavior =
+            defaults.string(forKey: Key.escapeKeyBehavior.rawValue)
+            .flatMap { EscapeKeyBehavior(rawValue: $0) } ?? .popBackOrClose
         appearance =
             defaults.string(forKey: Key.appearance.rawValue).flatMap(AppAppearance.init) ?? .system
         compactMode = defaults.bool(forKey: Key.compactMode.rawValue)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -12,6 +12,7 @@ enum AppSettingsKey: String, CaseIterable {
     case hyperKeyQuickPress = "hyperKeyQuickPress"
     case emojiSkinTone = "emojiSkinTone"
     case popToRootTimeout = "popToRootTimeout"
+    case escapeKeyBehavior = "escapeKeyBehavior"
     case appearance = "appearance"
     case compactMode = "compactMode"
     case showFavoritesInCompactMode = "showFavoritesInCompactMode"

--- a/Tinycast/Features/Settings/EscapeKeyBehavior.swift
+++ b/Tinycast/Features/Settings/EscapeKeyBehavior.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// What Escape does on an empty search field. Mirrors Raycast's "Escape Key Behavior"; an unset
+/// key reads as `.popBackOrClose`, Raycast's own default.
+enum EscapeKeyBehavior: String, CaseIterable, Identifiable, Sendable {
+    /// Back one screen; at the root, close.
+    case popBackOrClose = "popBackOrClose"
+    /// Always close, and reset to root search at once. Backspace and the chevron still go back.
+    case closeAndPopToRoot = "closeAndPopToRoot"
+
+    /// Raycast spells the same two options in kebab case; anything else is skipped, never guessed.
+    init?(raycastValue: String) {
+        switch raycastValue {
+        case "pop-back-or-close": self = .popBackOrClose
+        case "close-and-pop-to-root": self = .closeAndPopToRoot
+        default: return nil
+        }
+    }
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .popBackOrClose: return "Pop back or close"
+        case .closeAndPopToRoot: return "Close and pop to root"
+        }
+    }
+}

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -163,6 +163,14 @@ struct GeneralSettingsView: View {
                     SettingsRowTitle(.generalGeneral, "Pop to Root Search")
                     Text("Reset to the launcher this long after the window closes.")
                 }
+                Picker(selection: $settings.escapeKeyBehavior) {
+                    ForEach(EscapeKeyBehavior.allCases) { behavior in
+                        Text(behavior.title).tag(behavior)
+                    }
+                } label: {
+                    SettingsRowTitle(.generalGeneral, "Escape Key Behavior")
+                    Text("Choose what happens when pressing Escape on an empty search field.")
+                }
                 // Empty only when TIS fails; one layout still lists, so the row stays put.
                 if !inputSources.isEmpty {
                     Picker(selection: $settings.autoSwitchInputSourceID) {

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -155,6 +155,9 @@ enum SettingsSearchCatalog {
             .generalGeneral, "Pop to Root Search",
             keywords: ["reset", "timeout", "back"]),
         .init(
+            .generalGeneral, "Escape Key Behavior",
+            keywords: ["esc", "back", "close", "root", "navigation", "keyboard"]),
+        .init(
             .generalGeneral, "Auto-switch input source",
             keywords: ["keyboard", "layout", "language", "abc"])
     ]

--- a/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
@@ -42,7 +42,7 @@ final class UninstallCoordinator {
         self.core = core
     }
 
-    /// The palette is already up, so this swaps the sub-screen rather than re-showing it.
+    /// The palette is already up, so this pushes the sub-screen rather than re-showing it.
     func beginUninstall(_ app: AppEntry) {
         guard app.kind == .application else { return }
         // What stops a name or a shared bundle-ID namespace being misattributed.
@@ -50,7 +50,7 @@ final class UninstallCoordinator {
         session.begin(
             app: app, otherAppNames: others.map(\.name),
             otherBundleIDs: others.compactMap(\.bundleID), isRunning: runningApps.isRunning(app))
-        palette.prepare(mode: .uninstall)
+        palette.push(mode: .uninstall)
     }
 
     /// The one funnel for the screen's ↵ and Actions row, so neither skips the confirmation.
@@ -79,7 +79,7 @@ final class UninstallCoordinator {
                 removeUninstalledReferences(app)
                 await appIndex.refresh()
             }
-            palette.prepare(mode: .launcher)
+            if !palette.pop() { palette.prepare(mode: .launcher) }
             await presentUninstallReport(report)
         }
     }

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -60,13 +60,15 @@ final class PaletteCoordinator {
         mode: PaletteMode, restoreAnyMode: Bool = false, seeding query: String? = nil
     ) {
         let preserved = windowController.consumePreservedState()
+        // Only a visible palette has somewhere to go back to; a summon is a new stack, not a push.
+        let pushes = windowController.isVisible && palette.mode != mode
         // A carried query always opens fresh: restoring the previous screen would drop it.
-        if let query {
-            palette.prepare(mode: mode)
-            palette.query = query
-        } else if !(preserved && (restoreAnyMode || palette.mode == mode)) {
+        if pushes {
+            palette.push(mode: mode)
+        } else if query != nil || !(preserved && (restoreAnyMode || palette.mode == mode)) {
             palette.prepare(mode: mode)
         }
+        if let query { palette.query = query }
         windowController.show()
         if palette.mode == .fileSearch { fileSearch.search(palette.query) }
         // Re-scan on open so an app uninstalled since the last scan drops out of the launcher.
@@ -76,6 +78,11 @@ final class PaletteCoordinator {
     func hidePalette(restoreFocus: Bool = true) {
         fileSearch.cancel()
         windowController.hide(restoreFocus: restoreFocus)
+    }
+
+    /// Drop the preserved screen at once, ignoring the Pop to Root Search timeout.
+    func popToRootNow() {
+        windowController.popToRootNow()
     }
 
     /// True for the slim compact bar: compact on, launcher root, empty, not overflowed.

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -6,20 +6,25 @@ enum PaletteEscapeAction: Equatable {
     case leaveArgumentField
     case clearQuery
     case exitExtensionScreen
-    case exitToLauncher
+    case goBack
     case hidePalette
 
     static func resolve(
-        menuOpen: Bool, argumentFocused: Bool, query: String, mode: PaletteMode
+        menuOpen: Bool, argumentFocused: Bool, query: String, mode: PaletteMode,
+        canGoBack: Bool, behavior: EscapeKeyBehavior
     ) -> Self {
         if menuOpen { return .closeMenu }
         // An argument field is a step deeper than the query, so it is left before anything clears.
         if argumentFocused { return .leaveArgumentField }
         if !query.isEmpty { return .clearQuery }
-        // An extension pops its own navigation stack before the command is left.
-        if mode == .extensionCommand { return .exitExtensionScreen }
-        // Chat is a surface of its own, so leaving it lands on the launcher, not on nothing.
-        if mode == .ai { return .exitToLauncher }
-        return .hidePalette
+        switch behavior {
+        case .closeAndPopToRoot:
+            // Closing outranks even an extension's own sub-views; Backspace still goes back.
+            return .hidePalette
+        case .popBackOrClose:
+            // An extension pops its own navigation stack before the command is left.
+            if mode == .extensionCommand { return .exitExtensionScreen }
+            return canGoBack ? .goBack : .hidePalette
+        }
     }
 }

--- a/Tinycast/Palette/PaletteNavigationStack.swift
+++ b/Tinycast/Palette/PaletteNavigationStack.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// One screen's restorable state, snapshotted when another screen is pushed over it.
+struct PaletteFrame: Equatable {
+    var mode: PaletteMode
+    var query: String
+    var selection: Int
+    var clipboardFilter: ClipboardFilter
+}
+
+/// The screens under the current one, bottom first. Empty means the current screen is the root.
+struct PaletteNavigationStack: Equatable {
+    private(set) var parents: [PaletteFrame] = []
+
+    var canGoBack: Bool { !parents.isEmpty }
+
+    mutating func push(_ current: PaletteFrame) {
+        parents.append(current)
+    }
+
+    mutating func pop() -> PaletteFrame? {
+        parents.popLast()
+    }
+
+    mutating func reset() {
+        parents.removeAll()
+    }
+}

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -11,6 +11,8 @@ final class PaletteState {
     var isComposing = false
     /// The clipboard screen's type filter, reset with the rest of the screen state on each summon.
     var clipboardFilter: ClipboardFilter = .all
+    /// The screens this one was pushed over; a summon starts a new stack, a mode switch pushes.
+    var navigation = PaletteNavigationStack()
     /// Ordering out leaves the SwiftUI tree mounted, so a media preview needs this to stop playing.
     private(set) var isVisible = false
     /// Changes every time the palette is shown so the search field can re-focus.
@@ -60,8 +62,48 @@ final class PaletteState {
         isVisible = visible
     }
 
+    /// Become the root: every screen underneath is dropped, so Escape here closes the palette.
     func prepare(mode: PaletteMode) {
+        replace(mode: mode)
+        navigation.reset()
+    }
+
+    /// Swap this screen for another without descending; whatever sits underneath is left alone.
+    func replace(mode: PaletteMode) {
         self.mode = mode
+        resetScreen()
+    }
+
+    /// Descend to `mode`, keeping this screen underneath for Escape, Backspace and the chevron.
+    func push(mode: PaletteMode) {
+        navigation.push(
+            PaletteFrame(
+                mode: self.mode, query: query, selection: selection,
+                clipboardFilter: clipboardFilter))
+        self.mode = mode
+        resetScreen()
+    }
+
+    /// Restore the screen underneath. False means there was none, so the caller closes instead.
+    @discardableResult
+    func pop() -> Bool {
+        guard let frame = navigation.pop() else { return false }
+        // A bumped `resetToken` snaps lists to the top, throwing the selection just restored away.
+        let keptResetToken = resetToken
+        mode = frame.mode
+        resetScreen()
+        resetToken = keptResetToken
+        query = frame.query
+        selection = frame.selection
+        clipboardFilter = frame.clipboardFilter
+        followToken = UUID()
+        return true
+    }
+
+    var canGoBack: Bool { navigation.canGoBack }
+
+    /// Everything a screen change clears, whether it roots, descends or comes back.
+    private func resetScreen() {
         query = ""
         selection = 0
         isComposing = false

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -156,6 +156,15 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         core.palette.prepare(mode: .launcher)
     }
 
+    /// Pop to root without waiting out the timeout, which is what `closeAndPopToRoot` promises.
+    func popToRootNow() {
+        // The authorizing exception is the timer's too: a browser round trip must find its screen.
+        guard !core.extensions.isAuthorizing else { return }
+        popToRootTimer?.invalidate()
+        popToRootTimer = nil
+        popToRoot()
+    }
+
     /// True while a hidden palette still holds pre-close state; consuming cancels the reset.
     func consumePreservedState() -> Bool {
         guard let timer = popToRootTimer else { return false }
@@ -261,7 +270,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.onFieldEditorFocused = { [weak self] context in
             self?.core.inputSourceSwitcher.applySession(to: context)
         }
-        // Backspace in an empty search backs out of a sub-screen to a fresh root.
+        // Backspace in an empty search takes the same back step Escape and the chevron take.
         panel.onBareBackspace = { [weak self] in
             guard let core = self?.core, core.palette.mode != .launcher, core.palette.query.isEmpty
             else { return false }
@@ -275,15 +284,15 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 core.palette.selection = 0
                 return true
             }
-            if core.palette.mode == .aiHistory {
-                core.palette.prepare(mode: .ai)
-                return true
-            }
             if core.palette.mode == .ai, core.aiChatCoordinator.removeLastAttachment() {
                 return true
             }
-            core.palette.prepare(mode: .launcher)
-            return true
+            // An extension owns the step until its own stack is empty, exactly as Escape leaves it.
+            if core.palette.mode == .extensionCommand {
+                core.extensionCoordinator.exitExtensionScreen()
+                return true
+            }
+            return core.palette.pop()
         }
         installPasteMonitor()
         // Handled at the panel: the field editor or a missing main menu eats these first.
@@ -295,7 +304,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 self.core.palette.noteFavoriteSlot(index)
                 return true
             }
-            // Escape has no character, so it matches by key code.
+            // Pop to Root Search (⌘⎋): Escape has no character, so it matches by key code.
             if Int(event.keyCode) == kVK_Escape {
                 self.core.palette.prepare(mode: .launcher)
                 return true

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -418,7 +418,8 @@ struct RootPaletteView: View {
                 if vm.isControlListOpen { return .ignored }
                 switch PaletteEscapeAction.resolve(
                     menuOpen: menuOpen, argumentFocused: argumentFocused != nil, query: vm.query,
-                    mode: vm.mode)
+                    mode: vm.mode, canGoBack: vm.canGoBack,
+                    behavior: settings.escapeKeyBehavior)
                 {
                 case .closeMenu:
                     closeMenus()
@@ -428,10 +429,14 @@ struct RootPaletteView: View {
                     vm.query = ""
                 case .exitExtensionScreen:
                     core.extensionCoordinator.exitExtensionScreen()
-                case .exitToLauncher:
-                    exitToLauncher()
+                case .goBack:
+                    goBack()
                 case .hidePalette:
                     core.paletteCoordinator.hidePalette()
+                    // The option's own name promises the reset does not wait out the timeout.
+                    if settings.escapeKeyBehavior == .closeAndPopToRoot {
+                        core.paletteCoordinator.popToRootNow()
+                    }
                 }
                 return .handled
             }
@@ -572,9 +577,9 @@ struct RootPaletteView: View {
         HStack(alignment: .center, spacing: 0) {
             // Matches the list rows and section headers' own indent below.
             headerGutter(width: Theme.Spacing.md * 2)
-            // Sub-screens of the root search, so their header icon is a back chevron.
-            if vm.mode != .launcher {
-                Button(action: navigateBack) {
+            // A chevron is drawn only where it leads somewhere; elsewhere the screen names itself.
+            if hasBackStep {
+                Button(action: goBack) {
                     Image(systemName: "chevron.left")
                         .font(Theme.Typography.headerIcon)
                         .symbolRenderingMode(.hierarchical)
@@ -583,6 +588,7 @@ struct RootPaletteView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .tooltip(backTooltip)
             } else {
                 Image(systemName: vm.mode.systemImage)
                     .font(Theme.Typography.headerIcon)
@@ -1083,21 +1089,26 @@ struct RootPaletteView: View {
         open(.argumentOptions, highlighting: 0)
     }
 
-    private func navigateBack() {
-        if vm.mode == .aiHistory {
-            vm.prepare(mode: .ai)
-        } else {
-            exitToLauncher()
-        }
+    /// A back affordance may never close the window: it is drawn only over a screen to return to.
+    private var hasBackStep: Bool {
+        // An extension's own navigation is a step the palette's stack cannot see.
+        vm.canGoBack || (vm.mode == .extensionCommand && core.extensions.navigationDepth > 1)
     }
 
-    /// Back out to a fresh root search, the same reset `prepare` does on show.
-    private func exitToLauncher() {
+    /// Derived from the setting, never a literal, so a shown cap cannot drift from behaviour.
+    private var backTooltip: String {
+        let back = settings.escapeKeyBehavior == .popBackOrClose ? "⎋" : "⌫"
+        return "Go back \(back)  ·  Root search ⌘⎋"
+    }
+
+    /// The one back edge: the chevron, bare Backspace and Escape all land here.
+    private func goBack() {
+        // An extension owns the step until its own stack is empty, then it pops ours the same way.
         if vm.mode == .extensionCommand {
             core.extensionCoordinator.exitExtensionScreen()
             return
         }
-        vm.prepare(mode: .launcher)
+        if !vm.pop() { core.paletteCoordinator.hidePalette() }
     }
 
     private func activateSelection() {

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -435,8 +435,9 @@ The switcher's glyph comes from the selection. Codex uses OpenAI's mark; Claude 
 own marks; an API model resolves through its connection. It never depends on `modelOptions`, which for
 Codex is empty until the app-server has answered `model/list`; opening the chat on a Codex model warms that list so the title is the
 display name from the first frame. Tab hands chat on to the clipboard, and Escape on an empty
-composer backs it out to the launcher; both go through `prepare`, so the unsent draft is dropped
-rather than carried into a field that would search it. History leaves by the ordinary sub-screen
+composer takes the same back step every screen takes — to whatever the chat was opened from, or out of
+the palette when the chat is the root. Either way the unsent draft is dropped rather than carried into
+a field that would search it. History leaves by the ordinary sub-screen
 route — Tab carries its query to the launcher — because there the field really is a search. Neither
 exit touches the conversation: it lives on `AIChatState`, so Tab away and back resumes the same
 transcript.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -56,10 +56,13 @@ only the closure wiring; the behaviour is `PaletteCoordinator`'s.
 ## Screens
 
 `PaletteState` (mode / query / selection / `focusToken`) is the bridge between the panel and the app.
-Showing the palette calls `prepare(mode:)`, which resets state and bumps `focusToken` (a UUID) so the
-SwiftUI search field re-focuses.
+Showing the palette calls `prepare(mode:)`, which resets state, empties the navigation stack and bumps
+`focusToken` (a UUID) so the SwiftUI search field re-focuses — unless the palette is already visible on
+another screen, in which case `showPalette` calls `push(mode:)` instead and the current screen becomes
+the one Escape goes back to.
 
-Hiding schedules Pop to Root Search, and `PaletteWindowController.popToRoot` is its only path: the
+Hiding schedules Pop to Root Search, and `PaletteWindowController.popToRoot` is its only path — the
+timer's, and `popToRootNow()`'s, which skips the wait for the `.closeAndPopToRoot` Escape: the
 palette returns to the launcher *and* chat starts a new conversation, at once or after
 `popToRootTimeout`, unless a re-summon inside that window consumes the pending reset first. An
 unfinished chat is a thing being done, exactly like a typed query, so the screen and the conversation
@@ -85,17 +88,38 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 | `.customCommandArguments` | `CustomCommandArgumentsScreen` | `CustomCommandArgumentsView` (see [custom-commands.md](custom-commands.md#arguments)) |
 | `.extensionCommand` | `ExtensionCommandScreen` | `ExtensionCommandView` (see [extensions.md](extensions.md)) |
 
-Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab rings the three
-surfaces a reader opens directly — launcher → AI chat → clipboard → launcher** — unless the screen
+Every mode but `.launcher` is a sub-screen, and what it backs out to is whatever the navigation stack
+holds under it. **Tab rings the three surfaces a reader opens directly — launcher → AI chat →
+clipboard → launcher** — unless the screen
 claims it through `tabTarget(from:backwards:)` (an extension's `Form` walks its own fields), or the
 selected row declares arguments, in which case it walks those fields first (see below); every other mode exits
 to the launcher rather than joining the ring, and is reached by a command or a global hotkey, with
 Uninstall only from a launcher app's Actions menu, scoped to that app. Chat is skipped whole when
 `aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced. **Escape clears a
-non-empty query before it leaves the screen**, so one press clears and the next leaves: chat backs
-out to the launcher, an extension screen exits itself, and anywhere else the palette hides. A focused
+non-empty query before it leaves the screen**, so one press clears and the next leaves. A focused
 inline argument field is a rung above the query, so Escape hands focus back to the search field
 first — the query that found the command is still there to be cleared by the next press.
+
+**Leaving is one rule: Escape pops one screen, and at the bottom of the stack popping means hiding.**
+`PaletteNavigationStack` holds a `PaletteFrame` — mode, query, selection, clipboard filter — for each
+screen underneath the current one, so going back restores the screen the reader last saw rather than a
+fresh one. Where a screen came from is decided by the summon and nothing else, in
+`PaletteCoordinator.showPalette`: a hidden palette starts a new stack, so a screen opened by its own
+hotkey is a root and Escape closes it; a visible palette pushes, so the same screen opened from a
+launcher row goes back to that row with the query still typed. Chat is not special — it joins the stack
+like every other screen. An extension screen still leaves through
+`ExtensionCoordinator.exitExtensionScreen`, which pops the extension's own navigation first and only
+then pops the palette's.
+
+The header chevron, a bare backspace and Escape are the same step by construction: all three call
+`RootPaletteView.goBack()`. The chevron is drawn only where that step leads somewhere — a screen with
+nothing under it shows its own icon instead, since a back arrow that dismisses the window is a lie.
+An extension counts its own navigation here, so a command with sub-views pushed keeps the chevron even
+at the bottom of the palette's stack. **`EscapeKeyBehavior`** (Settings ▸ General) chooses what an
+empty field's Escape does — `.popBackOrClose`, the default and the rule above, or
+`.closeAndPopToRoot`, which hides and resets to the root at once, leaving backspace and the chevron as
+the way back. The chevron's tooltip derives its key cap from the setting, so it cannot advertise a key
+the setting has taken away.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
 pairing of a label with its key. It is drawn only when Tab really would open chat, a condition read
@@ -115,10 +139,10 @@ not a search field: it _is_ the current argument's input, so its placeholder nam
 submits rather than activating a row. It has no rows, which is why `isArgumentForm` is what keeps the
 ↵ pill drawn. Its state lives on `AppCore.customCommandArguments`, the way `.uninstall`'s target lives
 on `UninstallSession`, and leaving the mode cancels the pending run. A bare backspace steps back an
-argument before it falls through to the usual exit-to-launcher; Escape erases the half-typed answer
-first, and a second press hides the palette, ending the pending work with it. **Quicklinks used to be
-the other half of this pair and no longer are** — they collect their values in the header instead, so
-one surface asks for a row's arguments rather than two.
+argument before it falls through to the usual back step; Escape erases the half-typed answer first,
+and a second press pops to the screen underneath — or hides, when the form is the root — ending the
+pending work with it. **Quicklinks used to be the other half of this pair and no longer are** — they
+collect their values in the header instead, so one surface asks for a row's arguments rather than two.
 
 ### Inline row arguments
 
@@ -372,6 +396,8 @@ Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and a
 
 - **A bare backspace** — the field editor consumes it as an edit (`onBareBackspace`).
 - **Chords with no main menu item** — ⌘, and ⌘w, which an app with a menu bar would never see here.
+- **⌘⎋ — Pop to Root Search.** Escape carries no character, so `onCommandShortcut` matches it by key
+  code and calls `prepare(mode: .launcher)`, which empties the stack as well as the screen.
 - **The physical number-row slots.** `FavoriteSlots` matches ⌘1…⌘0 by key code before fixed command
   chords, then publishes the resolved position to the active screen. Only the launcher and clipboard
   screens intercept these slots; other screens keep their own ⌘-number shortcuts. The launcher's

--- a/docs/features/raycast-import.md
+++ b/docs/features/raycast-import.md
@@ -8,7 +8,8 @@ between them are both gone, deleted rather than carried.
 
 - **`RaycastDecoder` stays platform-UI-free** so `raycast-test` compiles it standalone. Which is why the
   decoder returns the payload's own bytes and `RaycastImportReader`, not the decoder, validates them
-  against `PopToRootTimeout` / `EmojiSkinTone` / `HyperKeyPhysicalKey` / `KeyShortcut`.
+  against `PopToRootTimeout` / `EscapeKeyBehavior` / `EmojiSkinTone` / `HyperKeyPhysicalKey` /
+  `KeyShortcut`.
 - **Recognition is the container signature and nothing else.** `RaycastDecoder.isExport` needs no
   passphrase, so the Backup pane runs it the moment a file is chosen and a wrong passphrase reports a
   wrong passphrase instead of "not a Raycast export".
@@ -55,6 +56,12 @@ grants no permission class.
 Script commands are not in a `.rayconfig` — they are files in a folder Raycast points at — so they
 have their own importer, described in
 [custom-commands.md](custom-commands.md#importing-raycast-scripts).
+
+`escapeKeyBehavior` rides beside `popToRootTimeout` in the same `general` object, and imports under the
+same option — relabelled **Pop to root & Escape** — since Raycast writes the two back to back. Raycast
+spells it in kebab case, so `EscapeKeyBehavior(raycastValue:)` maps `pop-back-or-close` and
+`close-and-pop-to-root` and skips anything else: exact-match only, never clamped to the nearest, the
+same rule the timeout follows.
 
 ## Layout
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,6 +89,8 @@ If a change touches anything in the right column, the harness on the left is man
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
 | `palette-placement-test` | `DesignSystem/Theme.swift`, `Palette/PalettePlacement.swift` |
+| `palette-navigation-test` | `Palette/PaletteNavigationStack.swift` and `PaletteState`'s `push`/`pop`/`prepare` — that going back restores the frame it stored |
+| `palette-escape-test` | `Palette/PaletteEscapeAction.swift`, `Settings/EscapeKeyBehavior.swift` — the whole decision table, both behaviours |
 | `hotkey-test` | `HotKeys/Model/DoubleTapModifier.swift`, `DoubleTapDetector.swift`, `HyperKey.swift`, `HotKeyAction.swift`, `Service/KeyShortcut.swift`, and the command→action mapping in `Launcher/Model/CommandID.swift` |
 | `fallback-test` | `Launcher/Model/Fallback.swift`, plus the `CommandID` and `Quicklink` ids it is built from |
 | `callout-test` | `DesignSystem/Theme.swift`, `HotKeys/UI/CalloutPlacement.swift` |
@@ -253,6 +255,16 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 
 - Palette hotkey opens the launcher; pressing it again closes it; Escape clears a non-empty query,
   then hides on a second press; clicking away closes it
+- Escape walks back the way it came: a screen opened from a launcher row returns to it with the query
+  still typed and the row still selected; the same screen opened by its own hotkey hides instead
+- Chat → history → Escape lands on the chat, and Escape again on whatever opened the chat
+- A clipboard type filter, an open ⌘K menu and an extension form's dropdown each swallow the first
+  Escape without navigating; the extension's own sub-view pops before the palette's stack does
+- ⌘⎋ from any depth reaches a root search with an empty field — verify with the palette not frontmost
+- Bare Backspace on an empty field mirrors Escape's back step under both Escape Key Behavior values,
+  and inside a form field it deletes text without ever navigating
+- Set Escape Key Behavior to "Close and pop to root": every empty-field Escape hides and the next
+  summon is a fresh root whatever the Pop to Root Search timeout says
 - Reopening focuses the search field with an empty query, in the same position and at the same size
 - Compact mode: typing expands it, and the search bar does **not** shift vertically during the swap
 - With a CJK IME: the placeholder clears as soon as composition starts and the composing text never
@@ -266,7 +278,7 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
   System Actions, Window Management, Custom Commands, Commands
 - With a non-ASCII input source active, ⌘K opens Actions; ↑/↓ move it, ↵ activates, Escape closes it
 - While a menu is open, typing does **not** change the query and the caret is hidden
-- Tab toggles launcher ↔ clipboard; bare Backspace on an empty query backs out of a sub-screen
+- Tab toggles launcher ↔ clipboard, and stays lateral: Escape after a Tab does not walk the ring back
 - Launching an app focuses it; escaping the palette returns focus to the app you came from
 - Paste from clipboard history lands in that app, not in Tinycast
 - No flash, flicker or reflow on open, and row metrics unchanged

--- a/website/content/docs/palette.md
+++ b/website/content/docs/palette.md
@@ -4,7 +4,8 @@ description: The one window Tinycast has — how to move around it, and where it
 ---
 
 Everything Tinycast does happens in one floating panel. Each feature is either the root launcher
-screen or a screen you reach from it, and every screen backs out to the launcher.
+screen or a screen you reach from it, and Escape walks back the way you came — to the screen you
+opened it from, or out of the palette when there is nothing underneath.
 
 ## Moving around
 
@@ -15,8 +16,9 @@ screen or a screen you reach from it, and every screen backs out to the launcher
 | <kbd>⌘</kbd><kbd>K</kbd>  | Open the Actions menu for the selection               |
 | <kbd>↑</kbd> <kbd>↓</kbd> | Move the selection                                    |
 | <kbd>⇥</kbd>              | Cycle between the launcher and clipboard              |
-| <kbd>⎋</kbd>              | Leave a screen, or dismiss the palette                |
+| <kbd>⎋</kbd>              | Go back one screen, or dismiss the palette            |
 | <kbd>⌫</kbd>              | On an empty field, step back one screen               |
+| <kbd>⌘</kbd><kbd>⎋</kbd>  | Jump straight back to the root search                 |
 | <kbd>⌘</kbd><kbd>,</kbd>  | Open Settings                                         |
 | <kbd>⌘</kbd><kbd>W</kbd>  | Close the window                                      |
 

--- a/website/content/docs/reference/settings.md
+++ b/website/content/docs/reference/settings.md
@@ -45,12 +45,13 @@ See [Hotkeys](/docs/reference/hotkeys#hyper-key).
 
 ### General
 
-| Setting                  | Options                                     | Default         |
-| ------------------------ | ------------------------------------------- | --------------- |
-| Launch at login          | —                                           | Off             |
-| Show in menu bar         | —                                           | **On**          |
-| Pop to Root Search       | Immediately · 5 · 15 · 30 · 60 · 90 seconds | **Immediately** |
-| Auto-switch input source | None, plus every enabled keyboard source    | **None**        |
+| Setting                  | Options                                     | Default               |
+| ------------------------ | ------------------------------------------- | --------------------- |
+| Launch at login          | —                                           | Off                   |
+| Show in menu bar         | —                                           | **On**                |
+| Pop to Root Search       | Immediately · 5 · 15 · 30 · 60 · 90 seconds | **Immediately**       |
+| Escape Key Behavior      | Pop back or close · Close and pop to root   | **Pop back or close** |
+| Auto-switch input source | None, plus every enabled keyboard source    | **None**              |
 
 Shortcuts keep working with the menu-bar icon hidden.
 

--- a/website/content/docs/reference/shortcuts.md
+++ b/website/content/docs/reference/shortcuts.md
@@ -17,8 +17,9 @@ These are fixed and not configurable. For shortcuts you record yourself, see
 | <kbd>⌃</kbd><kbd>N</kbd> / <kbd>⌃</kbd><kbd>P</kbd> | Same as <kbd>↓</kbd> / <kbd>↑</kbd>           |
 | <kbd>⌃</kbd><kbd>F</kbd> / <kbd>⌃</kbd><kbd>B</kbd> | Same as <kbd>→</kbd> / <kbd>←</kbd>           |
 | <kbd>⇥</kbd>                                        | Cycle launcher ↔ clipboard, or walk arguments |
-| <kbd>⎋</kbd>                                        | Leave a screen, or dismiss                    |
+| <kbd>⎋</kbd>                                        | Go back a screen, or dismiss                  |
 | <kbd>⌫</kbd>                                        | On an empty field, step back a screen         |
+| <kbd>⌘</kbd><kbd>⎋</kbd>                            | Back to the root search                       |
 | <kbd>⌘</kbd><kbd>,</kbd>                            | Settings                                      |
 | <kbd>⌘</kbd><kbd>W</kbd>                            | Close the window                              |
 


### PR DESCRIPTION
Escape now walks back through the screens it opened, instead of every screen
having its own idea of "back".

## The four rules

Taking the four points as written:

1. Escape with text in the search field clears the field — unchanged.
2. Escape in a view opened directly by its own hotkey closes the palette — unchanged.
3. Escape in a view reached from root search goes back to the launcher — new.
4. ⌘Escape from any view goes to root search — this already worked, undocumented
   and untested; it now has both.

> **A quirk on ⌘⎋ worth a decision.** macOS binds ⌘Esc to Game Overlay — symbolic
> hotkey `260`, [documented by Apple][overlay] — and WindowServer consumes it before
> any application receives it. The handler in `PaletteWindowController` is correct,
> and I confirmed the chord end to end with a hardware press against a traced build,
> but only after switching that shortcut off. The quirk is how it fails: on a stock
> macOS ⌘⎋ does nothing at all here, with no beep and no error, and the keystroke
> never reaches the process — so it is invisible from inside the app and easy to
> mistake for a bug in the palette. This predates the PR; I raise it because this is
> the first change to document and surface the chord, so it may be worth rebinding
> to something macOS does not already claim.

[overlay]: https://support.apple.com/en-au/105118

## How it works

`PaletteState` gains a `PaletteNavigationStack` of frames, each holding the mode,
query, selection and clipboard filter of the screen it covers. Escape pops one
frame, and at the bottom of the stack popping means hiding — so rules 2 and 3 are
the same rule seen from different depths.

Where a screen sits is decided by the summon and nothing else, in one line of
`PaletteCoordinator.showPalette`: a hidden palette starts a new stack, a visible
one pushes. No `origin:` parameter threaded through the call sites. That means a
screen opened by its own hotkey is a root and closes, while the same screen opened
from a launcher row goes back to that row with the query still typed and the row
still selected.

A third motion sits beside push and pop: `replace(mode:)` swaps the current screen
and leaves the stack alone. Starting a new chat uses it, so the launcher that
opened the old conversation is still there to go back to; so does one extension
command fired over another's screen, since stacking those would leave Escape
restoring a frame whose command had already been stopped.

The three back edges converge: the header chevron, bare Backspace and Escape all
call `RootPaletteView.goBack()`. An extension screen still leaves through
`exitExtensionScreen`, which pops the extension's own navigation before the
palette's — and the chevron and Backspace now honour that too, where before only
Escape did.

The chevron is drawn only where that step leads somewhere. Its old condition, "any
mode but the launcher", used to mean the same thing as "has a screen underneath",
and with a stack it no longer does — on a hotkey-opened screen it would have become
a back arrow that dismissed the window. A screen with nothing under it now shows
its own icon, and an extension counts its own navigation depth, so a command with
sub-views keeps the chevron.

**The setting:** Escape Key Behavior, under General beside Pop to Root Search.
"Pop back or close" is the default and the behaviour above; "Close and pop to root"
hides and resets at once, leaving Backspace and the chevron as the way back. It is
searchable in Settings and rides a settings backup like `popToRootTimeout` does —
it grants no capability and names nothing machine-local, so it belongs in
`mirrored` rather than the exclusions, and the coverage test enforces that.

**The import:** an imported settings file carries `escapeKeyBehavior` in the same
`general` object as `popToRootTimeout`, so it arrives under that same option,
relabelled "Pop to root & Escape". Exact-match only — an unrecognised value is
skipped rather than clamped to the nearest, the same rule the timeout follows.

**The timeout still applies** under "Pop back or close": Pop to Root Search is
already a setting here, and having Escape quietly ignore it would break it. Under
"Close and pop to root" the reset is immediate, since that option's name promises
it, and that immediate reset honours the same authorizing exception the timer does,
so an extension waiting on a browser round trip still finds its screen when it
returns. Nothing new is bound to go back under that option — bare Backspace already
does exactly that.

## What changes for existing use

- **A chat opened by its own hotkey now closes on Escape** rather than falling back
  to the launcher. Chat loses its special case and joins the stack like every other
  screen. This is the one place existing muscle memory changes.
- **Tab stays lateral.** The mode ring replaces the current screen rather than
  descending, so Escape after a Tab behaves exactly as it did.
- **A different mode's hotkey pressed while the palette is open pushes rather than
  re-roots**, which is the one case deriving provenance from the summon gets wrong.
  Escape then returns to the screen you were looking at.

## Testing

`palette-escape-test` is rewritten against the new resolver and covers the whole
decision table — both behaviours × `canGoBack` × seven modes × empty/typed ×
menu-open. New `palette-navigation-test` covers push/pop/replace/reset round trips
and that going back restores the frame it stored, including that a replaced screen
never adds a second frame. The import harness gains the new value's mapping,
including that an unrecognised one is skipped.

All 59 harnesses pass, the Debug build has no new warnings, and swift-format and
swiftlint are clean.

Manually exercised on a Debug build: the launcher→clipboard→back round trip with
the query and row restored, hotkey-opened screens closing, chat and chat history
two deep, uninstall, the clipboard type filter and ⌘K menu each swallowing the
first Escape, ⌘⎋ from depth, Backspace under both settings, the chevron appearing
only over a real back step, and a settings import. Two sub-checks I could not drive
from the outside: an extension's inner sub-view popping before the palette's stack,
and Escape closing an extension form's dropdown without navigating — both are
pre-existing code paths this change does not touch.
