### PR TITLE
Navigate inline command arguments with arrow keys

### DIFF
--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -4,12 +4,19 @@ import SwiftUI
 
 /// Borderless floating panel that hosts the SwiftUI command palette.
 final class PalettePanel: NSPanel {
+    enum HeaderFieldBoundary {
+        case leading
+        case trailing
+    }
+
     /// Bare backspace, which the field editor swallows before `onKeyPress` could see it.
     var onBareBackspace: (() -> Bool)?
     /// Command chords the field editor swallows, plus the ones no main menu handles.
     var onCommandShortcut: ((NSEvent) -> Bool)?
     /// The palette's typing context, handed over each time a field takes focus.
     var onFieldEditorFocused: ((NSTextInputContext) -> Void)?
+    /// Inline argument fields use arrows at their text boundaries to continue their focus ring.
+    var onHeaderFieldBoundaryArrow: ((HeaderFieldBoundary) -> Bool)?
     /// Arms hover from `sendEvent`, the one place both event streams pass through.
     weak var paletteState: PaletteState? {
         didSet {
@@ -22,6 +29,19 @@ final class PalettePanel: NSPanel {
 
     /// SwiftUI's text fields all edit through the window's one shared field editor.
     private var fieldEditor: NSTextView? { firstResponder as? NSTextView }
+
+    /// Nil while a selection can still collapse normally, or when the caret is not at an edge.
+    private func headerFieldBoundary(for event: NSEvent) -> HeaderFieldBoundary? {
+        guard event.modifierFlags.isDisjoint(with: [.command, .option, .control, .shift]),
+            let editor = fieldEditor, editor.selectedRange().length == 0
+        else { return nil }
+        switch Int(event.keyCode) {
+        case kVK_LeftArrow where editor.selectedRange().location == 0: return .leading
+        case kVK_RightArrow where editor.selectedRange().location == (editor.string as NSString).length:
+            return .trailing
+        default: return nil
+        }
+    }
 
     /// Mirrors the field editor's marked text. docs/features/palette.md#ime-composition
     private var compositionObserver: NotificationToken?
@@ -152,6 +172,11 @@ final class PalettePanel: NSPanel {
             Int(event.keyCode) == kVK_Delete,
             event.modifierFlags.isDisjoint(with: [.command, .option, .control, .shift]),
             onBareBackspace?() == true
+        {
+            return
+        }
+        if event.type == .keyDown, let boundary = headerFieldBoundary(for: event),
+            onHeaderFieldBoundaryArrow?(boundary) == true
         {
             return
         }

--- a/Tinycast/Palette/PaletteScreen.swift
+++ b/Tinycast/Palette/PaletteScreen.swift
@@ -141,11 +141,12 @@ struct PaletteHeaderAccessory {
         self.view = view
     }
 
-    /// Tab order: the next field, or nil once focus belongs back in the search field.
-    func fieldAfter(_ current: String?) -> String? {
+    /// Adjacent Tab field, or nil once focus belongs back in the search field.
+    func field(after current: String?, backwards: Bool) -> String? {
         guard let current, let index = fieldNames.firstIndex(of: current) else {
-            return fieldNames.first
+            return backwards ? fieldNames.last : fieldNames.first
         }
-        return fieldNames.indices.contains(index + 1) ? fieldNames[index + 1] : nil
+        let next = index + (backwards ? -1 : 1)
+        return fieldNames.indices.contains(next) ? fieldNames[next] : nil
     }
 }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -275,7 +275,12 @@ struct RootPaletteView: View {
                         .allowsHitTesting(menuOpen)
                 }
                 // The menu lives in its own window; this only reports the one to hang it from.
-                .background(WindowReader { hostWindow = $0 })
+                .background(
+                    WindowReader {
+                        hostWindow = $0
+                        installHeaderArrowHandler(in: $0)
+                    }
+                )
                 // The window's frame is the size source, so the glass and clip stay matched.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .background(Theme.Colors.panelScrim)
@@ -340,7 +345,10 @@ struct RootPaletteView: View {
             }
             // The hosted tree is its own hierarchy, so the highlight has to be pushed into it.
             .onChange(of: menuSelection) { syncMenuPanel(presenting: false) }
-            .onDisappear { menuPanel.hide() }
+            .onDisappear {
+                menuPanel.hide()
+                (hostWindow as? PalettePanel)?.onHeaderFieldBoundaryArrow = nil
+            }
             .onAppear { searchFocused = !screen.hidesSearchField }
             .modifier(SearchFieldHiding(hidden: hidesSearchField, apply: applySearchFieldHiding))
             // Several paths flip `paletteIsCollapsed`, so resize the window to match.
@@ -1052,9 +1060,28 @@ struct RootPaletteView: View {
             return cycleMode()
         }
         // Read from the local value: a `@FocusState` set in this tick still reads back stale.
-        let next = accessory.fieldAfter(argumentFocused)
+        let next = accessory.field(after: argumentFocused, backwards: backwards)
         argumentFocused = next
         searchFocused = next == nil
+    }
+
+    /// Right at an inline field's end and Left at its start continue the same ring as Tab.
+    private func installHeaderArrowHandler(in window: NSWindow?) {
+        guard let panel = window as? PalettePanel else { return }
+        panel.onHeaderFieldBoundaryArrow = { boundary in
+            guard !menuOpen, !vm.isControlListOpen, !isCollapsed,
+                let accessory = headerAccessory, !accessory.fieldNames.isEmpty
+            else { return false }
+            switch boundary {
+            case .leading:
+                // Query's left edge keeps its normal caret behavior; an argument moves back.
+                guard argumentFocused != nil else { return false }
+                advanceTabFocus(backwards: true)
+            case .trailing:
+                advanceTabFocus(backwards: false)
+            }
+            return true
+        }
     }
 
     /// AppKit selects the whole query as the field editor comes back, which is the wanted reset.

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -295,7 +295,9 @@ screens hold (see [palette.md](palette.md)).
   root, which would tear the command down before its `await confirmAlert(…)` ever returns.
 - **Command arguments** — a command declaring `arguments` shows inline fields sized to their
   placeholders, right after the typed text, exactly as Raycast does. Tab walks search field → each
-  argument → back; ↵ from any of them runs the command with the values as `props.arguments`; a blank
+  argument → back; Left/Right do the same only when their caret reaches a field boundary. Returning
+  to the search field selects its query, so Right first places the caret at its end and then enters
+  the first argument. ↵ from any of them runs the command with the values as `props.arguments`; a blank
   required argument blocks the launch and focuses the offending field. The fields get their own
   `FocusState` rather than joining the search field's, so the palette's one always-attached `TextField`
   (see [palette.md](palette.md)) keeps owning focus.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -177,7 +177,7 @@ these invariants:
   with the chip after it and no glyph repeating the row below. One measurement serves both: the
   field's own text, which is the prompt when nothing is typed and "" under `.afterQuery`.
 - Argument focus is its own `@FocusState`, `argumentFocused`, keyed by argument name. Every way out
-  — moving the selection, Escape, Tab past the last field — goes through
+  of its ring — moving the selection, Escape, Tab past the last field, or an arrow at its edge — goes through
   `returnFocusToSearchField()`, because the row that owned those fields is about to stop being
   selected and a field that unmounts while focused leaves the panel with no first responder at all.
   ↵ on a blank required argument focuses it instead of launching.


### PR DESCRIPTION
## Related issue

None filed — inline command arguments required Tab to leave the query field.

## What changed

Bare Left/Right now cross inline command-argument fields only when the caret reaches a text boundary, matching Raycast’s behavior.

Returning from an argument selects the query. Right first collapses that selection to the query’s end; Right again enters the first argument. The remaining argument order reuses the same focus ring as Tab/Shift-Tab.

Normal caret movement, text selections, modified arrow shortcuts, menus, and grid navigation stay unchanged.

## Tests & validation

All 60 harnesses pass. Debug build succeeds and `./Scripts/lint.sh` is clean.