### PR TITLE
fix(extensions): render search bar dropdowns

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -185,6 +185,11 @@ run palette-navigation-test Tinycast/Palette/PaletteState.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift \
                            Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
                            Tinycast/Features/CustomCommands/Model/CustomCommand.swift
+run palette-filter-test    Tinycast/Palette/PaletteMode.swift \
+                           Tinycast/Palette/PaletteFilterAction.swift \
+                           Tinycast/Features/Quicklinks/Model/Quicklink.swift \
+                           Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift \
+                           Tinycast/Features/CustomCommands/Model/CustomCommand.swift
 run palette-tab-test       Tinycast/Palette/PaletteMode.swift \
                            Tinycast/Palette/PaletteTabAction.swift \
                            Tinycast/Features/Quicklinks/Model/Quicklink.swift \
@@ -319,6 +324,10 @@ run ext-form-test          $E/Model/ExtensionFormMetrics.swift \
                            $E/Model/ExtensionDateExpression.swift \
                            $E/UI/ExtensionListKey.swift \
                            Tests/ext-list-key-test.swift
+run ext-accessory-test     $E/Model/RenderNode.swift \
+                           $E/Model/ExtensionPickerItem.swift \
+                           $E/Model/ExtensionSearchAccessory.swift \
+                           $E/Service/ExtensionStorage.swift
 run slow ext-test          -parse-as-library \
                            Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift \
@@ -331,6 +340,8 @@ run slow ext-test          -parse-as-library \
                            $E/Model/ExtensionRefreshPolicy.swift \
                            $E/Model/ExtensionRefreshState.swift \
                            $E/Model/RenderNode.swift \
+                           $E/Model/ExtensionPickerItem.swift \
+                           $E/Model/ExtensionSearchAccessory.swift \
                            $E/Service/ExtensionCatalog.swift \
                            $E/Service/ExtensionFetcher.swift \
                            $E/Service/ExtensionIconCache.swift \

