### PR TITLE
feat: add alias fields for extension commands

### DIFF
--- a/Tinycast/Features/Extensions/Settings/ExtensionsSettingsView.swift
+++ b/Tinycast/Features/Extensions/Settings/ExtensionsSettingsView.swift
@@ -469,6 +469,8 @@ private struct SettingsCardRow<Control: View>: View {
     var indent: CGFloat = 0
     /// A short fact about the row, beside its name rather than in the control column.
     var badge: String?
+    /// `nil` lets a pair of 120pt fields size themselves; other rows keep the shared 200pt slot.
+    var controlWidth: CGFloat? = Self.controlWidth
     @ViewBuilder var control: Control
 
     var body: some View {
@@ -497,30 +499,45 @@ private struct SettingsCardRow<Control: View>: View {
             .gridColumnAlignment(.leading)
             // One width for every control: else a toggle, a pop-up and a field end apart.
             control
-                .frame(width: SettingsCardRow.controlWidth, alignment: .trailing)
+                .frame(width: controlWidth, alignment: .trailing)
                 .gridColumnAlignment(.trailing)
         }
     }
 }
 
-/// One command: its shortcut, then any preferences it declares of its own.
+/// One command: alias and shortcut on the title row, then any preferences it declares of its own.
 private struct CommandRows: View {
     let installed: InstalledExtension
     let command: ExtensionCommand
+    @Environment(AppSettings.self) private var settings
+    @Environment(VisibilityStore.self) private var visibility
 
     /// A fact about the command, so it sits by the name as a badge rather than a warning colour.
     private var badge: String? { command.mode.isSupported ? nil : "Menu Bar" }
 
+    // Same key `AppIndex` already folds into `.userAlias`.
+    private var entryID: String {
+        ExtensionCommandRef(
+            extensionName: installed.manifest.name, commandName: command.name
+        ).entryID
+    }
+
+    // Hidden or unpublished commands never reach rank, so typing here would match nothing.
+    private var aliasReachesRanker: Bool {
+        settings.extensionsShowInLauncher && !visibility.hiddenItemKeys.contains(entryID)
+    }
+
     var body: some View {
-        SettingsCardRow(title: command.title, detail: command.description, badge: badge) {
-            if command.mode.isSupported {
-                // Per command, not per extension: a shortcut has to land on one thing to run.
-                ShortcutRecorder(
-                    action: .extensionCommand(
-                        entryID: ExtensionCommandRef(
-                            extensionName: installed.manifest.name, commandName: command.name
-                        ).entryID),
-                    isQuiet: true)
+        SettingsCardRow(
+            title: command.title, detail: command.description, badge: badge, controlWidth: nil
+        ) {
+            HStack(spacing: Theme.Spacing.lg) {
+                AliasField(key: entryID, name: command.title)
+                    .settingsEnabled(aliasReachesRanker)
+                if command.mode.isSupported {
+                    // Per command, not per extension: a shortcut has to land on one thing to run.
+                    ShortcutRecorder(action: .extensionCommand(entryID: entryID))
+                }
             }
         }
         // Indented under its command: at the same inset the association is reading order.

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -473,7 +473,7 @@ enum SettingsSearchCatalog {
             keywords: ["supported", "unsupported", "raycast api"]),
         .init(
             group: .extensionsInstalled, "Installed extensions",
-            keywords: ["library", "uninstall", "preferences", "appearance"]),
+            keywords: ["library", "uninstall", "preferences", "appearance", "alias", "shortcut"]),
         .init(
             .extensionsInstall, "Search extensions",
             keywords: ["store", "browse", "install", "registry"]),

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -6,7 +6,7 @@ produces, rendered natively into the palette. No Electron, no browser, no Node.j
 - [How it works](#how-it-works) · [The JS runtime](#the-js-runtime) ·
   [The Swift host](#the-swift-host) · [Rendering](#rendering)
 - [Turning it on](#turning-it-on) · [Installing extensions](#installing-extensions) ·
-  [Registries](#registries) · [Shortcuts](#shortcuts) · [What's supported](#whats-supported) ·
+  [Registries](#registries) · [Shortcuts](#shortcuts) · [Aliases](#aliases) · [What's supported](#whats-supported) ·
   [What isn't](#what-isnt-supported-yet) · [Working on the runtime](#working-on-the-runtime)
 
 ## Invariants
@@ -443,6 +443,15 @@ Its index is not pruned at launch the way the UUID-keyed ones are: the installed
 asynchronously and only while extensions are on, so at launch "not installed yet" and "gone" look
 identical, and pruning there would quietly drop a working binding. Uninstalling clears its own instead,
 along with the extension's stored preferences and its chosen icon.
+
+## Aliases
+
+A user alias binds to a **command**, keyed by the launcher entry id
+(`extension:<extension>/<command>`) — the same key the shortcut, favorite and ranking stores use.
+Settings › Extensions › the command › Alias is the writer; `AppIndex` already ranks it as
+`.userAlias`. The field sits beside the shortcut recorder on the command's title row, the same
+pairing Settings ▸ Commands uses. It dims when the command is hidden from launcher search — the
+global Show in launcher switch, or this extension's — because the ranker never sees the entry then.
 
 ## Background refresh
 

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -317,8 +317,9 @@ on `LauncherItemsSection` puts an `AliasField` on each row, dressed like the `Sh
 beside it; edits store as typed and trim when the field loses focus, and a blank means none. That
 list filters by **membership only**, keeping the index's name order — re-ranking it per keystroke
 would move the row being edited out from under its own field editor. A pane with a hand-written row
-hands `AliasField` the key itself: Settings ▸ Quicklinks passes `Quicklink.entryID`, and dims the
-field on a quicklink hidden from root search, whose entry the ranker never sees.
+hands `AliasField` the key itself: Settings ▸ Quicklinks passes `Quicklink.entryID`, Settings ▸
+Extensions passes `extension:<name>/<command>`, and both dim the field when the entry is hidden
+from launcher search, whose entry the ranker never sees.
 
 Aliases ride along in a settings backup (`launcherAliases`), and deleting what an alias points at —
 uninstalling an app, deleting a quicklink or custom command, uninstalling an extension — removes it

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -493,6 +493,12 @@ caches, TCC grants and login item, so this cannot disturb an installed copy.
 - Window commands move the window you were last in; cycle-on-repeat steps ½ → ⅓ → ⅔
 - "Top Half" lands flush with the top of the visible frame, on a secondary display too
 
+### Extensions
+
+- Every command under Settings ▸ Extensions has Add Alias, and Record Hotkey when the mode is
+  supported; an alias set there finds the command from its start and shows the chip
+- Hiding the extension from the launcher, or turning off Show in launcher, dims its alias fields
+
 ### Settings and backup
 
 - Every pane renders and the sidebar switches without flicker

--- a/website/content/docs/extensions/customising.md
+++ b/website/content/docs/extensions/customising.md
@@ -28,6 +28,13 @@ using them outside Apple's own context is not permitted.
 
 Icon choices **do** ride along in [settings backups](/docs/reference/backup).
 
+## Command alias
+
+Each command has an **Add Alias** field beside its shortcut recorder. Type `si` and that command
+ranks first when you search `si`, the same way an [application alias](/docs/launcher/aliases) works.
+
+The field dims when the command is hidden from launcher search.
+
 ## Uninstalling
 
 Removes the extension and everything attached to it: local storage, cache, preferences, its support

--- a/website/content/docs/extensions/index.md
+++ b/website/content/docs/extensions/index.md
@@ -35,7 +35,7 @@ runs. A fresh boot takes about 7 ms once warm.
 - [Installing extensions](/docs/extensions/installing) — the three routes, registries and package
   managers
 - [What works](/docs/extensions/compatibility) — the supported API surface and the known gaps
-- [Configuring one](/docs/extensions/customising) — preferences, icons and storage
+- [Configuring one](/docs/extensions/customising) — preferences, icons, aliases and storage
 
 ## Shortcuts and arguments
 

--- a/website/content/docs/launcher/aliases.md
+++ b/website/content/docs/launcher/aliases.md
@@ -12,7 +12,8 @@ and extension commands.
 ## Setting one
 
 Aliases are edited in **Settings**, on the row for the item, in any pane that lists launcher items:
-Applications, System Settings, System Actions, Commands, Quicklinks, and the feature panes.
+Applications, System Settings, System Actions, Commands, Quicklinks, Extensions, and the
+feature panes.
 
 There is a clear button on the field, and one alias per entry.
 

--- a/website/content/docs/reference/settings.md
+++ b/website/content/docs/reference/settings.md
@@ -82,7 +82,7 @@ Seven features, all off by default.
 | [Window Management](/docs/features/window-management) | Enable window management | Show in launcher, Cycle sizes on repeat, Gap (0–64 pt, default 0)           |
 | [Clipboard](/docs/features/clipboard)                 | _(always on)_            | Keep history for (**3 Months**), Disabled Applications, Clear history       |
 | [Emoji & Symbols](/docs/features/emoji)               | _(always on)_            | Emoji Skin Tone (**Default**)                                               |
-| [Extensions](/docs/extensions)                        | Enable extensions        | Show in launcher, package manager, registries, custom search paths, Storage |
+| [Extensions](/docs/extensions)                        | Enable extensions        | Show in launcher, per-command alias and shortcut, package manager, registries, custom search paths, Storage |
 
 Clipboard and Emoji have no feature switch — they are part of the palette itself.
 


### PR DESCRIPTION
Authored by @jjaychen1e. Opened on their behalf with their permission — rebased onto `main` and
pushed here because the original branch on their fork had "Allow edits by maintainers" off, so
[#557](https://github.com/abue-ammar/tinycast/pull/557) could not be updated in place. Commit
authorship is preserved. Supersedes #557. Closes #534

## Related issue

Closes #

## What changed

Settings ▸ Extensions gains a per-command **alias** field. Settings was the only missing piece — the
ranker already keys `.userAlias` by the launcher entry id `extension:<name>/<command>`, which is the
same key the shortcut, favorite and ranking stores use, so nothing under `Model/` or `Service/`
changed.

- `CommandRows` now puts an `AliasField` beside the `ShortcutRecorder` on the command's title row,
  the same pairing Settings ▸ Commands uses. `entryID` is computed once and both controls share it.
- The alias field dims when the command cannot reach the ranker — the global **Show in launcher**
  switch is off, or the entry is in `VisibilityStore.hiddenItemKeys`. Typing an alias there would
  match nothing, so it reads as disabled rather than silently dead.
- `SettingsCardRow` gains an optional `controlWidth`. Every other row keeps the shared 200 pt slot;
  passing `nil` lets the alias + shortcut pair size themselves, otherwise two controls get squeezed
  into one control's width.
- The recorder drops `isQuiet: true` on this row, so it matches the quicklink and command panes now
  that it is no longer the only control in the column.
- `SettingsSearchCatalog` picks up `alias` and `shortcut` keywords for the Installed extensions group.

Everything stays inside `Features/Extensions/` — no new `DesignSystem/` or `Theme` surface.

Docs updated in the same change: `docs/features/extensions.md` (new **Aliases** section),
`docs/features/launcher.md`, `docs/testing.md`, and the website pages for extensions, aliases and
the settings reference.

## Memory footprint

No new long-lived state, no new allocations on any palette path — this adds two SwiftUI controls to a
Settings row that already existed, and reuses the alias store the launcher panes already write to.
Not separately profiled.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no.

## Demo

Settings-only visual change; no before/after capture recorded.

## Drawbacks

- The disabled state covers reachability, not correctness: an alias already set stays stored while the
  command is hidden and starts working again when it is unhidden. That matches Quicklinks.
- Dropping `isQuiet` makes the recorder slightly louder on this row than it was. Intentional — it is
  now one of two controls, not a lone one.

## Tests & validation

- `./Scripts/run-tests.sh` — all 67 harnesses pass.
- Debug build clean, no new warnings.
- `./Scripts/lint.sh` — clean.
- `grep -rln 'import AppKit\|import SwiftUI\|import Cocoa' Tinycast/Features/*/Model/` — empty.
- No harness cases added: the change is confined to SwiftUI Settings views, and the alias keying it
  relies on is already covered by the launcher ranking harnesses.
- Not exercised by hand in a running app by me; the manual checks are written into
  `docs/testing.md` ▸ Extensions.
