### PR TITLE
Make Escape walk back through the screens it opened

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -149,6 +149,18 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run palette-escape-test    Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteEscapeAction.swift \
+                           Tinycast/Features/Settings/EscapeKeyBehavior.swift \
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift \
+                           Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+run palette-navigation-test Tinycast/Palette/PaletteState.swift \
+                           Tinycast/Palette/PaletteMode.swift \
+                           Tinycast/Palette/HoverArming.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
+                           Tinycast/Features/Clipboard/Model/ColorValue.swift \
+                           Tinycast/Features/Clipboard/Model/ColorFormat.swift \
+                           Tinycast/Features/Clipboard/Model/ColorSpaces.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -149,6 +149,7 @@ run hover-arming-test      Tinycast/Palette/HoverArming.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run palette-escape-test    Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteEscapeAction.swift \
+                           Tinycast/Palette/CommandEscapeTap.swift \
                            Tinycast/Features/Settings/EscapeKeyBehavior.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \

--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Foundation
 
 /// One press may never skip a step the user can still see and throw work away.
@@ -8,6 +9,15 @@ struct PaletteEscapeTests {
     static var passes = 0
 
     static func expect(_ actual: PaletteEscapeAction, _ expected: PaletteEscapeAction, _ message: String) {
+        if actual == expected {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message) — got \(actual), want \(expected)")
+        }
+    }
+
+    static func expectChord(_ actual: Bool, _ expected: Bool, _ message: String) {
         if actual == expected {
             passes += 1
         } else {
@@ -123,6 +133,30 @@ struct PaletteEscapeTests {
             resolve(menuOpen: true, argumentFocused: true, query: "search"),
             .closeMenu,
             "a menu still outranks the argument field beneath it")
+
+        // ⌘⎋ never reaches the responder chain, so what counts as the chord is decided in the tap.
+        expectChord(
+            CommandEscapeTap.isChord(keyCode: Int64(kVK_Escape), flags: [.maskCommand]),
+            true, "a bare ⌘⎋ is the root-search chord")
+        expectChord(
+            CommandEscapeTap.isChord(keyCode: Int64(kVK_Escape), flags: []),
+            false, "an unmodified Escape belongs to the palette's own handler")
+        expectChord(
+            CommandEscapeTap.isChord(
+                keyCode: Int64(kVK_Escape), flags: [.maskCommand, .maskAlternate]),
+            false, "⌥⌘⎋ is Force Quit and must pass straight through")
+        expectChord(
+            CommandEscapeTap.isChord(
+                keyCode: Int64(kVK_Escape), flags: [.maskCommand, .maskShift]),
+            false, "any further modifier spells somebody else's chord")
+        expectChord(
+            CommandEscapeTap.isChord(keyCode: Int64(kVK_ANSI_A), flags: [.maskCommand]),
+            false, "⌘A is not it")
+        // Caps Lock and fn ride along on real hardware without changing which chord was struck.
+        expectChord(
+            CommandEscapeTap.isChord(
+                keyCode: Int64(kVK_Escape), flags: [.maskCommand, .maskAlphaShift, .maskSecondaryFn]),
+            true, "the flags a real keyboard adds do not disqualify the chord")
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -16,79 +16,111 @@ struct PaletteEscapeTests {
         }
     }
 
+    /// The shipped default, so a case only spells out what it is actually about.
+    static func resolve(
+        menuOpen: Bool = false, argumentFocused: Bool = false, query: String = "",
+        mode: PaletteMode = .launcher, canGoBack: Bool = false,
+        behavior: EscapeKeyBehavior = .navigateBackOrClose
+    ) -> PaletteEscapeAction {
+        PaletteEscapeAction.resolve(
+            menuOpen: menuOpen, argumentFocused: argumentFocused, query: query, mode: mode,
+            canGoBack: canGoBack, behavior: behavior)
+    }
+
     static func main() {
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: true, argumentFocused: false, query: "notes", mode: .launcher),
+            resolve(menuOpen: true, query: "notes"),
             .closeMenu,
             "an open menu closes before anything else")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "notes", mode: .launcher),
+            resolve(query: "notes"),
             .clearQuery,
             "a typed launcher query clears before the palette hides")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "notes", mode: .extensionCommand),
+            resolve(query: "notes", mode: .extensionCommand),
             .clearQuery,
             "a typed extension query clears before the extension screen exits")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "", mode: .extensionCommand),
+            resolve(mode: .extensionCommand),
             .exitExtensionScreen,
-            "an empty extension query exits the extension screen")
+            "an empty extension query exits the extension screen, which owns its own stack")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .launcher),
+            resolve(),
             .hidePalette,
             "an empty launcher query hides the palette")
         // The two surfaces where the field is not a search field: an argument answer, a chat draft.
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "blue",
-                mode: .customCommandArguments),
+            resolve(query: "blue", mode: .customCommandArguments),
             .clearQuery,
             "a half-typed argument clears before the pending command is abandoned")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "", mode: .customCommandArguments),
+            resolve(mode: .customCommandArguments),
             .hidePalette,
             "an empty argument field hides the palette, which cancels the pending command")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: false, query: "why is the sky", mode: .ai),
+            resolve(query: "why is the sky", mode: .ai),
             .clearQuery,
             "an unsent chat draft clears before chat itself is left")
+
+        // Provenance, not the mode, decides whether there is anywhere to go back to.
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .ai),
-            .exitToLauncher,
-            "an empty composer backs chat out to the launcher rather than hiding the palette")
+            resolve(mode: .clipboard, canGoBack: true),
+            .goBack,
+            "a clipboard screen opened from the root search returns to it")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: false, argumentFocused: false, query: "", mode: .clipboard),
+            resolve(mode: .clipboard),
             .hidePalette,
-            "only chat backs out; an empty clipboard filter still hides the palette")
+            "the same screen summoned by its own hotkey is a root, so it hides")
         expect(
-            PaletteEscapeAction.resolve(menuOpen: true, argumentFocused: false, query: "", mode: .ai),
+            resolve(mode: .ai, canGoBack: true),
+            .goBack,
+            "chat is no different: reached from the root, it goes back to it")
+        expect(
+            resolve(mode: .ai),
+            .hidePalette,
+            "chat summoned by its own hotkey hides rather than falling back to the launcher")
+        expect(
+            resolve(query: "notes", mode: .clipboard, canGoBack: true),
+            .clearQuery,
+            "a typed query still clears before the back step it would otherwise skip")
+
+        // Close and pop to root: one press ends the session, whatever it was opened over.
+        expect(
+            resolve(mode: .clipboard, canGoBack: true, behavior: .closeAndPopToRoot),
+            .hidePalette,
+            "close-and-pop-to-root hides even where a back step exists")
+        expect(
+            resolve(mode: .extensionCommand, canGoBack: true, behavior: .closeAndPopToRoot),
+            .hidePalette,
+            "close-and-pop-to-root outranks an extension's own stack too")
+        expect(
+            resolve(query: "notes", behavior: .closeAndPopToRoot),
+            .clearQuery,
+            "clearing the query is the first press under either behavior")
+        expect(
+            resolve(menuOpen: true, canGoBack: true, behavior: .closeAndPopToRoot),
+            .closeMenu,
+            "a menu outranks the behavior setting beneath it")
+
+        expect(
+            resolve(menuOpen: true, mode: .ai),
             .closeMenu,
             "a menu outranks the chat screen it is drawn over")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: true, argumentFocused: false, query: "", mode: .extensionCommand),
+            resolve(menuOpen: true, mode: .extensionCommand),
             .closeMenu,
             "a menu outranks the extension screen it is drawn over")
         // An inline argument field is deeper than the query that found the command.
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: true, query: "search", mode: .launcher),
+            resolve(argumentFocused: true, query: "search"),
             .leaveArgumentField,
             "an argument field hands focus back before the query that found it clears")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: false, argumentFocused: true, query: "", mode: .launcher),
+            resolve(argumentFocused: true, canGoBack: true),
             .leaveArgumentField,
             "an empty query does not let the argument field skip its own step")
         expect(
-            PaletteEscapeAction.resolve(
-                menuOpen: true, argumentFocused: true, query: "search", mode: .launcher),
+            resolve(menuOpen: true, argumentFocused: true, query: "search"),
             .closeMenu,
             "a menu still outranks the argument field beneath it")
 