--- a/Tests/ext-accessory-test.swift
+++ b/Tests/ext-accessory-test.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+/// Only `RenderNode.arguments(from:)` reaches for the runtime, and this harness never runs JS.
+enum ExtensionRuntime {
+    static func jsonArray(from json: String) -> [Any] { [] }
+}
+
+enum ExtensionCatalog {
+    static func safeName(_ name: String) -> String { name }
+}
+
+enum ExtensionPreferenceValue: Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+}
+
+struct ExtensionPreferenceSchema {
+    let name: String
+    let required: Bool
+    let effectiveDefault: ExtensionPreferenceValue
+
+    var displayTitle: String { name }
+}
+
+/// The search-bar dropdown's pure rules: how its choices are read, and which one it starts on.
+@main
+@MainActor
+struct ExtensionSearchAccessoryTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func main() {
+        parsing()
+        seeding()
+        storageIsolation()
+        print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
+        print("\(passes) passed, \(failures) failed")
+        exit(failures == 0 ? 0 : 1)
+    }
+
+    static func node(_ json: String) -> RenderNode {
+        let wrapped = """
+            {"children":[{"id":1,"type":"__screen","props":{"active":true},"children":[\(json)]}]}
+            """
+        guard let tree = RenderTree(json: wrapped), let root = tree.activeRoot else {
+            fatalError("test tree did not decode")
+        }
+        return root
+    }
+
+    /// The shape the Visual Studio Code extension ships: items inside an untitled section.
+    static let listJSON = """
+        {"id":2,"type":"List","props":{
+            "searchBarAccessory":{"id":9,"type":"List.Dropdown","props":{
+                "tooltip":"Filter project types","defaultValue":"All Types","storeValue":true,
+                "onChange":{"$fn":"9:onChange"}},"children":[
+                {"id":10,"type":"List.Dropdown.Item","props":{
+                    "title":"All Types","value":"All Types"},"children":[]},
+                {"id":11,"type":"List.Dropdown.Section","props":{},"children":[
+                    {"id":12,"type":"List.Dropdown.Item","props":{
+                        "title":"Folders","value":"Folders",
+                        "icon":{"source":"folder-16"}},"children":[]},
+                    {"id":13,"type":"List.Dropdown.Item","props":{
+                        "title":"Workspaces","value":"Workspaces"},"children":[]}]}]}},
+            "children":[]}
+        """
+
+    /// Same dropdown with no props at all: nothing to seed it from but its own first choice.
+    static let bareJSON = """
+        {"id":2,"type":"List","props":{
+            "searchBarAccessory":{"id":9,"type":"List.Dropdown","props":{},"children":[
+                {"id":10,"type":"List.Dropdown.Item","props":{
+                    "title":"One","value":"one"},"children":[]},
+                {"id":11,"type":"List.Dropdown.Item","props":{
+                    "title":"Two","value":"two"},"children":[]}]}},
+            "children":[]}
+        """
+
+    static func parse(_ json: String) -> ExtensionSearchAccessory? {
+        ExtensionSearchAccessory(node: node(json).node("searchBarAccessory"))
+    }
+
+    static func parsing() {
+        guard let accessory = parse(listJSON) else {
+            check("a dropdown parses", false)
+            return
+        }
+        check("a dropdown parses", true)
+        check("node id kept", accessory.nodeID == 9)
+        check("onChange handle kept", accessory.onChange == "9:onChange")
+        check("defaultValue kept", accessory.defaultValue == "All Types")
+        check(
+            "storeValue names a storage key", accessory.storageKey == "searchBarAccessory",
+            accessory.storageKey ?? "nil")
+        check(
+            "items flatten in order, section carried",
+            accessory.items.map { "\($0.value)|\($0.section ?? "-")" }
+                == ["All Types|-", "Folders|-", "Workspaces|-"],
+            accessory.items.map(\.value).joined(separator: ","))
+        check("an item's icon survives", accessory.item(for: "Folders")?.iconValue != nil)
+        check("a title resolves from a value", accessory.title(for: "Folders") == "Folders")
+        check("a value no item claims still reads as itself", accessory.title(for: "x") == "x")
+        check("the held choice is the row the list opens on", accessory.index(of: "Workspaces") == 2)
+        check("an unheld choice opens on the first row", accessory.index(of: "Gone") == 0)
+
+        check("a List root is not a dropdown", ExtensionSearchAccessory(node: node(listJSON)) == nil)
+        let grid = listJSON.replacingOccurrences(of: "List.Dropdown", with: "Grid.Dropdown")
+            .replacingOccurrences(of: "\"type\":\"List\"", with: "\"type\":\"Grid\"")
+        check("a Grid dropdown parses too", parse(grid)?.items.count == 3)
+
+        guard let bare = parse(bareJSON) else {
+            check("a bare dropdown parses", false)
+            return
+        }
+        check("a bare dropdown parses", true)
+        check("without storeValue nothing is persisted", bare.storageKey == nil)
+        check("without a value the extension controls nothing", bare.controlledValue == nil)
+
+        let controlled = bareJSON.replacingOccurrences(
+            of: "\"props\":{}", with: "\"props\":{\"value\":\"two\"}")
+        check("a value prop is the extension's own", parse(controlled)?.controlledValue == "two")
+    }
+
+    /// Which choice a dropdown lands on before anyone has touched it.
+    static func seeding() {
+        guard let accessory = parse(listJSON), let bare = parse(bareJSON) else {
+            check("the seeding fixtures parse", false)
+            return
+        }
+        check("defaultValue seeds it", accessory.initialValue(stored: nil) == "All Types")
+        check(
+            "a stored pick wins while it still names an item",
+            accessory.initialValue(stored: "Folders") == "Folders")
+        check(
+            "a stale stored pick falls back to defaultValue",
+            accessory.initialValue(stored: "Gone") == "All Types")
+        check(
+            "with nothing to go on it starts on the first choice",
+            bare.initialValue(stored: nil) == "one", bare.initialValue(stored: nil) ?? "nil")
+        check(
+            "an empty dropdown seeds nothing",
+            ExtensionSearchAccessory(
+                node: node(
+                    """
+                    {"id":2,"type":"List","props":{"searchBarAccessory":{
+                        "id":9,"type":"List.Dropdown","props":{},"children":[]}},"children":[]}
+                    """
+                ).node("searchBarAccessory"))?.initialValue(stored: nil) == nil)
+    }
+
+    static func storageIsolation() {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tinycast-ext-accessory-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storage = ExtensionStorage(directory: directory)
+        storage.setLocalStorage(extension: "sample", key: "filter", value: .string("extension-data"))
+        storage.setAccessoryValue(extension: "sample", key: "filter", value: "selected")
+        check(
+            "a pick never lands in the namespace JavaScript reads",
+            storage.localStorageValue(extension: "sample", key: "filter") == .string("extension-data"))
+        check(
+            "a pick reads back on its own",
+            storage.accessoryValue(extension: "sample", key: "filter") == "selected")
+        storage.flush()
+
+        let reloaded = ExtensionStorage(directory: directory)
+        check(
+            "a pick survives a reload",
+            reloaded.accessoryValue(extension: "sample", key: "filter") == "selected")
+
+        // A store written before dropdowns held anything: the missing key must cost nothing.
+        storage.setLocalStorage(extension: "older", key: "kept", value: .string("value"))
+        storage.setPreference(extension: "older", key: "token", value: .string("secret"))
+        storage.flush()
+        let file = directory.appendingPathComponent("older.json")
+        if var older = (try? Data(contentsOf: file))
+            .flatMap({ try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        {
+            older.removeValue(forKey: "accessoryValues")
+            if let data = try? JSONSerialization.data(withJSONObject: older) {
+                try? data.write(to: file)
+            }
+        }
+        let older = ExtensionStorage(directory: directory)
+        check(
+            "a store with no accessory section keeps its localStorage",
+            older.localStorageValue(extension: "older", key: "kept") == .string("value"))
+        check(
+            "a store with no accessory section keeps its preferences",
+            older.preference(extension: "older", key: "token") == .string("secret"))
+    }
+
+    static func check(_ label: String, _ condition: Bool, _ detail: String = "") {
+        if condition {
+            passes += 1
+            print("ok    \(label)")
+        } else {
+            failures += 1
+            print("FAIL  \(label)\(detail.isEmpty ? "" : " — \(detail)")")
+        }
+    }
+}

--- a/Tests/ext-test.swift
+++ b/Tests/ext-test.swift
@@ -188,6 +188,7 @@ struct ExtensionTests {
         actionIconChecks()
         oauthUnitChecks()
         await runtimeChecks()
+        await searchAccessoryRuntimeChecks()
 
         print("\n\(passes) passed, \(failures) failed")
         exit(failures == 0 ? 0 : 1)
@@ -895,6 +896,89 @@ struct ExtensionTests {
 
         await swiftHelperChecks()
         zlibChecks()
+    }
+
+    /// Drives a dropdown-filtered command from its empty first render to visible results.
+    @MainActor
+    static func searchAccessoryRuntimeChecks() async {
+        let (runtime, _, recorder) = makeRuntime()
+        do {
+            try await runtime.boot(
+                config: .current(supportDirectory: FileManager.default.temporaryDirectory))
+        } catch {
+            check("search accessory runtime boots", false, error.localizedDescription)
+            return
+        }
+
+        let command = """
+            "use strict";
+            const { List } = require("@raycast/api");
+            const React = require("react");
+            const h = React.createElement;
+            module.exports.default = function Command() {
+              const [type, setType] = React.useState(null);
+              const accessory = h(List.Dropdown, {
+                defaultValue: "all",
+                onChange: setType,
+              },
+                h(List.Dropdown.Item, { title: "All Types", value: "all" }),
+                h(List.Dropdown.Item, { title: "Folders", value: "folders" })
+              );
+              return h(List, { searchBarAccessory: accessory },
+                type ? h(List.Item, { title: "filter=" + type }) : null
+              );
+            };
+            """
+        await runtime.start(
+            session: "sAccessory", code: command,
+            file: URL(fileURLWithPath: "/tmp/search-accessory.js"), mode: .view,
+            context: launchContext())
+        await settle()
+
+        guard let firstTree = recorder.trees.last else {
+            check("dropdown-filtered command renders", false)
+            runtime.shutdown()
+            return
+        }
+        let firstScreen = ExtensionScreen(tree: firstTree, query: "")
+        check("dropdown-filtered command starts empty", firstScreen.items.isEmpty)
+        guard
+            let accessory = ExtensionSearchAccessory(
+                node: firstTree.activeRoot?.node("searchBarAccessory")),
+            let initialValue = accessory.initialValue(stored: nil),
+            let handler = accessory.onChange
+        else {
+            check("live dropdown exposes an initial dispatch", false)
+            runtime.shutdown()
+            return
+        }
+        check("live dropdown exposes an initial dispatch", initialValue == "all")
+        check("an uncontrolled dropdown leaves the value to Swift", accessory.controlledValue == nil)
+
+        await runtime.dispatch(
+            session: "sAccessory", handler: handler,
+            payload: ExtensionRuntime.jsonString(from: [initialValue]))
+        await settle()
+        let seededScreen = recorder.trees.last.map { ExtensionScreen(tree: $0, query: "") }
+        check(
+            "initial dropdown dispatch reveals filtered rows",
+            seededScreen?.items.first?.node.string("title") == "filter=all",
+            seededScreen?.items.first?.node.string("title") ?? "no row")
+
+        let renderCount = recorder.trees.count
+        await settle(50)
+        check(
+            "a seeded dropdown settles rather than re-rendering",
+            recorder.trees.count == renderCount,
+            "\(renderCount) → \(recorder.trees.count)")
+
+        // The node id is what the held pick is keyed by, so a re-render must not renumber it.
+        check(
+            "the dropdown keeps its node id across renders",
+            recorder.trees.last.flatMap {
+                ExtensionSearchAccessory(node: $0.activeRoot?.node("searchBarAccessory"))?.nodeID
+            } == accessory.nodeID)
+        await runtime.stop(session: "sAccessory")
     }
 
     /// Raycast's `swift:` wrapper chmods its bundled helper before spawning it: store zips ship it 644.

--- a/Tests/palette-filter-test.swift
+++ b/Tests/palette-filter-test.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// ⌘P opens exactly one filter, and every mode that had no filter before still has none.
+@main
+@MainActor
+struct PaletteFilterTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(
+        _ actual: PaletteFilterAction, _ expected: PaletteFilterAction, _ message: String
+    ) {
+        if actual == expected {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message) — got \(actual), want \(expected)")
+        }
+    }
+
+    static func resolve(
+        collapsed: Bool = false, mode: PaletteMode, accessory: Bool = false
+    ) -> PaletteFilterAction {
+        PaletteFilterAction.resolve(
+            collapsed: collapsed, mode: mode, commandHasAccessory: accessory)
+    }
+
+    static func main() {
+        expect(
+            resolve(mode: .clipboard), .clipboardFilter,
+            "the clipboard's type filter is what ⌘P has always opened")
+        expect(
+            resolve(mode: .extensionCommand, accessory: true), .extensionAccessory,
+            "a running command's own dropdown answers ⌘P on its own screen")
+
+        // The regression this guards: a command's dropdown must not let the clipboard's filter
+        // open over it, and must not swallow ⌘P on a command that declared none.
+        expect(
+            resolve(mode: .extensionCommand, accessory: false), .ignored,
+            "a command with no dropdown leaves ⌘P alone rather than opening nothing")
+        expect(
+            resolve(mode: .clipboard, accessory: true), .clipboardFilter,
+            "off an extension screen the flag cannot reach the clipboard's own filter")
+
+        // Every other mode was untouched by ⌘P before and has to stay that way.
+        for mode in [
+            PaletteMode.launcher, .ai, .aiHistory, .emoji, .fileSearch, .calculatorHistory,
+            .quicklinks, .snippets, .schedule, .uninstall, .customCommandArguments
+        ] {
+            expect(
+                resolve(mode: mode), .ignored,
+                "\(mode.rawValue) has no header filter, so ⌘P stays with the field")
+            expect(
+                resolve(mode: mode, accessory: true), .ignored,
+                "\(mode.rawValue) opens no filter even if a stale accessory flag says so")
+        }
+
+        // Collapsed there is no header to hang a button off, so neither filter may open.
+        for mode in [PaletteMode.clipboard, .extensionCommand, .launcher] {
+            expect(
+                resolve(collapsed: true, mode: mode, accessory: true), .ignored,
+                "the compact bar draws no filter button, so ⌘P opens nothing on \(mode.rawValue)")
+        }
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		3C23AEA2FDDB7BD61278BD77 /* QuickActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5941CE8F08FD5986FED12E9 /* QuickActionsSettingsView.swift */; };
 		3C2812B921530D45B802B44C /* PaletteTabAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B107F5E532C8DE74430723B /* PaletteTabAction.swift */; };
 		3C30FB1AD99237898B4401C7 /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7DC9AD5E54C26387F29F6 /* MarkdownView.swift */; };
