### PR TITLE
Reduce clipboard capture CPU for large file selections

### DIFF
--- a/Tests/clipboard-file-performance.swift
+++ b/Tests/clipboard-file-performance.swift
@@ -1,0 +1,143 @@
+import AppKit
+
+@main
+@MainActor
+enum ClipboardSelectionBenchmark {
+    static let cap = ClipboardManager.maxCapturedFiles
+
+    static func board(_ urls: [URL], legacy: Bool) -> NSPasteboard {
+        let board = NSPasteboard.withUniqueName()
+        if urls.isEmpty { return board }
+        if legacy {
+            let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
+            board.declareTypes([type], owner: nil)
+            precondition(board.setPropertyList(urls.map(\.path), forType: type))
+        } else {
+            precondition(board.writeObjects(urls as [NSURL]))
+        }
+        return board
+    }
+
+    static func milliseconds(_ start: ContinuousClock.Instant) -> Double {
+        let time = start.duration(to: .now).components
+        return Double(time.seconds) * 1_000 + Double(time.attoseconds) / 1e15
+    }
+
+    static func cpu() -> Double {
+        var usage = rusage()
+        precondition(getrusage(RUSAGE_SELF, &usage) == 0)
+        return Double(usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) * 1_000
+            + Double(usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) / 1_000
+    }
+
+    static func verify(_ urls: [URL], expected: [String]?, roots: [String], legacy: Bool) {
+        let pasteboard = board(urls, legacy: legacy)
+        defer { pasteboard.releaseGlobally() }
+        precondition(ClipboardManager.fileURLs(on: pasteboard, volatileRoots: roots) == expected)
+    }
+
+    static func fixtures() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-file-benchmark-\(UUID().uuidString)", isDirectory: true)
+        let durable = directory.appendingPathComponent("durable", isDirectory: true)
+        let volatile = directory.appendingPathComponent("volatile", isDirectory: true)
+        try FileManager.default.createDirectory(at: durable, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: volatile, withIntermediateDirectories: true)
+        for index in 0..<10_000 {
+            try Data([120]).write(to: durable.appendingPathComponent("f\(index).txt"))
+        }
+        let staged = volatile.appendingPathComponent("staged.txt")
+        try Data([120]).write(to: staged)
+        for (name, target) in [
+            ("durable-link", durable.appendingPathComponent("f0.txt")),
+            ("volatile-link", staged),
+            ("broken-link", directory.appendingPathComponent("absent.txt"))
+        ] {
+            try FileManager.default.createSymbolicLink(
+                at: directory.appendingPathComponent(name), withDestinationURL: target)
+        }
+        return directory
+    }
+
+    static func main() throws {
+        let directory = try fixtures()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let durable = (0..<10_000).map { directory.appendingPathComponent("durable/f\($0).txt") }
+        let volatile = directory.appendingPathComponent("volatile/staged.txt")
+        var volatileRoot = directory.appendingPathComponent("volatile").resolvingSymlinksInPath().path
+        if volatileRoot.hasPrefix("/private/") { volatileRoot.removeFirst("/private".count) }
+        let roots = [volatileRoot + "/"]
+        let missing = directory.appendingPathComponent("missing.txt")
+        let durableLink = directory.appendingPathComponent("durable-link")
+        let volatileLink = directory.appendingPathComponent("volatile-link")
+        let brokenLink = directory.appendingPathComponent("broken-link")
+        for legacy in [false, true] {
+            verify([], expected: nil, roots: roots, legacy: legacy)
+            verify([missing, volatile, volatileLink, brokenLink], expected: nil, roots: roots, legacy: legacy)
+            let valid = [durableLink] + Array(durable.prefix(40))
+            let mixed = Array(repeating: missing, count: 40) + [volatile, volatileLink, brokenLink] + valid
+            verify(
+                mixed, expected: Array(valid.prefix(cap).map(\.standardizedFileURL.path).reversed()),
+                roots: roots, legacy: legacy)
+            for count in [1, cap - 1, cap, cap + 1] {
+                let urls = Array(durable.prefix(count))
+                verify(
+                    urls, expected: Array(urls.prefix(cap).map(\.path).reversed()), roots: roots,
+                    legacy: legacy)
+            }
+        }
+        let text = NSPasteboard.withUniqueName()
+        text.declareTypes([.string], owner: nil)
+        text.setString("https://example.com/report.pdf", forType: .string)
+        precondition(ClipboardManager.fileURLs(on: text, volatileRoots: roots) == nil)
+        text.releaseGlobally()
+
+        var results: [[String: Any]] = []
+        for legacy in [false, true] {
+            for (workload, count) in [
+                ("durable", cap), ("durable", 1_000), ("durable", 10_000),
+                ("missing", 10_000), ("rejected-prefix", 1_000)
+            ] {
+                let urls =
+                    workload == "missing"
+                    ? Array(repeating: missing, count: count)
+                    : (workload == "rejected-prefix" ? Array(repeating: missing, count: 40) : [])
+                        + Array(durable.prefix(count))
+                let pasteboard = board(urls, legacy: legacy)
+                let expected: [String]? =
+                    workload == "missing"
+                    ? nil
+                    : Array(durable.prefix(min(count, cap)).map(\.path).reversed())
+                precondition(ClipboardManager.fileURLs(on: pasteboard, volatileRoots: roots) == expected)
+                let iterations = 5
+                let startCPU = cpu()
+                let start = ContinuousClock.now
+                for _ in 0..<iterations {
+                    autoreleasepool {
+                        precondition(
+                            ClipboardManager.fileURLs(on: pasteboard, volatileRoots: roots) == expected)
+                    }
+                }
+                let wall = milliseconds(start) / Double(iterations)
+                let cpuTime = (cpu() - startCPU) / Double(iterations)
+                pasteboard.releaseGlobally()
+                results.append([
+                    "workload": workload, "files": count, "format": legacy ? "legacy" : "file-url",
+                    "iterations": iterations, "wall_ms_per_call": wall,
+                    "cpu_ms_per_call": cpuTime, "exact_output_passed": true
+                ])
+            }
+        }
+        let data = try JSONSerialization.data(withJSONObject: results, options: [.sortedKeys])
+        FileHandle.standardOutput.write(data + Data([10]))
+    }
+}
+
+@MainActor
+final class AppSettings {
+    var clipboardDisabledApps: Set<String> = []
+}
+
+final class NotificationToken {
+    init(_ observer: Any, center: NotificationCenter) {}
+}