--- a/Tests/palette-navigation-test.swift
+++ b/Tests/palette-navigation-test.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Going back has to look like never having left: same screen, same query, same row.
+@main
+@MainActor
+struct PaletteNavigationTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: Bool, _ message: String) {
+        if condition {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    /// A launcher with a search typed into it, which is what a back step has to bring back.
+    static func searchingLauncher() -> PaletteState {
+        let vm = PaletteState()
+        vm.prepare(mode: .launcher)
+        vm.query = "clipboard"
+        vm.selection = 3
+        return vm
+    }
+
+    static func main() {
+        let vm = searchingLauncher()
+        expect(!vm.canGoBack, "a prepared screen is a root with nothing behind it")
+
+        vm.push(mode: .clipboard)
+        expect(vm.mode == .clipboard && vm.query.isEmpty && vm.selection == 0,
+            "a pushed screen opens as fresh as a prepared one")
+        expect(vm.canGoBack, "the screen it was pushed over is still there to return to")
+
+        expect(vm.pop(), "a pushed screen has a step back")
+        expect(vm.mode == .launcher && vm.query == "clipboard" && vm.selection == 3,
+            "the back step restores the screen, its query and its selection")
+        expect(!vm.canGoBack, "the restored screen is the root again")
+        expect(!vm.pop(), "a root has nowhere left to go")
+        expect(vm.mode == .launcher && vm.query == "clipboard",
+            "a refused back step leaves the screen untouched")
+
+        // A list snapped to the top would throw away the very selection being restored.
+        let tokens = searchingLauncher()
+        tokens.push(mode: .emoji)
+        let reset = tokens.resetToken
+        let follow = tokens.followToken
+        expect(tokens.pop(), "the emoji screen goes back to the launcher")
+        expect(tokens.resetToken == reset, "a back step does not snap the restored list to the top")
+        expect(tokens.followToken != follow, "it scrolls the restored row into view instead")
+
+        let nested = searchingLauncher()
+        nested.push(mode: .ai)
+        nested.query = "why is the sky blue"
+        nested.push(mode: .aiHistory)
+        expect(nested.pop() && nested.mode == .ai && nested.query == "why is the sky blue",
+            "history returns to the chat draft it was opened over")
+        expect(nested.pop() && nested.mode == .launcher && nested.query == "clipboard",
+            "and chat returns to the search that found it")
+
+        // `replace` is for a screen swapping its own contents, which is not a step of its own.
+        let replaced = searchingLauncher()
+        replaced.push(mode: .ai)
+        replaced.replace(mode: .ai)
+        expect(replaced.canGoBack, "starting a new chat keeps whatever chat was opened over")
+        expect(replaced.pop() && replaced.mode == .launcher,
+            "so one back step still lands on the launcher")
+
+        let summoned = searchingLauncher()
+        summoned.push(mode: .clipboard)
+        summoned.prepare(mode: .emoji)
+        expect(!summoned.canGoBack, "a summon is a new root, not a step onto the old stack")
+
+        let ringed = searchingLauncher()
+        ringed.push(mode: .clipboard)
+        ringed.resetNavigation()
+        expect(!ringed.canGoBack && ringed.mode == .clipboard,
+            "crossing the Tab ring drops the stack without disturbing the screen")
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tests/palette-navigation-test.swift
+++ b/Tests/palette-navigation-test.swift
@@ -30,16 +30,19 @@ struct PaletteNavigationTests {
         expect(!vm.canGoBack, "a prepared screen is a root with nothing behind it")
 
         vm.push(mode: .clipboard)
-        expect(vm.mode == .clipboard && vm.query.isEmpty && vm.selection == 0,
+        expect(
+            vm.mode == .clipboard && vm.query.isEmpty && vm.selection == 0,
             "a pushed screen opens as fresh as a prepared one")
         expect(vm.canGoBack, "the screen it was pushed over is still there to return to")
 
         expect(vm.pop(), "a pushed screen has a step back")
-        expect(vm.mode == .launcher && vm.query == "clipboard" && vm.selection == 3,
+        expect(
+            vm.mode == .launcher && vm.query == "clipboard" && vm.selection == 3,
             "the back step restores the screen, its query and its selection")
         expect(!vm.canGoBack, "the restored screen is the root again")
         expect(!vm.pop(), "a root has nowhere left to go")
-        expect(vm.mode == .launcher && vm.query == "clipboard",
+        expect(
+            vm.mode == .launcher && vm.query == "clipboard",
             "a refused back step leaves the screen untouched")
 
         // A list snapped to the top would throw away the very selection being restored.
@@ -55,9 +58,11 @@ struct PaletteNavigationTests {
         nested.push(mode: .ai)
         nested.query = "why is the sky blue"
         nested.push(mode: .aiHistory)
-        expect(nested.pop() && nested.mode == .ai && nested.query == "why is the sky blue",
+        expect(
+            nested.pop() && nested.mode == .ai && nested.query == "why is the sky blue",
             "history returns to the chat draft it was opened over")
-        expect(nested.pop() && nested.mode == .launcher && nested.query == "clipboard",
+        expect(
+            nested.pop() && nested.mode == .launcher && nested.query == "clipboard",
             "and chat returns to the search that found it")
 
         // `replace` is for a screen swapping its own contents, which is not a step of its own.
@@ -65,7 +70,8 @@ struct PaletteNavigationTests {
         replaced.push(mode: .ai)
         replaced.replace(mode: .ai)
         expect(replaced.canGoBack, "starting a new chat keeps whatever chat was opened over")
-        expect(replaced.pop() && replaced.mode == .launcher,
+        expect(
+            replaced.pop() && replaced.mode == .launcher,
             "so one back step still lands on the launcher")
 
         let summoned = searchingLauncher()
@@ -76,7 +82,8 @@ struct PaletteNavigationTests {
         let ringed = searchingLauncher()
         ringed.push(mode: .clipboard)
         ringed.resetNavigation()
-        expect(!ringed.canGoBack && ringed.mode == .clipboard,
+        expect(
+            !ringed.canGoBack && ringed.mode == .clipboard,
             "crossing the Tab ring drops the stack without disturbing the screen")
 
         print("\(passes) passed, \(failures) failed")

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		2C9B845C83930B9EEA188C0C /* WindowLayoutInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A29ED24604BE67E562B07D /* WindowLayoutInspector.swift */; };
 		2D51D92BE8EAB5440F4C8517 /* ExtensionPaletteModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0FB3A9CA762A7A8DB99BA6 /* ExtensionPaletteModifiers.swift */; };
 		2E0957985928EC32511A5969 /* MCPServerEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0814A6707E67A3BD3772E119 /* MCPServerEditor.swift */; };
+		2E9641057A7B1FE1446BD14D /* EscapeKeyBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */; };
 		2E9CDC24A175FE8AAE4F03D9 /* InstalledAIStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817AF0E23DDCC95147B5AFB /* InstalledAIStream.swift */; };
 		2EBB42C7EB17F37628765B17 /* CurrencyData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C7F0C39D24F068A8F84864 /* CurrencyData.generated.swift */; };
 		2F2360730BE4992D5745FAD3 /* ExtensionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471E1C3C250FD0A89E2C6430 /* ExtensionListView.swift */; };
@@ -836,6 +837,7 @@
 		91151402A1A4586B2496BF35 /* NotesPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesPanel.swift; sourceTree = "<group>"; };
 		9188FA8A06EAE3E55FFCBC70 /* UpdateInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInstaller.swift; sourceTree = "<group>"; };
 		91D0784E49BC5899A585F285 /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
+		920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeKeyBehavior.swift; sourceTree = "<group>"; };
 		92AF20F1007F7F3DC1013C2A /* CalloutShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutShape.swift; sourceTree = "<group>"; };
 		92B4495E56754B05B5F3551D /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
 		934DBE501F116131DC1BF5CE /* CalcExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcExpressionParser.swift; sourceTree = "<group>"; };
@@ -2415,6 +2417,7 @@
 				A5A8F78D3F1BFA8E86F9CB47 /* AppAppearance.swift */,
 				7F64F4362989516482853CDB /* AppSettings.swift */,
 				384485BD1794D25503534525 /* AppSettingsKey.swift */,
+				920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */,
 				C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */,
 				8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */,
 				C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */,
@@ -2829,6 +2832,7 @@
 				0C1CACEF014462D3F581CE54 /* EmojiSettingsView.swift in Sources */,
 				017FB0EDDC9AF28ED81EA6A8 /* EntryIconView.swift in Sources */,
 				0FD2528627DE63DC9C6B8793 /* EntryNaming.swift in Sources */,
+				2E9641057A7B1FE1446BD14D /* EscapeKeyBehavior.swift in Sources */,
 				7D027F24478DAB019076CA10 /* EventDraft.swift in Sources */,
 				A33EA048BC22D7313F4D480C /* EventDraftFields.swift in Sources */,
 				A6200866E3416744A6E8B6E5 /* ExecutableLocator.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		4109B5CF37DCA4BCDAE46412 /* ShellCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFE3C41897391C14DB5A55C /* ShellCommandRunner.swift */; };
 		410F1B5FFAA44378AC9EC2DB /* SystemSettingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951E746BA1AD25D167A1775F /* SystemSettingsSettingsView.swift */; };
 		41C5B5B0E637FAA4AFD4BF13 /* BundleNameCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57694B58B0A17CAC1D697FAA /* BundleNameCache.swift */; };
+		42CDB6A71960204B194EDC8B /* CommandEscapeTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D05FD9A7137951B2EC6C39 /* CommandEscapeTap.swift */; };
 		43DBCE7B5A84D0D6322124F5 /* MessageHUDController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2CB71671625A1F446316A1 /* MessageHUDController.swift */; };
 		44646A576847F2D9FB68D8CF /* MCPServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F8B8787A7197579A6F6ECC /* MCPServerManager.swift */; };
 		4549280508130B232069071E /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112551581ECF83B53D405334 /* BackupSettingsView.swift */; };
