### PR TITLE
Improve Calendar menu bar

### DIFF
--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -29,6 +29,7 @@ struct CalendarTests {
         readSpan()
         menuBarWindow()
         menuBarFiltering()
+        menuBarToday()
         menuBarTitles()
         autoJoinFiresOnce()
         autoJoinRespectsArming()
@@ -325,6 +326,34 @@ struct CalendarTests {
             "the menu bar reads the same agenda as everything else, so all-day events are out")
     }
 
+    static func menuBarToday() {
+        let summary = MenuBarSummary(
+            leadMinutes: nil, hideAfterMinutes: nil, linkedOnly: false, calendar: calendar)
+        let morning = date(year: 2026, month: 8, day: 23, hour: 10)
+        let laterToday = event(id: "later", starting: date(year: 2026, month: 8, day: 23, hour: 15))
+        expect(
+            summary.event(from: [laterToday], now: morning)?.id == "later",
+            "Today carries an event later on the same day")
+
+        let justBeforeMidnight = date(year: 2026, month: 8, day: 23, hour: 23, minute: 30)
+        let midnight = event(id: "midnight", starting: date(year: 2026, month: 8, day: 24, hour: 0))
+        expect(
+            summary.event(from: [midnight], now: justBeforeMidnight)?.id == "midnight",
+            "Today keeps a meeting that starts exactly thirty minutes after midnight")
+        expect(
+            MenuBarSummary.hasUpcomingEvent(from: [midnight], now: justBeforeMidnight, calendar: calendar),
+            "the empty label agrees with the midnight grace")
+
+        let thirtyOneMinutesOut = date(year: 2026, month: 8, day: 23, hour: 23, minute: 29)
+        expect(
+            summary.event(from: [midnight], now: thirtyOneMinutesOut) == nil,
+            "Today does not keep tomorrow's event more than thirty minutes away")
+        expect(
+            !MenuBarSummary.hasUpcomingEvent(
+                from: [midnight], now: thirtyOneMinutesOut, calendar: calendar),
+            "the empty label appears once today is over and tomorrow is not imminent")
+    }
+
     static func menuBarTitles() {
         expect(MenuBarSummary.title("Standup") == "Standup", "a short title is untouched")
         let long = String(repeating: "a", count: MenuBarSummary.titleCap + 5)
@@ -464,9 +493,9 @@ struct CalendarTests {
         epoch.addingTimeInterval(TimeInterval(minutes * 60))
     }
 
-    static func date(year: Int, month: Int, day: Int, hour: Int) -> Date {
+    static func date(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0) -> Date {
         calendar.date(
-            from: DateComponents(year: year, month: month, day: day, hour: hour))!
+            from: DateComponents(year: year, month: month, day: day, hour: hour, minute: minute))!
     }
 
     static func link(_ text: String) -> MeetingLink? { MeetingLink.detect(in: text) }
@@ -485,6 +514,17 @@ struct CalendarTests {
             id: id, title: id, start: at(minutes),
             end: at(minutes).addingTimeInterval(TimeInterval(duration * 60)),
             isAllDay: isAllDay, isDeclined: isDeclined, calendarID: "cal", calendarName: "Work",
+            calendarItemID: id, link: link)
+    }
+
+    static func event(
+        id: String, starting start: Date, minutes duration: Int = 30,
+        link: MeetingLink? = MeetingLink.detect(in: "https://example.com/x")
+    ) -> MeetingEvent {
+        MeetingEvent(
+            id: id, title: id, start: start,
+            end: start.addingTimeInterval(TimeInterval(duration * 60)),
+            isAllDay: false, isDeclined: false, calendarID: "cal", calendarName: "Work",
             calendarItemID: id, link: link)
     }
 

--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -282,7 +282,8 @@ struct CalendarTests {
 
     // MARK: - The menu bar
 
-    static let automatic = MenuBarSummary(leadMinutes: 5, hideAfterMinutes: nil, linkedOnly: false)
+    static let automatic = MenuBarSummary(
+        leadMinutes: 5, hideAfterMinutes: nil, linkedOnly: false, hideCurrentAtStart: true)
 
     static func menuBarWindow() {
         let meeting = event(id: "standup", start: 60, minutes: 30)
@@ -299,6 +300,11 @@ struct CalendarTests {
         expect(
             automatic.event(from: [meeting], now: start) == nil,
             "Automatically clears it exactly at the start")
+
+        let showTimeLeft = MenuBarSummary(leadMinutes: 5, linkedOnly: false)
+        expect(
+            showTimeLeft.event(from: [meeting], now: start)?.id == "standup",
+            "Keep visible leaves the current event available for its time left")
 
         let lingering = MenuBarSummary(leadMinutes: 5, hideAfterMinutes: 5, linkedOnly: false)
         expect(

--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -259,13 +259,25 @@ struct CalendarTests {
         expect(
             UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(-1)) == "in 1 min",
             "a partial minute rounds up rather than reading as now")
-        expect(UpcomingWindow.countdown(to: start, now: start) == "now", "the start reads as now")
+        expect(UpcomingWindow.countdown(to: start, now: start) == "Now", "the start reads as Now")
         expect(
-            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(59)) == "now",
-            "the first minute after the start still reads as now")
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(299)) == "Now",
+            "the first five minutes after the start still read as Now")
         expect(
-            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(120)) == "2 min ago",
-            "past the start it counts up")
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(301)) == "Now",
+            "a started event stays Now outside the menu-bar-specific timer")
+        expect(
+            UpcomingWindow.countdown(to: start, now: start.addingTimeInterval(-619 * 60)) == "in 10 hr",
+            "a long wait rounds to hours")
+
+        let meeting = event(id: "standup", start: 60, minutes: 30)
+        expect(
+            UpcomingWindow.menuBarCountdown(for: meeting, now: start.addingTimeInterval(299)) == "Now",
+            "the menu bar says Now during the first five minutes")
+        expect(
+            UpcomingWindow.menuBarCountdown(for: meeting, now: start.addingTimeInterval(301))
+                == "24 min left",
+            "the menu bar switches to time left after five minutes")
     }
 
     // MARK: - The menu bar

--- a/Tests/calendar-test.swift
+++ b/Tests/calendar-test.swift
@@ -362,6 +362,13 @@ struct CalendarTests {
             MenuBarSummary.hasUpcomingEvent(from: [midnight], now: justBeforeMidnight, calendar: calendar),
             "the empty label agrees with the midnight grace")
 
