### PR TITLE
Step back to the root search instead of closing the window

### DIFF
--- a/Tests/palette-escape-test.swift
+++ b/Tests/palette-escape-test.swift
@@ -111,6 +111,11 @@ struct PaletteEscapeTests {
             resolve(menuOpen: true, canGoBack: true, behavior: .closeAndPopToRoot),
             .closeMenu,
             "a menu outranks the behavior setting beneath it")
+        // The setting is read before the stack is, so the fallback below it never reaches this.
+        expect(
+            resolve(mode: .clipboard, behavior: .closeAndPopToRoot),
+            .hidePalette,
+            "a screen summoned by its own hotkey closes under close-and-pop-to-root")
 
         expect(
             resolve(menuOpen: true, mode: .ai),

--- a/Tests/palette-navigation-test.swift
+++ b/Tests/palette-navigation-test.swift
@@ -45,6 +45,13 @@ struct PaletteNavigationTests {
             vm.mode == .launcher && vm.query == "clipboard",
             "a refused back step leaves the screen untouched")
 
+        // An empty stack is not the same as nothing behind it: only the root search is that.
+        let summonedScreen = PaletteState()
+        summonedScreen.prepare(mode: .clipboard)
+        expect(
+            summonedScreen.pop() && summonedScreen.mode == .launcher,
+            "a screen summoned by its own hotkey still leaves to the root search")
+
         // A list snapped to the top would throw away the very selection being restored.
         let tokens = searchingLauncher()
         tokens.push(mode: .emoji)
@@ -77,14 +84,17 @@ struct PaletteNavigationTests {
         let summoned = searchingLauncher()
         summoned.push(mode: .clipboard)
         summoned.prepare(mode: .emoji)
-        expect(!summoned.canGoBack, "a summon is a new root, not a step onto the old stack")
+        expect(
+            summoned.pop() && summoned.mode == .launcher,
+            "a summon drops the stack, so one step back is the root search, not what was on it")
 
         let ringed = searchingLauncher()
         ringed.push(mode: .clipboard)
         ringed.resetNavigation()
+        expect(ringed.mode == .clipboard, "crossing the Tab ring leaves the screen undisturbed")
         expect(
-            !ringed.canGoBack && ringed.mode == .clipboard,
-            "crossing the Tab ring drops the stack without disturbing the screen")
+            ringed.pop() && ringed.mode == .launcher,
+            "and the root search is still below it, so Escape never closes the window")
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -57,7 +57,8 @@ final class PaletteCoordinator {
 
     /// A palette already up is being navigated, not summoned: the screen under it is the back step.
     func navigate(to mode: PaletteMode) {
-        if windowController.isVisible, palette.mode != mode {
+        // Never the launcher: it is what every stack stands on, so reaching it is not a step onto one.
+        if windowController.isVisible, palette.mode != mode, mode != .launcher {
             palette.push(mode: mode)
         } else {
             palette.prepare(mode: mode)

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -69,7 +69,8 @@ final class PaletteState {
         isVisible = visible
     }
 
-    var canGoBack: Bool { !backStack.isEmpty }
+    /// The root search is below every other screen, whether or not one was pushed onto it.
+    var canGoBack: Bool { mode != .launcher }
 
     /// Open `mode` as the root: a fresh screen with nothing behind it to go back to.
     func prepare(mode: PaletteMode) {
@@ -89,9 +90,14 @@ final class PaletteState {
         replace(mode: mode)
     }
 
-    /// Restore the screen underneath, false when this one is the root.
+    /// Restore the screen underneath, false only on the root search, which has nothing below it.
     func pop() -> Bool {
-        guard let frame = backStack.popLast() else { return false }
+        guard let frame = backStack.popLast() else {
+            // A screen summoned by its own hotkey stacked nothing, and still leaves to the root.
+            guard mode != .launcher else { return false }
+            prepare(mode: .launcher)
+            return true
+        }
         openScreen(frame.mode)
         query = frame.query
         selection = frame.selection
@@ -100,7 +106,7 @@ final class PaletteState {
         return true
     }
 
-    /// Tab rings the root surfaces, so crossing to one leaves nothing behind it.
+    /// Tab rings the root surfaces, so crossing to one drops what the last was opened over.
     func resetNavigation() {
         backStack.removeAll()
     }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -1145,14 +1145,10 @@ struct RootPaletteView: View {
         open(.argumentOptions, highlighting: 0)
     }
 
-    /// An extension keeps its own stack, so it can have a step back the palette cannot see.
-    private var hasBackStep: Bool {
-        vm.canGoBack || (vm.mode == .extensionCommand && extensions.navigationDepth > 1)
-    }
-
-    /// Never promises a step the click does not take: a root screen closes rather than backs.
+    /// The chevron always steps back; Escape only agrees under the behavior that walks back.
     private var backHelp: String {
-        let escape = hasBackStep ? "Esc to go back" : "Esc to close"
+        let walksBack = settings.escapeKeyBehavior == .navigateBackOrClose
+        let escape = walksBack ? "Esc to go back" : "Esc to close"
         return "\(escape) or ⌘ Esc to go to root search"
     }
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -110,17 +110,23 @@ that returning looks like never having left — and offers four motions over it:
 | `prepare(mode:)` | become the root: open fresh, drop the stack |
 | `replace(mode:)` | swap the screen, keep what it was opened over (a new chat, not a new root) |
 | `push(mode:)` | open over the current screen, which a back step returns to |
-| `pop()` | restore the screen underneath; `false` when this one is the root |
+| `pop()` | restore the screen underneath, else the root search; `false` only on the root search |
 
 `pop()` bumps `followToken` rather than `resetToken`: the reset token exists to snap a list to the
 top, which would throw away the very selection being restored.
 
+**An empty stack is not the same as nothing behind it.** The root search is below every other
+screen — a hotkey summon, a Tab across the ring and any `prepare` all stack nothing — so `pop()`
+falls back to it, `canGoBack` is `mode != .launcher`, and `navigate(to:)` resets rather than pushes
+onto the launcher ([#529](https://github.com/abue-ammar/tinycast/issues/529)).
+
 **Escape clears a non-empty query before it leaves the screen**, so one press clears and the next
 leaves: an extension screen exits itself first (it keeps a stack the palette cannot see), then a
-pushed screen pops, and a root hides the palette. A focused inline argument field is a rung above the
-query, so Escape hands focus back to the search field first — the query that found the command is
-still there to be cleared by the next press. A bare backspace in an empty field takes the same step,
-and ⌘⎋ skips the whole stack for a fresh root search without closing the window.
+screen steps back — to what it was pushed over, or to the root search — and the root search hides
+the palette. A focused inline argument field is a rung above the query, so Escape hands focus back
+to the search field first — the query that found the command is still there to be cleared by the
+next press. A bare backspace in an empty field takes the same step, and ⌘⎋ skips the whole stack
+for a fresh root search without closing the window.
 
 `EscapeKeyBehavior` (General settings) can trade the walk back for the old behavior: under
 `closeAndPopToRoot` an empty field closes the window and resets it immediately, whatever Pop to Root
@@ -128,9 +134,9 @@ Search says. Clearing the query is still the first press either way.
 
 The header draws a back chevron on **every** screen but the launcher: leaving is what the icon
 slot means once you are off the root, and a slot that changed shape with provenance would read
-as two different controls. Where the click lands still depends on the stack — a pushed screen
-pops, a root one closes — so `backHelp` says which, rather than promising a step that is really
-a close. It lights to `textPrimary` under the pointer over `Theme.Duration.hover`, and
+as two different controls. The click always steps back; Escape only agrees under
+`navigateBackOrClose`, so `backHelp` reads the behavior rather than promising a key that would
+close instead. It lights to `textPrimary` under the pointer over `Theme.Duration.hover`, and
 `HeaderBackButton` keeps that hover state to itself so the header around it never re-renders.
 
 The launcher advertises the first hop in the header — `AI Chat` beside a `⇥` cap, the footer's own


### PR DESCRIPTION
## Related issue

Closes #529 — Esc and the back chevron close Tinycast instead of returning to the previous screen.

## What changed

`pop()` treated an empty back stack as "nothing behind this screen", but the root search sits below
every screen there is. Three ways in stack nothing — a hotkey summon, a Tab across the ring, and any
`prepare` — so Escape closed the window from a clipboard opened a keystroke earlier.

`pop()` now falls back to the root search when the stack is empty, and `canGoBack` is
`mode != .launcher` rather than a stack test. Escape, the chevron and a bare backspace all route
through `pop()`, so the three back edges agree without touching any of them. `navigate(to:)` no
longer pushes the launcher — it is the floor every stack stands on, so the toggle hotkey pressed over
a screen was stacking the root search on top of it and Escape walked *down* into what was just left.

`closeAndPopToRoot` is unaffected: the behavior is read before the stack is, so the fallback below it
is never reached. The chevron's tooltip reads that behavior now, since under it Escape closes while
the chevron still steps back.

## Tests & validation

All 64 harnesses pass, Debug builds with no new warnings, `lint.sh` clean. `palette-navigation-test`
gains the hotkey-summoned case and asserts the root-search fallback where it previously asserted a
dead end; `palette-escape-test` pins that close-and-pop-to-root outranks the fallback.

