### PR TITLE
Deliver empty-field Escape and return clipboard to the launcher

### DIFF
--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -58,6 +58,10 @@ struct PaletteEscapeTests {
             resolve(),
             .hidePalette,
             "an empty launcher query hides the palette")
+        expect(
+            resolve(canGoBack: true),
+            .hidePalette,
+            "the launcher never walks back: a leftover stack still hides, it does not pop")
         // The two surfaces where the field is not a search field: an argument answer, a chat draft.
         expect(
             resolve(query: "blue", mode: .customCommandArguments),
@@ -79,8 +83,8 @@ struct PaletteEscapeTests {
             "a clipboard screen opened from the root search returns to it")
         expect(
             resolve(mode: .clipboard),
-            .hidePalette,
-            "the same screen summoned by its own hotkey is a root, so it hides")
+            .goToLauncher,
+            "a clipboard root opened by Tab or its hotkey walks back to the launcher")
         expect(
             resolve(mode: .ai, canGoBack: true),
             .goBack,
@@ -99,6 +103,10 @@ struct PaletteEscapeTests {
             resolve(mode: .clipboard, canGoBack: true, behavior: .closeAndPopToRoot),
             .hidePalette,
             "close-and-pop-to-root hides even where a back step exists")
+        expect(
+            resolve(mode: .clipboard, behavior: .closeAndPopToRoot),
+            .hidePalette,
+            "close-and-pop-to-root also hides a clipboard root, instead of walking to the launcher")
         expect(
             resolve(mode: .extensionCommand, canGoBack: true, behavior: .closeAndPopToRoot),
             .hidePalette,
@@ -157,6 +165,23 @@ struct PaletteEscapeTests {
             CommandEscapeTap.isChord(
                 keyCode: Int64(kVK_Escape), flags: [.maskCommand, .maskAlphaShift, .maskSecondaryFn]),
             true, "the flags a real keyboard adds do not disqualify the chord")
+
+        expectChord(
+            PaletteEscapeAction.shouldClaimFromSendEvent(
+                isComposing: false, isControlListOpen: false, isEditingField: false),
+            true, "an empty-field Escape must be claimed before the field editor drops it")
+        expectChord(
+            PaletteEscapeAction.shouldClaimFromSendEvent(
+                isComposing: true, isControlListOpen: false, isEditingField: false),
+            false, "an IME composition keeps Escape so it can cancel marked text")
+        expectChord(
+            PaletteEscapeAction.shouldClaimFromSendEvent(
+                isComposing: false, isControlListOpen: true, isEditingField: false),
+            false, "an open control list closes itself, so sendEvent must not steal the key")
+        expectChord(
+            PaletteEscapeAction.shouldClaimFromSendEvent(
+                isComposing: false, isControlListOpen: false, isEditingField: true),
+            false, "an extension form field owns Escape while it is editing")
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tests/palette-navigation-test.swift
+++ b/Tests/palette-navigation-test.swift
@@ -86,6 +86,13 @@ struct PaletteNavigationTests {
             !ringed.canGoBack && ringed.mode == .clipboard,
             "crossing the Tab ring drops the stack without disturbing the screen")
 
+        let stacked = PaletteState()
+        stacked.prepare(mode: .clipboard)
+        stacked.push(mode: .launcher)
+        expect(
+            stacked.mode == .launcher && !stacked.canGoBack,
+            "the launcher is the root, so opening it drops whatever was underneath")
+
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
     }

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -57,6 +57,10 @@ final class PaletteCoordinator {
 
     /// A palette already up is being navigated, not summoned: the screen under it is the back step.
     func navigate(to mode: PaletteMode) {
+        if mode == .launcher {
+            palette.prepare(mode: .launcher)
+            return
+        }
         if windowController.isVisible, palette.mode != mode {
             palette.push(mode: mode)
         } else {

--- a/Tinycast/Palette/PaletteEscapeAction.swift
+++ b/Tinycast/Palette/PaletteEscapeAction.swift
@@ -7,6 +7,8 @@ enum PaletteEscapeAction: Equatable {
     case clearQuery
     case exitExtensionScreen
     case goBack
+    /// Clipboard on the Tab ring has no stack, but it still walks back to the launcher.
+    case goToLauncher
     case hidePalette
 
     static func resolve(
@@ -20,6 +22,17 @@ enum PaletteEscapeAction: Equatable {
         guard behavior == .navigateBackOrClose else { return .hidePalette }
         // An extension pops its own navigation stack before the command is left.
         if mode == .extensionCommand { return .exitExtensionScreen }
+        // The header has no back chevron here, so a leftover stack must not walk back.
+        if mode == .launcher { return .hidePalette }
+        // Tab / hotkey clipboard is a root, but Raycast still lands on the launcher.
+        if mode == .clipboard { return canGoBack ? .goBack : .goToLauncher }
         return canGoBack ? .goBack : .hidePalette
+    }
+
+    /// The field editor binds Escape to `cancelOperation:` and drops an empty-field press.
+    static func shouldClaimFromSendEvent(
+        isComposing: Bool, isControlListOpen: Bool, isEditingField: Bool
+    ) -> Bool {
+        !isComposing && !isControlListOpen && !isEditingField
     }
 }

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -11,6 +11,8 @@ final class PalettePanel: NSPanel {
 
     /// Bare backspace, which the field editor swallows before `onKeyPress` could see it.
     var onBareBackspace: (() -> Bool)?
+    /// Bare Escape, which the field editor turns into `cancelOperation:` before `onKeyPress`.
+    var onBareEscape: (() -> Bool)?
     /// Command chords the field editor swallows, plus the ones no main menu handles.
     var onCommandShortcut: ((NSEvent) -> Bool)?
     /// The palette's typing context, handed over each time a field takes focus.
@@ -172,6 +174,18 @@ final class PalettePanel: NSPanel {
             Int(event.keyCode) == kVK_Delete,
             event.modifierFlags.isDisjoint(with: [.command, .option, .control, .shift]),
             onBareBackspace?() == true
+        {
+            return
+        }
+        if event.type == .keyDown,
+            Int(event.keyCode) == kVK_Escape,
+            !event.isARepeat,
+            event.modifierFlags.isDisjoint(with: [.command, .option, .control, .shift]),
+            PaletteEscapeAction.shouldClaimFromSendEvent(
+                isComposing: paletteState?.isComposing == true,
+                isControlListOpen: paletteState?.isControlListOpen == true,
+                isEditingField: paletteState?.isEditingField == true),
+            onBareEscape?() == true
         {
             return
         }

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -85,6 +85,11 @@ final class PaletteState {
 
     /// Open `mode` over the current screen, which a back step returns to.
     func push(mode: PaletteMode) {
+        // The launcher never draws a back step, so it cannot sit on top of another screen.
+        if mode == .launcher {
+            prepare(mode: .launcher)
+            return
+        }
         backStack.append(PaletteFrame(mode: self.mode, query: query, selection: selection))
         replace(mode: mode)
     }

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -298,7 +298,12 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             if core.palette.mode == .ai, core.aiChatCoordinator.removeLastAttachment() {
                 return true
             }
-            return core.palette.pop()
+            if core.palette.pop() { return true }
+            if core.palette.mode == .clipboard {
+                core.palette.prepare(mode: .launcher)
+                return true
+            }
+            return false
         }
         installPasteMonitor()
         // Handled at the panel: the field editor or a missing main menu eats these first.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -279,6 +279,7 @@ struct RootPaletteView: View {
                     WindowReader {
                         hostWindow = $0
                         installHeaderArrowHandler(in: $0)
+                        installBareEscapeHandler(in: $0)
                     }
                 )
                 // The window's frame is the size source, so the glass and clip stay matched.
@@ -347,7 +348,10 @@ struct RootPaletteView: View {
             .onChange(of: menuSelection) { syncMenuPanel(presenting: false) }
             .onDisappear {
                 menuPanel.hide()
-                (hostWindow as? PalettePanel)?.onHeaderFieldBoundaryArrow = nil
+                if let panel = hostWindow as? PalettePanel {
+                    panel.onHeaderFieldBoundaryArrow = nil
+                    panel.onBareEscape = nil
+                }
             }
             .onAppear { searchFocused = !screen.hidesSearchField }
             .modifier(SearchFieldHiding(hidden: hidesSearchField, apply: applySearchFieldHiding))
@@ -422,31 +426,7 @@ struct RootPaletteView: View {
                 return screen.pasteKeepingWindowOpen(at: selection) ? .handled : .ignored
             }
             .onKeyPress(.escape) {
-                // An open list closes itself first, exactly as the ⌘K menu does.
-                if vm.isControlListOpen { return .ignored }
-                switch PaletteEscapeAction.resolve(
-                    menuOpen: menuOpen, argumentFocused: argumentFocused != nil, query: vm.query,
-                    mode: vm.mode, canGoBack: vm.canGoBack,
-                    behavior: settings.escapeKeyBehavior)
-                {
-                case .closeMenu:
-                    closeMenus()
-                case .leaveArgumentField:
-                    returnFocusToSearchField()
-                case .clearQuery:
-                    vm.query = ""
-                case .exitExtensionScreen:
-                    core.extensionCoordinator.exitExtensionScreen()
-                case .goBack:
-                    goBack()
-                case .hidePalette:
-                    core.paletteCoordinator.hidePalette()
-                    // This behavior promises a root search on reopen, whatever the delay says.
-                    if settings.escapeKeyBehavior == .closeAndPopToRoot {
-                        core.paletteCoordinator.popToRootNow()
-                    }
-                }
-                return .handled
+                handleEscapeKey() ? .handled : .ignored
             }
             .onKeyPress(keys: [.tab], phases: .down) { press in
                 // ⇥ inside an open list belongs to the list, not to the form's field order.
@@ -1065,6 +1045,42 @@ struct RootPaletteView: View {
         searchFocused = next == nil
     }
 
+    /// Field editor binds Escape to cancelOperation, so sendEvent must run this first.
+    private func handleEscapeKey() -> Bool {
+        if vm.isComposing || vm.isControlListOpen { return false }
+        switch PaletteEscapeAction.resolve(
+            menuOpen: menuOpen, argumentFocused: argumentFocused != nil, query: vm.query,
+            mode: vm.mode, canGoBack: vm.canGoBack,
+            behavior: settings.escapeKeyBehavior)
+        {
+        case .closeMenu:
+            closeMenus()
+        case .leaveArgumentField:
+            returnFocusToSearchField()
+        case .clearQuery:
+            vm.query = ""
+        case .exitExtensionScreen:
+            core.extensionCoordinator.exitExtensionScreen()
+        case .goBack:
+            goBack()
+        case .goToLauncher:
+            vm.prepare(mode: .launcher)
+        case .hidePalette:
+            core.paletteCoordinator.hidePalette()
+            // This behavior promises a root search on reopen, whatever the delay says.
+            if settings.escapeKeyBehavior == .closeAndPopToRoot {
+                core.paletteCoordinator.popToRootNow()
+            }
+        }
+        return true
+    }
+
+    /// Claims empty-field Escape in sendEvent; onKeyPress never sees that press.
+    private func installBareEscapeHandler(in window: NSWindow?) {
+        guard let panel = window as? PalettePanel else { return }
+        panel.onBareEscape = { handleEscapeKey() }
+    }
+
     /// Right at an inline field's end and Left at its start continue the same ring as Tab.
     private func installHeaderArrowHandler(in window: NSWindow?) {
         guard let panel = window as? PalettePanel else { return }
@@ -1111,7 +1127,9 @@ struct RootPaletteView: View {
 
     /// An extension keeps its own stack, so it can have a step back the palette cannot see.
     private var hasBackStep: Bool {
-        vm.canGoBack || (vm.mode == .extensionCommand && extensions.navigationDepth > 1)
+        vm.canGoBack
+            || vm.mode == .clipboard
+            || (vm.mode == .extensionCommand && extensions.navigationDepth > 1)
     }
 
     /// Never promises a step the click does not take: a root screen closes rather than backs.
@@ -1125,7 +1143,12 @@ struct RootPaletteView: View {
             core.extensionCoordinator.exitExtensionScreen()
             return
         }
-        if !vm.pop() { core.paletteCoordinator.hidePalette() }
+        if vm.pop() { return }
+        if vm.mode == .clipboard {
+            vm.prepare(mode: .launcher)
+            return
+        }
+        core.paletteCoordinator.hidePalette()
     }
 
     private func activateSelection() {

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -98,9 +98,11 @@ Uninstall only from a launcher app's Actions menu, scoped to that app. Chat is s
 **The summon decides where a screen sits, not the mode.** `PaletteCoordinator.navigate(to:)` is the
 one rule: a palette already on screen is being *navigated*, so the current screen is pushed and
 becomes the step back; a hidden one is being *summoned*, so the new screen is a root with nothing
-behind it. Every mode command and every global hotkey funnels through `showPalette`, which calls it —
-so typing "Clipboard History" at the root and pressing ↵ leaves a step back to the search that found
-it, while the Clipboard History hotkey does not. Nothing per-feature encodes this.
+behind it. The launcher is the exception — it never draws a back chevron, so `push(.launcher)`
+`prepare`s instead of stacking, and an empty-field Escape on it always hides. Every mode command and
+every global hotkey funnels through `showPalette`, which calls `navigate` — so typing "Clipboard
+History" at the root and pressing ↵ leaves a step back to the search that found it, while the
+Clipboard History hotkey does not. Nothing per-feature encodes this.
 
 `PaletteState` holds the screens below `mode` as `[PaletteFrame]` — mode, query and selection, enough
 that returning looks like never having left — and offers four motions over it:
@@ -117,10 +119,11 @@ top, which would throw away the very selection being restored.
 
 **Escape clears a non-empty query before it leaves the screen**, so one press clears and the next
 leaves: an extension screen exits itself first (it keeps a stack the palette cannot see), then a
-pushed screen pops, and a root hides the palette. A focused inline argument field is a rung above the
-query, so Escape hands focus back to the search field first — the query that found the command is
-still there to be cleared by the next press. A bare backspace in an empty field takes the same step,
-and ⌘⎋ skips the whole stack for a fresh root search without closing the window.
+pushed screen pops. A clipboard root — Tab or its own hotkey — still walks back to the launcher,
+like Raycast. Every other root hides the palette. A focused inline argument field is a rung above
+the query, so Escape hands focus back to the search field first — the query that found the command
+is still there to be cleared by the next press. A bare backspace in an empty field takes the same
+step, and ⌘⎋ skips the whole stack for a fresh root search without closing the window.
 
 `EscapeKeyBehavior` (General settings) can trade the walk back for the old behavior: under
 `closeAndPopToRoot` an empty field closes the window and resets it immediately, whatever Pop to Root
@@ -129,8 +132,8 @@ Search says. Clearing the query is still the first press either way.
 The header draws a back chevron on **every** screen but the launcher: leaving is what the icon
 slot means once you are off the root, and a slot that changed shape with provenance would read
 as two different controls. Where the click lands still depends on the stack — a pushed screen
-pops, a root one closes — so `backHelp` says which, rather than promising a step that is really
-a close. It lights to `textPrimary` under the pointer over `Theme.Duration.hover`, and
+pops, a clipboard root returns to the launcher, and any other root closes — so `backHelp` says
+which, rather than promising a step that is really a close. It lights to `textPrimary` under the pointer over `Theme.Duration.hover`, and
 `HeaderBackButton` keeps that hover state to itself so the header around it never re-renders.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own
@@ -407,6 +410,10 @@ Most ⌘/⌃ chords reach SwiftUI's `onKeyPress` fine. Several kinds do not. All
 handled in `PalettePanel.sendEvent` before `super` hands the event to the responder chain:
 
 - **A bare backspace** — the field editor consumes it as an edit (`onBareBackspace`).
+- **A bare Escape** — AppKit binds it to `cancelOperation:` on the field editor, the same
+  selector as ⌘. When the query is empty there is nothing to cancel, so the key dies unless
+  `sendEvent` claims it (`onBareEscape`). An IME composition, an open control list, and an
+  extension form field keep the key, because each of those has its own cancel.
 - **Chords with no main menu item** — ⌘, and ⌘w, which an app with a menu bar would never see here.
 - **The physical number-row slots.** `FavoriteSlots` matches ⌘1…⌘0 by key code before fixed command
   chords, then publishes the resolved position to the active screen. Only the launcher and clipboard

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,6 +89,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `pasteboard-test` | `Clipboard/Service/ClipboardManager.swift` capture and `Paster.write` — what a Finder copy reads as, and what a file entry writes back |
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
 | `palette-navigation-test` | `Palette/PaletteState.swift`'s screen motions — `prepare`, `replace`, `push`, `pop` |
+| `palette-escape-test` | `PaletteEscapeAction` — the walk-back table, the ⌘⎋ chord, and which empty-field Escape `sendEvent` must claim |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
 | `palette-placement-test` | `DesignSystem/Theme.swift`, `Palette/PalettePlacement.swift` |
 | `hotkey-test` | `HotKeys/Model/DoubleTapModifier.swift`, `DoubleTapDetector.swift`, `HyperKey.swift`, `HotKeyAction.swift`, `Service/KeyShortcut.swift`, and the command→action mapping in `Launcher/Model/CommandID.swift` |
@@ -277,8 +278,9 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
   then hides on a second press; clicking away closes it
 - Search a mode command (Clipboard History, Search Emoji, Search Quicklinks, Search Files, AI Chat)
   and run it: Escape returns to the launcher **with the query still typed and the row still
-  selected**, and the next press clears it. The same screen from its own global hotkey hides the
-  palette instead, and shows its own header icon rather than a back chevron
+  selected**, and the next press clears it. Clipboard History opened by Tab or its own hotkey
+  also returns to the launcher. Every other screen from its own global hotkey hides the palette
+  instead, and shows its own header icon rather than a back chevron
 - ⌘⎋ from any depth lands on an empty root search with the window still open — **must be checked on
   a real keyboard**: macOS claims the chord, so `CommandEscapeTap` is the only thing that delivers it
   and it needs Accessibility granted to the running build. With the palette closed, ⌘⎋ still does

--- a/website/content/docs/features/clipboard.md
+++ b/website/content/docs/features/clipboard.md
@@ -6,7 +6,7 @@ description: Text and images, searchable, filtered by type, pasted back where yo
 Tinycast keeps what you copy and lets you paste any of it back into the app you were using.
 
 Reach it with <kbd>⇥</kbd> from the launcher, the **Clipboard History** command, or its own global
-shortcut recorded in **Settings → Clipboard**.
+shortcut recorded in **Settings → Clipboard**. <kbd>⎋</kbd> returns to the launcher from all three.
 
 The footer names where a paste will land — "Paste to Notes" — so you always know the target.
 

--- a/website/content/docs/palette.md
+++ b/website/content/docs/palette.md
@@ -15,7 +15,7 @@ screen or a screen you reach from it, and <kbd>⎋</kbd> walks back the way you 
 | <kbd>⌘</kbd><kbd>K</kbd>  | Open the Actions menu for the selection               |
 | <kbd>↑</kbd> <kbd>↓</kbd> | Move the selection                                    |
 | <kbd>⇥</kbd>              | Cycle between the launcher and clipboard              |
-| <kbd>⎋</kbd>              | Clear the search, go back a screen, then close        |
+| <kbd>⎋</kbd>              | Clear the search, go back a screen (clipboard included), then close |
 | <kbd>⌘</kbd><kbd>⎋</kbd>  | Back to the root search from any depth                |
 | <kbd>⌫</kbd>              | On an empty field, step back one screen               |
 | <kbd>⌘</kbd><kbd>,</kbd>  | Open Settings                                         |


### PR DESCRIPTION
## Related issue

Closes #523

## What changed

Empty-field Escape often did nothing after #504, because the field editor binds Escape to `cancelOperation:` and SwiftUI's `onKeyPress` never saw the second press. `PalettePanel.sendEvent` now claims a bare Escape the same way it claims a bare backspace, except while an IME is composing, a control list is open, or an extension form is editing.

The launcher is the root: `push(.launcher)` / `navigate(to: .launcher)` prepare instead of stacking, so the main hotkey while Clipboard is up can no longer leave Clipboard under a launcher that draws no back chevron. Empty Escape on the launcher always hides.

A Clipboard root opened by Tab or its hotkey walks back to the launcher instead of hiding, like Raycast. The header chevron and empty-field ⌫ take the same step. **Close window and pop to root** still hides.

## Memory footprint

Not measured. This is key routing and a navigation rule; it adds no retained caches or new windows. Expect no change from baseline.

Leak-tested: n/a (no new long-lived objects)

## Drawbacks

- Chat opened by its own hotkey still hides on Escape. Only Clipboard on the Tab ring walks home.
- A before/after recording is not attached.

## Tests & validation

- `./Scripts/run-tests.sh palette-escape-test`
- `./Scripts/run-tests.sh palette-navigation-test`
- Debug build, `CODE_SIGNING_ALLOWED=NO`, succeeded
- New cases: sendEvent must claim empty-field Escape; launcher never sits on a stack; Clipboard root → `goToLauncher`; close-and-pop-to-root still hides a Clipboard root

Hand-checked on Tinycast Dev:

- [ ] Empty query, second Escape closes the launcher
- [ ] Tab or Clipboard hotkey, empty Escape returns to the launcher
- [ ] Search **Clipboard History** ↵, Escape restores that search
- [ ] Main hotkey while Clipboard is up, then Escape, closes (does not reopen Clipboard)
- [ ] CJK IME: Escape cancels composition first