+		3CA5E8EB5D591F710C8AD897 /* ExtensionPickerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD80BC6110C36450C2FF751 /* ExtensionPickerItem.swift */; };
 		3D00EF47CECC95BAEDD372FA /* SettingsScrollTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC407C844BE73916C6C526F1 /* SettingsScrollTarget.swift */; };
 		3D56F518ABEF5851534A710C /* AISettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C975F928132D3DAB1BB569F0 /* AISettingsStore.swift */; };
 		3DAB1821040DCA295BEB4437 /* AICommandSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ABB8CDB1469F8755B12567 /* AICommandSection.swift */; };
@@ -194,6 +195,7 @@
 		552B7230E78D2C05793EC013 /* ExtensionNodeShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A0A3867D1B8E1D3284471 /* ExtensionNodeShims.swift */; };
 		555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F1080FB443A1D0616790E /* FavoritesStore.swift */; };
 		55CDBFDB13B816FFFB6CC867 /* MCPTrustPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A724FAAD08B77AA54D080E45 /* MCPTrustPolicy.swift */; };
+		5679661058689EC8FF1C5C11 /* PaletteFilterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621B09CB5CF15517D9FDAB5B /* PaletteFilterAction.swift */; };
 		56E4958BCEF1FED10B4A796E /* UpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */; };
 		56EB00CB2815CC268829C97B /* AIAttachmentPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBB9959DB6CA493D241080C /* AIAttachmentPolicy.swift */; };
 		576CE9CDD0E373C8FFEA5D1D /* WindowLayoutPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB691265C48648210F1F6D7 /* WindowLayoutPreview.swift */; };
@@ -444,6 +446,7 @@
 		CE270F368B8D824A2B8A0A71 /* ChatHistoryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A061D1B64684905BA0E998C5 /* ChatHistoryScreen.swift */; };
 		CEE0B612FFDB0AFFEF23A8A1 /* SearchScopesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC45597561DCD90F51506F7 /* SearchScopesSection.swift */; };
 		CF1015EA1573EFBBA647B93B /* ExtensionRegistriesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA081CD5CEA054447D0691F /* ExtensionRegistriesSheet.swift */; };
+		CF59A1D1C7FE76558B638460 /* ExtensionSearchAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBBC69BC9727C5E3FE77120 /* ExtensionSearchAccessory.swift */; };
 		CFAC92920F69461FA653AEDA /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB44DCF1B6B9C9846CFB053D /* CameraView.swift */; };
 		CFBD94098A1F79035DD53ED4 /* SelectionFollowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2702F140F8DBF373D2ED11A5 /* SelectionFollowing.swift */; };
 		D023C469FB541A7175AACA3B /* ExtensionCommandMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43675F37B244C5CBC293CFE2 /* ExtensionCommandMetadata.swift */; };
@@ -506,6 +509,7 @@
 		EBCDF88CD59A4B6F21F945C6 /* Quicklink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3385A84985A52E2DA3596 /* Quicklink.swift */; };
 		EBFD65E82A7633ECB132A4D4 /* RaycastDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA2AB248B239E2EF9276187 /* RaycastDecoder.swift */; };
 		EC39E2815103B5C4BEE8AED6 /* ExtensionFormKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57640B0DA3F71E66CECA871C /* ExtensionFormKey.swift */; };
+		ECAE658F8DCCE74E49FDFFC2 /* ExtensionSearchAccessoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB044816D6A7BC72E676A6C /* ExtensionSearchAccessoryButton.swift */; };
 		ECD777BD408E9DC2C93CFC1B /* CalcUnitExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639F73227BB0A4B9CD889D81 /* CalcUnitExpression.swift */; };
 		ED62826E3D7CEB357865F9EB /* CalcDimension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E0A469BE1984BEF1A9A50 /* CalcDimension.swift */; };
 		EDD7861202ECC1B0FA3B278E /* FileSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7420F642776452B469182D0 /* FileSearchResult.swift */; };
