### PR TITLE
docs: Correct search scopes settings location

### DIFF
--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -34,8 +34,9 @@ earliest scope wins).
 
 ## Search scopes
 
-`SearchScopes` (`Launcher/Model/SearchScopes.swift`) owns the paths; the list is user-editable in General
-Settings and persisted as `AppSettings.searchScopes`. A scope is either a directory or a single `.app`
+`SearchScopes` (`Launcher/Model/SearchScopes.swift`) owns the paths; the list is user-editable in
+Settings → Applications → Search Scopes and persisted as `AppSettings.searchScopes`.
+A scope is either a directory or a single `.app`
 bundle, stored tilde-abbreviated so the UI reads cleanly and a settings backup stays portable.
 
 Enumeration descends **one subfolder deep** — a scope's own `.app` children, plus any inside an


### PR DESCRIPTION
## Related issue

None. This is a documentation-only correction under the contribution guide's docs exception; please apply the `docs` label if appropriate.

## What changed

Correct the launcher documentation's search scopes location from General Settings to Settings → Applications → Search Scopes. `ApplicationsSettingsView` renders `SearchScopesSection` at the top of the Applications pane; the old directions send users to the wrong page.

## Memory footprint

Not applicable: Markdown-only change, with no application behavior or resource usage changes. Memory measurements and leak testing were not run.

## Drawbacks

None.

## Tests & validation

- Verified the location against `ApplicationsSettingsView.swift`, `SearchScopesSection.swift`, and the Applications search scopes settings anchor.
- `git diff --check` passed.
- No tests added. App build and runtime tests were not run for this documentation-only correction.