+        let appointment = event(
+            id: "appointment", starting: date(year: 2026, month: 8, day: 23, hour: 16), link: nil)
+        expect(
+            !MenuBarSummary.hasUpcomingEvent(
+                from: [appointment], now: morning, linkedOnly: true, calendar: calendar),
+            "Only show events with meetings also removes a linkless event from the empty-label rule")
+
         let thirtyOneMinutesOut = date(year: 2026, month: 8, day: 23, hour: 23, minute: 29)
         expect(
             summary.event(from: [midnight], now: thirtyOneMinutesOut) == nil,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -396,6 +396,7 @@ final class AppCore {
             {
                 _ = $0.autoJoinMeetings
                 _ = $0.menuBarEvents
+                _ = $0.calendarMenuBarDisplay
             }, reproject: { $0.calendarCoordinator.applyClock() })
         track(
             {

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -388,6 +388,7 @@ final class AppCore {
             {
                 _ = $0.calendarEnabled
                 _ = $0.calendarShowInLauncher
+                _ = $0.calendarLauncherLimit
             }, reproject: { $0.calendarCoordinator.applyEnabled() })
         track(
             { _ = $0.calendarIncludesTomorrow },

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -90,6 +90,9 @@ private struct MenuBarMenu: View {
             Button("Join \(meeting.title)") {
                 AppCore.shared.calendarCoordinator.join(meeting)
             }
+            Button("Open in Calendar...") {
+                AppCore.shared.calendarCoordinator.openInCalendar(meeting)
+            }
             Divider()
         }
         Button("Open \(appName)") {

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -17,7 +17,7 @@ struct TinycastApp: App {
     }
 
     var body: some Scene {
-        MenuBarExtra(isInserted: $showInMenuBar) {
+        MenuBarExtra(isInserted: launcherMenuBarInsertion) {
             MenuBarMenu(appName: appName)
         } label: {
             MenuBarLabel(appName: appName)
@@ -42,6 +42,25 @@ struct TinycastApp: App {
                 } else {
                     calendarMenuBarDisplay = CalendarMenuBarDisplay.disabled.rawValue
                 }
+            })
+    }
+
+    /// The calendar item replaces the launcher item while it is enabled, so the menu bar has one
+    /// Tinycast entry instead of two. Turning the calendar display off restores the user's
+    /// launcher preference immediately.
+    private var launcherMenuBarInsertion: Binding<Bool> {
+        Binding(
+            get: {
+                showInMenuBar
+                    && calendarMenuBarDisplay == CalendarMenuBarDisplay.disabled.rawValue
+            },
+            set: { inserted in
+                // SwiftUI may write `false` when the calendar takes this slot. That is not a user
+                // request to hide the launcher permanently.
+                guard calendarMenuBarDisplay == CalendarMenuBarDisplay.disabled.rawValue else {
+                    return
+                }
+                showInMenuBar = inserted
             })
     }
 

--- a/Tinycast/App/TinycastApp.swift
+++ b/Tinycast/App/TinycastApp.swift
@@ -5,6 +5,8 @@ struct TinycastApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
     // `@AppStorage` republishes only on change, avoiding a scene ⇄ binding loop.
     @AppStorage(SettingsKey.showInMenuBar) private var showInMenuBar = true
+    @AppStorage(SettingsKey.calendarMenuBarDisplay)
+    private var calendarMenuBarDisplay = CalendarMenuBarDisplay.disabled.rawValue
 
     // Channel-aware: "Tinycast", "Tinycast Dev", or "Tinycast Beta".
     private let appName = Bundle.main.appDisplayName
@@ -16,30 +18,31 @@ struct TinycastApp: App {
 
     var body: some Scene {
         MenuBarExtra(isInserted: $showInMenuBar) {
-            if let meeting = AppCore.shared.calendarCoordinator.menuBarEvent {
-                Button("Join \(meeting.title)") {
-                    AppCore.shared.calendarCoordinator.join(meeting)
-                }
-                Divider()
-            }
-            Button("Open \(appName)") {
-                AppCore.shared.paletteCoordinator.showPalette(mode: .launcher)
-            }
-            Button("Clipboard History") {
-                AppCore.shared.paletteCoordinator.showPalette(mode: .clipboard)
-            }
-            Divider()
-            Button("Check for Updates...") { AppCore.shared.updateCoordinator.checkForUpdates() }
-            Button("Support \(appName)...") { AppCore.shared.supportCoordinator.showSupport() }
-            Button("Settings...") { AppCore.shared.settingsCoordinator.showSettings() }
-                .keyboardShortcut(",")
-            Divider()
-            // No ⌘Q: the app menu binds it to Close Settings, and two contradictory ⌘Qs is a lie.
-            Button("Quit \(appName)") { NSApp.terminate(nil) }
+            MenuBarMenu(appName: appName)
         } label: {
             MenuBarLabel(appName: appName)
         }
         .commands { menuBarCommands }
+
+        MenuBarExtra(isInserted: calendarMenuBarInsertion) {
+            MenuBarMenu(appName: appName)
+        } label: {
+            CalendarMenuBarLabel(appName: appName)
+        }
+    }
+
+    private var calendarMenuBarInsertion: Binding<Bool> {
+        Binding(
+            get: { calendarMenuBarDisplay != CalendarMenuBarDisplay.disabled.rawValue },
+            set: { inserted in
+                if inserted {
+                    if calendarMenuBarDisplay == CalendarMenuBarDisplay.disabled.rawValue {
+                        calendarMenuBarDisplay = CalendarMenuBarDisplay.meetingIcon.rawValue
+                    }
+                } else {
+                    calendarMenuBarDisplay = CalendarMenuBarDisplay.disabled.rawValue
+                }
+            })
     }
 
     /// Declared, not assigned to `NSApp.mainMenu`: SwiftUI rebuilds the menu on any scene change.
@@ -57,5 +60,32 @@ struct TinycastApp: App {
             Button("Close Settings") { AppCore.shared.settingsCoordinator.closeSettings() }
                 .keyboardShortcut("q")
         }
+    }
+}
+
+private struct MenuBarMenu: View {
+    let appName: String
+
+    var body: some View {
+        if let meeting = AppCore.shared.calendarCoordinator.menuBarEvent {
+            Button("Join \(meeting.title)") {
+                AppCore.shared.calendarCoordinator.join(meeting)
+            }
+            Divider()
+        }
+        Button("Open \(appName)") {
+            AppCore.shared.paletteCoordinator.showPalette(mode: .launcher)
+        }
+        Button("Clipboard History") {
+            AppCore.shared.paletteCoordinator.showPalette(mode: .clipboard)
+        }
+        Divider()
+        Button("Check for Updates...") { AppCore.shared.updateCoordinator.checkForUpdates() }
+        Button("Support \(appName)...") { AppCore.shared.supportCoordinator.showSupport() }
+        Button("Settings...") { AppCore.shared.settingsCoordinator.showSettings() }
+            .keyboardShortcut(",")
+        Divider()
+        // No ⌘Q: the app menu binds it to Close Settings, and two contradictory ⌘Qs is a lie.
+        Button("Quit \(appName)") { NSApp.terminate(nil) }
     }
 }

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -59,6 +59,7 @@ struct SettingsBackup: Codable {
         // `autoJoinMeetings` and `cameraPreview` are absent: an import must arm neither.
         var autoJoinConfirms: Bool?
         var menuBarEvents: Int?
+        var calendarMenuBarDisplay: Int?
         var menuBarLinkedEventsOnly: Bool?
         var hideCurrentEvent: Int?
         // Safe to carry: it silences a prompt rather than granting anything.
@@ -136,6 +137,7 @@ extension SettingsBackup {
             joinWindowMinutes: s.joinWindowMinutes.rawValue,
             autoJoinConfirms: s.autoJoinConfirms,
             menuBarEvents: s.menuBarEvents.rawValue,
+            calendarMenuBarDisplay: s.calendarMenuBarDisplay.rawValue,
             menuBarLinkedEventsOnly: s.menuBarLinkedEventsOnly,
             hideCurrentEvent: s.hideCurrentEvent.rawValue,
             supportReminders: s.supportRemindersEnabled)
@@ -365,6 +367,12 @@ extension SettingsBackup {
         }
         if let raw = s.menuBarEvents, let lead = MenuBarEvents(rawValue: raw) {
             settings.menuBarEvents = lead
+            count += 1
+        }
+        if let raw = s.calendarMenuBarDisplay,
+            let display = CalendarMenuBarDisplay(rawValue: raw)
+        {
+            settings.calendarMenuBarDisplay = display
             count += 1
         }
         if let flag = s.menuBarLinkedEventsOnly {

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -53,6 +53,7 @@ struct SettingsBackup: Codable {
         var quicklinkConfirmsBeforeDelete: Bool?
         // `calendarEnabled` is absent: an import must not grant calendar access.
         var calendarShowInLauncher: Bool?
+        var calendarLauncherLimit: Int?
         // Carried: it narrows what is read rather than widening what may be reached.
         var calendarIncludesTomorrow: Bool?
         var joinWindowMinutes: Int?
@@ -133,6 +134,7 @@ extension SettingsBackup {
             quicklinkSelectionFallback: s.quicklinkSelectionFallback.rawValue,
             quicklinkConfirmsBeforeDelete: s.quicklinkConfirmsBeforeDelete,
             calendarShowInLauncher: s.calendarShowInLauncher,
+            calendarLauncherLimit: s.calendarLauncherLimit.rawValue,
             calendarIncludesTomorrow: s.calendarIncludesTomorrow,
             joinWindowMinutes: s.joinWindowMinutes.rawValue,
             autoJoinConfirms: s.autoJoinConfirms,
@@ -351,6 +353,10 @@ extension SettingsBackup {
         }
         if let flag = s.calendarShowInLauncher {
             settings.calendarShowInLauncher = flag
+            count += 1
+        }
+        if let raw = s.calendarLauncherLimit, let limit = CalendarLauncherLimit(rawValue: raw) {
+            settings.calendarLauncherLimit = limit
             count += 1
         }
         if let flag = s.calendarIncludesTomorrow {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -39,6 +39,7 @@ enum SettingsBackupCoverage {
         "joinWindowMinutes": .joinWindowMinutes,
         "autoJoinConfirms": .autoJoinConfirms,
         "menuBarEvents": .menuBarEvents,
+        "calendarMenuBarDisplay": .calendarMenuBarDisplay,
         "menuBarLinkedEventsOnly": .menuBarLinkedEventsOnly,
         "hideCurrentEvent": .hideCurrentEvent,
         "supportReminders": .supportReminders

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -35,6 +35,7 @@ enum SettingsBackupCoverage {
         "quicklinkConfirmsBeforeDelete": .quicklinkConfirmsBeforeDelete,
         "extensionsShowInLauncher": .extensionsShowInLauncher,
         "calendarShowInLauncher": .calendarShowInLauncher,
+        "calendarLauncherLimit": .calendarLauncherLimit,
         "calendarIncludesTomorrow": .calendarIncludesTomorrow,
         "joinWindowMinutes": .joinWindowMinutes,
         "autoJoinConfirms": .autoJoinConfirms,

--- a/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
+++ b/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
@@ -4,10 +4,10 @@ import Foundation
 struct MenuBarSummary: Sendable {
     /// Nil means to keep the next event visible for the rest of today.
     let leadMinutes: Int?
-    /// How long past the start the event stays. Nil is "Automatically" — it goes as it starts.
-    let hideAfterMinutes: Int?
     /// Only events Tinycast could actually join; the rest are appointments, not meetings.
     let linkedOnly: Bool
+    private let hideCurrentAtStart: Bool
+    private let hideAfterMinutes: Int?
     private let calendar: Calendar
 
     /// Long enough to recognise a meeting, short enough to leave the menu bar usable.
@@ -17,12 +17,14 @@ struct MenuBarSummary: Sendable {
     static let nextDayGrace: TimeInterval = 30 * 60
 
     init(
-        leadMinutes: Int?, hideAfterMinutes: Int?, linkedOnly: Bool,
+        leadMinutes: Int?, hideAfterMinutes: Int? = nil, linkedOnly: Bool,
+        hideCurrentAtStart: Bool = false,
         calendar: Calendar = .current
     ) {
         self.leadMinutes = leadMinutes
-        self.hideAfterMinutes = hideAfterMinutes
         self.linkedOnly = linkedOnly
+        self.hideCurrentAtStart = hideCurrentAtStart
+        self.hideAfterMinutes = hideAfterMinutes
         self.calendar = calendar
     }
 
@@ -56,9 +58,9 @@ struct MenuBarSummary: Sendable {
         return now >= event.start - TimeInterval(leadMinutes * 60)
     }
 
-    /// The grace never outlives the meeting, the way the join card's own window does not.
     private func hidesAt(_ event: MeetingEvent) -> Date {
-        guard let hideAfterMinutes else { return event.start }
+        if hideCurrentAtStart { return event.start }
+        guard let hideAfterMinutes else { return event.end }
         return min(event.start + TimeInterval(hideAfterMinutes * 60), event.end)
     }
 }

--- a/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
+++ b/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
@@ -2,19 +2,44 @@ import Foundation
 
 /// Which event the menu bar carries, and for how long. Every clock read is an injected `now`.
 struct MenuBarSummary: Sendable {
-    let leadMinutes: Int
+    /// Nil means to keep the next event visible for the rest of today.
+    let leadMinutes: Int?
     /// How long past the start the event stays. Nil is "Automatically" — it goes as it starts.
     let hideAfterMinutes: Int?
     /// Only events Tinycast could actually join; the rest are appointments, not meetings.
     let linkedOnly: Bool
+    private let calendar: Calendar
 
     /// Long enough to recognise a meeting, short enough to leave the menu bar usable.
     static let titleCap = 24
+    /// A midnight meeting is useful when it is about to start, but should not keep today's menu bar
+    /// occupied for hours.
+    static let nextDayGrace: TimeInterval = 30 * 60
+
+    init(
+        leadMinutes: Int?, hideAfterMinutes: Int?, linkedOnly: Bool,
+        calendar: Calendar = .current
+    ) {
+        self.leadMinutes = leadMinutes
+        self.hideAfterMinutes = hideAfterMinutes
+        self.linkedOnly = linkedOnly
+        self.calendar = calendar
+    }
 
     /// The earliest event still inside its window, so one hiding hands the space to the next.
     func event(from events: [MeetingEvent], now: Date) -> MeetingEvent? {
         UpcomingWindow.agenda(from: events, now: now).first {
-            (!linkedOnly || $0.link != nil) && now >= $0.start - lead && now < hidesAt($0)
+            (!linkedOnly || $0.link != nil) && isInsideLead(for: $0, now: now)
+                && now < hidesAt($0)
+        }
+    }
+
+    /// The empty label and the all-day menu-bar choice share one definition of "upcoming".
+    static func hasUpcomingEvent(
+        from events: [MeetingEvent], now: Date, calendar: Calendar = .current
+    ) -> Bool {
+        UpcomingWindow.agenda(from: events, now: now).contains {
+            calendar.isDate($0.start, inSameDayAs: now) || $0.start <= now + nextDayGrace
         }
     }
 
@@ -24,7 +49,12 @@ struct MenuBarSummary: Sendable {
         return title.prefix(titleCap - 1).trimmingCharacters(in: .whitespaces) + "…"
     }
 
-    private var lead: TimeInterval { TimeInterval(leadMinutes * 60) }
+    private func isInsideLead(for event: MeetingEvent, now: Date) -> Bool {
+        guard let leadMinutes else {
+            return Self.hasUpcomingEvent(from: [event], now: now, calendar: calendar)
+        }
+        return now >= event.start - TimeInterval(leadMinutes * 60)
+    }
 
     /// The grace never outlives the meeting, the way the join card's own window does not.
     private func hidesAt(_ event: MeetingEvent) -> Date {

--- a/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
+++ b/Tinycast/Features/Calendar/Model/MenuBarSummary.swift
@@ -38,10 +38,12 @@ struct MenuBarSummary: Sendable {
 
     /// The empty label and the all-day menu-bar choice share one definition of "upcoming".
     static func hasUpcomingEvent(
-        from events: [MeetingEvent], now: Date, calendar: Calendar = .current
+        from events: [MeetingEvent], now: Date, linkedOnly: Bool = false,
+        calendar: Calendar = .current
     ) -> Bool {
         UpcomingWindow.agenda(from: events, now: now).contains {
-            calendar.isDate($0.start, inSameDayAs: now) || $0.start <= now + nextDayGrace
+            (!linkedOnly || $0.link != nil)
+                && (calendar.isDate($0.start, inSameDayAs: now) || $0.start <= now + nextDayGrace)
         }
     }
 

--- a/Tinycast/Features/Calendar/Model/UpcomingWindow.swift
+++ b/Tinycast/Features/Calendar/Model/UpcomingWindow.swift
@@ -29,8 +29,24 @@ struct UpcomingWindow: Sendable {
 
     static func countdown(to start: Date, now: Date) -> String {
         let delta = start.timeIntervalSince(now)
-        if delta > 0 { return "in \(Int((delta / 60).rounded(.up))) min" }
-        let elapsed = Int((-delta / 60).rounded(.down))
-        return elapsed == 0 ? "now" : "\(elapsed) min ago"
+        if delta > 0 { return "in \(duration(delta, rounding: .up))" }
+        return "Now"
+    }
+
+    /// The menu bar names the time left once a meeting has been underway for five minutes.
+    static func menuBarCountdown(for event: MeetingEvent, now: Date) -> String {
+        if now < event.start { return countdown(to: event.start, now: now) }
+        if now < event.start.addingTimeInterval(5 * 60) { return "Now" }
+        if now < event.end { return "\(duration(event.end.timeIntervalSince(now), rounding: .down)) left" }
+        return "Now"
+    }
+
+    private static func duration(
+        _ interval: TimeInterval, rounding: FloatingPointRoundingRule
+    ) -> String {
+        let minutes = max(1, Int((interval / 60).rounded(rounding)))
+        guard minutes > 60 else { return "\(minutes) min" }
+        let hours = max(1, Int((Double(minutes) / 60).rounded()))
+        return "\(hours) hr"
     }
 }

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -81,7 +81,7 @@ struct CalendarSettingsView: View {
                     }
                 } label: {
                     Text("Show Upcoming Events")
-                    Text("How early an event reaches the menu bar.")
+                    Text("When the next event reaches the menu bar. Today includes the next 30 minutes after midnight.")
                 }
                 .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
                 Toggle(isOn: $settings.menuBarLinkedEventsOnly) {

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -67,19 +67,28 @@ struct CalendarSettingsView: View {
             .settingsEnabled(settings.calendarEnabled)
 
             Section {
+                Picker(selection: $settings.calendarMenuBarDisplay) {
+                    ForEach(CalendarMenuBarDisplay.allCases) { display in
+                        Text(display.title).tag(display)
+                    }
+                } label: {
+                    Text("Calendar in Menu Bar")
+                    Text("Show a meeting icon or its title and countdown independently of Tinycast's icon.")
+                }
                 Picker(selection: $settings.menuBarEvents) {
-                    ForEach(MenuBarEvents.allCases) { lead in
+                    ForEach(MenuBarEvents.allCases.dropFirst()) { lead in
                         Text(lead.title).tag(lead)
                     }
                 } label: {
-                    Text("Show Events in Menu Bar")
-                    Text("Show current or upcoming events in the menu bar.")
+                    Text("Show Upcoming Events")
+                    Text("How early an event reaches the menu bar.")
                 }
+                .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
                 Toggle(isOn: $settings.menuBarLinkedEventsOnly) {
                     Text("Only show events with meetings")
                 }
                 .toggleStyle(.checkbox)
-                .settingsEnabled(settings.menuBarEvents != .never)
+                .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
                 Picker(selection: $settings.hideCurrentEvent) {
                     ForEach(HideCurrentEvent.allCases) { hide in
                         Text(hide.title).tag(hide)
@@ -88,7 +97,7 @@ struct CalendarSettingsView: View {
                     Text("Hide Current Event")
                     Text("Hide a started event automatically, or after the time you choose.")
                 }
-                .settingsEnabled(settings.menuBarEvents != .never)
+                .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
             } header: {
                 Text("Menu Bar")
             }

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -18,6 +18,18 @@ struct CalendarSettingsView: View {
                 isEnabled: enabledBinding,
                 showsInLauncher: $settings.calendarShowInLauncher)
 
+            Section {
+                Picker(selection: $settings.calendarLauncherLimit) {
+                    ForEach(CalendarLauncherLimit.allCases) { limit in
+                        Text(limit.title).tag(limit)
+                    }
+                } label: {
+                    Text("Upcoming meetings in launcher")
+                    Text("Choose how many upcoming meetings appear alongside apps and commands.")
+                }
+            }
+            .settingsEnabled(settings.calendarEnabled && settings.calendarShowInLauncher)
+
             if store.access == .denied {
                 Section {
                     SettingsRow(
@@ -95,7 +107,7 @@ struct CalendarSettingsView: View {
                     }
                 } label: {
                     Text("Hide Current Event")
-                    Text("Hide a started event automatically, or after the time you choose.")
+                    Text("Choose whether to hide a started event or show its time left.")
                 }
                 .settingsEnabled(settings.calendarMenuBarDisplay != .disabled)
             } header: {

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -30,7 +30,18 @@ struct CalendarSettingsView: View {
             }
             .settingsEnabled(settings.calendarEnabled && settings.calendarShowInLauncher)
 
-            if store.access == .denied {
+            if store.access == .notDetermined {
+                Section {
+                    SettingsRow(
+                        title: "Calendar access is needed",
+                        subtitle: "Allow Tinycast to read events and find meeting links."
+                    ) {
+                        Button("Allow Calendar Access…") {
+                            core.calendarCoordinator.setCalendarEnabled(true)
+                        }
+                    }
+                }
+            } else if store.access == .denied {
                 Section {
                     SettingsRow(
                         title: "Calendar access is off",

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -66,7 +66,8 @@ final class CalendarCoordinator {
         let summary = MenuBarSummary(
             leadMinutes: settings.menuBarEvents == .today ? nil : settings.menuBarEvents.rawValue,
             hideAfterMinutes: settings.hideCurrentEvent.minutes,
-            linkedOnly: settings.menuBarLinkedEventsOnly)
+            linkedOnly: settings.menuBarLinkedEventsOnly,
+            hideCurrentAtStart: settings.hideCurrentEvent.hidesAtStart)
         return summary.event(from: store.events, now: clock.now)
     }
 
@@ -172,7 +173,8 @@ final class CalendarCoordinator {
             appIndex.setMeetings([])
             return
         }
-        appIndex.setMeetings(agenda.map(Self.entry(for:)))
+        let meetings = settings.calendarLauncherLimit.maximum.map { Array(agenda.prefix($0)) } ?? agenda
+        appIndex.setMeetings(meetings.map(Self.entry(for:)))
     }
 
     private static func entry(for meeting: MeetingEvent) -> AppEntry {

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -51,6 +51,12 @@ final class CalendarCoordinator {
     /// Live rather than clock-driven: a chord reads this with nothing ticking.
     var agenda: [MeetingEvent] { UpcomingWindow.agenda(from: store.events, now: Date()) }
 
+    /// The calendar label keeps its plain icon until today's events are exhausted, with a small
+    /// grace across midnight for a meeting that starts imminently.
+    var hasUpcomingMenuBarEvent: Bool {
+        MenuBarSummary.hasUpcomingEvent(from: store.events, now: clock.now)
+    }
+
     /// The event the menu bar carries, or nil for the plain icon.
     var menuBarEvent: MeetingEvent? {
         guard
@@ -58,7 +64,7 @@ final class CalendarCoordinator {
             settings.menuBarEvents != .never
         else { return nil }
         let summary = MenuBarSummary(
-            leadMinutes: settings.menuBarEvents.rawValue,
+            leadMinutes: settings.menuBarEvents == .today ? nil : settings.menuBarEvents.rawValue,
             hideAfterMinutes: settings.hideCurrentEvent.minutes,
             linkedOnly: settings.menuBarLinkedEventsOnly)
         return summary.event(from: store.events, now: clock.now)

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -53,7 +53,10 @@ final class CalendarCoordinator {
 
     /// The event the menu bar carries, or nil for the plain icon.
     var menuBarEvent: MeetingEvent? {
-        guard settings.calendarEnabled, settings.menuBarEvents != .never else { return nil }
+        guard
+            settings.calendarEnabled, settings.calendarMenuBarDisplay != .disabled,
+            settings.menuBarEvents != .never
+        else { return nil }
         let summary = MenuBarSummary(
             leadMinutes: settings.menuBarEvents.rawValue,
             hideAfterMinutes: settings.hideCurrentEvent.minutes,
@@ -119,7 +122,8 @@ final class CalendarCoordinator {
     func applyClock() {
         armAutoJoin()
         let watched =
-            paletteVisible || settings.menuBarEvents != .never || settings.autoJoinMeetings
+            paletteVisible || settings.calendarMenuBarDisplay != .disabled
+            || settings.autoJoinMeetings
         guard settings.calendarEnabled, watched else {
             clock.stop()
             return

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -76,12 +76,14 @@ final class CalendarCoordinator {
 
     /// The switch funnels here so enabling, which is also consent, confirms first.
     func setCalendarEnabled(_ enabled: Bool) {
-        guard enabled != settings.calendarEnabled else { return }
         if !enabled {
+            guard settings.calendarEnabled else { return }
             settings.calendarEnabled = false
             return
         }
 
+        // TCC can be reset while the feature remains enabled; that state needs the same consent path.
+        guard !settings.calendarEnabled || store.access == .notDetermined else { return }
         NSApp.activate(ignoringOtherApps: true)
         Task {
             guard

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -54,7 +54,8 @@ final class CalendarCoordinator {
     /// The calendar label keeps its plain icon until today's events are exhausted, with a small
     /// grace across midnight for a meeting that starts imminently.
     var hasUpcomingMenuBarEvent: Bool {
-        MenuBarSummary.hasUpcomingEvent(from: store.events, now: clock.now)
+        MenuBarSummary.hasUpcomingEvent(
+            from: store.events, now: clock.now, linkedOnly: settings.menuBarLinkedEventsOnly)
     }
 
     /// The event the menu bar carries, or nil for the plain icon.

--- a/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
+++ b/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
@@ -49,8 +49,8 @@ struct CalendarMenuBarLabel: View {
     }
 
     private func text(for meeting: MeetingEvent) -> String {
-        let countdown = UpcomingWindow.countdown(
-            to: meeting.start, now: AppCore.shared.meetingClock.now)
+        let countdown = UpcomingWindow.menuBarCountdown(
+            for: meeting, now: AppCore.shared.meetingClock.now)
         return "\(MenuBarSummary.title(meeting.title)) • \(countdown)"
     }
 }

--- a/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
+++ b/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
@@ -29,9 +29,23 @@ struct CalendarMenuBarLabel: View {
                     .accessibilityLabel("\(appName): \(text(for: meeting))")
             }
         } else {
-            Image(systemName: "calendar")
-                .accessibilityLabel("\(appName) calendar")
+            if AppCore.shared.settings.calendarMenuBarDisplay == .meetingTitle,
+                hasUpcomingEventToday
+            {
+                Image(systemName: "calendar")
+                    .accessibilityLabel("\(appName) calendar")
+            } else if AppCore.shared.settings.calendarMenuBarDisplay == .meetingTitle {
+                Text("No upcoming events")
+                    .accessibilityLabel("\(appName): No upcoming events")
+            } else {
+                Image(systemName: "calendar")
+                    .accessibilityLabel("\(appName) calendar")
+            }
         }
+    }
+
+    private var hasUpcomingEventToday: Bool {
+        AppCore.shared.calendarCoordinator.agenda.contains { Calendar.current.isDateInToday($0.start) }
     }
 
     private func text(for meeting: MeetingEvent) -> String {

--- a/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
+++ b/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
@@ -30,7 +30,7 @@ struct CalendarMenuBarLabel: View {
             }
         } else {
             if AppCore.shared.settings.calendarMenuBarDisplay == .meetingTitle,
-                hasUpcomingEventToday
+                hasUpcomingEvent
             {
                 Image(systemName: "calendar")
                     .accessibilityLabel("\(appName) calendar")
@@ -44,8 +44,8 @@ struct CalendarMenuBarLabel: View {
         }
     }
 
-    private var hasUpcomingEventToday: Bool {
-        AppCore.shared.calendarCoordinator.agenda.contains { Calendar.current.isDateInToday($0.start) }
+    private var hasUpcomingEvent: Bool {
+        AppCore.shared.calendarCoordinator.hasUpcomingMenuBarEvent
     }
 
     private func text(for meeting: MeetingEvent) -> String {

--- a/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
+++ b/Tinycast/Features/Calendar/UI/MenuBarLabel.swift
@@ -1,24 +1,42 @@
 import SwiftUI
 
-/// Reading the coordinator here scopes Observation to the label rather than the scene.
+/// The launcher item has no calendar state, so hiding it cannot hide the calendar item.
 struct MenuBarLabel: View {
+    let appName: String
+
+    var body: some View {
+        Image(systemName: "macwindow.on.rectangle")
+            .accessibilityLabel(appName)
+    }
+}
+
+/// Reading the coordinator here scopes Observation to the calendar label rather than either scene.
+struct CalendarMenuBarLabel: View {
     let appName: String
 
     private var meeting: MeetingEvent? { AppCore.shared.calendarCoordinator.menuBarEvent }
 
     var body: some View {
         if let meeting {
-            Label(text(for: meeting), systemImage: meeting.link?.provider.sfSymbol ?? "calendar")
-                .accessibilityLabel("\(appName): \(text(for: meeting))")
+            switch AppCore.shared.settings.calendarMenuBarDisplay {
+            case .disabled:
+                EmptyView()
+            case .meetingIcon:
+                Image(systemName: meeting.link?.provider.sfSymbol ?? "calendar")
+                    .accessibilityLabel("\(appName): \(meeting.title)")
+            case .meetingTitle:
+                Text(text(for: meeting))
+                    .accessibilityLabel("\(appName): \(text(for: meeting))")
+            }
         } else {
-            Image(systemName: "macwindow.on.rectangle")
-                .accessibilityLabel(appName)
+            Image(systemName: "calendar")
+                .accessibilityLabel("\(appName) calendar")
         }
     }
 
     private func text(for meeting: MeetingEvent) -> String {
         let countdown = UpcomingWindow.countdown(
             to: meeting.start, now: AppCore.shared.meetingClock.now)
-        return "\(MenuBarSummary.title(meeting.title)) · \(countdown)"
+        return "\(MenuBarSummary.title(meeting.title)) • \(countdown)"
     }
 }

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -45,10 +45,17 @@ enum MenuBarEvents: Int, CaseIterable, Identifiable, Sendable {
     case five = 5
     case ten = 10
     case thirty = 30
+    case today = -1
 
     var id: Int { rawValue }
 
-    var title: String { self == .never ? "Never" : "\(rawValue) minutes before" }
+    var title: String {
+        switch self {
+        case .never: "Never"
+        case .today: "Today"
+        default: "\(rawValue) minutes before"
+        }
+    }
 }
 
 /// The calendar's independent menu-bar presence. Zero matches an unset preference.

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -76,7 +76,29 @@ enum CalendarMenuBarDisplay: Int, CaseIterable, Identifiable, Sendable {
 }
 
 /// How long a started event holds the menu bar. Zero, the default, means it goes as it starts.
+enum CalendarLauncherLimit: Int, CaseIterable, Identifiable, Sendable {
+    case one = 1
+    case three = 3
+    case five = 5
+    case all = 0
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .one: "1 next"
+        case .three: "3 next"
+        case .five: "5 next"
+        case .all: "All"
+        }
+    }
+
+    var maximum: Int? { self == .all ? nil : rawValue }
+}
+
+/// Whether a started event remains in the menu bar long enough to show its time left.
 enum HideCurrentEvent: Int, CaseIterable, Identifiable, Sendable {
+    case dontHide = -1
     case automatically = 0
     case afterFive = 5
     case afterTen = 10
@@ -85,11 +107,15 @@ enum HideCurrentEvent: Int, CaseIterable, Identifiable, Sendable {
     var id: Int { rawValue }
 
     var title: String {
-        self == .automatically ? "Automatically" : "After \(rawValue) minutes"
+        switch self {
+        case .dontHide: "Keep visible — show time left"
+        case .automatically: "Automatically"
+        default: "After \(rawValue) minutes"
+        }
     }
 
-    /// Nil is "hide at the start"; `MenuBarSummary` reads it that way.
-    var minutes: Int? { self == .automatically ? nil : rawValue }
+    var hidesAtStart: Bool { self == .automatically }
+    var minutes: Int? { rawValue > 0 ? rawValue : nil }
 }
 
 @MainActor
@@ -291,6 +317,10 @@ final class AppSettings {
         }
     }
 
+    var calendarLauncherLimit: CalendarLauncherLimit {
+        didSet { defaults.set(calendarLauncherLimit.rawValue, forKey: Key.calendarLauncherLimit.rawValue) }
+    }
+
     /// Narrows the fetch itself rather than what is shown, so every surface reads the same days.
     var calendarIncludesTomorrow: Bool {
         didSet {
@@ -483,6 +513,10 @@ final class AppSettings {
         calendarShowInLauncher =
             defaults.object(forKey: Key.calendarShowInLauncher.rawValue) == nil
             || defaults.bool(forKey: Key.calendarShowInLauncher.rawValue)
+        calendarLauncherLimit =
+            defaults.object(forKey: Key.calendarLauncherLimit.rawValue)
+            .flatMap { $0 as? Int }
+            .flatMap(CalendarLauncherLimit.init(rawValue:)) ?? .three
         calendarIncludesTomorrow =
             defaults.object(forKey: Key.calendarIncludesTomorrow.rawValue) == nil
             || defaults.bool(forKey: Key.calendarIncludesTomorrow.rawValue)
@@ -506,8 +540,9 @@ final class AppSettings {
             defaults.object(forKey: Key.menuBarLinkedEventsOnly.rawValue) == nil
             || defaults.bool(forKey: Key.menuBarLinkedEventsOnly.rawValue)
         hideCurrentEvent =
-            HideCurrentEvent(rawValue: defaults.integer(forKey: Key.hideCurrentEvent.rawValue))
-            ?? .automatically
+            defaults.object(forKey: Key.hideCurrentEvent.rawValue)
+            .flatMap { $0 as? Int }
+            .flatMap(HideCurrentEvent.init(rawValue:)) ?? .dontHide
         windowManagementEnabled = defaults.bool(forKey: Key.windowManagementEnabled.rawValue)
         windowManagementShowInLauncher =
             defaults.object(forKey: Key.windowManagementShowInLauncher.rawValue) == nil

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 /// Keys shared between `@AppStorage` sites, so app and Settings bind to the same one.
 enum SettingsKey {
-    /// Menu-bar icon visibility — read by `MenuBarExtra(isInserted:)` and the Settings toggle.
+    /// The launcher icon's visibility — read by its `MenuBarExtra` and the General toggle.
     static let showInMenuBar = "showInMenuBar"
+    static let calendarMenuBarDisplay = "calendarMenuBarDisplay"
 }
 
 /// Delay before a closed palette pops to root; an unset key reads as `.immediately`.
@@ -48,6 +49,23 @@ enum MenuBarEvents: Int, CaseIterable, Identifiable, Sendable {
     var id: Int { rawValue }
 
     var title: String { self == .never ? "Never" : "\(rawValue) minutes before" }
+}
+
+/// The calendar's independent menu-bar presence. Zero matches an unset preference.
+enum CalendarMenuBarDisplay: Int, CaseIterable, Identifiable, Sendable {
+    case disabled = 0
+    case meetingIcon = 1
+    case meetingTitle = 2
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .disabled: "Disabled"
+        case .meetingIcon: "Meeting Icon"
+        case .meetingTitle: "Meeting Title"
+        }
+    }
 }
 
 /// How long a started event holds the menu bar. Zero, the default, means it goes as it starts.
@@ -295,6 +313,12 @@ final class AppSettings {
         didSet { defaults.set(menuBarEvents.rawValue, forKey: Key.menuBarEvents.rawValue) }
     }
 
+    var calendarMenuBarDisplay: CalendarMenuBarDisplay {
+        didSet {
+            defaults.set(calendarMenuBarDisplay.rawValue, forKey: Key.calendarMenuBarDisplay.rawValue)
+        }
+    }
+
     var menuBarLinkedEventsOnly: Bool {
         didSet {
             defaults.set(
@@ -463,8 +487,14 @@ final class AppSettings {
             || defaults.bool(forKey: Key.autoJoinConfirms.rawValue)
         cameraPreview = defaults.bool(forKey: Key.cameraPreview.rawValue)
         // Both default to their zero case, so an unset key needs no presence check.
-        menuBarEvents =
+        let savedMenuBarEvents =
             MenuBarEvents(rawValue: defaults.integer(forKey: Key.menuBarEvents.rawValue)) ?? .never
+        menuBarEvents = savedMenuBarEvents
+        calendarMenuBarDisplay =
+            defaults.object(forKey: Key.calendarMenuBarDisplay.rawValue)
+            .flatMap { $0 as? Int }
+            .flatMap(CalendarMenuBarDisplay.init(rawValue:))
+            ?? (savedMenuBarEvents == .never ? .disabled : .meetingIcon)
         menuBarLinkedEventsOnly =
             defaults.object(forKey: Key.menuBarLinkedEventsOnly.rawValue) == nil
             || defaults.bool(forKey: Key.menuBarLinkedEventsOnly.rawValue)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -48,6 +48,7 @@ enum AppSettingsKey: String, CaseIterable {
     case autoJoinConfirms = "autoJoinConfirms"
     case cameraPreview = "cameraPreview"
     case menuBarEvents = "menuBarEvents"
+    case calendarMenuBarDisplay = "calendarMenuBarDisplay"
     case menuBarLinkedEventsOnly = "menuBarLinkedEventsOnly"
     case hideCurrentEvent = "hideCurrentEvent"
     case aiEnabled = "aiEnabled"

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -42,6 +42,7 @@ enum AppSettingsKey: String, CaseIterable {
     case extensionCustomSearchPaths = "extensionCustomSearchPaths"
     case calendarEnabled = "calendarEnabled"
     case calendarShowInLauncher = "calendarShowInLauncher"
+    case calendarLauncherLimit = "calendarLauncherLimit"
     case calendarIncludesTomorrow = "calendarIncludesTomorrow"
     case joinWindowMinutes = "joinWindowMinutes"
     case autoJoinMeetings = "autoJoinMeetings"

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -184,8 +184,9 @@ scene. It falls back to a calendar glyph when nothing is due, so the calendar it
 out from under the user. In **Meeting Title** mode, once no event remains today it instead reads
 `No upcoming events`.
 
-A click opens the usual menu, with `Join <title>` added on top. **A bare click never joins**: the
-menu bar is not a button, and a mis-click there would open a call.
+A click opens the usual menu, with `Join <title>` and `Open in Calendar...` added on top. The latter
+opens that event in Calendar.app. **A bare click never joins**: the menu bar is not a button, and a
+mis-click there would open a call.
 
 ## Auto join and the preview
 

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -170,7 +170,8 @@ never hides an enabled calendar display. The display choice is **Disabled**, **M
 characters — a hard cap is the only thing that bounds a menu bar. `CalendarMenuBarLabel` reads the
 coordinator rather than the stores, which scopes Observation to the label instead of re-running either
 scene. It falls back to a calendar glyph when nothing is due, so the calendar item never disappears
-out from under the user.
+out from under the user. In **Meeting Title** mode, once no event remains today it instead reads
+`No upcoming events`.
 
 A click opens the usual menu, with `Join <title>` added on top. **A bare click never joins**: the
 menu bar is not a button, and a mis-click there would open a call.

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -125,6 +125,14 @@ All five leave the launcher when the feature is off **or** when "Show in launche
 `CalendarCoordinator.applyEnabled`, the `applyQuicklinksPresence` twin. Their shortcuts, the join
 card and the menu bar are unaffected: only launcher search is.
 
+The Calendar settings can limit the individual meeting entries in launcher search to the next 1, 3,
+or 5 meetings, or leave them all visible. New installations default to the next 3 meetings so a busy
+calendar does not crowd out apps and commands.
+
+For the menu bar, **Keep visible — show time left** leaves a started meeting up until it ends: it
+changes from `Now` during the first five minutes to its remaining time. The other choices preserve
+the option to hide a current event immediately or after a chosen delay.
+
 | Command | Does | Bindable |
 | --- | --- | --- |
 | Join Next Meeting | Opens the link for the carded, running, or next meeting. | yes |

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -35,6 +35,9 @@ events as searchable launcher entries.
   go through it, so they cannot drift apart. Because an event ending changes nothing in EventKit,
   the filter alone is not enough for the launcher slice: `CalendarCoordinator` republishes it on the
   minute boundary and on every summon.
+- **The menu bar's `Today` horizon follows the same empty-state rule.** It carries any remaining
+  event that starts today, plus an event within 30 minutes after midnight; only then does the title
+  mode read `No upcoming events`.
 - **`calendarEnabled` doubles as consent**, so it is in `SettingsBackupCoverage.deliberatelyExcluded`
   and only `CalendarCoordinator.setCalendarEnabled` may write it. Tinycast's own dialog comes first,
   the macOS prompt second, and only from the gesture that asked.

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -164,10 +164,13 @@ which is `[start - lead, start)` for **Automatically** and `[start - lead, min(s
 for the timed options. Because the earliest qualifying event wins, one hiding hands the space to the
 next with no extra logic.
 
-`MenuBarLabel` reads the coordinator rather than the stores, which is what scopes Observation to the
-label instead of re-running the whole `MenuBarExtra` scene. It falls back to the app's own glyph when
-nothing is due, so the item never disappears out from under the user, and the title is capped at
-`MenuBarSummary.titleCap` characters — a hard cap is the only thing that bounds a menu bar.
+The calendar has its own `MenuBarExtra`, separate from Tinycast's launcher icon, so hiding the latter
+never hides an enabled calendar display. The display choice is **Disabled**, **Meeting Icon**, or
+**Meeting Title**; the title reads `title • in X min` and is capped at `MenuBarSummary.titleCap`
+characters — a hard cap is the only thing that bounds a menu bar. `CalendarMenuBarLabel` reads the
+coordinator rather than the stores, which scopes Observation to the label instead of re-running either
+scene. It falls back to a calendar glyph when nothing is due, so the calendar item never disappears
+out from under the user.
 
 A click opens the usual menu, with `Join <title>` added on top. **A bare click never joins**: the
 menu bar is not a button, and a mis-click there would open a call.
@@ -219,8 +222,9 @@ and the empty schedule reads `MeetingSpan.orPhrase` off the store that did the q
 placeholder names no days at all: it is a static `PaletteMode` string, and one that advertised a span
 it could not read would be wrong half the time.
 
-Both menu-bar enums put their default at `rawValue == 0`, so `defaults.integer(forKey:)` returning 0
-for an unset key lands on `.never` and `.automatically` rather than fighting them.
+The calendar display and both timing enums put their default at `rawValue == 0`, so an unset preference
+lands on disabled, `.never`, or `.automatically` rather than fighting them. Existing menu-bar users
+are migrated to the meeting-icon display.
 
 The Permissions pane shows calendar access alongside Accessibility, but only ever opens System
 Settings: the Calendar pane's own switch is the one place that may prompt.

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -182,7 +182,8 @@ characters — a hard cap is the only thing that bounds a menu bar. `CalendarMen
 coordinator rather than the stores, which scopes Observation to the label instead of re-running either
 scene. It falls back to a calendar glyph when nothing is due, so the calendar item never disappears
 out from under the user. In **Meeting Title** mode, once no event remains today it instead reads
-`No upcoming events`.
+`No upcoming events`. When **Only show events with meetings** is on, linkless appointments do not
+keep the fallback calendar icon visible either.
 
 A click opens the usual menu, with `Join <title>` and `Open in Calendar...` added on top. The latter
 opens that event in Calendar.app. **A bare click never joins**: the menu bar is not a button, and a

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -40,7 +40,8 @@ events as searchable launcher entries.
   mode read `No upcoming events`.
 - **`calendarEnabled` doubles as consent**, so it is in `SettingsBackupCoverage.deliberatelyExcluded`
   and only `CalendarCoordinator.setCalendarEnabled` may write it. Tinycast's own dialog comes first,
-  the macOS prompt second, and only from the gesture that asked.
+  the macOS prompt second, and only from the gesture that asked. If TCC is reset while the setting is
+  still on, the Calendar pane offers that same path again rather than stranding the feature.
 - **Per-calendar toggles live on `CalendarStore`, not `AppSettings`.** Calendar identifiers are
   machine-specific, so they are deliberately outside the backup mirror — the same reasoning as
   `palettePosition`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -377,7 +377,8 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - `Only show events with meetings` hides a linkless event and shows it again when unchecked
 - Hide Current Event on Automatically clears the entry at the start and hands the space to the next
   event inside its lead time; on 5 minutes it lingers counting up, then clears
-- Clicking the menu bar item opens the menu with `Join <title>` on top — a bare click never joins
+- Clicking the menu bar item opens `Join <title>`, then `Open in Calendar...`; the latter opens that
+  event in Calendar.app, while a bare click never joins
 - Camera Preview on: ↵ on the join card opens the panel **already showing live video** — no black
   frame, no blank mid-preview; ↵ joins, Esc drops the join; the camera light goes out with the
   panel, and the first run prompts once, before any panel appears

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -364,6 +364,8 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 
 - With Calendar **off**: no launcher entries, no card, no permission prompt at launch
 - Enabling shows the consent dialog **before** the macOS prompt; declining prompts for nothing
+- After Calendar permission is reset, Settings ▸ Calendar offers `Allow Calendar Access…` and asks
+  again; after denial it offers System Settings instead
 - With a meeting four minutes out, an empty palette shows the card on top, provider glyph and all
 - The countdown steps on the minute boundary rather than on a keystroke
 - ↵ joins: a Zoom link opens the Zoom app, and the browser where no app claims the scheme


### PR DESCRIPTION
## Related issue

Closes #402

## What changed

- Adds Calendar as an independent menu-bar display that can replace Tinycast's normal item while both are enabled.
- Shows a useful event title and countdown, then `No upcoming events` only after today's eligible events (or an event starting within 30 minutes after midnight) are exhausted.
- Respects `Only show events with meetings` in that empty-state decision, supports current-event time-left behavior, and limits launcher results to 1, 3, 5, or all upcoming meetings.
- Adds `Open in Calendar…` below the menu-bar Join action.
- Recovers from a TCC Calendar reset: when macOS reports `Not asked yet`, Settings ▸ Calendar shows `Allow Calendar Access…` and routes back through Tinycast's existing confirmation and EventKit request path. A denied state still opens System Settings.

## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | Not measured |
| Palette open            | Not measured |
| Feature in use (peak)   | Not measured |
| Palette closed, settled | Not measured |

Leak-tested: Not run. The local app was intentionally removed while reproducing the Calendar permission reset; fresh runtime measurements will be added with the visual demo.

## Demo

Visual comparison and screenshots will be added separately.

## Drawbacks

The permission recovery can fix only a build that contains this change. Calendar permission is bound by macOS to the signed app identity, so an already-installed stable build needs a release containing the fix before it can request access again.

## Tests & validation

- `calendar-test` passed.
- `./Scripts/lint.sh` passed (existing warnings only).
- Debug build completed successfully with `CODE_SIGNING_ALLOWED=NO`.
- Reviewed the Calendar permission-reset path manually in the stable build: reset leaves EventKit at `Not asked yet`; before this change, that state had no in-app affordance to invoke `requestFullAccessToEvents()`.
- The complete harness suite had one unrelated failure: `storage-relocation-test` deliberately fails because its removal deadline has passed; the remaining 29 harnesses passed.