@@ -711,6 +715,7 @@
 		4EF9F16C3F5567240FF03122 /* CalcQuantity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcQuantity.swift; sourceTree = "<group>"; };
 		4FA081CD5CEA054447D0691F /* ExtensionRegistriesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRegistriesSheet.swift; sourceTree = "<group>"; };
 		4FAE24CC14F7DFECD1BD7FB1 /* PopoverMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverMenu.swift; sourceTree = "<group>"; };
+		4FBBC69BC9727C5E3FE77120 /* ExtensionSearchAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionSearchAccessory.swift; sourceTree = "<group>"; };
 		4FBE70702D22F894C6B1A790 /* AITool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITool.swift; sourceTree = "<group>"; };
 		50A8322A12267B2A82422281 /* CalcNumberBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcNumberBase.swift; sourceTree = "<group>"; };
 		50E2E570E54DEEF29FF2B65E /* NotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesView.swift; sourceTree = "<group>"; };
@@ -738,6 +743,7 @@
 		5B330ABFC83721904159DDF2 /* MeetingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEvent.swift; sourceTree = "<group>"; };
 		5B883E55507FA5BE11A31B54 /* MCPServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerConnection.swift; sourceTree = "<group>"; };
 		5BBDB6A6CE9564ADA2D16F53 /* AppDisplayName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDisplayName.swift; sourceTree = "<group>"; };
+		5CB044816D6A7BC72E676A6C /* ExtensionSearchAccessoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionSearchAccessoryButton.swift; sourceTree = "<group>"; };
 		5D2DDA019FE0EF38A91AA495 /* ExtensionCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCommandView.swift; sourceTree = "<group>"; };
 		5D6FD4FBAC3F5E6255D62773 /* MenuBarSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarSummary.swift; sourceTree = "<group>"; };
 		5DADE9F769787D44F72A2071 /* ShortcutRecorderPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderPopover.swift; sourceTree = "<group>"; };
@@ -747,6 +753,7 @@
 		60CCB1A47E0022BAEDD1EE96 /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
 		61D7B06067FB35E7CC6C1E09 /* FallbacksSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbacksSettingsView.swift; sourceTree = "<group>"; };
 		61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkDestination.swift; sourceTree = "<group>"; };
+		621B09CB5CF15517D9FDAB5B /* PaletteFilterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteFilterAction.swift; sourceTree = "<group>"; };
 		622E1F1C01B954DCA2199BCD /* ScrollIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollIntent.swift; sourceTree = "<group>"; };
 		62F2B0F5FDD503E6BB739A47 /* UninstallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallView.swift; sourceTree = "<group>"; };
 		639F73227BB0A4B9CD889D81 /* CalcUnitExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcUnitExpression.swift; sourceTree = "<group>"; };
@@ -978,6 +985,7 @@
 		CA9287418DC6C04437FB4BAF /* ColorValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorValue.swift; sourceTree = "<group>"; };
 		CA97F3257C2FA99BF185ED8A /* CalcOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcOperator.swift; sourceTree = "<group>"; };
 		CBCCFC1039C315D2F74418FE /* UpdateWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateWindowView.swift; sourceTree = "<group>"; };
+		CBD80BC6110C36450C2FF751 /* ExtensionPickerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPickerItem.swift; sourceTree = "<group>"; };
 		CBFF39C46E98D0808B188E2E /* FileSearchIgnoreList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchIgnoreList.swift; sourceTree = "<group>"; };
 		CC02192DE787DBE081C589B8 /* KeychainSecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainSecretStore.swift; sourceTree = "<group>"; };
 		CC2FF20C8537905F65AEF2EB /* QuicklinkArgumentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsRow.swift; sourceTree = "<group>"; };
@@ -1586,9 +1594,11 @@
 				47B4E3146143B6120340EC01 /* ExtensionLaunchType.swift */,
 				30BBF211CE6A076EAF8D6C33 /* ExtensionManifest.swift */,
 				0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */,
+				CBD80BC6110C36450C2FF751 /* ExtensionPickerItem.swift */,
 				5133D376B62B69B9C8F03590 /* ExtensionRefreshPolicy.swift */,
 				582A70CF432F5E0144E57369 /* ExtensionRefreshState.swift */,
 				810AA3AD31C7E11932E34F28 /* ExtensionRegistry.swift */,
+				4FBBC69BC9727C5E3FE77120 /* ExtensionSearchAccessory.swift */,
 				7732FB0ED92C8FBFE22599CE /* ExtensionStoreResponse.swift */,
 				08A1D354C1785923E612848C /* RenderNode.swift */,
 			);
@@ -2120,6 +2130,7 @@
 				5B1FC5C77AA5F4DD6E2D9B4D /* ExtensionPickerList.swift */,
 				996CF61F3B13A573B8D5A11F /* ExtensionRefreshIndicator.swift */,
 				CCCBDD92DEAD780A1DC423CA /* ExtensionScreen.swift */,
+				5CB044816D6A7BC72E676A6C /* ExtensionSearchAccessoryButton.swift */,
 				A7751EBF0F632A123B4A2363 /* ExtensionTintColors.swift */,
 			);
 			path = UI;
@@ -2264,6 +2275,7 @@
 				418527DD2F2370A1B82A13B7 /* PaletteDropGuideView.swift */,
 				524404EF88622426B0AA4E33 /* PaletteEnvironment.swift */,
 				53D7E98E448F05816493DB37 /* PaletteEscapeAction.swift */,
+				621B09CB5CF15517D9FDAB5B /* PaletteFilterAction.swift */,
 				1534DB79CC23709ABC5E9D9B /* PaletteMode.swift */,
 				BA9F3FA9925873D25EAF7D03 /* PalettePanel.swift */,
 				802BD2F4CC057228F2528217 /* PalettePlacement.swift */,
@@ -2902,6 +2914,7 @@
 				FA386C9B6DA24481565D506D /* ExtensionPackageManager.swift in Sources */,
 				2D51D92BE8EAB5440F4C8517 /* ExtensionPaletteModifiers.swift in Sources */,
 				8B265BFDDDDAFCC45B35BDCB /* ExtensionPickerField.swift in Sources */,
+				3CA5E8EB5D591F710C8AD897 /* ExtensionPickerItem.swift in Sources */,
 				F5CC30A7FD6D8F11187D631B /* ExtensionPickerList.swift in Sources */,
 				D3C7265B00695CE274ED5A23 /* ExtensionRefreshIndicator.swift in Sources */,
 				45C35CBBED43903124081D00 /* ExtensionRefreshPolicy.swift in Sources */,
@@ -2910,6 +2923,8 @@
 				6FC9F74D9119AC25D178D748 /* ExtensionRegistry.swift in Sources */,
 				50A3CB2A348F8E03D467B169 /* ExtensionRuntime.swift in Sources */,
 				F51785CF5A6EC0B87D6802C9 /* ExtensionScreen.swift in Sources */,
