### PR TITLE
Polish native action menu grouping and corners

### DIFF
--- a/Tinycast/DesignSystem/PopoverMenu.swift
+++ b/Tinycast/DesignSystem/PopoverMenu.swift
@@ -21,6 +21,7 @@ struct PopoverMenuItem {
     let icon: PopoverMenuIcon
     let isLoading: Bool
     var sectionTitle: String?
+    var startsSection: Bool
     var shortcut: String?
     /// A value the row states rather than a chord it runs — what a "Copy as" row copies.
     var detail: String?
@@ -30,13 +31,14 @@ struct PopoverMenuItem {
 
     init(
         title: String, icon: PopoverMenuIcon, isLoading: Bool = false, sectionTitle: String? = nil,
-        shortcut: String? = nil, detail: String? = nil,
+        startsSection: Bool = false, shortcut: String? = nil, detail: String? = nil,
         isDestructive: Bool = false, action: @escaping () -> Void
     ) {
         self.title = title
         self.icon = icon
         self.isLoading = isLoading
         self.sectionTitle = sectionTitle
+        self.startsSection = startsSection
         self.shortcut = shortcut
         self.detail = detail
         self.isDestructive = isDestructive
@@ -45,12 +47,12 @@ struct PopoverMenuItem {
 
     init(
         title: String, systemImage: String, isLoading: Bool = false, sectionTitle: String? = nil,
-        shortcut: String? = nil, isDestructive: Bool = false,
+        startsSection: Bool = false, shortcut: String? = nil, isDestructive: Bool = false,
         action: @escaping () -> Void
     ) {
         self.init(
             title: title, icon: .symbol(systemImage), isLoading: isLoading,
-            sectionTitle: sectionTitle, shortcut: shortcut,
+            sectionTitle: sectionTitle, startsSection: startsSection, shortcut: shortcut,
             isDestructive: isDestructive, action: action)
     }
 }
@@ -111,6 +113,17 @@ struct PopoverMenu: View {
                             }
                             PopoverMenuRow(item: items[index], selected: index == selection) {
                                 onActivate(index)
+                            }
+                        }
+                        .overlay(alignment: .top) {
+                            if index > 0, items[index].startsSection {
+                                Rectangle()
+                                    .fill(Theme.Colors.separator)
+                                    .frame(height: Theme.Size.hairline)
+                                    .padding(.horizontal, Theme.Spacing.md)
+                                    .offset(y: -Theme.Size.menuRowSpacing)
+                                    .allowsHitTesting(false)
+                                    .accessibilityHidden(true)
                             }
                         }
                         .id(index)

--- a/Tinycast/Features/AI/UI/AIScreen.swift
+++ b/Tinycast/Features/AI/UI/AIScreen.swift
@@ -30,19 +30,22 @@ struct AIScreen: PaletteScreen {
             })
         if chat.lastAssistantText != nil {
             items.append(
-                PopoverMenuItem(title: "Copy Last Response", systemImage: "doc.on.doc") {
+                PopoverMenuItem(title: "Copy Last Response", systemImage: "doc.on.doc", startsSection: true) {
                     coordinator.copyLastResponse()
                 })
         }
         if !chat.pendingAttachments.isEmpty {
             items.append(
-                PopoverMenuItem(title: "Remove Attachments", systemImage: "paperclip") {
+                PopoverMenuItem(
+                    title: "Remove Attachments", systemImage: "paperclip",
+                    startsSection: chat.lastAssistantText == nil
+                ) {
                     coordinator.clearAttachments()
                 })
         }
         items.append(
             PopoverMenuItem(
-                title: "Chat History", systemImage: "clock.arrow.circlepath"
+                title: "Chat History", systemImage: "clock.arrow.circlepath", startsSection: true
             ) {
                 coordinator.showHistory()
             })

--- a/Tinycast/Features/AI/UI/ChatHistoryScreen.swift
+++ b/Tinycast/Features/AI/UI/ChatHistoryScreen.swift
@@ -86,7 +86,7 @@ enum ChatHistoryActionsMenu {
                     coordinator.openChat(id: conversation.id)
                 },
                 PopoverMenuItem(
-                    title: "Delete Chat", systemImage: "trash", shortcut: "⌃X",
+                    title: "Delete Chat", systemImage: "trash", startsSection: true, shortcut: "⌃X",
                     isDestructive: true
                 ) {
                     coordinator.deleteChat(id: conversation.id)

--- a/Tinycast/Features/Calculator/UI/CalculatorHistoryScreen.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorHistoryScreen.swift
@@ -151,7 +151,8 @@ enum CalcHistoryActionsMenu {
                     core.calculatorCoordinator.copyHistoryExpression(entry)
                 },
                 PopoverMenuItem(
-                    title: "Delete Entry", systemImage: "trash", shortcut: "⌃X", isDestructive: true
+                    title: "Delete Entry", systemImage: "trash", startsSection: true, shortcut: "⌃X",
+                    isDestructive: true
                 ) {
                     calcHistory.remove(entry)
                 },

--- a/Tinycast/Features/Calendar/UI/MeetingCardView.swift
+++ b/Tinycast/Features/Calendar/UI/MeetingCardView.swift
@@ -76,7 +76,7 @@ enum MeetingActionsMenu {
         }
         items.append(
             PopoverMenuItem(
-                title: "Open in Calendar", systemImage: "calendar",
+                title: "Open in Calendar", systemImage: "calendar", startsSection: true,
                 shortcut: meeting.link == nil ? "↵" : nil
             ) {
                 core.calendarCoordinator.openInCalendar(meeting)

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -163,18 +163,22 @@ enum ClipboardActionsMenu {
             ]
         if item.isPinned {
             items.append(
-                PopoverMenuItem(title: "Unpin Entry", systemImage: "pin.slash", shortcut: "⌘.") {
+                PopoverMenuItem(
+                    title: "Unpin Entry", systemImage: "pin.slash", startsSection: true, shortcut: "⌘."
+                ) {
                     core.clipboardCoordinator.togglePinnedClip(item)
                 })
         } else {
             items.append(
-                PopoverMenuItem(title: "Pin Entry", systemImage: "pin", shortcut: "⌘.") {
+                PopoverMenuItem(
+                    title: "Pin Entry", systemImage: "pin", startsSection: true, shortcut: "⌘."
+                ) {
                     core.clipboardCoordinator.togglePinnedClip(item)
                 })
         }
         if item.kind == .image || item.kind == .file {
             items.append(
-                PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {
+                PopoverMenuItem(title: "Show in Finder", systemImage: "folder", startsSection: true) {
                     core.clipboardCoordinator.revealClip(item)
                 })
         }
@@ -190,7 +194,8 @@ enum ClipboardActionsMenu {
         }
         items.append(
             PopoverMenuItem(
-                title: "Delete Entry", systemImage: "trash", shortcut: "⌃X", isDestructive: true
+                title: "Delete Entry", systemImage: "trash", startsSection: true, shortcut: "⌃X",
+                isDestructive: true
             ) {
                 store.remove(item)
             })

--- a/Tinycast/Features/FileSearch/UI/FileSearchScreen.swift
+++ b/Tinycast/Features/FileSearch/UI/FileSearchScreen.swift
@@ -74,7 +74,7 @@ enum FileSearchActionsMenu {
                     title: "Show in Finder", systemImage: "folder", shortcut: "⌘↵"
                 ) { core.fileSearchCoordinator.showInFinder(result) },
                 PopoverMenuItem(
-                    title: "Copy Path", systemImage: "doc.on.clipboard"
+                    title: "Copy Path", systemImage: "doc.on.clipboard", startsSection: true
                 ) { core.fileSearchCoordinator.copyPath(result) }
             ])
     }

--- a/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
+++ b/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
@@ -56,7 +56,7 @@ enum AppActionsMenu {
         if app.canRevealInFinder {
             items.append(
                 PopoverMenuItem(
-                    title: "Show in Finder", systemImage: "folder", shortcut: "⌘↵"
+                    title: "Show in Finder", systemImage: "folder", startsSection: true, shortcut: "⌘↵"
                 ) {
                     core.launcherCoordinator.showInFinder(app)
                 })
@@ -79,7 +79,8 @@ enum AppActionsMenu {
         if app.kind == .application {
             items.append(
                 PopoverMenuItem(
-                    title: "Uninstall Application", systemImage: "trash", isDestructive: true
+                    title: "Uninstall Application", systemImage: "trash", startsSection: true,
+                    isDestructive: true
                 ) {
                     core.uninstallCoordinator.beginUninstall(app)
                 })
@@ -90,7 +91,7 @@ enum AppActionsMenu {
                 items.append(
                     PopoverMenuItem(
                         title: enabled ? "Disable Background Refresh" : "Enable Background Refresh",
-                        systemImage: enabled ? "pause.circle" : "play.circle"
+                        systemImage: enabled ? "pause.circle" : "play.circle", startsSection: true
                     ) {
                         core.extensions.toggleBackgroundRefresh(for: app)
                     })
@@ -102,12 +103,15 @@ enum AppActionsMenu {
                 }
             }
             items.append(
-                PopoverMenuItem(title: "Configure Extension", systemImage: "slider.horizontal.3") {
+                PopoverMenuItem(
+                    title: "Configure Extension", systemImage: "slider.horizontal.3", startsSection: true
+                ) {
                     core.extensionCoordinator.showExtensionSettings(for: app)
                 })
             items.append(
                 PopoverMenuItem(
-                    title: "Uninstall Extension", systemImage: "trash", isDestructive: true
+                    title: "Uninstall Extension", systemImage: "trash", startsSection: true,
+                    isDestructive: true
                 ) {
                     core.extensionCoordinator.confirmUninstall(app)
                 })

--- a/Tinycast/Features/Launcher/UI/FallbackActionsMenu.swift
+++ b/Tinycast/Features/Launcher/UI/FallbackActionsMenu.swift
@@ -13,7 +13,9 @@ enum FallbackActionsMenu {
                 PopoverMenuItem(
                     title: fallback.openVerb, systemImage: "list.bullet.rectangle", shortcut: "↵"
                 ) { core.fallbackCoordinator.run(fallback, query: query) },
-                PopoverMenuItem(title: "Configure Fallbacks…", systemImage: "slider.horizontal.3") {
+                PopoverMenuItem(
+                    title: "Configure Fallbacks…", systemImage: "slider.horizontal.3", startsSection: true
+                ) {
                     core.fallbackCoordinator.showSettings()
                 }
             ])

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
@@ -126,7 +126,7 @@ enum QuicklinkActionsMenu {
                 })
         }
         items.append(
-            PopoverMenuItem(title: "Edit Quicklink", systemImage: "pencil") {
+            PopoverMenuItem(title: "Edit Quicklink", systemImage: "pencil", startsSection: true) {
                 core.paletteCoordinator.hidePalette(restoreFocus: false)
                 core.quicklinkCoordinator.editQuicklink(quicklink)
             })
@@ -136,10 +136,15 @@ enum QuicklinkActionsMenu {
             })
         items.append(
             quicklink.isPinned
-                ? PopoverMenuItem(title: "Unpin Quicklink", systemImage: "pin.slash", shortcut: "⌘.") {
+                ? PopoverMenuItem(
+                    title: "Unpin Quicklink", systemImage: "pin.slash", startsSection: true,
+                    shortcut: "⌘."
+                ) {
                     core.quicklinkCoordinator.toggleQuicklinkPinned(id: quicklink.id)
                 }
-                : PopoverMenuItem(title: "Pin Quicklink", systemImage: "pin", shortcut: "⌘.") {
+                : PopoverMenuItem(
+                    title: "Pin Quicklink", systemImage: "pin", startsSection: true, shortcut: "⌘."
+                ) {
                     core.quicklinkCoordinator.toggleQuicklinkPinned(id: quicklink.id)
                 })
         items.append(
@@ -156,14 +161,16 @@ enum QuicklinkActionsMenu {
             !QuicklinkDestination.containsPlaceholder(quicklink.link)
         {
             items.append(
-                PopoverMenuItem(title: "Show in Finder", systemImage: "folder", shortcut: "⌘F") {
+                PopoverMenuItem(
+                    title: "Show in Finder", systemImage: "folder", startsSection: true, shortcut: "⌘F"
+                ) {
                     core.paletteCoordinator.hidePalette(restoreFocus: false)
                     AppLauncher.showInFinder(URL(fileURLWithPath: path))
                 })
         }
         items.append(
             PopoverMenuItem(
-                title: "Delete Quicklink", systemImage: "trash", shortcut: "⌘⌫",
+                title: "Delete Quicklink", systemImage: "trash", startsSection: true, shortcut: "⌘⌫",
                 isDestructive: true
             ) {
                 Task { await core.quicklinkCoordinator.deleteQuicklink(id: quicklink.id) }

--- a/Tinycast/Features/Snippets/UI/SnippetsScreen.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetsScreen.swift
@@ -84,7 +84,7 @@ enum SnippetActionsMenu {
                 PopoverMenuItem(title: "Paste Snippet", systemImage: "text.quote", shortcut: "↵") {
                     core.snippetCoordinator.expandSnippetFromPalette(id: record.id)
                 },
-                PopoverMenuItem(title: "Edit Snippet", systemImage: "pencil") {
+                PopoverMenuItem(title: "Edit Snippet", systemImage: "pencil", startsSection: true) {
                     core.paletteCoordinator.hidePalette(restoreFocus: false)
                     core.snippetCoordinator.editSnippet(record)
                 },
@@ -92,7 +92,7 @@ enum SnippetActionsMenu {
                     core.paletteCoordinator.hidePalette(restoreFocus: false)
                     core.snippetCoordinator.editSnippet(nil)
                 },
-                PopoverMenuItem(title: "Show in Finder", systemImage: "folder") {
+                PopoverMenuItem(title: "Show in Finder", systemImage: "folder", startsSection: true) {
                     core.snippetCoordinator.showSnippetInFinder(record)
                 }
             ])

--- a/Tinycast/Features/Uninstall/UI/UninstallScreen.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallScreen.swift
@@ -104,11 +104,14 @@ enum UninstallActionsMenu {
             items.append(
                 PopoverMenuItem(
                     title: checked ? "Unselect File" : "Select File",
-                    systemImage: checked ? "circle" : "checkmark.circle", shortcut: "⌘↵"
+                    systemImage: checked ? "circle" : "checkmark.circle", startsSection: true,
+                    shortcut: "⌘↵"
                 ) { session.toggle(candidate.id) })
         }
         items.append(
-            PopoverMenuItem(title: "Copy Path", systemImage: "doc.on.clipboard", shortcut: "⌥⌘C") {
+            PopoverMenuItem(
+                title: "Copy Path", systemImage: "doc.on.clipboard", startsSection: true, shortcut: "⌥⌘C"
+            ) {
                 core.uninstallCoordinator.copyUninstallPath(candidate)
             })
         items.append(

--- a/Tinycast/Palette/MenuPanel.swift
+++ b/Tinycast/Palette/MenuPanel.swift
@@ -45,36 +45,58 @@ final class MenuPanelController {
     private var panel: MenuPanel?
     private var hosting: NSHostingView<AnyView>?
     private weak var parent: NSWindow?
+    private var clipsToMenuCorners = false
 
     /// `bottomBar`'s own padding: a menu's edge must line up with the button it hangs off.
     private static let inset: CGFloat = Theme.Spacing.md
 
     var isOpen: Bool { panel?.isVisible ?? false }
 
-    func show(_ content: AnyView, corner: Corner, parent: NSWindow, core: AppCore) {
+    func show(
+        _ content: AnyView, corner: Corner, parent: NSWindow, core: AppCore, clipsToMenuCorners: Bool
+    ) {
         let root = AnyView(content.paletteEnvironment(core))
         let panel = ensurePanel(state: core.palette)
-        if let hosting {
-            hosting.rootView = root
-        } else {
-            let view = NSHostingView(rootView: root)
-            view.sizingOptions = [.intrinsicContentSize]
-            panel.contentView = view
-            hosting = view
-        }
+        setContent(root, clipsToMenuCorners: clipsToMenuCorners, in: panel)
         self.parent = parent
         // Open disarmed: a menu opened by click lands under the pointer, which chose no row of it.
         core.palette.disarmHoverHighlight(pointerAt: NSEvent.mouseLocation)
         layout(corner: corner, parent: parent)
-        guard panel.parent == nil else { return }
-        parent.addChildWindow(panel, ordered: .above)
+        if panel.parent == nil { parent.addChildWindow(panel, ordered: .above) }
+        refreshShadow(panel)
     }
 
     /// Rebuilds the hosted tree in place: the panel keeps its window, so nothing flickers.
-    func update(_ content: AnyView, corner: Corner, core: AppCore) {
-        guard let hosting, let parent else { return }
-        hosting.rootView = AnyView(content.paletteEnvironment(core))
+    func update(_ content: AnyView, corner: Corner, core: AppCore, clipsToMenuCorners: Bool) {
+        guard let panel, let parent else { return }
+        setContent(AnyView(content.paletteEnvironment(core)), clipsToMenuCorners: clipsToMenuCorners, in: panel)
         layout(corner: corner, parent: parent)
+    }
+
+    private func setContent(_ root: AnyView, clipsToMenuCorners: Bool, in panel: MenuPanel) {
+        if let hosting, self.clipsToMenuCorners == clipsToMenuCorners {
+            hosting.rootView = root
+            return
+        }
+        let view = NSHostingView(rootView: root)
+        if clipsToMenuCorners {
+            view.wantsLayer = true
+            view.layer?.cornerRadius = Theme.Radius.menuPanel
+            view.layer?.cornerCurve = .continuous
+            view.layer?.masksToBounds = true
+            view.layer?.allowsEdgeAntialiasing = true
+        }
+        view.sizingOptions = [.intrinsicContentSize]
+        panel.contentView = view
+        hosting = view
+        self.clipsToMenuCorners = clipsToMenuCorners
+    }
+
+    private func refreshShadow(_ panel: MenuPanel) {
+        guard clipsToMenuCorners else { return }
+        hosting?.layoutSubtreeIfNeeded()
+        panel.displayIfNeeded()
+        panel.invalidateShadow()
     }
 
     func hide() {
@@ -115,5 +137,6 @@ final class MenuPanelController {
         // Every arrow key re-pushes the tree, and only the highlight moved.
         guard panel.frame != frame else { return }
         panel.setFrame(frame, display: true)
+        refreshShadow(panel)
     }
 }

--- a/Tinycast/Palette/PaletteScreen.swift
+++ b/Tinycast/Palette/PaletteScreen.swift
@@ -10,6 +10,7 @@ enum PaletteAxis {
 @MainActor struct PaletteMenuContent {
     let rowCount: Int
     let isLoading: (Int) -> Bool
+    let clipsToMenuCorners: Bool
     /// Built on demand: `moveMenu` resolves the open menu on every arrow key.
     let view: () -> AnyView
     /// Bounds-checked by the caller against `rowCount`, so a row index is always one this menu has.
@@ -17,12 +18,13 @@ enum PaletteAxis {
 
     init(
         rowCount: Int, view: @escaping () -> AnyView, activate: @escaping (Int) -> Void,
-        isLoading: @escaping (Int) -> Bool = { _ in false }
+        isLoading: @escaping (Int) -> Bool = { _ in false }, clipsToMenuCorners: Bool = false
     ) {
         self.rowCount = rowCount
         self.view = view
         self.activate = activate
         self.isLoading = isLoading
+        self.clipsToMenuCorners = clipsToMenuCorners
     }
 
     init(
@@ -38,7 +40,7 @@ enum PaletteAxis {
                         width: width, onActivate: onActivate))
             },
             activate: { popover.items[$0].action() },
-            isLoading: { popover.items[$0].isLoading })
+            isLoading: { popover.items[$0].isLoading }, clipsToMenuCorners: true)
     }
 }
 

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -967,9 +967,12 @@ struct RootPaletteView: View {
         }
         let view = AnyView(content.view())
         if presenting, let hostWindow {
-            menuPanel.show(view, corner: corner, parent: hostWindow, core: core)
+            menuPanel.show(
+                view, corner: corner, parent: hostWindow, core: core,
+                clipsToMenuCorners: content.clipsToMenuCorners)
         } else {
-            menuPanel.update(view, corner: corner, core: core)
+            menuPanel.update(
+                view, corner: corner, core: core, clipsToMenuCorners: content.clipsToMenuCorners)
         }
     }
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -365,6 +365,12 @@ they already hold.
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.
 
+`PopoverMenuItem.startsSection` draws a separator in the existing gap above a row. It takes no
+layout space or selection index, so the menu keeps its row positions, dimensions, and navigation.
+Built-in action menus mark boundaries between opening or copying, managing the item, settings, and
+deletion. Menus offering one kind of action, such as calculator copies, color formats, or emoji
+transfers, keep their rows in one group.
+
 ### The menu's own window
 
 A menu is **not** an overlay inside the palette: `MenuPanelController` hosts it in a `MenuPanel`, a
@@ -379,6 +385,12 @@ The panel is a second SwiftUI hierarchy, so it observes nothing of `RootPaletteV
 `syncMenuPanel` pushes a rebuilt tree on every `openMenu` or `menuSelection` change, and
 `paletteEnvironment` injects the same stores into both hierarchies so they cannot drift.
 `WindowReader` reports the palette's `NSWindow`, which the menu's frame is placed against.
+
+`PaletteMenuContent` opts into `clipsToMenuCorners` when wrapping a native `PopoverMenu`. Its hosting
+view's backing layer uses the continuous `menuPanel` corner with edge antialiasing. AppKit draws the
+window shadow from that outline, refreshed after layout and display on show and resize. Custom
+extension panels keep their original hosting setup. Switching between native and custom content
+replaces the hosting view so layer styling stays with the menu that requested it.
 
 ## Menu-open input freeze
 


### PR DESCRIPTION
**I used Codex to help write and check this change.**

## Related issue

The maintainer requested these visual changes in our conversation. There isn't a linked GitHub issue yet.

## What changed

Native action menus now have separators between groups of related actions, smoother corners, and a refreshed window shadow when the menu opens or changes size. This covers the existing launcher, clipboard, calculator history, file search, snippets, quicklinks, meetings, AI, chat history, fallback, and uninstall menus.

The separators use the existing space between rows, so menu dimensions and selection indices stay the same. Calculator copy actions, color formats, and emoji actions keep one group and get the shared corner and shadow changes. Third party extension panels keep their existing rendering.

Actions, their order, visibility conditions, and keyboard shortcuts are unchanged. The patch also updates the palette documentation.

## Memory footprint

Debug build on macOS 27.0 beta, measured with `footprint`. These figures are physical footprint in decimal MB.

| Step | Memory |
| --- | --- |
| Idle after launch | 31.44 MB |
| Palette open | 53.54 MB |
| Feature in use, observed process peak | 56.56 MB |
| Palette closed, settled | Still needs checking |

The leak check did not pass. `leaks --noContent --nostacks` reported 416 allocations totaling 19,936 bytes on this branch. A separate build of unchanged `main` at `1855c81` reported 415 allocations totaling 19,888 bytes. Both reports list `NSXPCConnection` root cycles.

## Demo

Before and after screenshots to be added.

## Drawbacks

The separators fit inside the existing row gap and add no vertical breathing room. Menus with conditional actions need a final visual pass across the available states.

## Tests & validation

- All 64 existing harnesses passed. The two extension harnesses needed a rerun with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` to load the Xcode SwiftUI macro plugin.
- The Debug build succeeded with no new source warnings.
- Lint passed with existing warnings.
- Model import purity and `git diff --check` passed.
- Comparing the changed action definitions against `main`, with separator metadata and whitespace excluded, showed identical actions and shortcuts.
- Checked the original application menu change in the running app, including selection and menu resizing.
- Read the full diff and based the single commit on `main` at `1855c81`.
