### PR TITLE
Bound clipboard URL decoding for large file selections

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -52,19 +52,22 @@ if [ "$only" = "--index" ]; then
     printf '[' > "$DB"
 fi
 
-# run [slow] [-O] <name> <source...> — queue the harness. `slow` dispatches it in the first wave.
+# run [slow] [-O] [index] <name> <source...> — queue the harness. `slow` dispatches it in the first
+# wave; `index` claims editor flags for a harness that is compiled by hand rather than by the suite.
 run() {
-    local opt=-Onone pri=1
+    local opt=-Onone pri=1 index_only=0
     while :; do
         case "$1" in
-            slow) pri=0; shift;;
-            -O)   opt=-O; shift;;
-            *)    break;;
+            slow)  pri=0; shift;;
+            -O)    opt=-O; shift;;
+            index) index_only=1; shift;;
+            *)     break;;
         esac
     done
     local name=$1
     shift
     if [ -n "$only" ] && [ "$name" != "$only" ]; then return 0; fi
+    if [ "$index_only" -eq 1 ] && [ "$emit_db" -eq 0 ]; then return 0; fi
     ran=$((ran + 1))
 
     # Absolute paths throughout: sourcekit-lsp resolves the command itself and does not apply
@@ -76,10 +79,14 @@ run() {
         printf '{"directory":"%s","command":"swiftc -swift-version 6 -sdk %s' \
             "$PWD" "$(xcrun --show-sdk-path --sdk macosx)" >> "$DB"
         printf ' %s' "${sources[@]}" >> "$DB"
-        # Claim only the harness itself. The command still lists every shipped source it compiles, so
-        # symbols resolve inside the harness — but claiming those sources here would hand them this
-        # 3-file command instead of the app's, and `.compile` is last-wins.
-        printf '","files":["%s/Tests/%s.swift"]}' "$PWD" "$name" >> "$DB"
+        # Claim every file under `Tests/`: the harness and any helper compiled beside it. A shipped
+        # source stays unclaimed, because it would get this short command instead of the app's full
+        # one and `.compile` is last-wins — but the app never compiles anything in `Tests/`.
+        local claimed=""
+        for source in "${sources[@]}"; do
+            case "$source" in *"/Tests/"*) claimed="$claimed${claimed:+,}\"$source\"";; esac
+        done
+        printf '","files":[%s]}' "$claimed" >> "$DB"
         return 0
     fi
 
