### PR TITLE
fix: resolve ntd to TWD

### DIFF
--- a/Tests/calc-test.swift
+++ b/Tests/calc-test.swift
@@ -726,6 +726,9 @@ struct CalcTests {
         // ISO 4217's own name for CNY is "Yuan Renminbi"; CLDR carries only "Chinese Yuan"
         expectError("1 rmb to usd", "No exchange rate for CNY.")
         expectError("1 renminbi to usd", "No exchange rate for CNY.")
+        // CLDR signs TWD "NT$", so `ntd` is what Taiwan types; `twd` keeps working
+        expectError("1 ntd to usd", "No exchange rate for TWD.")
+        expectError("1299 usd to ntd", "No exchange rate for TWD.")
         // Slang is no longer carried: CLDR has no "quid", and we don't hand-maintain synonyms
         expectNil("50 quid to usd")
         expectNil("100 bucks to eur")

--- a/Tinycast/Features/Calculator/Model/CalcCurrency.swift
+++ b/Tinycast/Features/Calculator/Model/CalcCurrency.swift
@@ -118,6 +118,11 @@ enum CalcCurrency {
         "CNY": ["rmb", "renminbi"]  // ISO 4217 names CNY "Yuan Renminbi"; CLDR says "Chinese Yuan"
     ]
 
+    /// Codes daily use spells from CLDR's sign, not ISO 4217. docs/features/calculator.md
+    private static let signCodes: [String: [String]] = [
+        "TWD": ["ntd"]  // CLDR writes TWD "NT$", so Taiwan types the sign's code, not TWD
+    ]
+
     /// Hand-written because no standards body names a coin. docs/features/calculator.md
     static let crypto: [(code: String, name: String, aliases: [String])] = [
         ("ADA", "Cardano", ["cardano"]),
@@ -172,6 +177,10 @@ enum CalcCurrency {
             for word in words { table[word] = def }
         }
         for (code, words) in isoNames {
+            guard let def = defs[code] else { continue }
+            for word in words { table[word] = def }
+        }
+        for (code, words) in signCodes {
             guard let def = defs[code] else { continue }
             for word in words { table[word] = def }
         }

--- a/docs/features/calculator.md
+++ b/docs/features/calculator.md
@@ -27,9 +27,10 @@ in (see Currency below).
   whose Full Calendar Access grant a calculator must never provoke mid-keystroke. `workdays` is
   therefore an ordinary time unit, and `calendarEnabled` stays the Calendar feature's own consent.
 - **`CurrencyData.generated.swift` is emitted by `node Scripts/gen-currencies.js`** and never hand-edited.
-  Three currency tables are hand-maintained, all in `CalcCurrency`: `contested`, the nouns several
+  Four currency tables are hand-maintained, all in `CalcCurrency`: `contested`, the nouns several
   currencies share (`dollars`, `pounds`); `isoNames`, the standard's own names where CLDR substitutes
-  a different one (ISO 4217 calls CNY "Yuan Renminbi"); and `crypto`, which no standards body names.
+  a different one (ISO 4217 calls CNY "Yuan Renminbi"); `signCodes`, the codes daily use spells from
+  CLDR's sign instead (`NT$` makes TWD `ntd`); and `crypto`, which no standards body names.
   Do not add slang or synonyms to any of them — no source of truth, so they rot.
 
 ## Evaluation pipeline
@@ -445,6 +446,11 @@ truth. `isoNames` is the narrow exception that proves the rule: where ISO 4217 i
 currency and CLDR substitutes a different word, the standard's name is carried with the standard as
 its source — CNY is "Yuan Renminbi" to ISO 4217, so `rmb` and `renminbi` resolve, while CLDR's own
 "Chinese Yuan" supplies `yuan` through the generator.
+
+`signCodes` is the same exception read off the other source. CLDR's sign for a currency is sometimes
+a letter pair the region spells as a code — it writes TWD `NT$`, and Taiwan writes `NTD` where the
+standard says `TWD`. The single-character `signs` table cannot carry a two-letter prefix, so the code
+it implies is carried here instead, with CLDR as its source. The standard code always keeps working.
 
 ### Crypto
 


### PR DESCRIPTION
## Related issue

Closes #539

## What changed

`1299 usd to ntd` did nothing, because `ntd` reached no currency. It now resolves to TWD.

CLDR signs TWD `NT$`, so Taiwan writes NTD where ISO 4217 writes TWD. `CurrencyData.signs` is keyed by `Character` and cannot carry a two-letter prefix, so the code that sign implies is hand-written in a new `CalcCurrency.signCodes` — a fourth hand-maintained table beside `contested`, `isoNames` and `crypto`, with CLDR as its source, so it is not the slang the other tables refuse. It is applied last in `byName`, after the generated nouns, and claims a word nothing else does. `twd` is unchanged.

## Memory footprint

Not measured. The change is one entry in a `static let` lookup table built once, on a model type that allocates nothing per query; there is no path here that could move the numbers.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | n/a    |
| Palette open            | n/a    |
| Feature in use (peak)   | n/a    |
| Palette closed, settled | n/a    |

Leak-tested: n/a — no new ownership, observer or task.

## Drawbacks

A fourth hand-maintained currency table, which the docs warn against. It earns the exception the same way `isoNames` does: the entry is read off CLDR's own sign rather than invented, so it has a source that can be checked. TWD is the only currency whose CLDR sign implies a code different from its ISO one, so the table is expected to stay at one row.

## Tests & validation

`./Scripts/run-tests.sh` — all 67 harnesses pass. Added to `calc-test`: `1 ntd to usd` and `1299 usd to ntd` both reach `No exchange rate for TWD.`, proving the code resolves against the fixture's deliberately TWD-less rate table. Debug build compiles with no new warnings; `./Scripts/lint.sh` is clean.