+				CF59A1D1C7FE76558B638460 /* ExtensionSearchAccessory.swift in Sources */,
+				ECAE658F8DCCE74E49FDFFC2 /* ExtensionSearchAccessoryButton.swift in Sources */,
 				606809BC14D6613B847036D0 /* ExtensionStorage.swift in Sources */,
 				9608AFDEDC3B330E64F53437 /* ExtensionStoreClient.swift in Sources */,
 				0120AF7AB3AD249C484C8A03 /* ExtensionStoreResponse.swift in Sources */,
@@ -3031,6 +3046,7 @@
 				A47E49315D60D94CF75E22C9 /* PaletteDropGuideView.swift in Sources */,
 				695898F8FF98200F180FC2CA /* PaletteEnvironment.swift in Sources */,
 				8E30C461429C894907FAD94D /* PaletteEscapeAction.swift in Sources */,
+				5679661058689EC8FF1C5C11 /* PaletteFilterAction.swift in Sources */,
 				25E7E031DCF72BFF19725344 /* PaletteMode.swift in Sources */,
 				8090FBE343746D9D43EE2B24 /* PalettePanel.swift in Sources */,
 				1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */,

--- a/Tinycast/Features/Extensions/Model/ExtensionPickerItem.swift
+++ b/Tinycast/Features/Extensions/Model/ExtensionPickerItem.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// One choice offered by a picker's list, from a `Form.Dropdown`/`Form.TagPicker` or from the
+/// search-bar dropdown an extension handed the screen in `searchBarAccessory`.
+struct ExtensionPickerItem: Identifiable, Equatable {
+    let value: String
+    let title: String
+    var detail: String?
+    var iconValue: RenderValue?
+    /// The section this choice was declared under, drawn above the first of them.
+    var section: String?
+
+    var id: String { value }
+
+    /// A picker's choices: direct children, or grouped in sections that carry the heading.
+    static func items(in node: RenderNode) -> [ExtensionPickerItem] {
+        var items: [ExtensionPickerItem] = []
+        func walk(_ node: RenderNode, section: String?) {
+            for child in node.children {
+                if child.type.hasSuffix(".Item") {
+                    let value = child.string("value") ?? ""
+                    items.append(
+                        ExtensionPickerItem(
+                            value: value, title: child.string("title") ?? value,
+                            iconValue: child.props["icon"], section: section))
+                } else if child.type.hasSuffix(".Section") {
+                    walk(child, section: child.string("title"))
+                }
+            }
+        }
+        walk(node, section: nil)
+        return items
+    }
+}

--- a/Tinycast/Features/Extensions/Model/ExtensionSearchAccessory.swift
+++ b/Tinycast/Features/Extensions/Model/ExtensionSearchAccessory.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The `List.Dropdown`/`Grid.Dropdown` an extension put in the search bar. The runtime keeps the
+/// component hook-free, so Swift holds the selection and reports every change through `onChange`.
+struct ExtensionSearchAccessory: Equatable {
+    /// The render node's id, which is what the session keys the held selection by.
+    let nodeID: Int
+    let items: [ExtensionPickerItem]
+    let onChange: String?
+    /// A `value` prop: while the extension supplies one it owns the selection, not the user.
+    let controlledValue: String?
+    let defaultValue: String?
+    /// Where `storeValue` parks the pick, or nil when the dropdown never asked to persist one.
+    let storageKey: String?
+    let placeholder: String?
+    let tooltip: String?
+
+    init?(node: RenderNode?) {
+        guard let node, node.type == "List.Dropdown" || node.type == "Grid.Dropdown" else {
+            return nil
+        }
+        nodeID = node.id
+        items = ExtensionPickerItem.items(in: node)
+        onChange = node.handler("onChange")
+        controlledValue = node.string("value")
+        defaultValue = node.string("defaultValue")
+        // Raycast keys the stored pick by the dropdown's own id; one per command needs no id.
+        storageKey =
+            node.bool("storeValue") == true ? (node.string("id") ?? "searchBarAccessory") : nil
+        placeholder = node.string("placeholder")
+        tooltip = node.string("tooltip")
+    }
+
+    /// Raycast's order: the stored pick while it still names a choice, else `defaultValue`, else
+    /// the first choice — a dropdown always shows one.
+    func initialValue(stored: String?) -> String? {
+        if let stored, items.contains(where: { $0.value == stored }) { return stored }
+        return defaultValue ?? items.first?.value
+    }
+
+    /// What the closed control reads as; a value no item claims is still the value.
+    func title(for value: String?) -> String? {
+        guard let value else { return placeholder ?? tooltip }
+        return item(for: value)?.title ?? value
+    }
+
+    func item(for value: String?) -> ExtensionPickerItem? {
+        guard let value else { return nil }
+        return items.first { $0.value == value }
+    }
+
+    /// The row the list opens on, so the choice it holds is the one already highlighted.
+    func index(of value: String?) -> Int {
+        items.firstIndex { $0.value == value } ?? 0
+    }
+}

