### PR TITLE
Let Escape walk back out of the Tab ring

### DIFF
--- a/Tests/palette-navigation-test.swift
+++ b/Tests/palette-navigation-test.swift
@@ -84,7 +84,27 @@ struct PaletteNavigationTests {
         ringed.resetNavigation()
         expect(
             !ringed.canGoBack && ringed.mode == .clipboard,
-            "crossing the Tab ring drops the stack without disturbing the screen")
+            "closing the Tab ring drops the stack without disturbing the screen")
+
+        let hopped = searchingLauncher()
+        hopped.pushCarryingQuery(mode: .clipboard)
+        expect(
+            hopped.mode == .clipboard && hopped.query == "clipboard" && hopped.selection == 3,
+            "a ring hop carries the query and the row it was on")
+        expect(
+            hopped.pop() && hopped.mode == .launcher && hopped.query == "clipboard",
+            "and the screen it crossed from is the step back")
+
+        let chatted = searchingLauncher()
+        chatted.push(mode: .ai)
+        chatted.query = "why is the sky blue"
+        chatted.push(mode: .clipboard)
+        expect(
+            chatted.pop() && chatted.mode == .ai && chatted.query == "why is the sky blue",
+            "Tab out of chat leaves the draft to come back to")
+        expect(
+            chatted.pop() && chatted.mode == .launcher,
+            "and a second step back reaches the launcher the ring started on")
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }

--- a/Tinycast/Palette/PaletteState.swift
+++ b/Tinycast/Palette/PaletteState.swift
@@ -100,7 +100,13 @@ final class PaletteState {
         return true
     }
 
-    /// Tab rings the root surfaces, so crossing to one leaves nothing behind it.
+    /// Tab's step deeper into the ring: the screen crossed from is the step back, query and all.
+    func pushCarryingQuery(mode: PaletteMode) {
+        backStack.append(PaletteFrame(mode: self.mode, query: query, selection: selection))
+        self.mode = mode
+    }
+
+    /// Tab closing the ring on the launcher, which is its root: nothing is left behind it.
     func resetNavigation() {
         backStack.removeAll()
     }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -1070,16 +1070,17 @@ struct RootPaletteView: View {
         }
     }
 
-    /// Crossing chat's edge opens a fresh screen, so a draft never lands in a list.
+    /// A ring hop leaves a step back — except the hop closing the ring on the launcher, its root.
     private func cycleMode() {
         switch PaletteTabAction.resolve(
             mode: vm.mode, aiEnabled: settings.aiEnabled,
             clipboardEnabled: settings.clipboardEnabled)
         {
-        case .carryQuery(let mode):
-            vm.mode = mode
+        case .carryQuery(.launcher):
+            vm.mode = .launcher
             vm.resetNavigation()
-        case .freshScreen(let mode): vm.prepare(mode: mode)
+        case .carryQuery(let mode): vm.pushCarryingQuery(mode: mode)
+        case .freshScreen(let mode): vm.push(mode: mode)
         case .ask: core.aiChatCoordinator.ask(vm.query)
         }
     }

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -110,6 +110,7 @@ that returning looks like never having left — and offers four motions over it:
 | `prepare(mode:)` | become the root: open fresh, drop the stack |
 | `replace(mode:)` | swap the screen, keep what it was opened over (a new chat, not a new root) |
 | `push(mode:)` | open over the current screen, which a back step returns to |
+| `pushCarryingQuery(mode:)` | the same step, with the query and row kept: Tab's hop into the ring |
 | `pop()` | restore the screen underneath; `false` when this one is the root |
 
 `pop()` bumps `followToken` rather than `resetToken`: the reset token exists to snap a list to the
@@ -145,6 +146,11 @@ still a `.freshScreen`: that field holds a half-written message rather than a qu
 dropped into a filter matches nothing. `.ask` is its own case rather than a `carryQuery(.ai)` because
 the text is submitted, not seeded, and the hint reads the case back out (`== .ask`) instead of
 restating the rule.
+
+**A ring hop is a step, so Escape walks back out the way Tab came in** — launcher → chat → clipboard
+takes two presses to unwind, and the back chevron's tooltip stops promising a step it cannot take.
+The launcher is the ring's root, so the hop that closes the ring resets the stack instead of stacking
+a third screen; ringing round forever therefore never grows the stack past two.
 
 `.customCommandArguments` — `PaletteMode.isArgumentForm` — is the one mode where the search field is
 not a search field: it _is_ the current argument's input, so its placeholder names that argument and ↵


### PR DESCRIPTION
## Related issue

Closes #529

## What changed

Tab's ring hops cleared the back stack, so Escape had nothing to pop and closed the palette instead
of stepping back. Only the launcher → chat hop behaved, and by accident: `.ask` routes through
`PaletteCoordinator`, whose `navigate(to:)` pushes because the palette is already on screen.

A ring hop now pushes the screen it left. `push(mode:)` covers the hop out of chat, which still opens
fresh so no half-written message lands in the clipboard's filter, and a new
`pushCarryingQuery(mode:)` covers the hops whose query narrows both ends — it records the frame and
swaps the mode without clearing the query or the row, which is what `.carryQuery` always did.

The non-obvious half is the launcher case. The launcher is the ring's root, so the hop that closes
the ring still resets the stack: `case .carryQuery(.launcher)` in `cycleMode()`. Without it, tabbing
round in circles would stack screens forever; with it the stack never exceeds two. It also keeps
today's behaviour for the sub-screens that leave via Tab (emoji, snippets, an extension command) —
they all resolve to `.carryQuery(.launcher)` and still land on a root.

## Memory footprint

Unchanged — the back stack holds at most two `PaletteFrame`s, and it already held one on every
pushed screen. No new allocation, no new ownership, nothing retained past a palette close.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no — no new object, task, observer or closure; the diff moves two `PaletteMode` values
and an array append.

## Demo

No visual change. The only thing that renders differently is the back chevron's tooltip, which now
reads "Esc to go back" on a clipboard reached by Tab because that is now what Esc does.

## Drawbacks

Escape from the clipboard reached by Tab no longer closes the palette in one press — that is the
requested behaviour, but it is a change in muscle memory for anyone who tabbed over and hit Escape to
dismiss. `EscapeKeyBehavior.closeAndPopToRoot` still closes on the first empty-field press for anyone
who wants the old feel, and ⌘⎋ still skips the whole stack.

Shift-Tab rings forward rather than backward (pre-existing: `advanceTabFocus` calls `cycleMode()` for
both directions), so it now pushes too. Not touched here.

## Tests & validation

`./Scripts/run-tests.sh` — all 67 harnesses pass. `palette-navigation-test` gains coverage for a ring
hop carrying the query and row, its step back, and the two-step unwind of launcher → chat → clipboard.
`palette-tab-test` is unchanged: `PaletteTabAction` still resolves the same destinations.

Debug build compiles with no new warnings; `./Scripts/lint.sh` is clean.

By hand: chat off — ⌘Space, Tab to the clipboard, Esc returns to the launcher, Esc closes. Chat on —
Tab to chat, Tab to the clipboard, Esc back to chat with the draft intact, Esc to the launcher, Esc
closes. Sub-screens opened by command still pop as before, and a screen opened by its own hotkey
still closes on the first Esc.