### PR TITLE
Recover Calendar access after TCC reset

### DIFF
--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -30,7 +30,18 @@ struct CalendarSettingsView: View {
             }
             .settingsEnabled(settings.calendarEnabled && settings.calendarShowInLauncher)
 
-            if store.access == .denied {
+            if settings.calendarEnabled, store.access == .notDetermined {
+                Section {
+                    SettingsRow(
+                        title: "Calendar access is needed",
+                        subtitle: "Allow Tinycast to read events and find meeting links."
+                    ) {
+                        Button("Allow Calendar Access…") {
+                            core.calendarCoordinator.setCalendarEnabled(true)
+                        }
+                    }
+                }
+            } else if store.access == .denied {
                 Section {
                     SettingsRow(
                         title: "Calendar access is off",

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -74,12 +74,14 @@ final class CalendarCoordinator {
 
     /// The switch funnels here so enabling, which is also consent, confirms first.
     func setCalendarEnabled(_ enabled: Bool) {
-        guard enabled != settings.calendarEnabled else { return }
         if !enabled {
+            guard settings.calendarEnabled else { return }
             settings.calendarEnabled = false
             return
         }
 
+        // TCC can be reset while the feature remains enabled; that state needs the same consent path.
+        guard !settings.calendarEnabled || store.access == .notDetermined else { return }
         NSApp.activate(ignoringOtherApps: true)
         Task {
             guard

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -40,7 +40,8 @@ events as searchable launcher entries.
   mode read `No upcoming events`.
 - **`calendarEnabled` doubles as consent**, so it is in `SettingsBackupCoverage.deliberatelyExcluded`
   and only `CalendarCoordinator.setCalendarEnabled` may write it. Tinycast's own dialog comes first,
-  the macOS prompt second, and only from the gesture that asked.
+  the macOS prompt second, and only from the gesture that asked. If TCC is reset while the setting is
+  still on, the Calendar pane offers that same path again rather than stranding the feature.
 - **Per-calendar toggles live on `CalendarStore`, not `AppSettings`.** Calendar identifiers are
   machine-specific, so they are deliberately outside the backup mirror — the same reasoning as
   `palettePosition`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -444,6 +444,8 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 
 - With Calendar **off**: no launcher entries, no card, no permission prompt at launch
 - Enabling shows the consent dialog **before** the macOS prompt; declining prompts for nothing
+- After Calendar permission is reset, Settings ▸ Calendar offers `Allow Calendar Access…` and asks
+  again; after denial it offers System Settings instead
 - With a meeting four minutes out, an empty palette shows the card on top, provider glyph and all
 - The countdown steps on the minute boundary rather than on a keystroke
 - ↵ joins: a Zoom link opens the Zoom app, and the browser where no app claims the scheme


### PR DESCRIPTION
## Related issue

Follow-up to #402, whose calendar menu-bar work has already merged.

## What changed

When Calendar permission has been reset in macOS and EventKit reports `Not asked yet`, Settings ▸ Calendar now shows `Allow Calendar Access…`. It reuses the existing confirmation and EventKit request flow even if the Calendar feature preference is already enabled. The denied state still directs the user to System Settings.

## Memory footprint

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | Not measured |
| Palette open            | Not measured |
| Feature in use (peak)   | Not measured |
| Palette closed, settled | Not measured |

Leak-tested: Not run; this is a small settings recovery path with no new long-lived owner, timer, or observer.

## Demo

Not included. The change only exposes the existing permission flow in a previously unreachable state.

## Drawbacks

The fix is effective only in builds that contain it. An already-installed release without this code cannot trigger the macOS prompt from its `Not asked yet` state.

## Tests & validation

- All 62 harnesses passed, including `calendar-test`.
- `./Scripts/lint.sh` passed (existing warnings only).
- Debug build completed successfully with `CODE_SIGNING_ALLOWED=NO`.
- The manual Calendar sweep now covers resetting permission, retrying from Settings, and the denied-state Settings shortcut.