### PR TITLE
Let the Permissions pane ask for calendar access

### DIFF
--- a/Tinycast/Features/Calendar/Service/CalendarStore.swift
+++ b/Tinycast/Features/Calendar/Service/CalendarStore.swift
@@ -39,10 +39,15 @@ final class CalendarStore {
         hiddenCalendarIDs = Set(defaults.stringArray(forKey: hiddenKey) ?? [])
     }
 
+    /// TCC sends nothing when a grant changes in Settings, so anything acting on `access` re-reads.
+    func refreshAccess() {
+        access = Permissions.calendarAccess()
+    }
+
     // MARK: - Lifecycle
 
     func start() {
-        access = Permissions.calendarAccess()
+        refreshAccess()
         guard access == .granted else { return }
         observeWake()
         // Deferred: the first EventKit query pays for its XPC warm-up, and launch protects itself.
@@ -61,7 +66,7 @@ final class CalendarStore {
     /// Tinycast's own consent dialog has already been accepted by the time this runs.
     func requestAccess() async -> Bool {
         let granted = await Permissions.requestCalendarAccess()
-        access = Permissions.calendarAccess()
+        refreshAccess()
         guard granted else { return false }
         // A store built before the grant never sees the new calendars; drop it and rebuild.
         changeObserver = nil
@@ -111,7 +116,7 @@ final class CalendarStore {
 
     /// `EKEventStore` is not `Sendable`, so this stays on main; only pure values leave.
     func reload() {
-        access = Permissions.calendarAccess()
+        refreshAccess()
         guard access == .granted else {
             publish([])
             return

--- a/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
+++ b/Tinycast/Features/Calendar/Settings/CalendarSettingsView.swift
@@ -140,6 +140,8 @@ struct CalendarSettingsView: View {
         .formStyle(.grouped)
         .settingsScrollTarget(.calendar)
         .releasesFocusOnOutsideClick()
+        // The snapshot is only reloaded while the feature runs, so a grant made in Settings lands here.
+        .onAppear { store.refreshAccess() }
     }
 
     /// Routed through the coordinator so enabling, which is also consent, confirms first.

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -80,8 +80,8 @@ final class CalendarCoordinator {
             return
         }
 
-        // TCC can be reset while the feature remains enabled; that state needs the same consent path.
-        guard !settings.calendarEnabled || store.access == .notDetermined else { return }
+        // Asking again is the only way back: Settings cannot add an app TCC has no record of.
+        guard !settings.calendarEnabled || store.access != .granted else { return }
         NSApp.activate(ignoringOtherApps: true)
         Task {
             guard
@@ -94,9 +94,9 @@ final class CalendarCoordinator {
                     confirmRole: .standard)
             else { return }
 
-            settings.calendarEnabled = true
-            // The one prompt for this feature, raised from the gesture that asked for it.
             guard await store.requestAccess() else { return }
+            // The flag is consent, so it is written only once macOS has actually granted access.
+            settings.calendarEnabled = true
             applyEnabled()
         }
     }

--- a/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
+++ b/Tinycast/Features/Calendar/UI/CalendarCoordinator.swift
@@ -81,6 +81,7 @@ final class CalendarCoordinator {
         }
 
         // Asking again is the only way back: Settings cannot add an app TCC has no record of.
+        store.refreshAccess()
         guard !settings.calendarEnabled || store.access != .granted else { return }
         NSApp.activate(ignoringOtherApps: true)
         Task {

--- a/Tinycast/Features/Settings/Panes/PermissionsSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/PermissionsSettingsView.swift
@@ -2,6 +2,7 @@ import Combine
 import SwiftUI
 
 struct PermissionsSettingsView: View {
+    @Environment(AppCore.self) private var core
     @State private var accessibilityTrusted = Permissions.isAccessibilityTrusted()
     @State private var calendarAccess = Permissions.calendarAccess()
     private let refreshTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
@@ -47,11 +48,20 @@ struct PermissionsSettingsView: View {
                 }
 
                 LabeledContent {
-                    Button("Open…") { Permissions.openCalendarSettings() }
+                    Button(calendarNeedsPrompt ? "Grant Access…" : "Open…") {
+                        // Settings lists no app TCC was never asked about, so asking is the way in.
+                        if calendarNeedsPrompt {
+                            core.calendarCoordinator.setCalendarEnabled(true)
+                        } else {
+                            Permissions.openCalendarSettings()
+                        }
+                    }
                 } label: {
-                    Text("Manage in System Settings")
-                    // Only the Calendar pane's own switch may ask for this, so this never prompts.
-                    Text("Opens Privacy & Security › Calendars.")
+                    Text(calendarNeedsPrompt ? "Grant access" : "Manage in System Settings")
+                    Text(
+                        calendarNeedsPrompt
+                            ? "Turns the calendar on, then asks macOS for access."
+                            : "Opens Privacy & Security › Calendars.")
                 }
             } header: {
                 SettingsSectionHeader(.permissionsCalendars)
@@ -62,6 +72,8 @@ struct PermissionsSettingsView: View {
         .onAppear(perform: refresh)
         .onReceive(refreshTimer) { _ in refresh() }
     }
+
+    private var calendarNeedsPrompt: Bool { calendarAccess == .notDetermined }
 
     private var calendarStatus: (title: String, symbol: String, tint: Color) {
         switch calendarAccess {

--- a/Tinycast/Palette/MenuPanel.swift
+++ b/Tinycast/Palette/MenuPanel.swift
@@ -69,7 +69,8 @@ final class MenuPanelController {
     /// Rebuilds the hosted tree in place: the panel keeps its window, so nothing flickers.
     func update(_ content: AnyView, corner: Corner, core: AppCore, clipsToMenuCorners: Bool) {
         guard let panel, let parent else { return }
-        setContent(AnyView(content.paletteEnvironment(core)), clipsToMenuCorners: clipsToMenuCorners, in: panel)
+        setContent(
+            AnyView(content.paletteEnvironment(core)), clipsToMenuCorners: clipsToMenuCorners, in: panel)
         layout(corner: corner, parent: parent)
     }
 

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -40,8 +40,10 @@ events as searchable launcher entries.
   mode read `No upcoming events`.
 - **`calendarEnabled` doubles as consent**, so it is in `SettingsBackupCoverage.deliberatelyExcluded`
   and only `CalendarCoordinator.setCalendarEnabled` may write it. Tinycast's own dialog comes first,
-  the macOS prompt second, and only from the gesture that asked. If TCC is reset while the setting is
-  still on, the Calendar pane offers that same path again rather than stranding the feature.
+  the macOS prompt second, and only from the gesture that asked. **It is written only after macOS
+  grants**, so a prompt that fails or is dismissed can never leave the feature reading as on with no
+  access. Enabling is re-offered whenever access is anything but granted — by the Calendar pane and by
+  the Permissions pane — so a TCC record lost after the setting was already on never strands it.
 - **Per-calendar toggles live on `CalendarStore`, not `AppSettings`.** Calendar identifiers are
   machine-specific, so they are deliberately outside the backup mirror — the same reasoning as
   `palettePosition`.
@@ -248,5 +250,9 @@ preference lands on `.disabled` and `.today` rather than fighting them. `MenuBar
 `.disabled` is the one switch that takes the item out of the menu bar, and a second one would only
 disagree with it.
 
-The Permissions pane shows calendar access alongside Accessibility, but only ever opens System
-Settings: the Calendar pane's own switch is the one place that may prompt.
+The Permissions pane shows calendar access alongside Accessibility, and when TCC has no record it
+offers the same consent path rather than only opening System Settings — the Calendars pane there
+lists no app that has never asked, so a `notDetermined` state that could only be sent to Settings was
+a dead end. Both entry points funnel through `CalendarCoordinator.setCalendarEnabled`, so Tinycast's
+dialog still comes first. A denial is the one state that Settings alone can undo, and both panes send
+it there.

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -250,6 +250,12 @@ preference lands on `.disabled` and `.today` rather than fighting them. `MenuBar
 `.disabled` is the one switch that takes the item out of the menu bar, and a second one would only
 disagree with it.
 
+`CalendarStore.access` is a snapshot, refreshed on `start`, on every `reload` and after a request —
+TCC announces nothing when a grant changes in Settings. `refreshAccess()` is why anything that acts on
+`access` outside those three re-reads first: the enable path, so its guard cannot bounce off a stale
+`.granted` and leave a dead button, and the Calendar pane on appear, so a grant made in Settings while
+the feature was off is not reported as still missing.
+
 The Permissions pane shows calendar access alongside Accessibility, and when TCC has no record it
 offers the same consent path rather than only opening System Settings — the Calendars pane there
 lists no app that has never asked, so a `notDetermined` state that could only be sent to Settings was


### PR DESCRIPTION
## Related issue

Closes #538

## What changed

The reported status was correct — TCC genuinely had no record for Tinycast, which is why the app is
absent from the Calendars list in the issue's screenshot. `EKEventStore.authorizationStatus(for:
.event)` returned `.notDetermined`, so "Not asked yet" was accurate. The bug was that **nothing in
the app could ask, and System Settings could not be used instead**:

- **Privacy & Security ▸ Calendars has no "+" button.** macOS lists only apps that have already
  prompted, so the pane's `Open…` button sent people to a screen where Tinycast cannot be added.
- **`setCalendarEnabled` wrote `settings.calendarEnabled = true` before `requestAccess()`.** A prompt
  that threw or was dismissed left the switch reading as on with no access.
- **The re-ask guard was `store.access == .notDetermined`** (and before #521, `enabled !=
  settings.calendarEnabled`), so with the switch already on, nothing could ask again. That is
  exactly "can not request access as well" on v0.10.15.

#521 fixed the Calendar pane only, and it is in `v0.10.17-beta.86` — not in stable. The **Permissions**
pane, which is where the issue's repro steps go, was still a dead end on `main`.

Three changes:

- `PermissionsSettingsView` offers **Grant Access…** when access is `notDetermined`, routed through
  `CalendarCoordinator.setCalendarEnabled(true)` so Tinycast's own confirm dialog still comes first.
  `.granted` and `.denied` keep the `Open…` button — a denial is the one state System Settings can
  undo.
- `calendarEnabled` is written **after** macOS grants, so a failed prompt can never strand the
  feature with the switch on.
- The re-ask guard widens from `access == .notDetermined` to `access != .granted`.

The `MenuPanel.swift` hunk is unrelated pre-existing drift that `Scripts/format.sh` corrected.

Ruled out along the way: signing and Info.plist are not involved. A probe app signed with the
`Tinycast Self-Signed` identity, carrying the same `NSCalendarsFullAccessUsageDescription`, prompts
correctly on macOS 27 and then reads `fullAccess` with 3 calendars.

## Memory footprint

Not measured — no allocation, no new state and no new long-lived owner. Two `Bool` branches in an
existing settings row, and one statement reordered in a coordinator that already existed.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no — nothing is retained, observed or cancelled by this change.

## Demo

The Calendars row in the Permissions pane gains a `Grant Access…` button in the `notDetermined`
state; everything else is unchanged. I could not capture a side-by-side clip: `osascript` has no
assistive access on this machine, so the Settings window cannot be driven to that pane
programmatically. Happy to add one if it's wanted before merge.

## Drawbacks

- Pressing **Grant Access…** from the Permissions pane turns the calendar feature on as well, because
  `calendarEnabled` *is* the consent record. The confirm dialog says so before macOS prompts, and it
  is the same path as the Calendar pane's switch, so there is no second consent shape.
- Users already stuck with `calendarEnabled = true` plus no TCC record keep that state in their prefs.
  #521's recovery section in the Calendar pane still covers them, and the Permissions pane now does
  too, so it is recoverable rather than requiring a defaults reset.

## Tests & validation

- `./Scripts/run-tests.sh` — all 64 harnesses pass.
- Debug build: no new warnings.
- `./Scripts/lint.sh` — clean.
- Model-purity grep over `Features/*/Model/` — clean.
- By hand: built a probe app under the `Tinycast Self-Signed` identity to confirm
  `requestFullAccessToEvents()` prompts and that `authorizationStatus` then reports `fullAccess`
  (3 calendars) on macOS 27, and that a terminal-launched binary is attributed to its parent process
  rather than the bundle — which is why the diagnosis used a launched `.app`.