@@ -982,6 +983,7 @@
 		D03E3DB2E1E28057B98FC1DF /* ExtensionFieldHint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFieldHint.swift; sourceTree = "<group>"; };
 		D0508EBDFD6E59370AB2E5B7 /* UninstallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallScreen.swift; sourceTree = "<group>"; };
 		D0C8025ED5F2833127E20C05 /* ExtensionFieldChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFieldChrome.swift; sourceTree = "<group>"; };
+		D0D05FD9A7137951B2EC6C39 /* CommandEscapeTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandEscapeTap.swift; sourceTree = "<group>"; };
 		D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPaletteView.swift; sourceTree = "<group>"; };
 		D245764DB29BFEEB47A024A1 /* WindowLayoutNumberField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowLayoutNumberField.swift; sourceTree = "<group>"; };
 		D28281DFC434C75F8A594635 /* ReleaseFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseFeed.swift; sourceTree = "<group>"; };
@@ -2237,6 +2239,7 @@
 		BCE065D58E699AFB41A13CD3 /* Palette */ = {
 			isa = PBXGroup;
 			children = (
+				D0D05FD9A7137951B2EC6C39 /* CommandEscapeTap.swift */,
 				9D4C3D9FA2F775DC650985D8 /* HoverArming.swift */,
 				BF96A1566757811AD434C0F9 /* MenuPanel.swift */,
 				C004F2C2EFDD340A73C6AB02 /* PaletteCoordinator.swift */,
@@ -2801,6 +2804,7 @@
 				F13789E3732E844EE7584561 /* ColorValue.swift in Sources */,
 				4EBFBA1CC7DA9B22C396DBEC /* CommandArgumentsRow.swift in Sources */,
 				89872774514D83EC2BD60F1E /* CommandCatalog.swift in Sources */,
+				42CDB6A71960204B194EDC8B /* CommandEscapeTap.swift in Sources */,
 				BEAAD72E748375E0039AC90F /* CommandID.swift in Sources */,
 				51E8877F53ABA0E51B2493FA /* CommandOutputPresenter.swift in Sources */,
 				C45CCAE9AE2D3BCAC2BF80BE /* CommandOutputView.swift in Sources */,

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -229,6 +229,8 @@ enum Theme {
         static let exit: TimeInterval = 0.12
         /// Fade-in/out for a hover `Tooltip`.
         static let tooltip: TimeInterval = 0.15
+        /// A control lighting up under the pointer; short enough to feel like a response.
+        static let hover: TimeInterval = 0.12
         static let copyFeedback: TimeInterval = 1.2
         static let chatFooter: TimeInterval = 0.12
         /// A Settings search result scrolling its section into view, then the pulse that marks it.

--- a/Tinycast/Features/AI/UI/AIChatCoordinator.swift
+++ b/Tinycast/Features/AI/UI/AIChatCoordinator.swift
@@ -144,16 +144,19 @@ final class AIChatCoordinator {
 
     func startNewChat() {
         chat.startNewChat()
-        palette.prepare(mode: .ai)
+        // A fresh conversation, not a fresh root: whatever opened chat is still behind it.
+        palette.replace(mode: .ai)
     }
 
     func showHistory() {
-        palette.prepare(mode: .aiHistory)
+        palette.push(mode: .aiHistory)
     }
 
     func openChat(id: UUID) {
         guard chat.open(id: id) else { return }
-        palette.prepare(mode: .ai)
+        // History is left behind rather than stacked under, so one back step leaves chat for good.
+        _ = palette.pop()
+        palette.replace(mode: .ai)
     }
 
     func deleteChat(id: UUID) {

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -28,6 +28,7 @@ struct SettingsBackup: Codable {
         var emojiSkinTone: String?
         var showInMenuBar: Bool?
         var popToRootSeconds: Int?
+        var escapeKeyBehavior: String?
         var appearance: String?
         var compactMode: Bool?
         var showFavoritesInCompactMode: Bool?
@@ -119,6 +120,7 @@ extension SettingsBackup {
             showInMenuBar: UserDefaults.standard.object(forKey: SettingsKey.showInMenuBar) as? Bool
                 ?? true,
             popToRootSeconds: s.popToRootTimeout.rawValue,
+            escapeKeyBehavior: s.escapeKeyBehavior.rawValue,
             appearance: s.appearance.rawValue,
             compactMode: s.compactMode,
             showFavoritesInCompactMode: s.showFavoritesInCompactMode,
@@ -282,6 +284,10 @@ extension SettingsBackup {
         }
         if let secs = s.popToRootSeconds, let timeout = PopToRootTimeout(rawValue: secs) {
             settings.popToRootTimeout = timeout
+            count += 1
+        }
+        if let raw = s.escapeKeyBehavior, let behavior = EscapeKeyBehavior(rawValue: raw) {
+            settings.escapeKeyBehavior = behavior
             count += 1
         }
         if let raw = s.appearance, let appearance = AppAppearance(rawValue: raw) {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -13,6 +13,7 @@ enum SettingsBackupCoverage {
         "hyperKeyQuickPress": .hyperKeyQuickPress,
         "emojiSkinTone": .emojiSkinTone,
         "popToRootSeconds": .popToRootTimeout,
+        "escapeKeyBehavior": .escapeKeyBehavior,
         "appearance": .appearance,
         "compactMode": .compactMode,
         "showFavoritesInCompactMode": .showFavoritesInCompactMode,

--- a/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCoordinator.swift
@@ -146,7 +146,7 @@ final class ExtensionCoordinator {
         switch command.mode {
         case .view:
             // Switch the palette over first, so the launching state is what the user sees.
-            palette.prepare(mode: .extensionCommand)
+            paletteCoordinator.navigate(to: .extensionCommand)
             // A shortcut fires while hidden, where a view command has nowhere to render.
             if !paletteCoordinator.isVisible {
                 paletteCoordinator.showPalette(mode: .extensionCommand)
@@ -172,7 +172,7 @@ final class ExtensionCoordinator {
         Task {
             if await extensions.popNavigation() { return }
             await extensions.stop()
-            palette.prepare(mode: .launcher)
+            if !palette.pop() { paletteCoordinator.hidePalette() }
         }
     }
 

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -177,6 +177,11 @@ final class AppSettings {
         didSet { defaults.set(popToRootTimeout.rawValue, forKey: Key.popToRootTimeout.rawValue) }
     }
 
+    /// Whether Escape walks back through the screens the palette opened, or just closes it.
+    var escapeKeyBehavior: EscapeKeyBehavior {
+        didSet { defaults.set(escapeKeyBehavior.rawValue, forKey: Key.escapeKeyBehavior.rawValue) }
+    }
+
     /// Follow macOS, or pin Tinycast to one appearance. Applied by `AppCore.applyAppearance()`.
     var appearance: AppAppearance {
         didSet { defaults.set(appearance.rawValue, forKey: Key.appearance.rawValue) }
@@ -486,6 +491,9 @@ final class AppSettings {
         popToRootTimeout =
             PopToRootTimeout(rawValue: defaults.integer(forKey: Key.popToRootTimeout.rawValue))
             ?? .immediately
+        escapeKeyBehavior =
+            defaults.string(forKey: Key.escapeKeyBehavior.rawValue).flatMap(EscapeKeyBehavior.init)
+            ?? .navigateBackOrClose
         appearance =
             defaults.string(forKey: Key.appearance.rawValue).flatMap(AppAppearance.init) ?? .system
         compactMode = defaults.bool(forKey: Key.compactMode.rawValue)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -12,6 +12,7 @@ enum AppSettingsKey: String, CaseIterable {
     case hyperKeyQuickPress = "hyperKeyQuickPress"
     case emojiSkinTone = "emojiSkinTone"
     case popToRootTimeout = "popToRootTimeout"
+    case escapeKeyBehavior = "escapeKeyBehavior"
     case appearance = "appearance"
     case compactMode = "compactMode"
     case showFavoritesInCompactMode = "showFavoritesInCompactMode"

--- a/Tinycast/Features/Settings/EscapeKeyBehavior.swift
+++ b/Tinycast/Features/Settings/EscapeKeyBehavior.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// What Escape does on the palette once the search field it would have cleared is already empty.
+enum EscapeKeyBehavior: String, CaseIterable, Identifiable, Sendable {
+    case navigateBackOrClose
+    case closeAndPopToRoot
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .navigateBackOrClose: return "Navigate back or close window"
+        case .closeAndPopToRoot: return "Close window and pop to root"
+        }
+    }
+}

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -163,6 +163,14 @@ struct GeneralSettingsView: View {
                     SettingsRowTitle(.generalGeneral, "Pop to Root Search")
                     Text("Reset to the launcher this long after the window closes.")
                 }
+                Picker(selection: $settings.escapeKeyBehavior) {
+                    ForEach(EscapeKeyBehavior.allCases) { behavior in
+                        Text(behavior.title).tag(behavior)
+                    }
+                } label: {
+                    SettingsRowTitle(.generalGeneral, "Escape Key Behavior")
+                    Text("What Escape does once the search field is already empty.")
+                }
                 // Empty only when TIS fails; one layout still lists, so the row stays put.
                 if !inputSources.isEmpty {
                     Picker(selection: $settings.autoSwitchInputSourceID) {

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -155,6 +155,9 @@ enum SettingsSearchCatalog {
             .generalGeneral, "Pop to Root Search",
             keywords: ["reset", "timeout", "back"]),
         .init(
+            .generalGeneral, "Escape Key Behavior",
+            keywords: ["escape", "esc", "back", "close", "navigate"]),
+        .init(
             .generalGeneral, "Auto-switch input source",
             keywords: ["keyboard", "layout", "language", "abc"])
     ]

--- a/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallCoordinator.swift
@@ -50,7 +50,7 @@ final class UninstallCoordinator {
         session.begin(
             app: app, otherAppNames: others.map(\.name),
             otherBundleIDs: others.compactMap(\.bundleID), isRunning: runningApps.isRunning(app))
-        palette.prepare(mode: .uninstall)
+        paletteCoordinator.navigate(to: .uninstall)
     }
 
     /// The one funnel for the screen's ↵ and Actions row, so neither skips the confirmation.
@@ -79,7 +79,7 @@ final class UninstallCoordinator {
                 removeUninstalledReferences(app)
                 await appIndex.refresh()
             }
-            palette.prepare(mode: .launcher)
+            if !palette.pop() { palette.prepare(mode: .launcher) }
             await presentUninstallReport(report)
         }
     }

--- a/Tinycast/Palette/CommandEscapeTap.swift
+++ b/Tinycast/Palette/CommandEscapeTap.swift
@@ -1,0 +1,103 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// C entry point: the decision is a key-code compare, so it is made here rather than crossing out.
+private func commandEscapeTapCallback(
+    proxy: CGEventTapProxy, type: CGEventType, event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard let userInfo else { return Unmanaged.passUnretained(event) }
+    let tap = Unmanaged<CommandEscapeTap>.fromOpaque(userInfo).takeUnretainedValue()
+
+    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        MainActor.assumeIsolated { tap.reenable() }
+        return Unmanaged.passUnretained(event)
+    }
+    guard
+        CommandEscapeTap.isChord(
+            keyCode: event.getIntegerValueField(.keyboardEventKeycode), flags: event.flags)
+    else { return Unmanaged.passUnretained(event) }
+
+    let claimed = MainActor.assumeIsolated { tap.fire() }
+    return claimed ? nil : Unmanaged.passUnretained(event)
+}
+
+/// ⌘⎋ is claimed upstream of every app, so the palette takes it where it enters the system.
+///
+/// The window server binds the chord itself, so it never reaches `onCommandShortcut` the way ⌘.
+/// and ⌘w do: no keystroke is left by the time the responder chain runs, and a head-inserted HID
+/// tap is the one place earlier than that. See docs/features/palette.md.
+@MainActor
+final class CommandEscapeTap {
+    /// Claims the chord and returns true, or declines it so the rest of the system still gets it.
+    private let onChord: () -> Bool
+
+    private var tapPort: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    init(onChord: @escaping () -> Bool) {
+        self.onChord = onChord
+    }
+
+    isolated deinit {
+        tearDown()
+    }
+
+    /// True only for a bare ⌘⎋: any further modifier spells somebody else's chord.
+    nonisolated static func isChord(keyCode: Int64, flags: CGEventFlags) -> Bool {
+        keyCode == Int64(kVK_Escape)
+            && flags.intersection([.maskCommand, .maskAlternate, .maskControl, .maskShift])
+                == .maskCommand
+    }
+
+    /// Called on every show: a tap refused for want of Accessibility is retried the next time.
+    func enable() {
+        guard let port = installIfNeeded() else { return }
+        CGEvent.tapEnable(tap: port, enable: true)
+    }
+
+    func disable() {
+        guard let tapPort else { return }
+        CGEvent.tapEnable(tap: tapPort, enable: false)
+    }
+
+    private func installIfNeeded() -> CFMachPort? {
+        if let tapPort { return tapPort }
+        // Head of the HID stream: anywhere later and the system hotkey has already eaten the chord.
+        guard
+            let port = CGEvent.tapCreate(
+                tap: .cghidEventTap,
+                place: .headInsertEventTap,
+                options: .defaultTap,
+                eventsOfInterest: 1 << CGEventType.keyDown.rawValue,
+                callback: commandEscapeTapCallback,
+                userInfo: Unmanaged.passUnretained(self).toOpaque()),
+            let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0)
+        else { return nil }
+        tapPort = port
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        return port
+    }
+
+    private func tearDown() {
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+            self.runLoopSource = nil
+        }
+        if let tapPort {
+            CGEvent.tapEnable(tap: tapPort, enable: false)
+            CFMachPortInvalidate(tapPort)
+            self.tapPort = nil
+        }
+    }
+
+    fileprivate func fire() -> Bool {
+        onChord()
+    }
+
+    /// The system disables a tap it thinks is too slow; ours only ever compares two integers.
+    fileprivate func reenable() {
+        if let tapPort { CGEvent.tapEnable(tap: tapPort, enable: true) }
+    }
+}

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -55,18 +55,25 @@ final class PaletteCoordinator {
         }
     }
 
+    /// A palette already up is being navigated, not summoned: the screen under it is the back step.
+    func navigate(to mode: PaletteMode) {
+        if windowController.isVisible, palette.mode != mode {
+            palette.push(mode: mode)
+        } else {
+            palette.prepare(mode: mode)
+        }
+    }
+
     /// Shows the palette, honoring Pop to Root Search. See docs/features/palette.md#state-flow.
     func showPalette(
         mode: PaletteMode, restoreAnyMode: Bool = false, seeding query: String? = nil
     ) {
         let preserved = windowController.consumePreservedState()
-        // A carried query always opens fresh: restoring the previous screen would drop it.
-        if let query {
-            palette.prepare(mode: mode)
-            palette.query = query
-        } else if !(preserved && (restoreAnyMode || palette.mode == mode)) {
-            palette.prepare(mode: mode)
+        // A carried query always opens the screen fresh: restoring the previous one would drop it.
+        if query != nil || !(preserved && (restoreAnyMode || palette.mode == mode)) {
+            navigate(to: mode)
         }
+        if let query { palette.query = query }
         windowController.show()
         if palette.mode == .fileSearch { fileSearch.search(palette.query) }
         // Re-scan on open so an app uninstalled since the last scan drops out of the launcher.
@@ -76,6 +83,11 @@ final class PaletteCoordinator {
     func hidePalette(restoreFocus: Bool = true) {
         fileSearch.cancel()
         windowController.hide(restoreFocus: restoreFocus)
+    }
+
+    /// Reset to the root search now rather than after the Pop to Root Search delay.
+    func popToRootNow() {
+        windowController.popToRootNow()
     }
 
     /// True for the slim compact bar: compact on, launcher root, empty, not overflowed.

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -6,20 +6,20 @@ enum PaletteEscapeAction: Equatable {
     case leaveArgumentField
     case clearQuery
     case exitExtensionScreen
-    case exitToLauncher
+    case goBack
     case hidePalette
 
     static func resolve(
-        menuOpen: Bool, argumentFocused: Bool, query: String, mode: PaletteMode
+        menuOpen: Bool, argumentFocused: Bool, query: String, mode: PaletteMode,
+        canGoBack: Bool, behavior: EscapeKeyBehavior
     ) -> Self {
         if menuOpen { return .closeMenu }
         // An argument field is a step deeper than the query, so it is left before anything clears.
         if argumentFocused { return .leaveArgumentField }
         if !query.isEmpty { return .clearQuery }
+        guard behavior == .navigateBackOrClose else { return .hidePalette }
         // An extension pops its own navigation stack before the command is left.
         if mode == .extensionCommand { return .exitExtensionScreen }
-        // Chat is a surface of its own, so leaving it lands on the launcher, not on nothing.
-        if mode == .ai { return .exitToLauncher }
-        return .hidePalette
+        return canGoBack ? .goBack : .hidePalette
     }
 }

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -1,10 +1,19 @@
 import Foundation
 
+/// A screen to return to, held with enough state that going back looks like never having left.
+struct PaletteFrame: Equatable {
+    let mode: PaletteMode
+    let query: String
+    let selection: Int
+}
+
 /// Palette state shared between the panel's SwiftUI tree and the coordinator.
 @MainActor
 @Observable
 final class PaletteState {
     var mode: PaletteMode = .launcher
+    /// The screens below `mode`, innermost last: a summon starts a new one, navigating pushes on.
+    private(set) var backStack: [PaletteFrame] = []
     var query: String = ""
     var selection: Int = 0
     /// True while an IME holds marked text, which leaves `query` empty. The panel publishes it.
@@ -15,7 +24,7 @@ final class PaletteState {
     private(set) var isVisible = false
     /// Changes every time the palette is shown so the search field can re-focus.
     var focusToken = UUID()
-    /// Bumped only by `prepare`, so lists snap to the top even when nothing else changed.
+    /// Bumped when a screen opens fresh, so lists snap to the top even when nothing else changed.
     var resetToken = UUID()
     /// Bumped when an action reorders the list, so the highlight scrolls back into view.
     var followToken = UUID()
@@ -60,7 +69,43 @@ final class PaletteState {
         isVisible = visible
     }
 
+    var canGoBack: Bool { !backStack.isEmpty }
+
+    /// Open `mode` as the root: a fresh screen with nothing behind it to go back to.
     func prepare(mode: PaletteMode) {
+        backStack.removeAll()
+        replace(mode: mode)
+    }
+
+    /// Swap the screen in place, leaving whatever it was opened over still behind it.
+    func replace(mode: PaletteMode) {
+        openScreen(mode)
+        resetToken = UUID()
+    }
+
+    /// Open `mode` over the current screen, which a back step returns to.
+    func push(mode: PaletteMode) {
+        backStack.append(PaletteFrame(mode: self.mode, query: query, selection: selection))
+        replace(mode: mode)
+    }
+
+    /// Restore the screen underneath, false when this one is the root.
+    func pop() -> Bool {
+        guard let frame = backStack.popLast() else { return false }
+        openScreen(frame.mode)
+        query = frame.query
+        selection = frame.selection
+        // Not `resetToken`: snapping to the top would throw away the selection restored here.
+        followToken = UUID()
+        return true
+    }
+
+    /// Tab rings the root surfaces, so crossing to one leaves nothing behind it.
+    func resetNavigation() {
+        backStack.removeAll()
+    }
+
+    private func openScreen(_ mode: PaletteMode) {
         self.mode = mode
         query = ""
         selection = 0
@@ -74,7 +119,6 @@ final class PaletteState {
         dropHoverHighlight()
         menuOpen = false
         focusToken = UUID()
-        resetToken = UUID()
     }
 
     /// Long enough that ⌘↵ or ⌘K never flashes the numbering, short enough to feel like a reveal.

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -156,6 +156,14 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         core.palette.prepare(mode: .launcher)
     }
 
+    /// Skip the Pop to Root Search delay, for a close that means to reset as well as hide.
+    func popToRootNow() {
+        guard !core.extensions.isAuthorizing else { return }
+        popToRootTimer?.invalidate()
+        popToRootTimer = nil
+        popToRoot()
+    }
+
     /// True while a hidden palette still holds pre-close state; consuming cancels the reset.
     func consumePreservedState() -> Bool {
         guard let timer = popToRootTimer else { return false }
@@ -261,10 +269,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.onFieldEditorFocused = { [weak self] context in
             self?.core.inputSourceSwitcher.applySession(to: context)
         }
-        // Backspace in an empty search backs out of a sub-screen to a fresh root.
+        // Backspace in an empty search takes the same back step Escape does.
         panel.onBareBackspace = { [weak self] in
-            guard let core = self?.core, core.palette.mode != .launcher, core.palette.query.isEmpty
-            else { return false }
+            guard let core = self?.core, core.palette.query.isEmpty else { return false }
             // A form field owns the key: the text it deletes is the field's, not a query's.
             if core.palette.isEditingField { return false }
             // The argument form steps back through the answers first, one key per field.
@@ -275,15 +282,14 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 core.palette.selection = 0
                 return true
             }
-            if core.palette.mode == .aiHistory {
-                core.palette.prepare(mode: .ai)
+            if core.palette.mode == .extensionCommand {
+                core.extensionCoordinator.exitExtensionScreen()
                 return true
             }
             if core.palette.mode == .ai, core.aiChatCoordinator.removeLastAttachment() {
                 return true
             }
-            core.palette.prepare(mode: .launcher)
-            return true
+            return core.palette.pop()
         }
         installPasteMonitor()
         // Handled at the panel: the field editor or a missing main menu eats these first.

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -17,6 +17,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     private let dropGuides = PaletteDropGuideController()
     /// ⌘V: `Edit ▸ Paste` claims it before `sendEvent` whenever the board also carries text.
     private var pasteMonitor: Any?
+    /// ⌘⎋: the window server claims it, so no keystroke is left for the responder chain to see.
+    private lazy var commandEscapeTap = CommandEscapeTap { [weak self] in
+        guard let self, self.panel?.isKeyWindow == true else { return false }
+        self.core.palette.prepare(mode: .launcher)
+        return true
+    }
 
     /// What a drag in flight needs: where home is, and whether releasing now would land there.
     private struct DragSession {
@@ -61,6 +67,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             // Events go stale while the palette is closed, and the countdown only ticks while up.
             core.calendarCoordinator.paletteDidShow()
             core.palette.noteVisible(true)
+            // Only while we are on screen: a system-wide tap has no business outliving the window.
+            commandEscapeTap.enable()
             // Non-activating, so summoning never raises our own aux windows behind it.
             panel.makeKeyAndOrderFront(nil)
             panel.orderFrontRegardless()
@@ -109,6 +117,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     func hide(restoreFocus: Bool) {
         panel?.orderOut(nil)
+        commandEscapeTap.disable()
         core.inputSourceSwitcher.endSession()
         core.calendarCoordinator.paletteDidHide()
         core.palette.noteVisible(false)
@@ -299,11 +308,6 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
                 let index = FavoriteSlots.index(forKeyCode: event.keyCode)
             {
                 self.core.palette.noteFavoriteSlot(index)
-                return true
-            }
-            // Escape has no character, so it matches by key code.
-            if Int(event.keyCode) == kVK_Escape {
-                self.core.palette.prepare(mode: .launcher)
                 return true
             }
             guard let character = Self.commandCharacter(from: event) else { return false }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -577,17 +577,9 @@ struct RootPaletteView: View {
         HStack(alignment: .center, spacing: 0) {
             // Matches the list rows and section headers' own indent below.
             headerGutter(width: Theme.Spacing.md * 2)
-            // Drawn only where it leads somewhere: a directly summoned screen is its own root.
-            if hasBackStep {
-                Button(action: goBack) {
-                    Image(systemName: "chevron.left")
-                        .font(Theme.Typography.headerIcon)
-                        .symbolRenderingMode(.hierarchical)
-                        .foregroundStyle(.secondary)
-                        .frame(width: Theme.Size.headerIconSlot)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+            // Every sub-screen leaves the same way, so the slot reads the same on all of them.
+            if vm.mode != .launcher {
+                HeaderBackButton(help: backHelp, action: goBack)
             } else {
                 Image(systemName: vm.mode.systemImage)
                     .font(Theme.Typography.headerIcon)
@@ -1095,6 +1087,12 @@ struct RootPaletteView: View {
         vm.canGoBack || (vm.mode == .extensionCommand && extensions.navigationDepth > 1)
     }
 
+    /// Never promises a step the click does not take: a root screen closes rather than backs.
+    private var backHelp: String {
+        let escape = hasBackStep ? "Esc to go back" : "Esc to close"
+        return "\(escape) or ⌘ Esc to go to root search"
+    }
+
     private func goBack() {
         if vm.mode == .extensionCommand {
             core.extensionCoordinator.exitExtensionScreen()
@@ -1158,6 +1156,28 @@ private struct MenuCircleButton: View {
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
         .frosted(in: Circle())
+    }
+}
+
+/// Hover state lives here, so lighting the chevron never re-renders the header around it.
+private struct HeaderBackButton: View {
+    let help: String
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "chevron.left")
+                .font(Theme.Typography.headerIcon)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(hovered ? Theme.Colors.textPrimary : Theme.Colors.textSecondary)
+                .frame(width: Theme.Size.headerIconSlot)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .animation(.easeOut(duration: Theme.Duration.hover), value: hovered)
+        .help(help)
     }
 }
 

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -418,7 +418,8 @@ struct RootPaletteView: View {
                 if vm.isControlListOpen { return .ignored }
                 switch PaletteEscapeAction.resolve(
                     menuOpen: menuOpen, argumentFocused: argumentFocused != nil, query: vm.query,
-                    mode: vm.mode)
+                    mode: vm.mode, canGoBack: vm.canGoBack,
+                    behavior: settings.escapeKeyBehavior)
                 {
                 case .closeMenu:
                     closeMenus()
@@ -428,10 +429,14 @@ struct RootPaletteView: View {
                     vm.query = ""
                 case .exitExtensionScreen:
                     core.extensionCoordinator.exitExtensionScreen()
-                case .exitToLauncher:
-                    exitToLauncher()
+                case .goBack:
+                    goBack()
                 case .hidePalette:
                     core.paletteCoordinator.hidePalette()
+                    // This behavior promises a root search on reopen, whatever the delay says.
+                    if settings.escapeKeyBehavior == .closeAndPopToRoot {
+                        core.paletteCoordinator.popToRootNow()
+                    }
                 }
                 return .handled
             }
@@ -572,9 +577,9 @@ struct RootPaletteView: View {
         HStack(alignment: .center, spacing: 0) {
             // Matches the list rows and section headers' own indent below.
             headerGutter(width: Theme.Spacing.md * 2)
-            // Sub-screens of the root search, so their header icon is a back chevron.
-            if vm.mode != .launcher {
-                Button(action: navigateBack) {
+            // Drawn only where it leads somewhere: a directly summoned screen is its own root.
+            if hasBackStep {
+                Button(action: goBack) {
                     Image(systemName: "chevron.left")
                         .font(Theme.Typography.headerIcon)
                         .symbolRenderingMode(.hierarchical)
@@ -1035,7 +1040,9 @@ struct RootPaletteView: View {
             mode: vm.mode, aiEnabled: settings.aiEnabled,
             clipboardEnabled: settings.clipboardEnabled)
         {
-        case .carryQuery(let mode): vm.mode = mode
+        case .carryQuery(let mode):
+            vm.mode = mode
+            vm.resetNavigation()
         case .freshScreen(let mode): vm.prepare(mode: mode)
         case .ask: core.aiChatCoordinator.ask(vm.query)
         }
@@ -1083,21 +1090,17 @@ struct RootPaletteView: View {
         open(.argumentOptions, highlighting: 0)
     }
 
-    private func navigateBack() {
-        if vm.mode == .aiHistory {
-            vm.prepare(mode: .ai)
-        } else {
-            exitToLauncher()
-        }
+    /// An extension keeps its own stack, so it can have a step back the palette cannot see.
+    private var hasBackStep: Bool {
+        vm.canGoBack || (vm.mode == .extensionCommand && extensions.navigationDepth > 1)
     }
 
-    /// Back out to a fresh root search, the same reset `prepare` does on show.
-    private func exitToLauncher() {
+    private func goBack() {
         if vm.mode == .extensionCommand {
             core.extensionCoordinator.exitExtensionScreen()
             return
         }
-        vm.prepare(mode: .launcher)
+        if !vm.pop() { core.paletteCoordinator.hidePalette() }
     }
 
     private func activateSelection() {

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -435,11 +435,11 @@ The switcher's glyph comes from the selection. Codex uses OpenAI's mark; Claude 
 own marks; an API model resolves through its connection. It never depends on `modelOptions`, which for
 Codex is empty until the app-server has answered `model/list`; opening the chat on a Codex model warms that list so the title is the
 display name from the first frame. Tab hands chat on to the clipboard, and Escape on an empty
-composer backs it out to the launcher; both go through `prepare`, so the unsent draft is dropped
-rather than carried into a field that would search it. History leaves by the ordinary sub-screen
-route — Tab carries its query to the launcher — because there the field really is a search. Neither
-exit touches the conversation: it lives on `AIChatState`, so Tab away and back resumes the same
-transcript.
+composer takes chat's own back step — to whatever opened it, or out of the palette when its hotkey
+did; either way the unsent draft is dropped rather than carried into a field that would search it.
+History is pushed over chat and pops back to it, and Tab carries its query to the launcher because
+there the field really is a search. Neither exit touches the conversation: it lives on `AIChatState`,
+so Tab away and back resumes the same transcript.
 
 The model switcher is `fixedSize` with its title shortened in `AIChatCoordinator` (26 characters,
 middle ellipsis) rather than truncated by layout: a flexible label claimed the row up to its max

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -57,7 +57,8 @@ only the closure wiring; the behaviour is `PaletteCoordinator`'s.
 
 `PaletteState` (mode / query / selection / `focusToken`) is the bridge between the panel and the app.
 Showing the palette calls `prepare(mode:)`, which resets state and bumps `focusToken` (a UUID) so the
-SwiftUI search field re-focuses.
+SwiftUI search field re-focuses. `prepare` is one of four motions over the screen — see
+[Navigation](#navigation).
 
 Hiding schedules Pop to Root Search, and `PaletteWindowController.popToRoot` is its only path: the
 palette returns to the launcher *and* chat starts a new conversation, at once or after
@@ -85,17 +86,49 @@ palette indexes into it. Adding a mode means adding a conformer, not a branch in
 | `.customCommandArguments` | `CustomCommandArgumentsScreen` | `CustomCommandArgumentsView` (see [custom-commands.md](custom-commands.md#arguments)) |
 | `.extensionCommand` | `ExtensionCommandScreen` | `ExtensionCommandView` (see [extensions.md](extensions.md)) |
 
-Every mode but `.launcher` is a sub-screen that backs out to the launcher. **Tab rings the three
-surfaces a reader opens directly — launcher → AI chat → clipboard → launcher** — unless the screen
-claims it through `tabTarget(from:backwards:)` (an extension's `Form` walks its own fields), or the
-selected row declares arguments, in which case it walks those fields first (see below); every other mode exits
-to the launcher rather than joining the ring, and is reached by a command or a global hotkey, with
+**Tab rings the three surfaces a reader opens directly — launcher → AI chat → clipboard → launcher**
+— unless the screen claims it through `tabTarget(from:backwards:)` (an extension's `Form` walks its
+own fields), or the selected row declares arguments, in which case it walks those fields first (see
+below); every other mode stays off the ring, and is reached by a command or a global hotkey, with
 Uninstall only from a launcher app's Actions menu, scoped to that app. Chat is skipped whole when
-`aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced. **Escape clears a
-non-empty query before it leaves the screen**, so one press clears and the next leaves: chat backs
-out to the launcher, an extension screen exits itself, and anywhere else the palette hides. A focused
-inline argument field is a rung above the query, so Escape hands focus back to the search field
-first — the query that found the command is still there to be cleared by the next press.
+`aiEnabled` is off, which leaves the launcher ↔ clipboard flip the ring replaced.
+
+### Navigation
+
+**The summon decides where a screen sits, not the mode.** `PaletteCoordinator.navigate(to:)` is the
+one rule: a palette already on screen is being *navigated*, so the current screen is pushed and
+becomes the step back; a hidden one is being *summoned*, so the new screen is a root with nothing
+behind it. Every mode command and every global hotkey funnels through `showPalette`, which calls it —
+so typing "Clipboard History" at the root and pressing ↵ leaves a step back to the search that found
+it, while the Clipboard History hotkey does not. Nothing per-feature encodes this.
+
+`PaletteState` holds the screens below `mode` as `[PaletteFrame]` — mode, query and selection, enough
+that returning looks like never having left — and offers four motions over it:
+
+| Motion | Meaning |
+| --- | --- |
+| `prepare(mode:)` | become the root: open fresh, drop the stack |
+| `replace(mode:)` | swap the screen, keep what it was opened over (a new chat, not a new root) |
+| `push(mode:)` | open over the current screen, which a back step returns to |
+| `pop()` | restore the screen underneath; `false` when this one is the root |
+
+`pop()` bumps `followToken` rather than `resetToken`: the reset token exists to snap a list to the
+top, which would throw away the very selection being restored.
+
+**Escape clears a non-empty query before it leaves the screen**, so one press clears and the next
+leaves: an extension screen exits itself first (it keeps a stack the palette cannot see), then a
+pushed screen pops, and a root hides the palette. A focused inline argument field is a rung above the
+query, so Escape hands focus back to the search field first — the query that found the command is
+still there to be cleared by the next press. A bare backspace in an empty field takes the same step,
+and ⌘⎋ skips the whole stack for a fresh root search without closing the window.
+
+`EscapeKeyBehavior` (General settings) can trade the walk back for the old behavior: under
+`closeAndPopToRoot` an empty field closes the window and resets it immediately, whatever Pop to Root
+Search says. Clearing the query is still the first press either way.
+
+The header draws a back chevron **only where there is somewhere to go** — `canGoBack`, or an
+extension whose own `navigationDepth` is past 1 — so a directly summoned screen shows its own icon
+rather than a chevron that would close the window.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
 pairing of a label with its key. It is drawn only when Tab really would open chat, a condition read
@@ -115,7 +148,7 @@ not a search field: it _is_ the current argument's input, so its placeholder nam
 submits rather than activating a row. It has no rows, which is why `isArgumentForm` is what keeps the
 ↵ pill drawn. Its state lives on `AppCore.customCommandArguments`, the way `.uninstall`'s target lives
 on `UninstallSession`, and leaving the mode cancels the pending run. A bare backspace steps back an
-argument before it falls through to the usual exit-to-launcher; Escape erases the half-typed answer
+argument before it falls through to the usual back step; Escape erases the half-typed answer
 first, and a second press hides the palette, ending the pending work with it. **Quicklinks used to be
 the other half of this pair and no longer are** — they collect their values in the header instead, so
 one surface asks for a row's arguments rather than two.
@@ -381,6 +414,9 @@ Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and a
   `onKeyPress(keys: ["."])` never fires. Pin (⌘.) therefore arrives through `onCommandShortcut`,
   which bumps `PaletteState.pinChordToken`; `RootPaletteView` observes that and resolves the row
   through the current screen, so **which** row gets pinned still comes from `screen.rows` alone.
+  ⌘⎋ arrives the same way and matches by key code, Escape carrying no character: it
+  `prepare(mode: .launcher)`s, which is one chord back to the root search from any depth, window
+  still open.
 
 Adding a chord that "does nothing" is almost always one of these three — check `sendEvent` before
 assuming the handler is wrong.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -400,8 +400,8 @@ left alone: the handler returns `.ignored` for them, and their own `onSubmit` st
 
 ## Chords `onKeyPress` never sees
 
-Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and all of them are handled in
-`PalettePanel.sendEvent` before `super` hands the event to the responder chain:
+Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Several kinds do not. All but the last are
+handled in `PalettePanel.sendEvent` before `super` hands the event to the responder chain:
 
 - **A bare backspace** — the field editor consumes it as an edit (`onBareBackspace`).
 - **Chords with no main menu item** — ⌘, and ⌘w, which an app with a menu bar would never see here.
@@ -414,12 +414,18 @@ Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Three kinds do not, and a
   `onKeyPress(keys: ["."])` never fires. Pin (⌘.) therefore arrives through `onCommandShortcut`,
   which bumps `PaletteState.pinChordToken`; `RootPaletteView` observes that and resolves the row
   through the current screen, so **which** row gets pinned still comes from `screen.rows` alone.
-  ⌘⎋ arrives the same way and matches by key code, Escape carrying no character: it
-  `prepare(mode: .launcher)`s, which is one chord back to the root search from any depth, window
-  still open.
+- **Chords the window server keeps for itself.** ⌘⎋ is the one that bites: macOS binds it before any
+  app sees it, so unlike ⌘. there is no keystroke left for `sendEvent` to intercept — a handler in
+  the responder chain compiles, runs never, and looks like a palette bug. `CommandEscapeTap` takes it
+  at the head of the HID stream instead, the one place earlier than the system's own binding, and
+  `prepare(mode: .launcher)`s: one chord back to the root search from any depth, window still open.
+  The tap is enabled only while the palette is on screen, watches `keyDown` alone, and declines the
+  chord whenever the panel is not key, so nothing else on the system loses ⌘⎋ to it. It is a
+  modifying tap, so it needs Accessibility — without that grant the chord is simply unavailable,
+  which is the only path this codebase has to it.
 
-Adding a chord that "does nothing" is almost always one of these three — check `sendEvent` before
-assuming the handler is wrong.
+Adding a chord that "does nothing" is almost always one of these — check `sendEvent`, and then
+whether macOS has claimed the chord, before assuming the handler is wrong.
 
 ## Emacs navigation chords
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -126,9 +126,12 @@ and ⌘⎋ skips the whole stack for a fresh root search without closing the win
 `closeAndPopToRoot` an empty field closes the window and resets it immediately, whatever Pop to Root
 Search says. Clearing the query is still the first press either way.
 
-The header draws a back chevron **only where there is somewhere to go** — `canGoBack`, or an
-extension whose own `navigationDepth` is past 1 — so a directly summoned screen shows its own icon
-rather than a chevron that would close the window.
+The header draws a back chevron on **every** screen but the launcher: leaving is what the icon
+slot means once you are off the root, and a slot that changed shape with provenance would read
+as two different controls. Where the click lands still depends on the stack — a pushed screen
+pops, a root one closes — so `backHelp` says which, rather than promising a step that is really
+a close. It lights to `textPrimary` under the pointer over `Theme.Duration.hover`, and
+`HeaderBackButton` keeps that hover state to itself so the header around it never re-renders.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
 pairing of a label with its key. It is drawn only when Tab really would open chat, a condition read

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -258,8 +258,11 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
   and run it: Escape returns to the launcher **with the query still typed and the row still
   selected**, and the next press clears it. The same screen from its own global hotkey hides the
   palette instead, and shows its own header icon rather than a back chevron
-- ⌘⎋ from any depth lands on an empty root search with the window still open; a bare ⌫ in an empty
-  field walks the same path Escape does
+- ⌘⎋ from any depth lands on an empty root search with the window still open — **must be checked on
+  a real keyboard**: macOS claims the chord, so `CommandEscapeTap` is the only thing that delivers it
+  and it needs Accessibility granted to the running build. With the palette closed, ⌘⎋ still does
+  whatever macOS does with it
+- A bare ⌫ in an empty field walks the same path Escape does
 - General ▸ Escape Key Behavior set to `Close window and pop to root`: Escape on any screen closes
   the window, and reopening lands on the root search whatever Pop to Root Search says
 - Reopening focuses the search field with an empty query, in the same position and at the same size

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,6 +87,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `clipboard-test` | `Clipboard/Model/ClipboardStore.swift`, `ClipboardFilter.swift`, `ClipboardFileKind.swift`, the colour trio |
 | `pasteboard-test` | `Clipboard/Service/ClipboardManager.swift` capture and `Paster.write` — what a Finder copy reads as, and what a file entry writes back |
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
+| `palette-navigation-test` | `Palette/PaletteState.swift`'s screen motions — `prepare`, `replace`, `push`, `pop` |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
 | `palette-placement-test` | `DesignSystem/Theme.swift`, `Palette/PalettePlacement.swift` |
 | `hotkey-test` | `HotKeys/Model/DoubleTapModifier.swift`, `DoubleTapDetector.swift`, `HyperKey.swift`, `HotKeyAction.swift`, `Service/KeyShortcut.swift`, and the command→action mapping in `Launcher/Model/CommandID.swift` |
@@ -253,6 +254,14 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 
 - Palette hotkey opens the launcher; pressing it again closes it; Escape clears a non-empty query,
   then hides on a second press; clicking away closes it
+- Search a mode command (Clipboard History, Search Emoji, Search Quicklinks, Search Files, AI Chat)
+  and run it: Escape returns to the launcher **with the query still typed and the row still
+  selected**, and the next press clears it. The same screen from its own global hotkey hides the
+  palette instead, and shows its own header icon rather than a back chevron
+- ⌘⎋ from any depth lands on an empty root search with the window still open; a bare ⌫ in an empty
+  field walks the same path Escape does
+- General ▸ Escape Key Behavior set to `Close window and pop to root`: Escape on any screen closes
+  the window, and reopening lands on the root search whatever Pop to Root Search says
 - Reopening focuses the search field with an empty query, in the same position and at the same size
 - Compact mode: typing expands it, and the search bar does **not** shift vertically during the swap
 - With a CJK IME: the placeholder clears as soon as composition starts and the composing text never

--- a/website/content/docs/palette.md
+++ b/website/content/docs/palette.md
@@ -4,7 +4,7 @@ description: The one window Tinycast has — how to move around it, and where it
 ---
 
 Everything Tinycast does happens in one floating panel. Each feature is either the root launcher
-screen or a screen you reach from it, and every screen backs out to the launcher.
+screen or a screen you reach from it, and <kbd>⎋</kbd> walks back the way you came.
 
 ## Moving around
 
@@ -15,7 +15,8 @@ screen or a screen you reach from it, and every screen backs out to the launcher
 | <kbd>⌘</kbd><kbd>K</kbd>  | Open the Actions menu for the selection               |
 | <kbd>↑</kbd> <kbd>↓</kbd> | Move the selection                                    |
 | <kbd>⇥</kbd>              | Cycle between the launcher and clipboard              |
-| <kbd>⎋</kbd>              | Leave a screen, or dismiss the palette                |
+| <kbd>⎋</kbd>              | Clear the search, go back a screen, then close        |
+| <kbd>⌘</kbd><kbd>⎋</kbd>  | Back to the root search from any depth                |
 | <kbd>⌫</kbd>              | On an empty field, step back one screen               |
 | <kbd>⌘</kbd><kbd>,</kbd>  | Open Settings                                         |
 | <kbd>⌘</kbd><kbd>W</kbd>  | Close the window                                      |

--- a/website/content/docs/reference/settings.md
+++ b/website/content/docs/reference/settings.md
@@ -50,6 +50,7 @@ See [Hotkeys](/docs/reference/hotkeys#hyper-key).
 | Launch at login          | —                                           | Off             |
 | Show in menu bar         | —                                           | **On**          |
 | Pop to Root Search       | Immediately · 5 · 15 · 30 · 60 · 90 seconds | **Immediately** |
+| Escape Key Behavior      | Navigate back or close window · Close window and pop to root | **Navigate back or close window** |
 | Auto-switch input source | None, plus every enabled keyboard source    | **None**        |
 
 Shortcuts keep working with the menu-bar icon hidden.

--- a/website/content/docs/reference/shortcuts.md
+++ b/website/content/docs/reference/shortcuts.md
@@ -17,7 +17,8 @@ These are fixed and not configurable. For shortcuts you record yourself, see
 | <kbd>⌃</kbd><kbd>N</kbd> / <kbd>⌃</kbd><kbd>P</kbd> | Same as <kbd>↓</kbd> / <kbd>↑</kbd>           |
 | <kbd>⌃</kbd><kbd>F</kbd> / <kbd>⌃</kbd><kbd>B</kbd> | Same as <kbd>→</kbd> / <kbd>←</kbd>           |
 | <kbd>⇥</kbd>                                        | Cycle launcher ↔ clipboard, or walk arguments |
-| <kbd>⎋</kbd>                                        | Leave a screen, or dismiss                    |
+| <kbd>⎋</kbd>                                        | Clear the search, go back a screen, then close |
+| <kbd>⌘</kbd><kbd>⎋</kbd>                            | Back to the root search from any depth        |
 | <kbd>⌫</kbd>                                        | On an empty field, step back a screen         |
 | <kbd>⌘</kbd><kbd>,</kbd>                            | Settings                                      |
 | <kbd>⌘</kbd><kbd>W</kbd>                            | Close the window                              |


### PR DESCRIPTION
## Make Escape walk back through the screens it opened

The palette had no memory of how it got to a screen. `PaletteState.mode` was a flat enum and every
transition went through `prepare(mode:)`, which resets everything — so Escape had to guess, with
hard-coded per-mode rules. Typing "Clipboard History" at the root, pressing ↵, then pressing Escape
closed the window instead of returning to the search that found it.

### The rule

**The summon decides provenance, not the mode.** `PaletteCoordinator.navigate(to:)` is the single
rule: a palette already on screen is being *navigated*, so the current screen is pushed and becomes
the step back; a hidden one is being *summoned*, so the new screen is a root with nothing behind it.
Every mode command and every global hotkey already funnels through `showPalette`, so this needs no
per-feature plumbing.

`PaletteState` holds the screens below `mode` as `[PaletteFrame]` — mode, query and selection, enough
that returning looks like never having left — with four motions over it:

| Motion | Meaning |
| --- | --- |
| `prepare(mode:)` | become the root: open fresh, drop the stack |
| `replace(mode:)` | swap the screen, keep what it was opened over (a new chat, not a new root) |
| `push(mode:)` | open over the current screen, which a back step returns to |
| `pop()` | restore the screen underneath; `false` when this one is the root |

`pop()` bumps `followToken` rather than `resetToken` — the reset token exists to snap a list to the
top, which would throw away the very selection being restored.

### What Escape does now

Clear a non-empty query → an extension screen exits itself (it keeps a stack the palette cannot see)
→ a pushed screen pops → a root hides the palette. A focused inline argument field is still a rung
above the query. Bare ⌫ in an empty field takes the same step, and all three back edges — Escape,
backspace, and the header chevron — now agree, where they previously disagreed.

### ⌘⎋ needs an event tap

⌘⎋ pops to the root search from any depth with the window still open. It cannot be done in the
responder chain: macOS binds the chord before any app sees it, so a handler there compiles, never
runs, and looks like a palette bug. `CommandEscapeTap` takes it at the head of the HID stream
instead — the one point earlier than the system's own binding.

The tap is enabled only while the palette is on screen, watches `keyDown` alone, and returns the
event untouched whenever the panel is not the key window, so nothing else on the system loses ⌘⎋ to
it. It is a modifying tap, so it rides on Accessibility — already required and prompted for
elsewhere in the app; no new permission class, and nothing here asks for Input Monitoring.

### The header chevron

Drawn on every screen but the launcher, so clipboard and emoji read the same as quicklinks and
snippets — a slot that changed shape with provenance would look like two different controls. Where
the click lands still follows the stack, and its tooltip says which rather than promising a step back
that is really a close. It lights to `textPrimary` under the pointer over a new `Theme.Duration.hover`,
with the hover state held inside `HeaderBackButton` so the header around it never re-renders.

### Setting

`Escape Key Behavior` in General, beside Pop to Root Search:

- **Navigate back or close window** (default) — the behaviour above.
- **Close window and pop to root** — an empty field closes the window and resets it immediately,
  whatever Pop to Root Search says.

Clearing the query is still the first press under either. Mirrored into settings backups.

### Behaviour changes worth calling out

- **Chat opened by its own global hotkey now closes on Escape** rather than falling back to the
  launcher — it is a root like any other directly summoned screen. Reached from the launcher, it
  goes back.
- **A global hotkey pressed while the palette is already open pushes**, so Escape returns to what was
  on screen. One rule rather than two, and it matches Raycast.

### Testing

- `palette-navigation-test` (new) — push/pop round-trips, the token discipline, `prepare` emptying
  the stack, `replace` preserving it.
- `palette-escape-test` — rewritten for the new decision table, plus the ⌘⎋ chord predicate
  (⌥⌘⎋ is Force Quit and must pass through; Caps Lock and fn riding along must not disqualify it).
- All 59 harnesses pass, Debug builds with no new warnings, `lint.sh` clean, and no AppKit/SwiftUI
  has leaked into `Features/*/Model/`.

### Still to verify by hand

⌘⎋ can only be confirmed on a real keyboard, and needs Accessibility granted to the build under
test — `Tinycast Dev.app` is its own bundle ID with its own TCC entry, so a grant to an installed
copy does not carry over. Worth confirming too that ⌘⎋ still reaches macOS normally while the
palette is closed.

The manual sweep in `docs/testing.md` has not been run yet.