@@ -99,6 +106,10 @@ run file-search-session-test Tinycast/Platform/Signposts.swift \
                              $L/SearchRelevance.swift \
                              Tinycast/Features/FileSearch/Model/*.swift \
                              Tinycast/Features/FileSearch/Service/*.swift
+run index file-search-performance Tinycast/Platform/Signposts.swift \
+                           $L/SearchRelevance.swift \
+                           Tinycast/Features/FileSearch/Model/*.swift \
+                           Tinycast/Features/FileSearch/Service/FileSearchService.swift
 run ranking-test           $L/SearchRelevance.swift $L/LauncherRankingStore.swift
 run scopes-test            $L/SearchScopes.swift
 run app-name-test          Tinycast/Platform/AppDisplayName.swift \
@@ -106,6 +117,7 @@ run app-name-test          Tinycast/Platform/AppDisplayName.swift \
                            $L/SearchRelevance.swift
 run favorites-test         $L/FavoriteSlots.swift
 run calc-test              Tinycast/Features/Calculator/Model/*.swift
+run index calc-performance Tinycast/Features/Calculator/Model/*.swift
 run calendar-test          Tinycast/Features/Calendar/Model/*.swift
 run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
@@ -121,6 +133,14 @@ run pasteboard-test        Tinycast/Platform/PasteboardFiles.swift \
                            Tinycast/Features/Clipboard/Model/ColorSpaces.swift \
                            Tinycast/Features/Clipboard/Service/ClipboardManager.swift \
                            Tinycast/Features/Clipboard/Service/Paster.swift
+run index clipboard-file-performance \
+                           Tinycast/Platform/PasteboardFiles.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardStore.swift \
+                           Tinycast/Features/Clipboard/Model/ClipboardFilter.swift \
+                           Tinycast/Features/Clipboard/Model/ColorValue.swift \
+                           Tinycast/Features/Clipboard/Model/ColorFormat.swift \
+                           Tinycast/Features/Clipboard/Model/ColorSpaces.swift \
+                           Tinycast/Features/Clipboard/Service/ClipboardManager.swift
 run emoji-test             Tinycast/Features/Emoji/Model/EmojiCatalog.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift \
                            Tinycast/Features/Emoji/Model/EmojiData.generated.swift
@@ -354,6 +374,7 @@ run mcp-test               Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/MCP/Model/*.swift \
                            Tinycast/Features/MCP/Settings/MCPSettingsStore.swift
 run -O text-diff-test      Tinycast/Features/QuickActions/Model/TextDiffEngine.swift
+run index text-diff-performance Tinycast/Features/QuickActions/Model/TextDiffEngine.swift
 run quick-action-test      Tinycast/Features/Settings/AppSettingsKey.swift \
                            Tinycast/Features/AI/Model/AIConnection.swift \
                            Tinycast/Features/AI/Model/AppleIntelligence.swift \

--- a/Tests/clipboard-file-performance.swift
+++ b/Tests/clipboard-file-performance.swift
@@ -1,42 +1,21 @@
 import AppKit
-import ObjectiveC
 
 @main
 @MainActor
 enum ClipboardSelectionBenchmark {
     static let cap = ClipboardManager.maxCapturedFiles
 
-    static func board(_ urls: [URL], format: String) -> NSPasteboard {
+    static func board(_ urls: [URL], legacy: Bool) -> NSPasteboard {
         let board = NSPasteboard.withUniqueName()
         if urls.isEmpty { return board }
-        if format != "file-url" {
+        if legacy {
             let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
             board.declareTypes([type], owner: nil)
             precondition(board.setPropertyList(urls.map(\.path), forType: type))
         } else {
             precondition(board.writeObjects(urls as [NSURL]))
         }
-        if format == "legacy-fallback" {
-            hideModernItems(on: board)
-            precondition(board.propertyList(forType: .init("NSFilenamesPboardType")) as? [String]
-                == urls.map(\.path))
-        }
         return board
-    }
-
-    // macOS synthesizes modern items from legacy filenames; hide them only on this private fixture.
-    static func hideModernItems(on pasteboard: NSPasteboard) {
-        let superclass: AnyClass = object_getClass(pasteboard)!
-        let name = "LegacyFilesFixture" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
-        let subclass: AnyClass = objc_allocateClassPair(superclass, name, 0)!
-        let getter = #selector(getter: NSPasteboard.pasteboardItems)
-        let method = class_getInstanceMethod(superclass, getter)!
-        let block: @convention(block) (AnyObject) -> NSArray = { _ in [] }
-        precondition(class_addMethod(
-            subclass, getter, imp_implementationWithBlock(block), method_getTypeEncoding(method)))
-        objc_registerClassPair(subclass)
-        object_setClass(pasteboard, subclass)
-        precondition(pasteboard.pasteboardItems?.isEmpty == true)
     }
 
     static func milliseconds(_ start: ContinuousClock.Instant) -> Double {
@@ -51,8 +30,8 @@ enum ClipboardSelectionBenchmark {
             + Double(usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) / 1_000
     }
 
-    static func verify(_ urls: [URL], expected: [String]?, roots: [String], format: String) {
-        let pasteboard = board(urls, format: format)
+    static func verify(_ urls: [URL], expected: [String]?, roots: [String], legacy: Bool) {
+        let pasteboard = board(urls, legacy: legacy)
         defer { pasteboard.releaseGlobally() }
         precondition(ClipboardManager.fileURLs(on: pasteboard, volatileRoots: roots) == expected)
     }
@@ -80,19 +59,6 @@ enum ClipboardSelectionBenchmark {
         return directory
     }
 
-    static func verifyPrecedence(modern: URL?, legacy: URL, roots: [String], expectedRead: [URL],
-                                 expectedCapture: [String]?) {
-        let pb = NSPasteboard.withUniqueName()
-        defer { pb.releaseGlobally() }
-        let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
-        pb.declareTypes(modern == nil ? [type] : [type, .fileURL], owner: nil)
-        precondition(pb.setPropertyList([legacy.path], forType: type))
-        if let modern { precondition(pb.setData(modern.dataRepresentation, forType: .fileURL)) }
-        precondition(pb.propertyList(forType: type) as? [String] == [legacy.path])
-        precondition(PasteboardFiles.urls(on: pb) == expectedRead)
-        precondition(ClipboardManager.fileURLs(on: pb, volatileRoots: roots) == expectedCapture)
-    }
-
     static func main() throws {
         let directory = try fixtures()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -105,29 +71,19 @@ enum ClipboardSelectionBenchmark {
         let durableLink = directory.appendingPathComponent("durable-link")
         let volatileLink = directory.appendingPathComponent("volatile-link")
         let brokenLink = directory.appendingPathComponent("broken-link")
-        for modern in [missing, volatile, volatileLink, brokenLink] {
-            verifyPrecedence(modern: modern, legacy: durable[0], roots: roots,
-                             expectedRead: [modern], expectedCapture: nil)
-        }
-        verifyPrecedence(modern: durable[1], legacy: durable[0], roots: roots,
-                         expectedRead: [durable[1]], expectedCapture: [durable[1].path])
-        for modern in [nil, URL(string: "https://example.com/not-a-file")] {
-            verifyPrecedence(modern: modern, legacy: durable[0], roots: roots,
-                             expectedRead: [durable[0]], expectedCapture: [durable[0].path])
-        }
-        for format in ["file-url", "legacy", "legacy-fallback"] {
-            verify([], expected: nil, roots: roots, format: format)
-            verify([missing, volatile, volatileLink, brokenLink], expected: nil, roots: roots, format: format)
+        for legacy in [false, true] {
+            verify([], expected: nil, roots: roots, legacy: legacy)
+            verify([missing, volatile, volatileLink, brokenLink], expected: nil, roots: roots, legacy: legacy)
             let valid = [durableLink] + Array(durable.prefix(40))
             let mixed = Array(repeating: missing, count: 40) + [volatile, volatileLink, brokenLink] + valid
             verify(
                 mixed, expected: Array(valid.prefix(cap).map(\.standardizedFileURL.path).reversed()),
-                roots: roots, format: format)
+                roots: roots, legacy: legacy)
             for count in [1, cap - 1, cap, cap + 1] {
                 let urls = Array(durable.prefix(count))
                 verify(
                     urls, expected: Array(urls.prefix(cap).map(\.path).reversed()), roots: roots,
-                    format: format)
+                    legacy: legacy)
             }
         }
         let text = NSPasteboard.withUniqueName()
@@ -137,7 +93,7 @@ enum ClipboardSelectionBenchmark {
         text.releaseGlobally()
 
         var results: [[String: Any]] = []
-        for format in ["file-url", "legacy", "legacy-fallback"] {
+        for legacy in [false, true] {
             for (workload, count) in [
                 ("durable", cap), ("durable", 1_000), ("durable", 10_000),
                 ("missing", 10_000), ("rejected-prefix", 1_000)
@@ -147,7 +103,7 @@ enum ClipboardSelectionBenchmark {
                     ? Array(repeating: missing, count: count)
                     : (workload == "rejected-prefix" ? Array(repeating: missing, count: 40) : [])
                         + Array(durable.prefix(count))
-                let pasteboard = board(urls, format: format)
+                let pasteboard = board(urls, legacy: legacy)
                 let expected: [String]? =
                     workload == "missing"
                     ? nil
@@ -166,16 +122,16 @@ enum ClipboardSelectionBenchmark {
                 let cpuTime = (cpu() - startCPU) / Double(iterations)
                 pasteboard.releaseGlobally()
                 results.append([
-                    "workload": workload, "files": count, "format": format,
+                    "workload": workload, "files": count, "format": legacy ? "legacy" : "file-url",
                     "iterations": iterations, "wall_ms_per_call": wall,
                     "cpu_ms_per_call": cpuTime, "exact_output_passed": true
                 ])
             }
         }
-        for format in ["file-url", "legacy", "legacy-fallback"] {
+        for legacy in [false, true] {
             for count in [cap, 10_000] {
                 let urls = Array(durable.prefix(count))
-                let pasteboard = board(urls, format: format)
+                let pasteboard = board(urls, legacy: legacy)
                 precondition(PasteboardFiles.urls(on: pasteboard) == urls)
                 let iterations = 5
                 let startCPU = cpu()
@@ -186,10 +142,12 @@ enum ClipboardSelectionBenchmark {
                 let wall = milliseconds(start) / Double(iterations)
                 let cpuTime = (cpu() - startCPU) / Double(iterations)
                 pasteboard.releaseGlobally()
-                results.append(["workload": "uncapped-reader", "files": count,
-                                "format": format, "iterations": iterations,
-                                "wall_ms_per_call": wall, "cpu_ms_per_call": cpuTime,
-                                "exact_output_passed": true])
+                results.append([
+                    "workload": "uncapped-reader", "files": count,
+                    "format": legacy ? "legacy" : "file-url", "iterations": iterations,
+                    "wall_ms_per_call": wall, "cpu_ms_per_call": cpuTime,
+                    "exact_output_passed": true
+                ])
             }
         }
         let data = try JSONSerialization.data(withJSONObject: results, options: [.sortedKeys])

--- a/Tests/clipboard-file-performance.swift
+++ b/Tests/clipboard-file-performance.swift
@@ -1,21 +1,42 @@
 import AppKit
+import ObjectiveC
 
 @main
 @MainActor
 enum ClipboardSelectionBenchmark {
     static let cap = ClipboardManager.maxCapturedFiles
 
-    static func board(_ urls: [URL], legacy: Bool) -> NSPasteboard {
+    static func board(_ urls: [URL], format: String) -> NSPasteboard {
         let board = NSPasteboard.withUniqueName()
         if urls.isEmpty { return board }
-        if legacy {
+        if format != "file-url" {
             let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
             board.declareTypes([type], owner: nil)
             precondition(board.setPropertyList(urls.map(\.path), forType: type))
         } else {
             precondition(board.writeObjects(urls as [NSURL]))
         }
+        if format == "legacy-fallback" {
+            hideModernItems(on: board)
+            precondition(board.propertyList(forType: .init("NSFilenamesPboardType")) as? [String]
+                == urls.map(\.path))
+        }
         return board
+    }
+
+    // macOS synthesizes modern items from legacy filenames; hide them only on this private fixture.
+    static func hideModernItems(on pasteboard: NSPasteboard) {
+        let superclass: AnyClass = object_getClass(pasteboard)!
+        let name = "LegacyFilesFixture" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let subclass: AnyClass = objc_allocateClassPair(superclass, name, 0)!
+        let getter = #selector(getter: NSPasteboard.pasteboardItems)
+        let method = class_getInstanceMethod(superclass, getter)!
+        let block: @convention(block) (AnyObject) -> NSArray = { _ in [] }
+        precondition(class_addMethod(
+            subclass, getter, imp_implementationWithBlock(block), method_getTypeEncoding(method)))
+        objc_registerClassPair(subclass)
+        object_setClass(pasteboard, subclass)
+        precondition(pasteboard.pasteboardItems?.isEmpty == true)
     }
 
     static func milliseconds(_ start: ContinuousClock.Instant) -> Double {
@@ -30,8 +51,8 @@ enum ClipboardSelectionBenchmark {
             + Double(usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) / 1_000
     }
 
-    static func verify(_ urls: [URL], expected: [String]?, roots: [String], legacy: Bool) {
-        let pasteboard = board(urls, legacy: legacy)
+    static func verify(_ urls: [URL], expected: [String]?, roots: [String], format: String) {
+        let pasteboard = board(urls, format: format)
         defer { pasteboard.releaseGlobally() }
         precondition(ClipboardManager.fileURLs(on: pasteboard, volatileRoots: roots) == expected)
     }
@@ -59,6 +80,19 @@ enum ClipboardSelectionBenchmark {
         return directory
     }
 
+    static func verifyPrecedence(modern: URL?, legacy: URL, roots: [String], expectedRead: [URL],
+                                 expectedCapture: [String]?) {
+        let pb = NSPasteboard.withUniqueName()
+        defer { pb.releaseGlobally() }
+        let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
+        pb.declareTypes(modern == nil ? [type] : [type, .fileURL], owner: nil)
+        precondition(pb.setPropertyList([legacy.path], forType: type))
+        if let modern { precondition(pb.setData(modern.dataRepresentation, forType: .fileURL)) }
+        precondition(pb.propertyList(forType: type) as? [String] == [legacy.path])
+        precondition(PasteboardFiles.urls(on: pb) == expectedRead)
+        precondition(ClipboardManager.fileURLs(on: pb, volatileRoots: roots) == expectedCapture)
+    }
+
     static func main() throws {
         let directory = try fixtures()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -71,19 +105,29 @@ enum ClipboardSelectionBenchmark {
         let durableLink = directory.appendingPathComponent("durable-link")
         let volatileLink = directory.appendingPathComponent("volatile-link")
         let brokenLink = directory.appendingPathComponent("broken-link")
-        for legacy in [false, true] {
-            verify([], expected: nil, roots: roots, legacy: legacy)
-            verify([missing, volatile, volatileLink, brokenLink], expected: nil, roots: roots, legacy: legacy)
+        for modern in [missing, volatile, volatileLink, brokenLink] {
+            verifyPrecedence(modern: modern, legacy: durable[0], roots: roots,
+                             expectedRead: [modern], expectedCapture: nil)
+        }
+        verifyPrecedence(modern: durable[1], legacy: durable[0], roots: roots,
+                         expectedRead: [durable[1]], expectedCapture: [durable[1].path])
+        for modern in [nil, URL(string: "https://example.com/not-a-file")] {
+            verifyPrecedence(modern: modern, legacy: durable[0], roots: roots,
+                             expectedRead: [durable[0]], expectedCapture: [durable[0].path])
+        }
+        for format in ["file-url", "legacy", "legacy-fallback"] {
+            verify([], expected: nil, roots: roots, format: format)
+            verify([missing, volatile, volatileLink, brokenLink], expected: nil, roots: roots, format: format)
             let valid = [durableLink] + Array(durable.prefix(40))
             let mixed = Array(repeating: missing, count: 40) + [volatile, volatileLink, brokenLink] + valid
             verify(
                 mixed, expected: Array(valid.prefix(cap).map(\.standardizedFileURL.path).reversed()),
-                roots: roots, legacy: legacy)
+                roots: roots, format: format)
             for count in [1, cap - 1, cap, cap + 1] {
                 let urls = Array(durable.prefix(count))
                 verify(
                     urls, expected: Array(urls.prefix(cap).map(\.path).reversed()), roots: roots,
-                    legacy: legacy)
+                    format: format)
             }
         }
         let text = NSPasteboard.withUniqueName()
@@ -93,7 +137,7 @@ enum ClipboardSelectionBenchmark {
         text.releaseGlobally()
 
         var results: [[String: Any]] = []
-        for legacy in [false, true] {
+        for format in ["file-url", "legacy", "legacy-fallback"] {
             for (workload, count) in [
                 ("durable", cap), ("durable", 1_000), ("durable", 10_000),
                 ("missing", 10_000), ("rejected-prefix", 1_000)
@@ -103,7 +147,7 @@ enum ClipboardSelectionBenchmark {
                     ? Array(repeating: missing, count: count)
                     : (workload == "rejected-prefix" ? Array(repeating: missing, count: 40) : [])
                         + Array(durable.prefix(count))
-                let pasteboard = board(urls, legacy: legacy)
+                let pasteboard = board(urls, format: format)
                 let expected: [String]? =
                     workload == "missing"
                     ? nil
@@ -122,10 +166,30 @@ enum ClipboardSelectionBenchmark {
                 let cpuTime = (cpu() - startCPU) / Double(iterations)
                 pasteboard.releaseGlobally()
                 results.append([
-                    "workload": workload, "files": count, "format": legacy ? "legacy" : "file-url",
+                    "workload": workload, "files": count, "format": format,
                     "iterations": iterations, "wall_ms_per_call": wall,
                     "cpu_ms_per_call": cpuTime, "exact_output_passed": true
                 ])
+            }
+        }
+        for format in ["file-url", "legacy", "legacy-fallback"] {
+            for count in [cap, 10_000] {
+                let urls = Array(durable.prefix(count))
+                let pasteboard = board(urls, format: format)
+                precondition(PasteboardFiles.urls(on: pasteboard) == urls)
+                let iterations = 5
+                let startCPU = cpu()
+                let start = ContinuousClock.now
+                for _ in 0..<iterations {
+                    autoreleasepool { precondition(PasteboardFiles.urls(on: pasteboard) == urls) }
+                }
+                let wall = milliseconds(start) / Double(iterations)
+                let cpuTime = (cpu() - startCPU) / Double(iterations)
+                pasteboard.releaseGlobally()
+                results.append(["workload": "uncapped-reader", "files": count,
+                                "format": format, "iterations": iterations,
+                                "wall_ms_per_call": wall, "cpu_ms_per_call": cpuTime,
+                                "exact_output_passed": true])
             }
         }
         let data = try JSONSerialization.data(withJSONObject: results, options: [.sortedKeys])

--- a/Tests/ext-refresh-test.swift
+++ b/Tests/ext-refresh-test.swift
@@ -20,7 +20,7 @@ struct ExtensionRefreshTests {
 
     static func baseJSON(interval: Any?) -> [String: Any] {
         var json: [String: Any] = [
-            "name": "status", "title": "Status", "mode": "no-view",
+            "name": "status", "title": "Status", "mode": "no-view"
         ]
         if let interval { json["interval"] = interval }
         return json

--- a/Tests/pasteboard-test.swift
+++ b/Tests/pasteboard-test.swift
@@ -2,7 +2,6 @@
 // Every case drives `NSPasteboard.withUniqueName()`: writing to `.general` would land in the
 // reader's own running Tinycast as a genuine copy.
 import AppKit
-import ObjectiveC
 
 @main
 @MainActor
@@ -19,9 +18,8 @@ struct PasteboardTests {
         volatileAndMissingFilesFallThrough()
         theBatchIsCapped()
         rejectedFilesDoNotCountTowardTheCap()
-        boundedReaderPreservesSelectionAndStopsChecking()
-        modernFilesSuppressLegacyFallback()
-        rawLegacyFallbackKeepsEveryFile()
+        theBoundedReaderStopsAtItsLimit()
+        aModernFileURLSuppressesTheLegacyFallback()
         fileEntriesWriteBackAsFiles()
         aVanishedFileWritesNothing()
 
@@ -198,6 +196,70 @@ struct PasteboardTests {
         }
     }
 
+    /// Bounding lives in the reader now, so both the limit and the predicate must stop exactly.
+    static func theBoundedReaderStopsAtItsLimit() {
+        let urls = (0..<100).map { URL(fileURLWithPath: "/fixture/\($0).txt") }
+        let pb = fileBoard(urls, legacy: false)
+        defer { pb.releaseGlobally() }
+        expect(PasteboardFiles.urls(on: pb) == urls, "the attachment reader stays uncapped")
+        for limit in [-1, 0, 1, cap - 1, cap, cap + 1, 100, Int.max] {
+            var visited: [URL] = []
+            let matched = PasteboardFiles.urls(on: pb, limit: limit) { url in
+                visited.append(url)
+                return true
+            }
+            let expected = Array(urls.prefix(max(0, limit)))
+            expect(matched == expected, "a limit of \(limit) bounds the result in board order")
+            expect(visited == expected, "and nothing is decoded past a limit of \(limit)")
+        }
+        var visited: [URL] = []
+        let afterRejections = PasteboardFiles.urls(on: pb, limit: cap) { url in
+            visited.append(url)
+            return visited.count > 40
+        }
+        expect(
+            afterRejections == Array(urls[40..<(40 + cap)]),
+            "rejected URLs do not consume the limit")
+        expect(
+            visited == Array(urls.prefix(40 + cap)),
+            "and every URL is tested once, with testing stopping at the limit")
+    }
+
+    /// A board naming a file in the modern flavour must never fall back, even when we reject it.
+    static func aModernFileURLSuppressesTheLegacyFallback() {
+        withScratch { dir in
+            let legacy = dir.appendingPathComponent("legacy.txt")
+            let modern = dir.appendingPathComponent("modern.txt")
+            let missing = dir.appendingPathComponent("missing.txt")
+            try? Data("legacy".utf8).write(to: legacy)
+            try? Data("modern".utf8).write(to: modern)
+            for url in [modern, missing, URL(string: "https://example.com/file")!] {
+                let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
+                let pb = board()
+                defer { pb.releaseGlobally() }
+                pb.declareTypes([type, .fileURL], owner: nil)
+                pb.setPropertyList([legacy.path], forType: type)
+                pb.setData(url.dataRepresentation, forType: .fileURL)
+
+                let named = url.isFileURL ? [url] : [legacy]
+                expect(
+                    PasteboardFiles.urls(on: pb) == named,
+                    "a modern file URL outranks the legacy paths beside it")
+                var visited: [URL] = []
+                let rejected = PasteboardFiles.urls(on: pb, limit: cap) { candidate in
+                    visited.append(candidate)
+                    return false
+                }
+                expect(rejected.isEmpty, "rejecting every candidate names no file")
+                expect(visited == named, "and a rejected modern URL still suppresses the fallback")
+                expect(
+                    ClipboardManager.fileURLs(on: pb, volatileRoots: [])
+                        == (url == missing ? nil : named.map(\.path)),
+                    "so a missing modern file never captures the legacy path instead")
+            }
+        }
+    }
+
     static func fileBoard(_ urls: [URL], legacy: Bool) -> NSPasteboard {
         let pb = board()
         if legacy {
@@ -208,104 +270,6 @@ struct PasteboardTests {
             expect(pb.writeObjects(urls as [NSURL]), "file URL fixture is written")
         }
         return pb
-    }
-
-    static func boundedReaderPreservesSelectionAndStopsChecking() {
-        let urls = (0..<100).map { URL(fileURLWithPath: "/fixture/\($0).txt") }
-        let pb = fileBoard(urls, legacy: false)
-        defer { pb.releaseGlobally() }
-        expect(PasteboardFiles.urls(on: pb) == urls, "the attachment reader remains uncapped")
-        for limit in [-1, 0, 1, 31, 32, 33, 100, Int.max] {
-            var visited: [URL] = []
-            let actual = PasteboardFiles.urls(on: pb, limit: limit) { url in
-                visited.append(url)
-                return true
-            }
-            let expected = Array(urls.prefix(max(0, limit)))
-            expect(actual == expected, "bounded reader preserves order at limit \(limit)")
-            expect(visited == expected, "no predicate call after limit \(limit)")
-        }
-        var visited: [URL] = []
-        let accepted = PasteboardFiles.urls(on: pb, limit: 32) { url in
-            visited.append(url)
-            return visited.count > 40
-        }
-        expect(accepted == Array(urls[40..<72]), "rejected URLs do not consume the reader limit")
-        expect(visited == Array(urls.prefix(72)), "each URL is tested once and checks stop at the cap")
-    }
-
-    static func modernFilesSuppressLegacyFallback() {
-        withScratch { dir in
-            let legacy = dir.appendingPathComponent("legacy.txt")
-            let modern = dir.appendingPathComponent("modern.txt")
-            try? Data("legacy".utf8).write(to: legacy)
-            try? Data("modern".utf8).write(to: modern)
-            let missing = dir.appendingPathComponent("missing.txt")
-            for url in [modern, missing, URL(string: "https://example.com/file")!] {
-                let pb = board()
-                defer { pb.releaseGlobally() }
-                let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
-                pb.declareTypes([type, .fileURL], owner: nil)
-                pb.setPropertyList([legacy.path], forType: type)
-                pb.setData(url.dataRepresentation, forType: .fileURL)
-                let expected = url.isFileURL ? [url] : [legacy]
-                expect(PasteboardFiles.urls(on: pb) == expected, "modern file URLs outrank legacy paths")
-                expect(PasteboardFiles.urls(on: pb, limit: 32) { _ in true } == expected,
-                       "the bounded reader preserves representation precedence")
-                var visited: [URL] = []
-                let rejected = PasteboardFiles.urls(on: pb, limit: 32) { candidate in
-                    visited.append(candidate)
-                    return false
-                }
-                expect(rejected.isEmpty && visited == expected,
-                       "rejected modern file URLs still suppress legacy fallback")
-                let capture: [String]? = url == missing ? nil : expected.map(\.path)
-                expect(ClipboardManager.fileURLs(on: pb, volatileRoots: []) == capture,
-                       "missing modern files do not cause legacy capture")
-            }
-        }
-    }
-
-    static func rawLegacyFallbackKeepsEveryFile() {
-        withScratch { dir in
-            let files = (0..<40).map { dir.appendingPathComponent("f\($0).txt") }
-            for file in files { try? Data("file".utf8).write(to: file) }
-            let missing = dir.appendingPathComponent("missing.txt")
-            for urls in [files, Array(repeating: missing, count: 40) + files,
-                         Array(repeating: missing, count: 40)] {
-                let pb = fileBoard(urls, legacy: true)
-                defer { pb.releaseGlobally() }
-                hideModernItems(on: pb)
-                expect(PasteboardFiles.urls(on: pb) == urls, "raw legacy extraction remains uncapped")
-                var visited: [URL] = []
-                let result = PasteboardFiles.urls(on: pb, limit: 32) { url in
-                    visited.append(url)
-                    return url != missing
-                }
-                let expected = Array(urls.filter { $0 != missing }.prefix(32))
-                expect(result == expected, "raw legacy skips rejections and preserves the first 32")
-                let expectedVisits = expected.isEmpty ? urls.count : (urls.first == missing ? 72 : 32)
-                expect(visited == Array(urls.prefix(expectedVisits)), "raw legacy predicates run once")
-                expect(ClipboardManager.fileURLs(on: pb, volatileRoots: [])
-                    == (expected.isEmpty ? nil : Array(expected.map(\.path).reversed())),
-                    "raw legacy capture matches the store insertion order")
-            }
-        }
-    }
-
-    // macOS synthesizes modern items from legacy filenames; hide them only on this private fixture.
-    static func hideModernItems(on pasteboard: NSPasteboard) {
-        let superclass: AnyClass = object_getClass(pasteboard)!
-        let name = "LegacyFilesFixture" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
-        let subclass: AnyClass = objc_allocateClassPair(superclass, name, 0)!
-        let getter = #selector(getter: NSPasteboard.pasteboardItems)
-        let method = class_getInstanceMethod(superclass, getter)!
-        let block: @convention(block) (AnyObject) -> NSArray = { _ in [] }
-        precondition(class_addMethod(
-            subclass, getter, imp_implementationWithBlock(block), method_getTypeEncoding(method)))
-        objc_registerClassPair(subclass)
-        object_setClass(pasteboard, subclass)
-        precondition(pasteboard.pasteboardItems?.isEmpty == true)
     }
 
     // MARK: - Writing

--- a/Tests/pasteboard-test.swift
+++ b/Tests/pasteboard-test.swift
@@ -2,6 +2,7 @@
 // Every case drives `NSPasteboard.withUniqueName()`: writing to `.general` would land in the
 // reader's own running Tinycast as a genuine copy.
 import AppKit
+import ObjectiveC
 
 @main
 @MainActor
@@ -18,6 +19,9 @@ struct PasteboardTests {
         volatileAndMissingFilesFallThrough()
         theBatchIsCapped()
         rejectedFilesDoNotCountTowardTheCap()
+        boundedReaderPreservesSelectionAndStopsChecking()
+        modernFilesSuppressLegacyFallback()
+        rawLegacyFallbackKeepsEveryFile()
         fileEntriesWriteBackAsFiles()
         aVanishedFileWritesNothing()
 
@@ -204,6 +208,104 @@ struct PasteboardTests {
             expect(pb.writeObjects(urls as [NSURL]), "file URL fixture is written")
         }
         return pb
+    }
+
+    static func boundedReaderPreservesSelectionAndStopsChecking() {
+        let urls = (0..<100).map { URL(fileURLWithPath: "/fixture/\($0).txt") }
+        let pb = fileBoard(urls, legacy: false)
+        defer { pb.releaseGlobally() }
+        expect(PasteboardFiles.urls(on: pb) == urls, "the attachment reader remains uncapped")
+        for limit in [-1, 0, 1, 31, 32, 33, 100, Int.max] {
+            var visited: [URL] = []
+            let actual = PasteboardFiles.urls(on: pb, limit: limit) { url in
+                visited.append(url)
+                return true
+            }
+            let expected = Array(urls.prefix(max(0, limit)))
+            expect(actual == expected, "bounded reader preserves order at limit \(limit)")
+            expect(visited == expected, "no predicate call after limit \(limit)")
+        }
+        var visited: [URL] = []
+        let accepted = PasteboardFiles.urls(on: pb, limit: 32) { url in
+            visited.append(url)
+            return visited.count > 40
+        }
+        expect(accepted == Array(urls[40..<72]), "rejected URLs do not consume the reader limit")
+        expect(visited == Array(urls.prefix(72)), "each URL is tested once and checks stop at the cap")
+    }
+
+    static func modernFilesSuppressLegacyFallback() {
+        withScratch { dir in
+            let legacy = dir.appendingPathComponent("legacy.txt")
+            let modern = dir.appendingPathComponent("modern.txt")
+            try? Data("legacy".utf8).write(to: legacy)
+            try? Data("modern".utf8).write(to: modern)
+            let missing = dir.appendingPathComponent("missing.txt")
+            for url in [modern, missing, URL(string: "https://example.com/file")!] {
+                let pb = board()
+                defer { pb.releaseGlobally() }
+                let type = NSPasteboard.PasteboardType("NSFilenamesPboardType")
+                pb.declareTypes([type, .fileURL], owner: nil)
+                pb.setPropertyList([legacy.path], forType: type)
+                pb.setData(url.dataRepresentation, forType: .fileURL)
+                let expected = url.isFileURL ? [url] : [legacy]
+                expect(PasteboardFiles.urls(on: pb) == expected, "modern file URLs outrank legacy paths")
+                expect(PasteboardFiles.urls(on: pb, limit: 32) { _ in true } == expected,
+                       "the bounded reader preserves representation precedence")
+                var visited: [URL] = []
+                let rejected = PasteboardFiles.urls(on: pb, limit: 32) { candidate in
+                    visited.append(candidate)
+                    return false
+                }
+                expect(rejected.isEmpty && visited == expected,
+                       "rejected modern file URLs still suppress legacy fallback")
+                let capture: [String]? = url == missing ? nil : expected.map(\.path)
+                expect(ClipboardManager.fileURLs(on: pb, volatileRoots: []) == capture,
+                       "missing modern files do not cause legacy capture")
+            }
+        }
+    }
+
+    static func rawLegacyFallbackKeepsEveryFile() {
+        withScratch { dir in
+            let files = (0..<40).map { dir.appendingPathComponent("f\($0).txt") }
+            for file in files { try? Data("file".utf8).write(to: file) }
+            let missing = dir.appendingPathComponent("missing.txt")
+            for urls in [files, Array(repeating: missing, count: 40) + files,
+                         Array(repeating: missing, count: 40)] {
+                let pb = fileBoard(urls, legacy: true)
+                defer { pb.releaseGlobally() }
+                hideModernItems(on: pb)
+                expect(PasteboardFiles.urls(on: pb) == urls, "raw legacy extraction remains uncapped")
+                var visited: [URL] = []
+                let result = PasteboardFiles.urls(on: pb, limit: 32) { url in
+                    visited.append(url)
+                    return url != missing
+                }
+                let expected = Array(urls.filter { $0 != missing }.prefix(32))
+                expect(result == expected, "raw legacy skips rejections and preserves the first 32")
+                let expectedVisits = expected.isEmpty ? urls.count : (urls.first == missing ? 72 : 32)
+                expect(visited == Array(urls.prefix(expectedVisits)), "raw legacy predicates run once")
+                expect(ClipboardManager.fileURLs(on: pb, volatileRoots: [])
+                    == (expected.isEmpty ? nil : Array(expected.map(\.path).reversed())),
+                    "raw legacy capture matches the store insertion order")
+            }
+        }
+    }
+
+    // macOS synthesizes modern items from legacy filenames; hide them only on this private fixture.
+    static func hideModernItems(on pasteboard: NSPasteboard) {
+        let superclass: AnyClass = object_getClass(pasteboard)!
+        let name = "LegacyFilesFixture" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let subclass: AnyClass = objc_allocateClassPair(superclass, name, 0)!
+        let getter = #selector(getter: NSPasteboard.pasteboardItems)
+        let method = class_getInstanceMethod(superclass, getter)!
+        let block: @convention(block) (AnyObject) -> NSArray = { _ in [] }
+        precondition(class_addMethod(
+            subclass, getter, imp_implementationWithBlock(block), method_getTypeEncoding(method)))
+        objc_registerClassPair(subclass)
+        object_setClass(pasteboard, subclass)
+        precondition(pasteboard.pasteboardItems?.isEmpty == true)
     }
 
     // MARK: - Writing

--- a/Tests/text-diff-performance.swift
+++ b/Tests/text-diff-performance.swift
@@ -33,8 +33,9 @@ enum TextDiffPerformance {
             checksum += chunks.count
         }
         let duration = start.duration(to: .now).components
-        let milliseconds = (Double(duration.seconds) * 1_000
-            + Double(duration.attoseconds) / 1e15) / Double(iterations)
+        let milliseconds =
+            (Double(duration.seconds) * 1_000
+                + Double(duration.attoseconds) / 1e15) / Double(iterations)
 
         let expected: [TextDiffEngine.Chunk]
         if workload == "equal" {
@@ -45,7 +46,8 @@ enum TextDiffPerformance {
             expected = [.deleted(original), .inserted(modified)]
         } else if workload == "sparse" {
             let suffix = String(original.dropFirst(3))
-            expected = [.deleted("old"), .inserted("new")]
+            expected =
+                [.deleted("old"), .inserted("new")]
                 + (suffix.isEmpty ? [] : [.equal(suffix)])
         } else {
             expected = (0..<count).flatMap { index in
@@ -78,8 +80,10 @@ enum TextDiffPerformance {
             ("a b", "b a"), ("one one two", "one two one"),
             ("café", "cafe\u{301}"), (" 👩🏽‍💻\n中文", "\t中文 👩🏽‍💻")
         ]
-        let fragments = ["", "a", "b", "a", " ", "  ", "\n", "\t", ".!?", "—",
-                         "café", "e\u{301}", "👩🏽‍💻", "中文", "مرحبا", "123"]
+        let fragments = [
+            "", "a", "b", "a", " ", "  ", "\n", "\t", ".!?", "—",
+            "café", "e\u{301}", "👩🏽‍💻", "中文", "مرحبا", "123"
+        ]
         var seed: UInt64 = 0x54494E5943415354
         func next(_ limit: Int) -> Int {
             seed = seed &* 6_364_136_223_846_793_005 &+ 1

--- a/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
+++ b/Tinycast/Features/Clipboard/Service/ClipboardManager.swift
@@ -109,11 +109,9 @@ final class ClipboardManager {
     nonisolated static func fileURLs(
         on pasteboard: NSPasteboard, volatileRoots roots: [String] = volatileRoots
     ) -> [String]? {
-        // Lazy, so a ten-thousand-file select-all stops checking the filesystem at the cap.
-        let durable = Array(
-            PasteboardFiles.urls(on: pasteboard).lazy
-                .filter { isDurable($0, roots: roots) }
-                .prefix(maxCapturedFiles))
+        let durable = PasteboardFiles.urls(on: pasteboard, limit: maxCapturedFiles) {
+            isDurable($0, roots: roots)
+        }
         // Nil rather than empty, so a copied `http` URL falls through and stays a link.
         guard !durable.isEmpty else { return nil }
         // Reversed on insert, so the first file copied ends up leading the history.

--- a/Tinycast/Platform/PasteboardFiles.swift
+++ b/Tinycast/Platform/PasteboardFiles.swift
@@ -7,46 +7,34 @@ enum PasteboardFiles {
 
     /// Empty when the board names no file, so a caller falls through to text or bytes.
     static func urls(on pasteboard: NSPasteboard) -> [URL] {
-        let items = (pasteboard.pasteboardItems ?? []).compactMap(url(from:))
-        if !items.isEmpty { return items }
-        guard let paths = pasteboard.propertyList(forType: legacyFilenames) as? [String] else {
-            return []
-        }
-        return paths.map { URL(fileURLWithPath: $0) }
+        urls(on: pasteboard, limit: .max) { _ in true }
     }
 
+    /// Filters while decoding, so a ten-thousand-file select-all stops decoding at the limit.
     static func urls(
         on pasteboard: NSPasteboard, limit: Int, matching predicate: (URL) -> Bool
     ) -> [URL] {
         guard limit > 0 else { return [] }
-        var result: [URL] = []
+        var matches: [URL] = []
         var hasFileURL = false
-        let items = pasteboard.pasteboardItems ?? []
-        var offset = 0
-        while offset < items.count {
-            let end = offset + min(limit, items.count - offset)
-            let batch = items[offset..<end].compactMap(url(from:))
-            hasFileURL = hasFileURL || !batch.isEmpty
-            for url in batch where predicate(url) {
-                result.append(url)
-                if result.count == limit { return result }
-            }
-            offset = end
+        for item in pasteboard.pasteboardItems ?? [] {
+            guard let url = url(from: item) else { continue }
+            hasFileURL = true
+            guard predicate(url) else { continue }
+            matches.append(url)
+            if matches.count == limit { return matches }
         }
+        // A modern flavour suppresses the fallback even when every URL was rejected.
         guard !hasFileURL,
             let paths = pasteboard.propertyList(forType: legacyFilenames) as? [String]
-        else { return result }
-        offset = 0
-        while offset < paths.count {
-            let end = offset + min(limit, paths.count - offset)
-            let batch = paths[offset..<end].map { URL(fileURLWithPath: $0) }
-            for url in batch where predicate(url) {
-                result.append(url)
-                if result.count == limit { return result }
-            }
-            offset = end
+        else { return matches }
+        for path in paths {
+            let url = URL(fileURLWithPath: path)
+            guard predicate(url) else { continue }
+            matches.append(url)
+            if matches.count == limit { return matches }
         }
-        return result
+        return matches
     }
 
     /// `public.file-url` arrives as UTF-8 data on most boards and as a string on some.

--- a/Tinycast/Platform/PasteboardFiles.swift
+++ b/Tinycast/Platform/PasteboardFiles.swift
@@ -15,6 +15,40 @@ enum PasteboardFiles {
         return paths.map { URL(fileURLWithPath: $0) }
     }
 
+    static func urls(
+        on pasteboard: NSPasteboard, limit: Int, matching predicate: (URL) -> Bool
+    ) -> [URL] {
+        guard limit > 0 else { return [] }
+        var result: [URL] = []
+        var hasFileURL = false
+        let items = pasteboard.pasteboardItems ?? []
+        var offset = 0
+        while offset < items.count {
+            let end = offset + min(limit, items.count - offset)
+            let batch = items[offset..<end].compactMap(url(from:))
+            hasFileURL = hasFileURL || !batch.isEmpty
+            for url in batch where predicate(url) {
+                result.append(url)
+                if result.count == limit { return result }
+            }
+            offset = end
+        }
+        guard !hasFileURL,
+            let paths = pasteboard.propertyList(forType: legacyFilenames) as? [String]
+        else { return result }
+        offset = 0
+        while offset < paths.count {
+            let end = offset + min(limit, paths.count - offset)
+            let batch = paths[offset..<end].map { URL(fileURLWithPath: $0) }
+            for url in batch where predicate(url) {
+                result.append(url)
+                if result.count == limit { return result }
+            }
+            offset = end
+        }
+        return result
+    }
+
     /// `public.file-url` arrives as UTF-8 data on most boards and as a string on some.
     private static func url(from item: NSPasteboardItem) -> URL? {
         if let data = item.data(forType: .fileURL),

--- a/docs/development.md
+++ b/docs/development.md
@@ -107,9 +107,13 @@ It reads the source lists from `run-tests.sh` itself, so they cannot drift from 
 compiles. `Scripts/sync-lsp.sh` runs it too. Three things it has to get right, all of which fail
 silently otherwise: every path is absolute, because `sourcekit-lsp` resolves the command itself and does
 not apply `directory` to relative arguments; the command carries an explicit `-sdk`; and each entry
-claims **only its own harness** in `files`. The command still lists every shipped source it compiles, so
-symbols resolve inside the harness — but claiming those sources too would hand them this three-file
-command instead of the app's, and `.compile` is last-wins.
+claims **only files under `Tests/`** — its harness plus any helper compiled beside it. The command
+still lists every shipped source it compiles, so symbols resolve inside the harness, but claiming a
+shipped source too would hand it this three-file command instead of the app's, and `.compile` is
+last-wins.
+
+A benchmark that stays out of the suite still needs flags, so `run-tests.sh` registers it as
+`run index <name> <source...>`: `--index` emits its compile command and the runner never queues it.
 
 Re-run it after adding a harness, then **Swift: Restart LSP Server** from the Command Palette — an
 already-running server does not re-read `.compile`.

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -51,7 +51,10 @@ returns nil rather than an empty array, so the text branch runs; caps a batch at
 **rejects a file under a volatile root** (`/tmp`, `/var/folders`, `~/Library/Caches`), because an
 app that stages a temp export beside better inline content must keep the inline content. Paths come
 back reversed so the *first* file copied ends up leading the history. Durability checks stop after
-32 accepted files; rejected paths do not consume the cap. Pasteboard decoding still reads all items.
+32 accepted files; rejected paths do not consume the cap. Capture decodes at most 32 pasteboard
+items at a time and stops requesting batches when the cap is reached. Even a rejected modern file
+URL suppresses the legacy filenames fallback. The uncapped `PasteboardFiles.urls(on:)` reader used
+by attachments still returns every file.
 
 `ClipboardManager` runs a 0.5s `Timer` watching `NSPasteboard.general.changeCount`. To avoid
 re-capturing Tinycast's own writes, every write stamps a private `internalType` marker on the

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -51,10 +51,10 @@ returns nil rather than an empty array, so the text branch runs; caps a batch at
 **rejects a file under a volatile root** (`/tmp`, `/var/folders`, `~/Library/Caches`), because an
 app that stages a temp export beside better inline content must keep the inline content. Paths come
 back reversed so the *first* file copied ends up leading the history. Durability checks stop after
-32 accepted files; rejected paths do not consume the cap. Capture decodes at most 32 pasteboard
-items at a time and stops requesting batches when the cap is reached. Even a rejected modern file
-URL suppresses the legacy filenames fallback. The uncapped `PasteboardFiles.urls(on:)` reader used
-by attachments still returns every file.
+32 accepted files, and decoding stops with them: the reader takes the cap and the durability test
+together rather than filtering a list it has already decoded whole. Rejected paths do not consume
+the cap, and even a rejected modern file URL suppresses the legacy filenames fallback. The uncapped
+`PasteboardFiles.urls(on:)` that attachments use is the same reader with no limit and no test.
 
 `ClipboardManager` runs a 0.5s `Timer` watching `NSPasteboard.general.changeCount`. To avoid
 re-capturing Tinycast's own writes, every write stamps a private `internalType` marker on the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,9 +64,9 @@ for the shared board. Its scratch tree lives under `temporaryDirectory`, which i
 root, so the cases about *reading* files inject an empty root list and the one case about durability
 is the one that runs against the shipped roots. Both file URL and legacy filename boards also cover
 the capture cap, exact ordering, rejected prefixes, duplicates and symlinks using private fixtures.
-The reader cases additionally cover predicate limits, modern/legacy precedence and uncapped extraction.
-Since macOS synthesizes modern items for a legacy write, a fixture-only subclass hides those items on
-one private board to exercise the raw legacy fallback without changing the production reader.
+The reader cases add the limit boundaries, the predicate call counts and modern/legacy precedence.
+Note that macOS synthesizes `public.file-url` items for any `NSFilenamesPboardType` write, so a
+legacy fixture still exercises the modern representation and the fallback branch stays unreached.
 
 Never join a compile to its run with `&&` in a `set -e` script. `set -e` is specified to ignore a
 failing command in a non-final AND-OR list member, so `swiftc … && /tmp/x` swallows a compile error and
@@ -226,10 +226,9 @@ iteration count for timings, or `--probe` to diff every chunk between two builds
 
 `Tests/clipboard-file-performance.swift` measures file capture with private pasteboards and temporary
 fixtures. It reports wall and process CPU time as JSON for modern and legacy formats, including
-32/1,000/10,000 durable files, rejected-input controls and uncapped-reader controls. A third format
-uses the same private-board fixture override to measure the raw legacy fallback explicitly.
-Keep it outside `run-tests.sh`; compare
-three fresh processes per build with identical `-O` settings:
+32/1,000/10,000 durable files, rejected-input controls and an uncapped-reader control that guards
+the attachment path against the bounded reader it now delegates to. Keep it outside
+`run-tests.sh`; compare three fresh processes per build with identical `-O` settings:
 
 ```sh
 swiftc -O -swift-version 6 Tinycast/Platform/PasteboardFiles.swift \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,9 @@ for the shared board. Its scratch tree lives under `temporaryDirectory`, which i
 root, so the cases about *reading* files inject an empty root list and the one case about durability
 is the one that runs against the shipped roots. Both file URL and legacy filename boards also cover
 the capture cap, exact ordering, rejected prefixes, duplicates and symlinks using private fixtures.
+The reader cases additionally cover predicate limits, modern/legacy precedence and uncapped extraction.
+Since macOS synthesizes modern items for a legacy write, a fixture-only subclass hides those items on
+one private board to exercise the raw legacy fallback without changing the production reader.
 
 Never join a compile to its run with `&&` in a `set -e` script. `set -e` is specified to ignore a
 failing command in a non-final AND-OR list member, so `swiftc … && /tmp/x` swallows a compile error and
@@ -223,7 +226,9 @@ iteration count for timings, or `--probe` to diff every chunk between two builds
 
 `Tests/clipboard-file-performance.swift` measures file capture with private pasteboards and temporary
 fixtures. It reports wall and process CPU time as JSON for modern and legacy formats, including
-32/1,000/10,000 durable files and rejected-input controls. Keep it outside `run-tests.sh`; compare
+32/1,000/10,000 durable files, rejected-input controls and uncapped-reader controls. A third format
+uses the same private-board fixture override to measure the raw legacy fallback explicitly.
+Keep it outside `run-tests.sh`; compare
 three fresh processes per build with identical `-O` settings:
 
 ```sh

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -195,6 +195,10 @@ search result that navigates and then sits there.
 `UninstallScanner.measure`, `FileSearchService.search`, and `Notes.search`. Open the Time Profiler or
 `os_signpost` instrument in Instruments and filter to that subsystem; nothing needs recompiling.
 
+None of the benchmarks below join the suite, so each is registered in `run-tests.sh` as `run index`
+instead: `--index` hands it editor flags without queueing it, and without that entry nothing in the
+file resolves. Keep the entry's source list matching the command beside it.
+
 Run the real Spotlight-backed file-search benchmark separately from the deterministic harnesses:
 
 ```sh
@@ -227,8 +231,8 @@ iteration count for timings, or `--probe` to diff every chunk between two builds
 `Tests/clipboard-file-performance.swift` measures file capture with private pasteboards and temporary
 fixtures. It reports wall and process CPU time as JSON for modern and legacy formats, including
 32/1,000/10,000 durable files, rejected-input controls and an uncapped-reader control that guards
-the attachment path against the bounded reader it now delegates to. Keep it outside
-`run-tests.sh`; compare three fresh processes per build with identical `-O` settings:
+the attachment path against the bounded reader it now delegates to. Compare three fresh processes
+per build with identical `-O` settings:
 
 ```sh
 swiftc -O -swift-version 6 Tinycast/Platform/PasteboardFiles.swift \


### PR DESCRIPTION
## Related issue

Closes #512. Follow-up to merged #507.

Submitted as a draft pending maintainer approval of the proposal and assessment of the memory/leak limitations below.

## What changed

A 10,000-file copy still decodes all 10,000 URLs before clipboard capture applies its 32-file limit. Decode in batches no larger than the capture cap, validate in source order, and stop at 32 accepted durable files. The final batch may decode up to 31 extra URLs; no durability predicate executes after the cap.

The existing uncapped attachment reader is unchanged. Modern file URLs suppress legacy filenames even when rejected. Nil/text fallback, symlinks, duplicates, volatile roots, standardized paths, reversed insertion order, the capture timer and internal/sensitive markers retain their behavior. No cache, dependency or visual change is introduced.

**Fresh baseline is current upstream `17ed8a1`**, including the maintainer-adjusted implementation merged in #507. This is a single commit based directly on that revision.

Apple M4 Pro / 24 GiB, macOS 26.6.2, Xcode 26.6, Swift 6.3.3. Identical `swiftc -O -swift-version 6` builds, three fresh processes per variant in alternating order, five timed calls after warm-up; synthetic fixture creation and private-pasteboard writes excluded. CPU is process user + system time; pasteboard-server CPU is excluded. Every call asserts exact output.

| Workload | Baseline median CPU | Candidate median CPU | Reduction |
| --- | ---: | ---: | ---: |
| 32 durable modern files | 0.756 ms | 0.536 ms | 29.1% |
| 1,000 durable modern files | 6.156 ms | 0.562 ms | 90.9% |
| 10,000 durable modern files | 56.928 ms | 0.750 ms | 98.7% |
| 10,000 missing modern files | 88.620 ms | 72.940 ms | 17.7% |
| 10,000 legacy-format files | 56.340 ms | 0.758 ms | 98.7% |
| 10,000 raw legacy fallback files | 34.703 ms | 3.221 ms | 90.7% |

For 10,000 modern files, CPU ranges across process means are 56.731–56.998 ms before and 0.735–1.080 ms after. Median wall time is 58.137 → 0.751 ms.

Separate instrumentation of the unchanged reader implementation confirms 10,000 → 32 URL decodes for valid capture, and 10,000 → 96 decodes / 72 predicate calls with 40 rejected inputs before accepted files. Instrumented timings are excluded.

macOS synthesizes modern items for normal `NSFilenamesPboardType` writes. The raw legacy fixture hides modern items only on one private pasteboard instance and verifies that all legacy paths remain present. This fixture override lives in the harnesses, not production.

The standalone series had variation on the unchanged uncapped reader. A separate same-board control compiles both implementations into one optimized binary and alternates order for 12 rounds in each of three fresh processes. Large uncapped CPU medians are 58.528 → 58.834 ms for modern items (+0.5%) and 35.686 → 35.576 ms for raw legacy (−0.3%), with overlapping ranges. No material large-input uncapped regression is established.

## Memory footprint

Refreshed on both complete Debug libraries after rebasing. Three fresh sandbox profiles per variant, alternating baseline/candidate order. The same host constructs AppCore, starts the real clipboard poller on a private board, opens the real palette, captures 10,000 files and waits five seconds after closing. It retains the input URL array and private board. AppCore.start and unrelated background services are excluded; helper processes are not included. Palette visibility at each measured stage was checked.

RSS in MiB, median [min–max]:

| Step | Baseline | Candidate |
| --- | ---: | ---: |
| Idle after launch | 81.81 [75.86–84.84] | 87.28 [82.12–89.67] |
| Palette open | 100.14 [88.16–103.70] | 106.33 [91.31–108.34] |
| Feature in use: process peak across cycle | 193.38 [183.33–199.38] | 187.33 [181.73–191.67] |
| Palette closed, settled | 131.52 [103.05–179.06] | 143.09 [111.42–159.42] |

`task_info(TASK_VM_INFO)` and `getrusage` supply the measurements. Kernel physical-footprint peak is 104.61 [99.08–106.33] → 99.50 [99.09–99.75] MiB; settled physical footprint is 63.58 [61.70–74.49] → 62.24 [61.45–65.52] MiB.

**RSS varies widely and the ranges overlap. The candidate’s settled median is higher in this refresh; this dataset does not establish a reliable RSS reduction or isolate a retained-memory regression.** Both builds exceed the project's 100 MB budget in this app-plus-fixture workload and do not return to startup RSS. These results do not satisfy a universal under-100-MB / return-to-baseline claim. Earlier controlled measurements are not substituted for this current-base comparison.

**Leak-tested: yes, with remaining broad UI reports.** Separate `MallocStackLogging=1 leaks --atExit` runs report:

| Scope | Allocations | Bytes |
| --- | ---: | ---: |
| Baseline UI | 344 | 21,504 |
| Candidate UI | 343 | 21,408 |
| Candidate built-library capture/write harness | 0 | 0 |

Both broad reports have the same root groups: three AppIntents/LinkServices NSXPCConnection cycles and 56 HIToolbox/CarbonCore keyboard-layout XML CFStrings. No root stack contains ClipboardManager or PasteboardFiles. These are existing framework signatures in both builds, not a zero-leak UI pass or a leak-elimination claim. Leak-instrumented runs are excluded from memory medians.

Follow-up baseline attribution (2026-09-09): two fresh minimal AppKit processes, with no Tinycast code linked, reproduce the baseline's exact 344 allocations / 21,504 bytes and both root families. Foundation-only controls report 0 / 0. Live scans reproduce both families in the sandbox (248 / 15,232); AppIntents/XPC cycles also reproduce without the sandbox (192 / 12,544 during both live scans). The keyboard-layout roots were only observed in the sandbox controls. Counts vary with asynchronous initialization and shutdown, so these are framework-origin scanner reports, not proof of universal leak freedom or a production fix. The 21 KiB baseline report cannot account for the tens of MiB of retained RSS, which remains unattributed.

## Demo

No visual change, so a before/after video is not applicable. The rebased built app passed computer-use smoke checks for timer-driven 10,000-file capture, exact first-32 ordering, rendered rows/previews and raw legacy capture. The production implementation is byte-identical to the earlier fully exercised version, whose isolated UI sweep covered search at/beyond the cap, filtering, navigation, pin/unpin, Copy, sensitive rejection, link fallback and clear-history cancellation. Further keyboard smoke checks during the refresh were stopped when user interaction changed focus.

The fixture verifies a fresh sandbox container, denied access to an outside canary and a process-local private replacement for NSPasteboard.general before AppCore construction. Real clipboard contents, external-app paste, global hotkeys, input switching, TCC and login items are excluded.

## Drawbacks

All-rejected input remains linear. The item array and legacy property list are still obtained whole, and each final batch may decode up to 31 unused URLs. This reduces capture CPU, not idle CPU. The added overload keeps the uncapped reader's behavior independent.

The RSS variability, budget exceedance and existing framework leak reports require maintainer assessment before this draft is ready to merge. No behavior change is intended.

## Tests & validation

- All **62 standalone harnesses** pass after rebasing, including both new upstream extension harnesses.
- **92/92** focused source checks and **92/92** checks against the actual built Debug app library; the latter also reports zero leaks.
- Negative/zero limits, 1/31/32/33 and Int.max boundaries; predicate invocation counts; modern/legacy precedence; raw legacy fallback; more than 32 rejected inputs; volatile/missing/broken symlinks; duplicates; uncapped extraction; file/text write-back, internal marker and vanished-file behavior.
- Both baseline/candidate Debug builds and the candidate Release build succeed. No new warnings; the existing AppIntents metadata-extraction warning remains.
- Lint passes with 54 existing warnings and none in changed files; recursive Model import purity and `git diff --check` pass.
- Three fresh-process CPU comparisons, three fresh interleaved uncapped controls, three fresh memory cycles per build and separate broad/focused leak runs. No builds or CPU benchmarks overlapped the memory campaign.
- Clipboard and testing docs updated. Full six-file diff read before submission; no inventory tooling or unrelated local changes included.
