### PR TITLE
Reduce Quick Actions diff matrix memory

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -338,6 +338,7 @@ run mcp-test               Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/AI/Model/JSONValue.swift \
                            Tinycast/Features/MCP/Model/*.swift \
                            Tinycast/Features/MCP/Settings/MCPSettingsStore.swift
+run -O text-diff-test      Tinycast/Features/QuickActions/Model/TextDiffEngine.swift
 run quick-action-test      Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/AI/Model/AIConnection.swift \
                            Tinycast/Features/AI/Model/AppleIntelligence.swift \

--- a/Tests/text-diff-performance.swift
+++ b/Tests/text-diff-performance.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+@main
+enum TextDiffPerformance {
+    static func main() throws {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        if arguments == ["--probe"] {
+            try probe()
+            return
+        }
+        guard let argument = arguments.first,
+            let count = Int(argument), (1...4_001).contains(count)
+        else { fatalError("Pass a token count from 1 through 4001, or --probe") }
+        let workload = arguments.count > 1 ? arguments[1] : "dense"
+        let iterations = arguments.count > 2 ? Int(arguments[2]) ?? 0 : 1
+        precondition(iterations > 0)
+
+        let original = workload == "empty" ? "" : input(word: "old", tokens: count)
+        let modified: String
+        switch workload {
+        case "dense", "empty": modified = input(word: "new", tokens: count)
+        case "sparse": modified = "new" + original.dropFirst(3)
+        case "equal": modified = original
+        default: fatalError("Workload must be dense, sparse, equal or empty")
+        }
+        _ = TextDiffEngine.diff(original: "warm up", modified: "warm down")
+
+        var chunks: [TextDiffEngine.Chunk] = []
+        var checksum = 0
+        let start = ContinuousClock.now
+        for _ in 0..<iterations {
+            chunks = TextDiffEngine.diff(original: original, modified: modified)
+            checksum += chunks.count
+        }
+        let duration = start.duration(to: .now).components
+        let milliseconds = (Double(duration.seconds) * 1_000
+            + Double(duration.attoseconds) / 1e15) / Double(iterations)
+
+        let expected: [TextDiffEngine.Chunk]
+        if workload == "equal" {
+            expected = [.equal(original)]
+        } else if workload == "empty" {
+            expected = [.inserted(modified)]
+        } else if count > TextDiffEngine.maxTokens {
+            expected = [.deleted(original), .inserted(modified)]
+        } else if workload == "sparse" {
+            let suffix = String(original.dropFirst(3))
+            expected = [.deleted("old"), .inserted("new")]
+                + (suffix.isEmpty ? [] : [.equal(suffix)])
+        } else {
+            expected = (0..<count).flatMap { index in
+                index.isMultiple(of: 2)
+                    ? [.deleted("old"), .inserted("new")] : [.equal(" ")]
+            }
+        }
+        precondition(chunks == expected, "Complete chunks must match the synthetic oracle")
+        precondition(checksum == expected.count * iterations)
+        let result: [String: Any] = [
+            "tokens_per_side": count,
+            "workload": workload,
+            "iterations": iterations,
+            "diff_milliseconds": milliseconds,
+            "chunks": chunks.count,
+            "exact_output_passed": true
+        ]
+        let data = try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys])
+        guard let json = String(data: data, encoding: .utf8) else { fatalError("JSON must be UTF-8") }
+        print(json)
+    }
+
+    static func input(word: String, tokens: Int) -> String {
+        (0..<tokens).map { $0.isMultiple(of: 2) ? word : " " }.joined()
+    }
+
+    static func probe() throws {
+        var pairs = [
+            ("", ""), ("", "new"), ("old", ""), ("same", "same"),
+            ("a b", "b a"), ("one one two", "one two one"),
+            ("café", "cafe\u{301}"), (" 👩🏽‍💻\n中文", "\t中文 👩🏽‍💻")
+        ]
+        let fragments = ["", "a", "b", "a", " ", "  ", "\n", "\t", ".!?", "—",
+                         "café", "e\u{301}", "👩🏽‍💻", "中文", "مرحبا", "123"]
+        var seed: UInt64 = 0x54494E5943415354
+        func next(_ limit: Int) -> Int {
+            seed = seed &* 6_364_136_223_846_793_005 &+ 1
+            return Int(seed >> 32) % limit
+        }
+        for _ in 0..<2_000 {
+            let original = (0..<next(20)).map { _ in fragments[next(fragments.count)] }.joined()
+            let modified = (0..<next(20)).map { _ in fragments[next(fragments.count)] }.joined()
+            pairs.append((original, modified))
+        }
+        let results = pairs.map { original, modified in
+            TextDiffEngine.diff(original: original, modified: modified).map { chunk in
+                switch chunk {
+                case .equal(let text): ["equal", text]
+                case .deleted(let text): ["deleted", text]
+                case .inserted(let text): ["inserted", text]
+                }
+            }
+        }
+        let data = try JSONSerialization.data(withJSONObject: results, options: [.sortedKeys])
+        guard let json = String(data: data, encoding: .utf8) else { fatalError("JSON must be UTF-8") }
+        print(json)
+    }
+}

--- a/Tests/text-diff-test.swift
+++ b/Tests/text-diff-test.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+@main
+enum TextDiffTests {
+    static func main() {
+        precondition(TextDiffEngine.maxTokens <= Int(UInt16.max), "LCS cells are UInt16")
+
+        precondition(TextDiffEngine.diff(original: "", modified: "") == [])
+        precondition(TextDiffEngine.diff(original: "", modified: "new") == [.inserted("new")])
+        precondition(TextDiffEngine.diff(original: "old", modified: "") == [.deleted("old")])
+        precondition(
+            TextDiffEngine.diff(original: "a b", modified: "b a")
+                == [.deleted("a "), .equal("b"), .inserted(" a")])
+        precondition(
+            TextDiffEngine.diff(original: "café 👩🏽‍💻\n", modified: "cafe 👩🏽‍💻\n")
+                == [.deleted("café"), .inserted("cafe"), .equal(" 👩🏽‍💻\n")])
+
+        for count in [TextDiffEngine.maxTokens - 1, TextDiffEngine.maxTokens] {
+            let original = (0..<count).map { $0.isMultiple(of: 2) ? "word" : " " }.joined()
+            let suffix = String(original.dropFirst(4))
+            let modified = "ward" + suffix
+            precondition(
+                TextDiffEngine.diff(original: original, modified: modified)
+                    == [.deleted("word"), .inserted("ward"), .equal(suffix)])
+        }
+
+        let overCap = String(repeating: "word ", count: TextDiffEngine.maxTokens / 2) + "word"
+        for (original, modified) in [(overCap, "short"), ("short", overCap)] {
+            precondition(
+                TextDiffEngine.diff(original: original, modified: modified)
+                    == [.deleted(original), .inserted(modified)])
+        }
+        precondition(TextDiffEngine.diff(original: overCap, modified: overCap) == [.equal(overCap)])
+        precondition(TextDiffEngine.diff(original: "", modified: overCap) == [.inserted(overCap)])
+        precondition(TextDiffEngine.diff(original: overCap, modified: "") == [.deleted(overCap)])
+        print("Exact chunks, Unicode, ties, high LCS values, token boundaries and fast paths passed")
+    }
+}

--- a/Tinycast/Features/QuickActions/Model/TextDiffEngine.swift
+++ b/Tinycast/Features/QuickActions/Model/TextDiffEngine.swift
@@ -8,7 +8,7 @@ enum TextDiffEngine: Sendable {
         case deleted(String)
     }
 
-    /// The LCS matrix is quadratic, so an unbounded diff of a long selection asks for gigabytes.
+    /// The matrix is quadratic, so an unbounded diff asks for gigabytes; a cell must fit `UInt16`.
     static let maxTokens = 4_000
 
     static func diff(original: String, modified: String) -> [Chunk] {
@@ -61,9 +61,9 @@ enum TextDiffEngine: Sendable {
         return tokens
     }
 
-    private static func longestCommonSubsequence(_ old: [String], _ new: [String]) -> [[Int]] {
+    private static func longestCommonSubsequence(_ old: [String], _ new: [String]) -> [[UInt16]] {
         var table = Array(
-            repeating: Array(repeating: 0, count: new.count + 1), count: old.count + 1)
+            repeating: Array(repeating: UInt16(0), count: new.count + 1), count: old.count + 1)
         for i in 0..<old.count {
             for j in 0..<new.count {
                 table[i + 1][j + 1] =

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -145,6 +145,8 @@ bar leaves text about 60% visible behind the title.
 
 `TextDiffEngine` shows what changed when the output is the input, edited. Its LCS matrix is
 quadratic, so past `maxTokens` a side it degrades to whole-text rather than asking for gigabytes.
+At the cap the matrix is the feature's largest allocation, so its cells are `UInt16` rather than
+`Int` — no LCS length can exceed `maxTokens`, and the six bytes an `Int` adds are 96 MB of zeroes.
 
 ## Reading the selection
 
@@ -206,4 +208,5 @@ failure handler, so automatic expansion stays silent as before.
 - Translate into a language that has not been downloaded: the panel offers the download, then
   translates.
 - Revoke Accessibility while enabled: a HUD explains instead of failing silently.
-- Harness: `quick-action-test` (action metadata, prompt boundaries, preview choices, diffs).
+- Harnesses: `quick-action-test` (action metadata, prompt boundaries, preview choices, diffs) and
+  `text-diff-test` (exact chunks, Unicode, ties, token boundaries and fast paths).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,6 +109,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `ext-test` | the extension runtime end to end — boots a real bundle in JavaScriptCore and renders it |
 | `ext-icon-test` | `Extensions/Service/ExtensionIconCache.swift` — artwork sizing and its fallback |
 | `entry-icon-test` | `EntryIcon` — that each case draws, caches and prints apart from the others, and that a moved `FileIconStamp` retires the bitmap decoded before it |
+| `text-diff-test` | `QuickActions/Model/TextDiffEngine.swift` — exact chunks, Unicode, ties, token-cap boundaries and fast paths |
 | `settings-backup-test` | `Settings/AppSettingsKey.swift`, `Backup/Model/SettingsBackupCoverage.swift` |
 | `backup-archive-test` | all of `Backup/Model/`, plus `Backup/Service/BackupStaging.swift` |
 | `updates-test` | `Updates/Model/` — version precedence, channel filtering, install route, readiness |
@@ -212,6 +213,10 @@ swiftc -O -swift-version 6 Tinycast/Features/Calculator/Model/*.swift \
 /tmp/calc-performance --probe  # every answer as JSON, to diff two builds
 /tmp/calc-performance --cold "10kg to lb"   # first query, including catalog decode
 ```
+
+`Tests/text-diff-performance.swift` is the same shape for `TextDiffEngine`: build it with `-O`
+against the engine, pass a token count, a workload (`dense`, `sparse`, `equal`, `empty`) and an
+iteration count for timings, or `--probe` to diff every chunk between two builds.
 
 `Signposts.interval` owns an explicit `defer` around the wrapped work on purpose. The obvious spelling
 leaks the interval when the work throws, because the `.end` emit is skipped on the throw path and the


### PR DESCRIPTION
## Related issue

Related to #502. Submitted as a draft for review while maintainer approval of the proposal and
assessment of the documented memory/leak limitations are pending.

## What changed

A Quick Actions diff at the 4,000-token cap can allocate about 122 MiB of LCS cell payload because
each length uses a 64-bit `Int`. Store those lengths in `UInt16`, whose range exceeds the unchanged
token cap, and assert that relationship before allocating the matrix.

Tokenization, recurrence, traceback, insertion tie-breaking, coalescing and the over-cap fallback
remain unchanged. There is no cache, persistence change or UI change. The patch adds exact boundary
tests, a deterministic output probe and reproducible measurement notes.

## Memory footprint

Controlled full-AppCore fixture, four fresh processes per build and 12 diff open/close cycles per
process; medians in MiB. This uses real optimized app objects and UI, with a verified fresh sandbox
profile, optional services disabled and no normal menu-bar scenes.

| Step | Baseline → candidate RSS |
| --- | --- |
| Idle after launch | 51.23 → 51.17 MiB |
| Palette open | 104.51 → 104.38 MiB |
| Feature in use (process peak) | 247.90 → 153.81 MiB (**38.0% less**) |
| Palette closed, settled | 233.77 → 139.61 MiB (**40.3% less**) |

Peak RSS ranges are 247.72–248.08 MiB before and 153.59–154.06 MiB after. Largest sampled
physical footprint falls from median 170.38 to 87.53 MiB; this is not a continuous footprint peak.
Settled footprint is variable (baseline 34.00–160.19 MiB; candidate 65.66–66.13 MiB), so a stable
settled-footprint saving is not claimed. These results do not establish the template's universal
under-100-MB / return-to-startup requirement.

Apple M4 Pro, 24 GiB RAM, macOS 26.6.2, Xcode 26.6, Swift 6.3.3. Identical optimized build flags
and synthetic 4,000-token input. Exact chunks pass on every cycle; all tracked result states,
controllers and panels release after every close. The independent standalone model comparison
also reduced median peak RSS 134.64 → 40.50 MiB and elapsed diff time 65.20 → 57.65 ms.
Full tables, variability, workload and limitations are in `docs/performance/text-diff.md`.

Leak-tested: yes, **reported framework leaks remain**. Separate allocation-stack runs report:

| Build | One cycle | 12 cycles |
| --- | ---: | ---: |
| Baseline | 344 allocations / 21,504 bytes | 344 allocations / 21,504 bytes |
| Candidate | 342 allocations / 21,312 bytes | 342 allocations / 21,312 bytes |

Roots are App Intents/LinkServices XPC cycles and AppKit/HIToolbox keyboard-layout initialization.
No reported root stack contains a Quick Actions/diff type; no cycle-dependent growth was observed.
The 192-byte difference is not attributed to the optimization. This is not a zero-leak pass.
An initial fixture trial aborted before the palette sample; the exact cause is unconfirmed. Its
successful debugger retry and the aborted trial are excluded from all reported measurements.

## Drawbacks

The cell type depends on the cap staying within `UInt16.max`; a precondition makes that constraint
explicit. The small-input and early-return timings vary slightly within overlapping ranges and
are not claimed as wins. The fixture limitations and remaining framework reports above need assessment before this draft
is considered ready to merge.

## Tests & validation

- Full standalone suite: 59 harnesses, including the new optimized `text-diff-test`.
- Exact baseline/candidate chunk equality for 2,008 deterministic short text pairs; Unicode,
  whitespace, repeated words and ambiguous ties included.
- Exact synthetic results at 3,999/4,000/4,001 tokens, high LCS values, either-side fallback and
  equal/empty fast paths; seven workload configurations, 42 fresh-process measurements.
- Debug build with signing disabled; lint, pure-model import scan and diff whitespace checks.
- Actual compiled Debug engine, panel state and result view exercised in an isolated host:
  streaming, completion, restart invalidation, errors/empty output, short/long/fallback rendering,
  scrolling, dark/light appearance, button callbacks and panel key dispatch passed.
- Full AppCore startup and launcher presentation now pass in the sandbox fixture. Live providers
  and external Copy/Replace delivery remain outside its scope. No visual change, so a before/after video is not applicable.

The local branch is based directly on current upstream `main` at
`66b95b2c18756fd7f2a45c1f00a0f3c3f2202321`. Local inventory tooling and unrelated workspace changes
are excluded from the patch.