--- a/Tinycast/Features/Extensions/Service/ExtensionManager.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionManager.swift
@@ -23,6 +23,8 @@ final class ExtensionManager: ExtensionRuntimeDelegate, ExtensionHostContext {
     private(set) var toasts: [ExtensionToast] = []
     /// Depth of the extension's own navigation stack; >1 means Escape should pop rather than close.
     private(set) var navigationDepth = 1
+    /// Each search-bar dropdown's choice, keyed by node so a pushed screen keeps its own.
+    private(set) var accessoryValues: [Int: String] = [:]
 
     /// Off means nothing scanned, published or held: the feature costs an unused stored property.
     private(set) var isEnabled = false
@@ -400,6 +402,7 @@ final class ExtensionManager: ExtensionRuntimeDelegate, ExtensionHostContext {
         running = nil
         toasts = []
         navigationDepth = 1
+        accessoryValues = [:]
     }
 
     // MARK: - Background refresh
@@ -647,6 +650,42 @@ final class ExtensionManager: ExtensionRuntimeDelegate, ExtensionHostContext {
         Task { await runtime.dispatch(session: sessionID, handler: handler, payload: payload) }
     }
 
+    // MARK: - Search-bar dropdowns
+
+    /// What the dropdown shows: the extension's own `value` when it controls one, else the pick.
+    func accessorySelection(_ accessory: ExtensionSearchAccessory) -> String? {
+        accessory.controlledValue ?? accessoryValues[accessory.nodeID]
+    }
+
+    /// A pick persists where the dropdown asked it to, then tells the extension, as Raycast does.
+    func chooseAccessorySelection(_ accessory: ExtensionSearchAccessory, value: String) {
+        accessoryValues[accessory.nodeID] = value
+        if let key = accessory.storageKey, let name = running?.extensionName {
+            storage.setAccessoryValue(extension: name, key: key, value: value)
+        }
+        guard let handler = accessory.onChange else { return }
+        dispatch(handler: handler, arguments: [value])
+    }
+
+    /// Raycast reports a dropdown's opening choice through `onChange`, and an extension that
+    /// filters its rows by that value draws nothing until it arrives. A controlled one needs none.
+    private func seedSearchBarAccessory(in tree: RenderTree) {
+        guard
+            let accessory = ExtensionSearchAccessory(
+                node: tree.activeRoot?.node("searchBarAccessory")),
+            accessory.controlledValue == nil, accessoryValues[accessory.nodeID] == nil,
+            let value = accessory.initialValue(stored: storedAccessoryValue(accessory))
+        else { return }
+        accessoryValues[accessory.nodeID] = value
+        guard let handler = accessory.onChange else { return }
+        dispatch(handler: handler, arguments: [value])
+    }
+
+    private func storedAccessoryValue(_ accessory: ExtensionSearchAccessory) -> String? {
+        guard let key = accessory.storageKey, let name = running?.extensionName else { return nil }
+        return storage.accessoryValue(extension: name, key: key)
+    }
+
     /// Pops the extension's stack; false when there is nothing to pop and the palette should close.
     func popNavigation() async -> Bool {
         guard let sessionID, navigationDepth > 1 else { return false }
@@ -663,6 +702,7 @@ final class ExtensionManager: ExtensionRuntimeDelegate, ExtensionHostContext {
         guard session == sessionID else { return }
         state = .rendered(tree)
         navigationDepth = tree.depth
+        seedSearchBarAccessory(in: tree)
     }
 
     func runtime(_ runtime: ExtensionRuntime, session: String, didFail message: String) {

--- a/Tinycast/Features/Extensions/Service/ExtensionStorage.swift
+++ b/Tinycast/Features/Extensions/Service/ExtensionStorage.swift
@@ -7,6 +7,28 @@ final class ExtensionStorage {
         var localStorage: [String: StoredValue] = [:]
         var caches: [String: [String: String]] = [:]
         var preferences: [String: StoredValue] = [:]
+        /// A search-bar dropdown's `storeValue` pick — host UI state, so not `LocalStorage`.
+        var accessoryValues: [String: String] = [:]
+
+        enum CodingKeys: String, CodingKey {
+            case localStorage, caches, preferences, accessoryValues
+        }
+
+        init() {}
+
+        /// Each section decodes on its own: one absent key must not take an extension's whole
+        /// store — API keys included — down with it, since a failed decode resets the file.
+        init(from decoder: Decoder) throws {
+            let store = try decoder.container(keyedBy: CodingKeys.self)
+            localStorage =
+                try store.decodeIfPresent([String: StoredValue].self, forKey: .localStorage) ?? [:]
+            caches =
+                try store.decodeIfPresent([String: [String: String]].self, forKey: .caches) ?? [:]
+            preferences =
+                try store.decodeIfPresent([String: StoredValue].self, forKey: .preferences) ?? [:]
+            accessoryValues =
+                try store.decodeIfPresent([String: String].self, forKey: .accessoryValues) ?? [:]
+        }
     }
 
     /// `LocalStorage` accepts strings, numbers and booleans and must return them with their type.
@@ -80,6 +102,16 @@ final class ExtensionStorage {
 
     func clearLocalStorage(extension name: String) {
         mutate(name) { $0.localStorage.removeAll() }
+    }
+
+    // MARK: - Search-bar dropdowns
+
+    func accessoryValue(extension name: String, key: String) -> String? {
+        store(for: name).accessoryValues[key]
+    }
+
+    func setAccessoryValue(extension name: String, key: String, value: String) {
+        mutate(name) { $0.accessoryValues[key] = value }
     }
 
     // MARK: - Cache

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandScreen.swift
@@ -103,6 +103,47 @@ struct ExtensionCommandScreen: PaletteScreen {
 
     func secondary(at selection: Int) -> Bool { false }
 
+    /// The `searchBarAccessory` dropdown; an empty one states and opens nothing, so it is none.
+    var searchAccessory: ExtensionSearchAccessory? {
+        guard let accessory = ExtensionSearchAccessory(node: screen.searchBarAccessory),
+            !accessory.items.isEmpty
+        else { return nil }
+        return accessory
+    }
+
+    /// The header control for it, as an opaque box the palette only seats and toggles.
+    func searchAccessoryButton(
+        _ accessory: ExtensionSearchAccessory, isOpen: Bool, action: @escaping () -> Void
+    ) -> AnyView {
+        AnyView(
+            ExtensionSearchAccessoryButton(
+                accessory: accessory, value: extensions.accessorySelection(accessory),
+                assetsPath: assetsPath, isOpen: isOpen, action: action))
+    }
+
+    /// Its choices as a palette menu, so the arrows, ↵, Escape and the click-away come free.
+    func searchAccessoryMenu(
+        menuSelection: Binding<Int>, onActivate: @escaping (Int) -> Void
+    ) -> PaletteMenuContent? {
+        guard let accessory = searchAccessory else { return nil }
+        let chosen = extensions.accessorySelection(accessory).map { Set([$0]) } ?? []
+        let assetsPath = assetsPath
+        let extensions = extensions
+        return PaletteMenuContent(
+            rowCount: accessory.items.count,
+            view: {
+                AnyView(
+                    ExtensionPickerList(
+                        items: accessory.items, selection: menuSelection.wrappedValue,
+                        chosen: chosen, assetsPath: assetsPath,
+                        width: ExtensionSearchAccessoryButton.listWidth, onSelect: onActivate,
+                        onHighlight: { menuSelection.wrappedValue = $0 }))
+            },
+            activate: { index in
+                extensions.chooseAccessorySelection(accessory, value: accessory.items[index].value)
+            })
+    }
+
     func body(selection: Int, scroll: ScrollIntent) -> AnyView {
         AnyView(
             ExtensionCommandView(

--- a/Tinycast/Features/Extensions/UI/ExtensionFormView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionFormView.swift
@@ -117,7 +117,7 @@ struct ExtensionFormView: View {
         case "Form.Dropdown":
             labelled(field) {
                 ExtensionPickerField(
-                    items: ExtensionFormView.items(in: field),
+                    items: ExtensionPickerItem.items(in: field),
                     chosen: [field.string("value") ?? ""].filter { !$0.isEmpty },
                     placeholder: field.string("placeholder") ?? "Select…",
                     title: field.string("title") ?? "Dropdown",
@@ -132,7 +132,7 @@ struct ExtensionFormView: View {
         case "Form.TagPicker":
             labelled(field) {
                 ExtensionPickerField(
-                    items: ExtensionFormView.items(in: field),
+                    items: ExtensionPickerItem.items(in: field),
                     chosen: field.array("value").compactMap(\.stringValue),
                     placeholder: field.string("placeholder") ?? "Select…",
                     title: field.string("title") ?? "Tags",
@@ -168,26 +168,6 @@ struct ExtensionFormView: View {
                     .foregroundStyle(.secondary)
             }
         }
-    }
-
-    /// Items may be direct children or grouped in sections.
-    static func items(in field: RenderNode) -> [ExtensionPickerItem] {
-        var items: [ExtensionPickerItem] = []
-        func walk(_ node: RenderNode, section: String?) {
-            for child in node.children {
-                if child.type.hasSuffix(".Item") {
-                    let value = child.string("value") ?? ""
-                    items.append(
-                        ExtensionPickerItem(
-                            value: value, title: child.string("title") ?? value,
-                            iconValue: child.props["icon"], section: section))
-                } else if child.type.hasSuffix(".Section") {
-                    walk(child, section: child.string("title"))
-                }
-            }
-        }
-        walk(field, section: nil)
-        return items
     }
 
     /// Labels sit left of controls without moving the control away from the palette centre.

--- a/Tinycast/Features/Extensions/UI/ExtensionPickerList.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionPickerList.swift
@@ -1,25 +1,18 @@
 import SwiftUI
 
-/// One choice offered by a picker's list.
-struct ExtensionPickerItem: Identifiable, Equatable {
-    let value: String
-    let title: String
-    var detail: String?
-    var iconValue: RenderValue?
-    /// The section this choice was declared under, drawn above the first of them.
-    var section: String?
-
-    var id: String { value }
-}
-
 /// The results a picker drops, styled as the ⌘K panel; the control above owns the query.
 struct ExtensionPickerList: View {
     @Environment(\.isDarkAppearance) private var isDark
+    /// Read for `hoverHighlightArmed`: a list landing under the pointer must light no row.
+    @Environment(PaletteState.self) private var palette
     let items: [ExtensionPickerItem]
     let selection: Int
     /// Values already chosen; a single-select picker passes the one it holds.
     let chosen: Set<String>
     let assetsPath: String?
+    /// Fixed, never intrinsic, so the list cannot jitter as its rows change. A form's picker
+    /// matches the field above it; a header dropdown hangs off a chip and drops narrower.
+    var width: CGFloat = ExtensionFormMetrics.controlWidth
     let onSelect: (Int) -> Void
     /// Moves the highlight under the pointer, so mouse and keyboard share one selection.
     let onHighlight: (Int) -> Void
@@ -29,7 +22,7 @@ struct ExtensionPickerList: View {
             list
         }
         .padding(Theme.Spacing.sm)
-        .frame(width: ExtensionFormMetrics.controlWidth)
+        .frame(width: width)
         .glassEffect(
             .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)
         )
@@ -61,7 +54,7 @@ struct ExtensionPickerList: View {
                                 onActivate: { onSelect(index) }
                             )
                             .id(index)
-                            .onHover { if $0 { onHighlight(index) } }
+                            .onHover { if $0, palette.hoverHighlightArmed { onHighlight(index) } }
                         }
                     }
                 }

--- a/Tinycast/Features/Extensions/UI/ExtensionSearchAccessoryButton.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionSearchAccessoryButton.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// The extension's search-bar dropdown, drawn as a header control. Not `HeaderMenuButton`: the
+/// choice it states carries an extension's own icon, which `PopoverMenuIcon` cannot name.
+struct ExtensionSearchAccessoryButton: View {
+    /// Room for a long choice beside its icon and tick, without a form field's 360pt sprawl.
+    static let listWidth: CGFloat = 240
+
+    let accessory: ExtensionSearchAccessory
+    /// The choice it holds; nil only until the first commit seeds one.
+    let value: String?
+    let assetsPath: String?
+    let isOpen: Bool
+    let action: () -> Void
+
+    /// Read from the view, so a resolved icon repaints when the surface flips appearance.
+    @Environment(\.isDarkAppearance) private var isDark
+
+    var body: some View {
+        BarButton(chrome: .rounded, action: action) {
+            HStack(spacing: Theme.Spacing.sm) {
+                if let icon {
+                    ExtensionIconView(resolved: icon, size: Theme.Size.menuIcon)
+                }
+                Text(accessory.title(for: value) ?? "")
+                    .font(Theme.Typography.bar)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                // The panel always drops below the header, so it never points back up flipped.
+                ExtensionDisclosureChevron(open: isOpen)
+            }
+            .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .help("\(accessory.tooltip ?? accessory.placeholder ?? "Filter")  ⌘P")
+    }
+
+    private var icon: ExtensionImage.Resolved? {
+        ExtensionImage.resolve(
+            accessory.item(for: value)?.iconValue, assetsPath: assetsPath, isDark: isDark)
+    }
+}

--- a/Tinycast/Palette/PaletteFilterAction.swift
+++ b/Tinycast/Palette/PaletteFilterAction.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Which type filter ⌘P opens. The header shows at most one, so this says which — and a running
+/// command's own dropdown answers first, so Tinycast's clipboard filter can never open over it.
+enum PaletteFilterAction: Equatable {
+    /// A running command's `searchBarAccessory` dropdown.
+    case extensionAccessory
+    case clipboardFilter
+    /// No filter on the header, so the key stays with the search field.
+    case ignored
+
+    static func resolve(
+        collapsed: Bool, mode: PaletteMode, commandHasAccessory: Bool
+    ) -> Self {
+        // The compact bar draws no header controls, so neither filter has a button to hang off.
+        guard !collapsed else { return .ignored }
+        switch mode {
+        case .extensionCommand: return commandHasAccessory ? .extensionAccessory : .ignored
+        case .clipboard: return .clipboardFilter
+        default: return .ignored
+        }
+    }
+}

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -228,6 +228,9 @@ struct RootPaletteView: View {
             return PaletteMenuContent(
                 popover: popover, selection: $menuSelection, width: headerMenuWidth,
                 onActivate: activateMenuItem)
+        case .extensionAccessory:
+            return extensionCommandScreen?.searchAccessoryMenu(
+                menuSelection: $menuSelection, onActivate: activateMenuItem)
         case nil: return nil
         }
     }
@@ -525,9 +528,14 @@ struct RootPaletteView: View {
                 guard press.modifiers.contains(.command),
                     ASCIIKeyboardLayout.matches(press.key, character: "p")
                 else { return .ignored }
-                let clipboardActive: Bool = !isCollapsed && vm.mode == .clipboard
-                guard clipboardActive else { return .ignored }
-                toggleClipboardFilter()
+                switch PaletteFilterAction.resolve(
+                    collapsed: isCollapsed, mode: vm.mode,
+                    commandHasAccessory: extensionCommandScreen?.searchAccessory != nil)
+                {
+                case .extensionAccessory: toggleExtensionSearchAccessory()
+                case .clipboardFilter: toggleClipboardFilter()
+                case .ignored: return .ignored
+                }
                 return .handled
             }
             // ⇧⌘F mirrors the Add/Remove Favorites row, closing an open menu the way that row does.
@@ -643,6 +651,14 @@ struct RootPaletteView: View {
                     )
                 }
             }
+            if !isCollapsed, let command = extensionCommandScreen,
+                let accessory = command.searchAccessory
+            {
+                headerGutter(width: Theme.Spacing.md)
+                command.searchAccessoryButton(
+                    accessory, isOpen: openMenu == .extensionAccessory,
+                    action: toggleExtensionSearchAccessory)
+            }
             headerGutter(width: Theme.Spacing.md * 2)
         }
         // Identical metrics in both states, so typing can't move the search bar.
@@ -651,6 +667,12 @@ struct RootPaletteView: View {
         .frame(maxWidth: .infinity)
         // Set after the show, so the field it names is focused rather than the search field.
         .onChange(of: vm.pendingArgumentEntryID) { focusPendingArgument() }
+    }
+
+    /// Mode-gated ahead of the cast, which would otherwise cost every other mode a list build.
+    private var extensionCommandScreen: ExtensionCommandScreen? {
+        guard vm.mode == .extensionCommand else { return nil }
+        return screen as? ExtensionCommandScreen
     }
 
     /// Whichever screen offers one; the compact bar has no room for it.
@@ -861,6 +883,17 @@ struct RootPaletteView: View {
         open(.clipboardFilter, highlighting: active)
     }
 
+    /// Opens on the choice the dropdown holds, exactly as the clipboard filter opens on its own.
+    private func toggleExtensionSearchAccessory() {
+        if openMenu == .extensionAccessory {
+            closeMenus()
+            return
+        }
+        guard let accessory = extensionCommandScreen?.searchAccessory else { return }
+        let value = extensions.accessorySelection(accessory)
+        open(.extensionAccessory, highlighting: accessory.index(of: value))
+    }
+
     /// Opens on the selected model, mirroring the clipboard filter's active-row behavior.
     private func toggleAIModel() {
         if openMenu == .aiModel {
@@ -945,7 +978,7 @@ struct RootPaletteView: View {
         case .app: .bottomLeading
         case .actions: .bottomTrailing
         case .argumentOptions: .belowHeaderTrailing
-        case .clipboardFilter, .aiModel, .aiReasoning: .belowHeaderTrailing
+        case .clipboardFilter, .aiModel, .aiReasoning, .extensionAccessory: .belowHeaderTrailing
         case nil: nil
         }
     }
@@ -1146,6 +1179,7 @@ struct RootPaletteView: View {
 /// The palette's in-window menus. One optional of these is the whole "only one is open" invariant.
 private enum OpenMenu {
     case actions
+    case extensionAccessory
     /// An `options=` argument field's choices, hung under the header where the chip sits.
     case argumentOptions
     case app

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -164,6 +164,19 @@ screens hold (see [palette.md](palette.md)).
   whole signal. `ExtensionScreen.Item`
   carries both the flat `selection` index and the scroll id, and is the `ForEach` identity of the row
   and the grid cell alike — see the scroll-id rule in [ui.md](../ui.md#rows-selection-hover).
+- **Search-bar dropdown** — `List.Dropdown` and `Grid.Dropdown` draw as
+  `ExtensionSearchAccessoryButton` at the header's trailing edge and drop `ExtensionPickerList` as one
+  of the palette's `OpenMenu` cases, so the arrows, ↵, Escape and the click-away come from the one menu
+  path and no second key handler exists to disagree with it. `PaletteFilterAction` routes ⌘P, so a
+  command's own dropdown answers before Tinycast's clipboard filter can. The list is
+  `listWidth` (240) rather than a form picker's 360: it hangs off a chip, not a field.
+  **Swift owns the selection** — the runtime keeps `makeSearchDropdown` hook-free so an extension may
+  call `List.Dropdown({…})` directly — so `ExtensionManager.accessoryValues` keys it by render-node id
+  and `seedSearchBarAccessory` reports the opening choice through `onChange` on the first commit, as
+  Raycast does; without that, a command filtering its rows by the value renders nothing (issue #511).
+  A `value` prop makes it controlled: the extension holds it, nothing is seeded, nothing reported.
+  `storeValue` parks the pick in `ExtensionStorage.accessoryValues` — host UI state, outside the
+  `LocalStorage` namespace JavaScript reads, and gone when the extension is uninstalled.
 - **Grid tiles** — `ExtensionGridLayout` reads the `Grid`'s `columns`, `aspectRatio`, `fit` and `inset`
   and is the one place tile geometry is decided. A tile is a column wide and `aspectRatio` tall, and its
   content is scaled to that tile rather than drawn at an icon size, which is what makes an image-heavy

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -346,18 +346,21 @@ the arrow outside it, and AppKit's own alternation over the field came straight 
 ## One menu at a time
 
 `RootPaletteView` holds a single `OpenMenu?` rather than a flag per menu, so "at most one is open" is
-structural instead of a pair of `onChange` handlers pushing each other closed. Three cases today —
-the ⌘K Actions menu (`.bottomTrailing`), the app menu (`.bottomLeading`) and the clipboard type
-filter (`.belowHeaderTrailing`, hung under its header button). `menuContent` resolves the open case to one
-`PaletteMenuContent` — a row count, a row action and a view built on demand — so ↑/↓, plain ↵, Esc and
-the click-away catcher serve every menu without knowing which is up. A screen supplies its rows as a
-`PopoverMenuContent` through `actions(at:)` and the default `menuContent` wraps them; a screen whose
-rows the palette's menu can't express overrides `menuContent` and hands over its own view instead —
-`ExtensionCommandScreen` is the only one, and the reason the seam exists (see
+structural instead of a pair of `onChange` handlers pushing each other closed. The ⌘K Actions menu
+hangs `.bottomTrailing`, the app menu `.bottomLeading`, and everything drawn as a header control —
+the clipboard type filter, the AI model and effort menus, an `options=` argument field's choices and
+a running command's `searchBarAccessory` dropdown — hangs `.belowHeaderTrailing`, under its own
+button. `menuContent` resolves the open case to one `PaletteMenuContent` — a row count, a row action
+and a view built on demand — so ↑/↓, plain ↵, Esc and the click-away catcher serve every menu without
+knowing which is up. A screen supplies its rows as a `PopoverMenuContent` through `actions(at:)` and
+the default `menuContent` wraps them; a screen whose rows the palette's menu can't express overrides
+`menuContent` and hands over its own view instead — `ExtensionCommandScreen` is the only one, for
+both its ⌘K panel and its search-bar dropdown, and the reason the seam exists (see
 [extensions.md](extensions.md)). The view is a closure because `moveMenu` resolves the open menu on
 every arrow key and needs the row count alone. Every open path goes through `open(_:highlighting:)`
-and states where the highlight starts: the first row, except the type filter, which opens on the
-active filter.
+and states where the highlight starts: the first row, except the pop-up-shaped menus — the type
+filter, the AI model and effort menus, an extension's search-bar dropdown — which open on the choice
+they already hold.
 
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.


### PR DESCRIPTION
## Summary

- render `List.Dropdown` and `Grid.Dropdown` search-bar accessories in extension commands
- dispatch the initial selection and persist `storeValue` independently from extension `LocalStorage`
- support mouse, keyboard, and `⌘P` interaction using the extension-owned picker surface
- add a JavaScriptCore regression probe that starts with an empty filtered list and verifies the initial dropdown dispatch reveals its rows

## Verification

- `./Scripts/run-tests.sh` — 63/63 harnesses passed
- `xcodebuild build -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug CODE_SIGNING_ALLOWED=NO` — passed
- `./Scripts/lint.sh` — clean
- model-layer AppKit/SwiftUI/Cocoa import check — clean
- regression probe observed red without the initial value dispatch and green with it restored

Closes #511