--- a/Tests/pasteboard-test.swift
+++ b/Tests/pasteboard-test.swift
@@ -8,6 +8,7 @@ import AppKit
 struct PasteboardTests {
     static var failures = 0
     static var passes = 0
+    static let cap = ClipboardManager.maxCapturedFiles
 
     static func main() {
         finderCopyReadsAsAFileNotItsName()
@@ -16,6 +17,7 @@ struct PasteboardTests {
         linksAndTextAreNotFiles()
         volatileAndMissingFilesFallThrough()
         theBatchIsCapped()
+        rejectedFilesDoNotCountTowardTheCap()
         fileEntriesWriteBackAsFiles()
         aVanishedFileWritesNothing()
 
@@ -136,13 +138,72 @@ struct PasteboardTests {
                 try? Data("x".utf8).write(to: url)
                 return url
             }
-            let pb = board()
-            pb.writeObjects(urls as [NSURL])
-            expect(
-                ClipboardManager.fileURLs(on: pb, volatileRoots: [])?.count
-                    == ClipboardManager.maxCapturedFiles,
-                "a select-all is capped rather than inserting every row")
+            for legacy in [false, true] {
+                for count in [1, cap - 1, cap, cap + 1, 40] {
+                    let pb = fileBoard(Array(urls.prefix(count)), legacy: legacy)
+                    defer { pb.releaseGlobally() }
+                    expect(
+                        ClipboardManager.fileURLs(on: pb, volatileRoots: [])
+                            == Array(urls.prefix(min(count, cap)).map(\.path).reversed()),
+                        "the first durable files stay reversed at the \(count)-file boundary (legacy: \(legacy))"
+                    )
+                }
+            }
         }
+    }
+
+    static func rejectedFilesDoNotCountTowardTheCap() {
+        withScratch { dir in
+            let volatile = dir.appendingPathComponent("volatile", isDirectory: true)
+            let staged = volatile.appendingPathComponent("staged.txt")
+            let missing = dir.appendingPathComponent("missing.txt")
+            let durableLink = dir.appendingPathComponent("durable-link")
+            let volatileLink = dir.appendingPathComponent("volatile-link")
+            let brokenLink = dir.appendingPathComponent("broken-link")
+            let files = (0..<40).map { dir.appendingPathComponent("f\($0).txt") }
+            do {
+                try FileManager.default.createDirectory(at: volatile, withIntermediateDirectories: true)
+                try Data("staged".utf8).write(to: staged)
+                for file in files { try Data("file".utf8).write(to: file) }
+                try FileManager.default.createSymbolicLink(at: durableLink, withDestinationURL: files[0])
+                try FileManager.default.createSymbolicLink(at: volatileLink, withDestinationURL: staged)
+                try FileManager.default.createSymbolicLink(at: brokenLink, withDestinationURL: missing)
+            } catch {
+                fail("cannot create file capture fixtures: \(error)")
+                return
+            }
+            var root = volatile.resolvingSymlinksInPath().path
+            if root.hasPrefix("/private/") { root.removeFirst("/private".count) }
+            let rejected = [missing, staged, volatileLink, brokenLink]
+            let accepted = [durableLink, files[0]] + files
+            let mixed = Array(repeating: missing, count: 40) + rejected + accepted
+            for legacy in [false, true] {
+                let empty = fileBoard(rejected, legacy: legacy)
+                defer { empty.releaseGlobally() }
+                expect(
+                    ClipboardManager.fileURLs(on: empty, volatileRoots: [root + "/"]) == nil,
+                    "missing, volatile and broken targets fall through (legacy: \(legacy))")
+                let pb = fileBoard(mixed, legacy: legacy)
+                defer { pb.releaseGlobally() }
+                expect(
+                    ClipboardManager.fileURLs(on: pb, volatileRoots: [root + "/"])
+                        == Array(accepted.prefix(cap).map(\.standardizedFileURL.path).reversed()),
+                    "rejected files do not consume the cap; links and duplicates keep their order (legacy: \(legacy))"
+                )
+            }
+        }
+    }
+
+    static func fileBoard(_ urls: [URL], legacy: Bool) -> NSPasteboard {
+        let pb = board()
+        if legacy {
+            let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
+            pb.declareTypes([type], owner: nil)
+            expect(pb.setPropertyList(urls.map(\.path), forType: type), "legacy fixture is written")
+        } else {
+            expect(pb.writeObjects(urls as [NSURL]), "file URL fixture is written")
+        }
+        return pb
     }
 
     // MARK: - Writing

--- a/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
+++ b/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
@@ -109,9 +109,11 @@ final class ClipboardManager {
     nonisolated static func fileURLs(
         on pasteboard: NSPasteboard, volatileRoots roots: [String] = volatileRoots
     ) -> [String]? {
-        let durable = PasteboardFiles.urls(on: pasteboard)
-            .filter { isDurable($0, roots: roots) }
-            .prefix(maxCapturedFiles)
+        // Lazy, so a ten-thousand-file select-all stops checking the filesystem at the cap.
+        let durable = Array(
+            PasteboardFiles.urls(on: pasteboard).lazy
+                .filter { isDurable($0, roots: roots) }
+                .prefix(maxCapturedFiles))
         // Nil rather than empty, so a copied `http` URL falls through and stays a link.
         guard !durable.isEmpty else { return nil }
         // Reversed on insert, so the first file copied ends up leading the history.

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -50,7 +50,8 @@ returns nil rather than an empty array, so the text branch runs; caps a batch at
 `maxCapturedFiles`, so a Finder select-all cannot insert ten thousand rows on one tick; and
 **rejects a file under a volatile root** (`/tmp`, `/var/folders`, `~/Library/Caches`), because an
 app that stages a temp export beside better inline content must keep the inline content. Paths come
-back reversed so the *first* file copied ends up leading the history.
+back reversed so the *first* file copied ends up leading the history. Durability checks stop after
+32 accepted files; rejected paths do not consume the cap. Pasteboard decoding still reads all items.
 
 `ClipboardManager` runs a 0.5s `Timer` watching `NSPasteboard.general.changeCount`. To avoid
 re-capturing Tinycast's own writes, every write stamps a private `internalType` marker on the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,8 @@ second case, and it is why `ClipboardManager.fileURLs(on:volatileRoots:)` and `P
 each take the thing they act on as a parameter: a seam that exists so the harness never has to reach
 for the shared board. Its scratch tree lives under `temporaryDirectory`, which is itself a volatile
 root, so the cases about *reading* files inject an empty root list and the one case about durability
-is the one that runs against the shipped roots.
+is the one that runs against the shipped roots. Both file URL and legacy filename boards also cover
+the capture cap, exact ordering, rejected prefixes, duplicates and symlinks using private fixtures.
 
 Never join a compile to its run with `&&` in a `set -e` script. `set -e` is specified to ignore a
 failing command in a non-final AND-OR list member, so `swiftc … && /tmp/x` swallows a compile error and
@@ -217,6 +218,19 @@ swiftc -O -swift-version 6 Tinycast/Features/Calculator/Model/*.swift \
 `Tests/text-diff-performance.swift` is the same shape for `TextDiffEngine`: build it with `-O`
 against the engine, pass a token count, a workload (`dense`, `sparse`, `equal`, `empty`) and an
 iteration count for timings, or `--probe` to diff every chunk between two builds.
+
+`Tests/clipboard-file-performance.swift` measures file capture with private pasteboards and temporary
+fixtures. It reports wall and process CPU time as JSON for modern and legacy formats, including
+32/1,000/10,000 durable files and rejected-input controls. Keep it outside `run-tests.sh`; compare
+three fresh processes per build with identical `-O` settings:
+
+```sh
+swiftc -O -swift-version 6 Tinycast/Platform/PasteboardFiles.swift \
+    Tinycast/Features/Clipboard/Model/{ClipboardStore,ClipboardFilter,ColorValue,ColorFormat,ColorSpaces}.swift \
+    Tinycast/Features/Clipboard/Service/ClipboardManager.swift \
+    Tests/clipboard-file-performance.swift -o /tmp/clipboard-file-performance
+/tmp/clipboard-file-performance
+```
 
 `Signposts.interval` owns an explicit `defer` around the wrapped work on purpose. The obvious spelling
 leaks the interval when the work throws, because the `.end` emit is skipped on the throw path and the


### PR DESCRIPTION
## Related issue

Closes #506.

Submitted as a draft for review while maintainer approval of the proposal and assessment of the documented memory/leak limitations are pending.

## What changed

A 10,000-file copy currently performs 10,000 existence/symlink checks before applying the 32-file history cap. Collect durable URLs in one loop and stop once 32 have been accepted. The durability predicate, nil fallback, standardized paths and reversed output order are unchanged; missing or volatile paths do not count toward the cap.

The patch adds exact cap/order/invalid-prefix/symlink coverage, a standalone private-pasteboard benchmark and its documented build command. Capture scheduling, privacy guards, store insertion and the pasteboard-mutation handshake are unchanged. There is no visual change.

**Measured capture CPU improvement:** Apple M4 Pro, 24 GiB, macOS 26.6.2, Xcode 26.6 / Swift 6.3.3; identical `-O -swift-version 6` builds, three fresh processes per variant, five timed calls after one warmup. Synthetic fixture creation and pasteboard writes are outside the timed region. CPU is process user+system time; pasteboard-server CPU is excluded.

| 10,000 durable files | Baseline → candidate median wall | Baseline → candidate median CPU |
| --- | --- | --- |
| Modern file URLs | 104.476 → 55.277 ms (47.1% lower) | 104.192 → 55.225 ms (47.0% lower) |
| Legacy filenames | 108.141 → 56.190 ms (48.0% lower) | 106.490 → 56.124 ms (47.3% lower) |

Modern wall-time ranges across process means are 104.445–108.881 ms before and 54.769–55.656 ms after. Separate instrumented copies count 10,000 → 32 predicate calls; those instrumented timings are excluded. A prefix of 40 missing entries before 1,000 durable files changes 1,040 → 72 checks, identically in both formats.

The modern 32-file median increases by 0.008 ms (2.1%); legacy 32-file ranges overlap. The all-missing modern median changes by +0.9% with overlapping ranges, while legacy changes by −1.5%. No material consistent regression is observed in these controls.

## Memory footprint

Three fresh sandboxed Debug UI-fixture processes per build, each linked to the respective complete app library at upstream `ed0397b` or this patch. The fixture initializes AppCore, starts the actual clipboard poller on a private board, presents the real clipboard palette, captures 10,000 synthetic file URLs and waits five seconds after closing. It retains its input URL array and private board; these are part of the fixture cost. AppCore.start, global hotkeys and unrelated background services are not started.

Medians in MiB, **resident memory (RSS)**:

| Step | Baseline → candidate |
| --- | --- |
| Idle after launch | 88.56 → 88.62 MiB |
| Palette open | 106.19 → 106.83 MiB |
| Feature in use (process peak across cycle) | 198.59 → 199.58 MiB |
| Palette closed, settled | 172.77 → 173.78 MiB |

Memory is read with `task_info(TASK_VM_INFO)` and `getrusage`. The kernel's recorded physical-footprint peak is median 105.31 → 105.59 MiB; settled footprint is 84.11 → 84.36 MiB. No memory reduction is claimed. Both builds exceed the project's budget in this controlled Debug fixture and do not return to startup memory. These measurements do not establish the universal under-100-MB / return-to-baseline requirement.

**Leak-tested: yes; broader UI fixture reports remain.** Separate debuggable `MallocStackLogging=1 leaks --atExit` runs report **344 allocations / 21,504 bytes in both baseline and candidate**. Reported roots are AppIntents/LinkServices XPC cycles and AppKit/HIToolbox keyboard-layout initialization; no reported root allocation stack contains `ClipboardManager.fileURLs` or `PasteboardFiles`. This is not a zero-leak UI pass. The narrower built-library service harness separately reports 0 leaks / 0 bytes.

## Drawbacks

Pasteboard decoding still reads every input before this bounded validation pass, so total work remains linear in the input size. The optimization reduces large-copy capture CPU, not idle CPU. Bounded URL decoding is a separate unmeasured follow-up and is excluded here.

The memory/leak limitations above need maintainer assessment before this draft is ready to merge. There are no intended behavior changes.

## Tests & validation

- All 60 standalone harnesses pass. Expanded `pasteboard-test`: 45/45 against both baseline and candidate, and 45/45 against the actual compiled Debug app library without source stubs.
- Exact first-32 reversed ordering; 1/31/32/33/40 boundaries; modern and legacy formats; more than 32 rejected inputs before accepted files; missing/volatile files; durable/volatile/broken symlinks; duplicates; text/link/empty fallback; private-board roundtrip and internal marker; vanished-file refusal preserving existing board contents.
- `Tests/clipboard-file-performance.swift` compiles with `-O`, creates and cleans up its own unique fixtures, emits JSON and passes all exact-output checks. The initial timing campaign used the same workload with externally prepared fixtures; the committed harness makes setup self-contained outside the timed region.
- Debug builds succeed with no new warnings; only the existing AppIntents metadata-extraction warning. Lint passes with the same 54 existing warnings, none in changed files. Model-purity and diff-whitespace checks pass.
- Computer use drove the real built clipboard UI and poller in a verified sandbox fixture: 10,000-file and mixed legacy captures, search at/beyond the cap, navigation, filtering, pin/unpin, Copy, sensitive-copy rejection, link fallback, reopening and clear-history cancellation passed.
- The fixture redirects its own `NSPasteboard.general` getter to a unique private board before initializing app services, and verifies container paths plus denied access to an outside canary. Test instrumentation is excluded from production. Real general-clipboard access, global-hotkey delivery and external-app paste remain outside the test scope.
- No visual change, so a before/after video is not applicable. Clipboard and testing documentation are updated.

Based directly on current upstream `main` at `ed0397b20f43be3146a8e6033d870d04084aa461`. The patch contains only this optimization, its tests/benchmark and relevant docs.
