### PR TITLE
Cycle halves across displays

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -256,11 +256,13 @@ run ext-icon-test          Tinycast/Platform/Appearance.swift \
 run system-action-test     Tinycast/Features/SystemActions/Model/SystemAction.swift
 run volume-test            Tinycast/Features/SystemActions/Model/VolumeLevel.swift
 run window-command-test    Tinycast/Features/WindowManagement/Model/WindowCommand.swift \
+                           Tinycast/Features/WindowManagement/Model/WindowCycle.swift \
                            Tinycast/Features/WindowManagement/Model/WindowPlacementEngine.swift \
                            Tinycast/Features/WindowManagement/Model/WindowActionMemory.swift
 run space-gesture-test     Tinycast/Features/WindowManagement/Model/WindowCommand.swift \
                            Tinycast/Features/WindowManagement/Model/SpaceGesture.swift
 run window-layout-test     Tinycast/Features/WindowManagement/Model/WindowCommand.swift \
+                           Tinycast/Features/WindowManagement/Model/WindowCycle.swift \
                            Tinycast/Features/WindowManagement/Model/WindowPlacementEngine.swift \
                            Tinycast/Features/WindowManagement/Model/WindowLayoutAnchor.swift \
                            Tinycast/Features/WindowManagement/Model/WindowLayoutDisplay.swift \

--- a/Tests/window-command-test.swift
+++ b/Tests/window-command-test.swift
@@ -35,17 +35,36 @@ struct WindowCommandTests {
 
     static func screens(_ list: WindowPlacementEngine.Screen...) -> [WindowPlacementEngine.Screen] { list }
 
-    static func frame(
+    static func placement(
         _ command: WindowCommand.ID, on screen: WindowPlacementEngine.Screen = mainScreen,
         window: CGRect = CGRect(x: 100, y: 100, width: 600, height: 400), gap: CGFloat = 0,
-        step: Int = 0, restore: CGRect? = nil, lastTile: WindowCommand.ID? = nil,
+        step: Int = 0, cycle: WindowCycle = .off, restore: CGRect? = nil,
+        lastTile: WindowCommand.ID? = nil,
         allScreens: [WindowPlacementEngine.Screen]? = nil
-    ) -> CGRect? {
+    ) -> WindowPlacementEngine.Placement? {
         WindowPlacementEngine.placement(
             for: WindowPlacementEngine.Input(
                 command: command, windowFrame: window, screens: allScreens ?? [screen], gap: gap,
-                step: step, restoreFrame: restore, lastTileCommand: lastTile)
-        )?.frame
+                step: step, cycle: cycle, restoreFrame: restore, lastTileCommand: lastTile))
+    }
+
+    static func frame(
+        _ command: WindowCommand.ID, on screen: WindowPlacementEngine.Screen = mainScreen,
+        window: CGRect = CGRect(x: 100, y: 100, width: 600, height: 400), gap: CGFloat = 0,
+        step: Int = 0, cycle: WindowCycle = .off, restore: CGRect? = nil,
+        lastTile: WindowCommand.ID? = nil,
+        allScreens: [WindowPlacementEngine.Screen]? = nil
+    ) -> CGRect? {
+        placement(
+            command, on: screen, window: window, gap: gap, step: step, cycle: cycle,
+            restore: restore, lastTile: lastTile, allScreens: allScreens)?.frame
+    }
+
+    static func length(
+        _ command: WindowCommand.ID, _ cycle: WindowCycle,
+        _ list: [WindowPlacementEngine.Screen] = [mainScreen]
+    ) -> Int {
+        WindowPlacementEngine.cycleLength(for: command, screens: list, cycle: cycle)
     }
 
     static func main() {
@@ -59,6 +78,7 @@ struct WindowCommandTests {
         testLargerSmaller()
         testNudges()
         testDisplays()
+        testDisplayCycle()
         testRestore()
         testMemory()
         testFuzz()
@@ -230,38 +250,53 @@ struct WindowCommandTests {
             frame(.firstTwoThirds)!.union(frame(.lastThird)!) == mainScreen.visibleFrame,
             "first two thirds and last third partition the screen")
 
-        // Cycling: halves only, ½ → ⅓ → ⅔, wrapping.
-        expectRect(frame(.leftHalf, step: 1)!, frame(.firstThird)!, "left half step 1 is a third")
+        // Size cycling: halves only, ½ → ⅓ → ⅔, wrapping.
         expectRect(
-            frame(.leftHalf, step: 2)!, frame(.firstTwoThirds)!, "left half step 2 is two thirds")
-        expectRect(frame(.leftHalf, step: 3)!, frame(.leftHalf)!, "left half step 3 wraps to the half")
-        expectRect(frame(.rightHalf, step: 1)!, frame(.lastThird)!, "right half step 1 is a third")
+            frame(.leftHalf, step: 1, cycle: .sizes)!, frame(.firstThird)!,
+            "left half step 1 is a third")
         expectRect(
-            frame(.rightHalf, step: 2)!, frame(.lastTwoThirds)!, "right half step 2 is two thirds")
+            frame(.leftHalf, step: 2, cycle: .sizes)!, frame(.firstTwoThirds)!,
+            "left half step 2 is two thirds")
         expectRect(
-            frame(.topHalf, step: 1)!, CGRect(x: 0, y: 0, width: 1440, height: 300),
+            frame(.leftHalf, step: 3, cycle: .sizes)!, frame(.leftHalf)!,
+            "left half step 3 wraps to the half")
+        expectRect(
+            frame(.rightHalf, step: 1, cycle: .sizes)!, frame(.lastThird)!,
+            "right half step 1 is a third")
+        expectRect(
+            frame(.rightHalf, step: 2, cycle: .sizes)!, frame(.lastTwoThirds)!,
+            "right half step 2 is two thirds")
+        expectRect(
+            frame(.topHalf, step: 1, cycle: .sizes)!, CGRect(x: 0, y: 0, width: 1440, height: 300),
             "top half step 1 is a vertical third")
         expectRect(
-            frame(.topHalf, step: 2)!, CGRect(x: 0, y: 0, width: 1440, height: 600),
+            frame(.topHalf, step: 2, cycle: .sizes)!, CGRect(x: 0, y: 0, width: 1440, height: 600),
             "top half step 2 is vertical two thirds")
         expectRect(
-            frame(.bottomHalf, step: 1)!, CGRect(x: 0, y: 600, width: 1440, height: 300),
+            frame(.bottomHalf, step: 1, cycle: .sizes)!,
+            CGRect(x: 0, y: 600, width: 1440, height: 300),
             "bottom half step 1 is a vertical third")
         expectRect(
-            frame(.bottomHalf, step: 2)!, CGRect(x: 0, y: 300, width: 1440, height: 600),
+            frame(.bottomHalf, step: 2, cycle: .sizes)!,
+            CGRect(x: 0, y: 300, width: 1440, height: 600),
             "bottom half step 2 is vertical two thirds")
 
         // A step handed to a command that doesn't cycle must be ignored outright.
         for step in 0...5 {
             expectRect(
-                frame(.firstThird, step: step)!, frame(.firstThird)!,
+                frame(.firstThird, step: step, cycle: .sizes)!, frame(.firstThird)!,
                 "non-cycling commands ignore step \(step)")
             expectRect(
-                frame(.maximize, step: step)!, frame(.maximize)!,
+                frame(.maximize, step: step, cycle: .sizes)!, frame(.maximize)!,
                 "maximize ignores step \(step)")
+            expectRect(
+                frame(.leftHalf, step: step)!, frame(.leftHalf)!,
+                "cycling switched off ignores step \(step)")
         }
         // Negative steps can't crash or escape the cycle.
-        expectRect(frame(.leftHalf, step: -1)!, frame(.firstTwoThirds)!, "negative steps normalize")
+        expectRect(
+            frame(.leftHalf, step: -1, cycle: .sizes)!, frame(.firstTwoThirds)!,
+            "negative steps normalize")
     }
 
     // MARK: - Non-divisible widths
@@ -630,6 +665,106 @@ struct WindowCommandTests {
             "a window off every display still resolves to one")
     }
 
+    // MARK: - Cycling across displays
+
+    static func testDisplayCycle() {
+        let left = mainScreen
+        let right = WindowPlacementEngine.Screen(
+            id: 2, frame: CGRect(x: 1440, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 1440, y: 0, width: 1440, height: 900))
+        let both = screens(right, left)
+        let onLeft = CGRect(x: 100, y: 100, width: 600, height: 400)
+
+        // The strip is two half-slots per display, so the length is a plain product.
+        expect(length(.leftHalf, .off, both) == 1, "cycling off is a length of one")
+        expect(length(.leftHalf, .sizes, both) == 3, "the size cycle is three steps")
+        expect(length(.leftHalf, .displays, both) == 4, "two displays give four slots")
+        expect(length(.maximize, .displays, both) == 1, "a non-cycling command never cycles")
+        expect(
+            length(.leftHalf, .displays) == 1,
+            "one display makes the display leg a no-op")
+
+        // The sequence the issue asks for: Left walks the strip backwards, wrapping.
+        let expected: [CGRect] = [
+            frame(.leftHalf, on: left)!, frame(.rightHalf, on: right)!,
+            frame(.leftHalf, on: right)!, frame(.rightHalf, on: left)!
+        ]
+        for (step, want) in expected.enumerated() {
+            expectRect(
+                frame(.leftHalf, window: onLeft, step: step, cycle: .displays, allScreens: both)!,
+                want, "left half display step \(step)")
+        }
+        expectRect(
+            frame(.leftHalf, window: onLeft, step: 4, cycle: .displays, allScreens: both)!,
+            expected[0], "the display cycle wraps")
+        expectRect(
+            frame(.leftHalf, window: onLeft, step: -1, cycle: .displays, allScreens: both)!,
+            expected[3], "a negative display step normalises")
+
+        // Right is the exact mirror, so the two shortcuts sweep the strip in opposite directions.
+        for (step, want) in [
+            frame(.rightHalf, on: left)!, frame(.leftHalf, on: right)!,
+            frame(.rightHalf, on: right)!, frame(.leftHalf, on: left)!
+        ].enumerated() {
+            expectRect(
+                frame(.rightHalf, window: onLeft, step: step, cycle: .displays, allScreens: both)!,
+                want, "right half display step \(step)")
+        }
+
+        // Top and Bottom walk the same strip, keeping their own axis.
+        expectRect(
+            frame(.topHalf, window: onLeft, step: 1, cycle: .displays, allScreens: both)!,
+            frame(.bottomHalf, on: right)!, "top half step 1 is the bottom half of the next display")
+        expectRect(
+            frame(.bottomHalf, window: onLeft, step: 1, cycle: .displays, allScreens: both)!,
+            frame(.topHalf, on: right)!, "bottom half step 1 is the top half of the next display")
+
+        // The size cycle stays on the host display, whatever else is plugged in.
+        for step in 0..<3 {
+            expectRect(
+                frame(.leftHalf, window: onLeft, step: step, cycle: .sizes, allScreens: both)!,
+                frame(.leftHalf, on: left, step: step, cycle: .sizes)!,
+                "the size cycle ignores the other display at step \(step)")
+        }
+
+        // One full lap visits every slot exactly once, from either starting display.
+        for start in [onLeft, CGRect(x: 1540, y: 100, width: 600, height: 400)] {
+            for command in [WindowCommand.ID.leftHalf, .rightHalf] {
+                let lap = (0..<length(command, .displays, both)).map {
+                    placement(
+                        command, window: start, step: $0, cycle: .displays, allScreens: both)!
+                }
+                expect(
+                    Set(lap.map(\.frame)).count == lap.count,
+                    "\(command.rawValue) visits four distinct slots")
+                expect(
+                    Set(lap.map(\.screenID)) == [1, 2],
+                    "\(command.rawValue) reaches both displays")
+            }
+        }
+
+        // The gap belongs to the destination, not to the display the window started on.
+        let narrow = WindowPlacementEngine.Screen(
+            id: 3, frame: CGRect(x: 1440, y: 0, width: 200, height: 900),
+            visibleFrame: CGRect(x: 1440, y: 0, width: 200, height: 900))
+        expectRect(
+            frame(
+                .leftHalf, window: onLeft, gap: 100, step: 2, cycle: .displays,
+                allScreens: screens(left, narrow))!,
+            frame(.leftHalf, on: narrow, gap: 100)!,
+            "the destination display sanitises the gap")
+
+        // No mode ever gives a non-cycling command a chain to walk.
+        for command in WindowCommand.ID.allCases
+        where !WindowCommandCatalog.cyclesOnRepeat.contains(command) {
+            for cycle in WindowCycle.allCases {
+                expect(
+                    length(command, cycle, both) == 1,
+                    "\(command.rawValue) has no cycle to walk under \(cycle.rawValue)")
+            }
+        }
+    }
+
     // MARK: - Restore
 
     static func testRestore() {
@@ -661,7 +796,7 @@ struct WindowCommandTests {
         var memory = WindowActionMemory<Int>()
         var decision = memory.decide(
             key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         expect(decision.step == 0, "a first press starts at step 0")
         expect(!decision.canRestore, "a never-seen window has nothing to restore to")
         expectRect(decision.restoreFrame, original, "the first press captures the original frame")
@@ -674,7 +809,7 @@ struct WindowCommandTests {
             let applied = frame(.leftHalf, step: expected)!
             decision = memory.decide(
                 key: 1, command: .leftHalf, currentFrame: memory.record(for: 1)!.appliedFrame,
-                currentScreenID: 1, cycleEnabled: true, now: clock)
+                currentScreenID: 1, cycleLength: 3, now: clock)
             expect(decision.step == expected, "the cycle advances to step \(expected)")
             expectRect(decision.restoreFrame, original, "the restore point survives step \(expected)")
             expect(decision.canRestore, "a seen window can be restored")
@@ -686,29 +821,29 @@ struct WindowCommandTests {
         // A different command, screen, or window resets the cycle.
         decision = memory.decide(
             key: 1, command: .rightHalf, currentFrame: memory.record(for: 1)!.appliedFrame,
-            currentScreenID: 1, cycleEnabled: true, now: clock)
+            currentScreenID: 1, cycleLength: 3, now: clock)
         expect(decision.step == 0, "a different command restarts the cycle")
         expectRect(decision.restoreFrame, original, "a different command keeps the restore point")
         decision = memory.decide(
             key: 1, command: .leftHalf, currentFrame: memory.record(for: 1)!.appliedFrame,
-            currentScreenID: 2, cycleEnabled: true, now: clock)
+            currentScreenID: 2, cycleLength: 3, now: clock)
         expect(decision.step == 0, "a different display restarts the cycle")
         decision = memory.decide(
             key: 99, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         expect(decision.step == 0 && !decision.canRestore, "another window has its own chain")
 
         // A user drag resets the cycle and re-anchors the restore point.
         var dragged = WindowActionMemory<Int>()
         let seed = dragged.decide(
             key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         dragged.commit(
             key: 1, command: .leftHalf, decision: seed, appliedFrame: half, screenID: 1, now: clock)
         let movedByUser = CGRect(x: 400, y: 400, width: 500, height: 300)
         decision = dragged.decide(
             key: 1, command: .leftHalf, currentFrame: movedByUser, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         expect(decision.step == 0, "a user drag restarts the cycle")
         expectRect(decision.restoreFrame, movedByUser, "a user drag re-anchors the restore point")
         expect(decision.lastTileCommand == nil, "a user drag forgets the remembered tile")
@@ -717,7 +852,7 @@ struct WindowCommandTests {
         let quantised = CGRect(x: half.minX + 1, y: half.minY, width: half.width - 1, height: half.height)
         decision = dragged.decide(
             key: 1, command: .leftHalf, currentFrame: quantised, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         expect(decision.step == 1, "a sub-tolerance difference keeps the cycle running")
         expect(decision.lastTileCommand == .leftHalf, "an untouched tile is remembered")
 
@@ -725,14 +860,14 @@ struct WindowCommandTests {
         var pinned = WindowActionMemory<Int>()
         var pinnedDecision = pinned.decide(
             key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: false, now: clock)
+            cycleLength: 1, now: clock)
         for _ in 0..<5 {
             pinned.commit(
                 key: 1, command: .leftHalf, decision: pinnedDecision, appliedFrame: half,
                 screenID: 1, now: clock)
             pinnedDecision = pinned.decide(
                 key: 1, command: .leftHalf, currentFrame: half, currentScreenID: 1,
-                cycleEnabled: false, now: clock)
+                cycleLength: 1, now: clock)
             expect(pinnedDecision.step == 0, "cycling off pins every repeat to step 0")
         }
 
@@ -741,40 +876,40 @@ struct WindowCommandTests {
         let maximized = mainScreen.visibleFrame
         var nonDecision = nonCycling.decide(
             key: 1, command: .maximize, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: length(.maximize, .sizes), now: clock)
         for _ in 0..<5 {
             nonCycling.commit(
                 key: 1, command: .maximize, decision: nonDecision, appliedFrame: maximized,
                 screenID: 1, now: clock)
             nonDecision = nonCycling.decide(
                 key: 1, command: .maximize, currentFrame: maximized, currentScreenID: 1,
-                cycleEnabled: true, now: clock)
+                cycleLength: length(.maximize, .sizes), now: clock)
             expect(nonDecision.step == 0, "a non-cycling command never advances")
         }
 
         var timed = WindowActionMemory<Int>(cycleTimeout: 60)
         let timedSeed = timed.decide(
             key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         timed.commit(
             key: 1, command: .leftHalf, decision: timedSeed, appliedFrame: half, screenID: 1,
             now: clock)
         expect(
             timed.decide(
                 key: 1, command: .leftHalf, currentFrame: half, currentScreenID: 1,
-                cycleEnabled: true, now: clock.addingTimeInterval(30)
+                cycleLength: 3, now: clock.addingTimeInterval(30)
             ).step == 1, "a cycle inside the timeout continues")
         expect(
             timed.decide(
                 key: 1, command: .leftHalf, currentFrame: half, currentScreenID: 1,
-                cycleEnabled: true, now: clock.addingTimeInterval(120)
+                cycleLength: 3, now: clock.addingTimeInterval(120)
             ).step == 0, "a cycle past the timeout restarts")
 
         // The restore point survives a run of different commands, then Restore is idempotent.
         var run = WindowActionMemory<Int>()
         var runDecision = run.decide(
             key: 1, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         run.commit(
             key: 1, command: .leftHalf, decision: runDecision, appliedFrame: half, screenID: 1,
             now: clock)
@@ -782,14 +917,14 @@ struct WindowCommandTests {
         for command in [WindowCommand.ID.maximize, .topRightQuarter, .centerThird] {
             runDecision = run.decide(
                 key: 1, command: command, currentFrame: applied, currentScreenID: 1,
-                cycleEnabled: true, now: clock)
+                cycleLength: 3, now: clock)
             applied = frame(command)!
             run.commit(
                 key: 1, command: command, decision: runDecision, appliedFrame: applied, screenID: 1,
                 now: clock)
         }
         runDecision = run.decide(
-            key: 1, command: .restore, currentFrame: applied, currentScreenID: 1, cycleEnabled: true,
+            key: 1, command: .restore, currentFrame: applied, currentScreenID: 1, cycleLength: 3,
             now: clock)
         expectRect(
             runDecision.restoreFrame, original, "the restore point survives three other commands")
@@ -801,7 +936,7 @@ struct WindowCommandTests {
             now: clock)
         let second = run.decide(
             key: 1, command: .restore, currentFrame: restored, currentScreenID: 1,
-            cycleEnabled: true, now: clock)
+            cycleLength: 3, now: clock)
         expectRect(
             frame(.restore, restore: second.restoreFrame)!, original, "a second restore is idempotent")
 
@@ -816,7 +951,7 @@ struct WindowCommandTests {
         for key in 0..<100 {
             let boundedDecision = bounded.decide(
                 key: key, command: .leftHalf, currentFrame: original, currentScreenID: 1,
-                cycleEnabled: true, now: clock)
+                cycleLength: 3, now: clock)
             bounded.commit(
                 key: key, command: .leftHalf, decision: boundedDecision, appliedFrame: half,
                 screenID: 1, now: clock)
@@ -861,51 +996,61 @@ struct WindowCommandTests {
             CGRect(x: 1439, y: 899, width: 1, height: 1)
         ]
         let gaps: [CGFloat] = [0, 1, 8, 25, 200]
+        let cycles: [WindowCycle] = WindowCycle.allCases
+        let steps = [0, 1, 5, -3]
 
         var checked = 0
         var problems: [String] = []
         for screens in displays {
             for window in windows {
                 for gap in gaps {
-                    for command in WindowCommand.ID.allCases {
-                        let input = WindowPlacementEngine.Input(
-                            command: command, windowFrame: window, screens: screens, gap: gap,
-                            step: 0, restoreFrame: window, lastTileCommand: nil)
-                        // A nil placement is a legitimate quiet no-op, not a failure.
-                        guard let placement = WindowPlacementEngine.placement(for: input) else { continue }
-                        checked += 1
-                        let rect = placement.frame
-                        let label = "\(command.rawValue) gap \(gap) window \(window)"
+                    for cycle in cycles {
+                        for step in steps {
+                            for command in WindowCommand.ID.allCases {
+                                let input = WindowPlacementEngine.Input(
+                                    command: command, windowFrame: window, screens: screens, gap: gap,
+                                    step: step, cycle: cycle, restoreFrame: window, lastTileCommand: nil)
+                                // A nil placement is a legitimate quiet no-op, not a failure.
+                                guard let placement = WindowPlacementEngine.placement(for: input) else {
+                                    continue
+                                }
+                                checked += 1
+                                let rect = placement.frame
+                                let label = "\(command.rawValue) gap \(gap) step \(step) window \(window)"
 
-                        if !(rect.minX.isFinite && rect.minY.isFinite && rect.width.isFinite
-                            && rect.height.isFinite)
-                        {
-                            problems.append("non-finite frame: \(label)")
-                        }
-                        if rect.width < 0 || rect.height < 0 {
-                            problems.append("negative size: \(label)")
-                        }
-                        guard let host = screens.first(where: { $0.id == placement.screenID })
-                        else {
-                            problems.append("unknown screen id: \(label)")
-                            continue
-                        }
-                        if rect.intersection(host.visibleFrame).isNull {
-                            problems.append("off-screen frame: \(label)")
-                        }
-                        // Determinism, and no drift when a command is applied twice at step 0.
-                        if WindowPlacementEngine.placement(for: input)?.frame != rect {
-                            problems.append("non-deterministic: \(label)")
-                        }
-                        var repeated = input
-                        repeated.windowFrame = rect
-                        if let again = WindowPlacementEngine.placement(for: repeated)?.frame,
-                            command != .makeLarger, command != .makeSmaller, command != .moveLeft,
-                            command != .moveRight, command != .moveUp, command != .moveDown,
-                            command != .nextDisplay, command != .previousDisplay,
-                            again != rect
-                        {
-                            problems.append("drifts on repeat: \(label) — \(rect) then \(again)")
+                                if !(rect.minX.isFinite && rect.minY.isFinite && rect.width.isFinite
+                                    && rect.height.isFinite)
+                                {
+                                    problems.append("non-finite frame: \(label)")
+                                }
+                                if rect.width < 0 || rect.height < 0 {
+                                    problems.append("negative size: \(label)")
+                                }
+                                guard let host = screens.first(where: { $0.id == placement.screenID })
+                                else {
+                                    problems.append("unknown screen id: \(label)")
+                                    continue
+                                }
+                                if rect.intersection(host.visibleFrame).isNull {
+                                    problems.append("off-screen frame: \(label)")
+                                }
+                                // Determinism, and no drift when a command is applied twice at step 0.
+                                if WindowPlacementEngine.placement(for: input)?.frame != rect {
+                                    problems.append("non-deterministic: \(label)")
+                                }
+                                var repeated = input
+                                repeated.windowFrame = rect
+                                // Only step 0 is meant to be idempotent: a cycle exists to move the window.
+                                if step == 0,
+                                    let again = WindowPlacementEngine.placement(for: repeated)?.frame,
+                                    command != .makeLarger, command != .makeSmaller, command != .moveLeft,
+                                    command != .moveRight, command != .moveUp, command != .moveDown,
+                                    command != .nextDisplay, command != .previousDisplay,
+                                    again != rect
+                                {
+                                    problems.append("drifts on repeat: \(label) — \(rect) then \(again)")
+                                }
+                            }
                         }
                     }
                 }

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		1C81DCEBEFFC1191751135F4 /* PalettePlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802BD2F4CC057228F2528217 /* PalettePlacement.swift */; };
 		1CA10DE219BAB97BFC29E54A /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */; };
 		1D79D5385578F8BB2285E594 /* QuicklinkArgumentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2FF20C8537905F65AEF2EB /* QuicklinkArgumentsRow.swift */; };
+		1DCD098ECB857BC39B81A8EC /* CustomQuickActionEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285900BC454E62D2A0706E39 /* CustomQuickActionEditorSheet.swift */; };
 		1E04684F05DFA84A8B667F20 /* PasteboardFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5C752F98428A767405AD12 /* PasteboardFiles.swift */; };
 		1E0A1B1B84673EF39871842C /* MarkdownCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570CE37C7133E28F7495ED91 /* MarkdownCodeView.swift */; };
 		1E48F2BED1C62873F424F180 /* SnippetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1847C927A1DA4EE0009201DF /* SnippetCoordinator.swift */; };
@@ -130,7 +131,6 @@
 		3B0E1DFB220BCBB7EADF65B7 /* AIRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F1010FAC9C0EC4DBDE58A8 /* AIRequestBody.swift */; };
 		3BC6CC35889FFC77D640C7CA /* SnippetsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2EF66267B0141279A43613 /* SnippetsSettingsView.swift */; };
 		3C23AEA2FDDB7BD61278BD77 /* QuickActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5941CE8F08FD5986FED12E9 /* QuickActionsSettingsView.swift */; };
-		01D236D5B6E911B9EC430F0C /* CustomQuickActionEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20BA0BB09DFAC9C67D184DD /* CustomQuickActionEditorSheet.swift */; };
 		3C2812B921530D45B802B44C /* PaletteTabAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B107F5E532C8DE74430723B /* PaletteTabAction.swift */; };
 		3C30FB1AD99237898B4401C7 /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7DC9AD5E54C26387F29F6 /* MarkdownView.swift */; };
 		3CA5E8EB5D591F710C8AD897 /* ExtensionPickerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD80BC6110C36450C2FF751 /* ExtensionPickerItem.swift */; };
@@ -386,6 +386,7 @@
 		ACE645630E536C93CA102050 /* VolumeHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90559D7DB9F6F3874CAFCDE /* VolumeHUDView.swift */; };
 		AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */; };
 		AD98F015439106F0E9D32015 /* RightClick.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7EFE2C8A212D6979C43E9F7 /* RightClick.swift */; };
+		ADB8D83A32A5F1CEF11E2DE6 /* BuiltInQuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E1C14C150F3EC6EC5D610B /* BuiltInQuickAction.swift */; };
 		ADC43E68C1B617D098C71D6E /* AIInstructions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6420FE45699DC3E53907CAE3 /* AIInstructions.swift */; };
 		ADE29D44A9504AC24FC17E72 /* CalcDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A97022BE0F95B5D19F0C26 /* CalcDateTime.swift */; };
 		AE16EC9C7B4C75871A67187D /* MarkdownTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D14B02D3FE262EADFD3404 /* MarkdownTableView.swift */; };
@@ -403,6 +404,7 @@
 		B589C3ECFF03C790102361D4 /* SupportReminderSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E393E2CA842C5B344C6B499 /* SupportReminderSchedule.swift */; };
 		B6525300EEDACE4F9DC3179E /* CalcCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0F5891A80B604FBE21897B /* CalcCurrency.swift */; };
 		B6C39F046F6B09CD7AA53F6B /* MeetingSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09511B0502D1B67F10604D3C /* MeetingSpan.swift */; };
+		B7205708F8DF13958927843A /* CustomQuickActionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D4D2146CE38403B2DDB072 /* CustomQuickActionStore.swift */; };
 		B72F17539405522E63D266F3 /* AIPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5861814F16B18935FBF034C /* AIPreamble.swift */; };
 		B748B0BA6AB0780CAB4DA304 /* MCPProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBED1FDAAD4735FDB4B2453A /* MCPProtocol.swift */; };
 		B83D909972DFFC37E2FB1304 /* SettingsSearchCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B580FD584B516AB666F1C81E /* SettingsSearchCatalog.swift */; };
@@ -478,6 +480,7 @@
 		DA55ED3548C2D6C1EB9F205D /* ExtensionFormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB596CB339D5C3AEBE550A3 /* ExtensionFormField.swift */; };
 		DA781EE329E4D88B9C72788C /* ExtensionActionsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A178C17DB989B6D2D71C021E /* ExtensionActionsPanel.swift */; };
 		DB6B294B3D15B0AABCE5427E /* PaletteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B0374FD5D74DBE23243CD /* PaletteScreen.swift */; };
+		DC0295A12EF56EF4C8378623 /* WindowCycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B1949D20DAEA3F80649D17 /* WindowCycle.swift */; };
 		DCAC5BBB64C93F559B25E6FD /* ExtensionAnimatedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF31AF26A4786B234ABB64 /* ExtensionAnimatedImage.swift */; };
 		DD0A7B02D15113A3D8712413 /* ExtensionListKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90C7C0B97C4745B8F94C4B /* ExtensionListKey.swift */; };
 		DD0DE9D16B0BAA8126EE9DB6 /* SettingsAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */; };
@@ -511,6 +514,7 @@
 		EA077323DE71DAF8FE17693C /* CalendarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC504A12A2D9CC00B502D9E /* CalendarCoordinator.swift */; };
 		EA2587800F2CA347788C6F8C /* UninstallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0508EBDFD6E59370AB2E5B7 /* UninstallScreen.swift */; };
 		EA89498DA03BDFA3858144BF /* AppActionsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C045C66BB654E4CB407A673 /* AppActionsMenu.swift */; };
+		EAF55A2080AAF3AC70D4FB93 /* CustomQuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADCDDCEBA1EBB74810BDFC4 /* CustomQuickAction.swift */; };
 		EAFC40D8851C50EB62198C7E /* InstalledAIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0BCEEE45732BE94136EEA8 /* InstalledAIManager.swift */; };
 		EBCDF88CD59A4B6F21F945C6 /* Quicklink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3385A84985A52E2DA3596 /* Quicklink.swift */; };
 		EBFD65E82A7633ECB132A4D4 /* RaycastDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA2AB248B239E2EF9276187 /* RaycastDecoder.swift */; };
@@ -537,9 +541,6 @@
 		F8E1B044D84E96FB455155CD /* AIModelDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B27ECEB1C09B14C403FC8 /* AIModelDiscoveryService.swift */; };
 		F8EC987B884BD2ED6A6690A9 /* SnippetKeywordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301BA9123035D6BFB808F763 /* SnippetKeywordListener.swift */; };
 		F9750CE5EC2E7E541F740A15 /* QuickActionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C83D437500107168E12647 /* QuickActionSettings.swift */; };
-		6142C52E3F757226CBEA70B9 /* CustomQuickActionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4788C2BF386574C066B0E4A5 /* CustomQuickActionStore.swift */; };
-		665DB552AAC70A73932C7E2D /* CustomQuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B975F162A0BC05F814D5221A /* CustomQuickAction.swift */; };
-		F53A9441B864E8EC55FB42EA /* BuiltInQuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC628CE839801099CCFF01F /* BuiltInQuickAction.swift */; };
 		FA05D882203673A9FEE5F421 /* UninstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFBFA70EF62B67F7357E0E /* UninstallCoordinator.swift */; };
 		FA386C9B6DA24481565D506D /* ExtensionPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFFB5180991764FB13FE0B /* ExtensionPackageManager.swift */; };
 		FB1D83A8BE027AC4F328D601 /* QuicklinkListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0935D49C0A0175E54E69682B /* QuicklinkListScreen.swift */; };
@@ -657,6 +658,7 @@
 		2702F140F8DBF373D2ED11A5 /* SelectionFollowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionFollowing.swift; sourceTree = "<group>"; };
 		273827EB5CC04F1951C40387 /* VolumeLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeLevel.swift; sourceTree = "<group>"; };
 		27773F8955543E8A24CC0D28 /* ClipboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardSettingsView.swift; sourceTree = "<group>"; };
+		285900BC454E62D2A0706E39 /* CustomQuickActionEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomQuickActionEditorSheet.swift; sourceTree = "<group>"; };
 		289FC415E1D1776DD1C4EB9E /* ApplicationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsSettingsView.swift; sourceTree = "<group>"; };
 		28B398912F4FB38912BD779C /* QuicklinkArgumentsAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkArgumentsAccessory.swift; sourceTree = "<group>"; };
 		28B962318915EF7AEAC4996D /* VolumeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeState.swift; sourceTree = "<group>"; };
@@ -771,6 +773,7 @@
 		582A70CF432F5E0144E57369 /* ExtensionRefreshState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRefreshState.swift; sourceTree = "<group>"; };
 		590A432CC25ED6372B453BFA /* ScheduleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleScreen.swift; sourceTree = "<group>"; };
 		5A1E7B96668721F12170CD72 /* WindowActionMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowActionMemory.swift; sourceTree = "<group>"; };
+		5ADCDDCEBA1EBB74810BDFC4 /* CustomQuickAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomQuickAction.swift; sourceTree = "<group>"; };
 		5B1FC5C77AA5F4DD6E2D9B4D /* ExtensionPickerList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPickerList.swift; sourceTree = "<group>"; };
 		5B2DBBB997953D2E50EBB050 /* MCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServer.swift; sourceTree = "<group>"; };
 		5B330ABFC83721904159DDF2 /* MeetingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEvent.swift; sourceTree = "<group>"; };
@@ -784,6 +787,7 @@
 		5DD86B3ABBB71BC6EA116D85 /* CameraAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAccess.swift; sourceTree = "<group>"; };
 		5F0A68B2040582996EFBA877 /* CommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCatalog.swift; sourceTree = "<group>"; };
 		60CCB1A47E0022BAEDD1EE96 /* CalculatorHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryView.swift; sourceTree = "<group>"; };
+		60D4D2146CE38403B2DDB072 /* CustomQuickActionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomQuickActionStore.swift; sourceTree = "<group>"; };
 		61D7B06067FB35E7CC6C1E09 /* FallbacksSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbacksSettingsView.swift; sourceTree = "<group>"; };
 		61FFFE3901140714D3A7BB4C /* QuicklinkDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkDestination.swift; sourceTree = "<group>"; };
 		621B09CB5CF15517D9FDAB5B /* PaletteFilterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteFilterAction.swift; sourceTree = "<group>"; };
@@ -928,6 +932,7 @@
 		A0BAA0471DD8CE4352F45FED /* ExtensionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCoordinator.swift; sourceTree = "<group>"; };
 		A1306524F57602D90FCF153C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		A178C17DB989B6D2D71C021E /* ExtensionActionsPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionActionsPanel.swift; sourceTree = "<group>"; };
+		A4B1949D20DAEA3F80649D17 /* WindowCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCycle.swift; sourceTree = "<group>"; };
 		A5873BB8728FD8BC5D256A21 /* CameraCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinator.swift; sourceTree = "<group>"; };
 		A5958B66BC7FD9FE3F2B8F49 /* MCPStdioTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStdioTransport.swift; sourceTree = "<group>"; };
 		A5A8F78D3F1BFA8E86F9CB47 /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
@@ -1003,16 +1008,12 @@
 		C214E40D42F4812F141C16A8 /* ColorPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPreview.swift; sourceTree = "<group>"; };
 		C2EAA357A9F0317320CFAADF /* TerminalLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLogView.swift; sourceTree = "<group>"; };
 		C3C83D437500107168E12647 /* QuickActionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionSettings.swift; sourceTree = "<group>"; };
-		4788C2BF386574C066B0E4A5 /* CustomQuickActionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomQuickActionStore.swift; sourceTree = "<group>"; };
-		B975F162A0BC05F814D5221A /* CustomQuickAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomQuickAction.swift; sourceTree = "<group>"; };
-		8DC628CE839801099CCFF01F /* BuiltInQuickAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInQuickAction.swift; sourceTree = "<group>"; };
 		C3E30EFA3197FC5EF1E85C21 /* BundleSignature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSignature.swift; sourceTree = "<group>"; };
 		C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAnchor.swift; sourceTree = "<group>"; };
 		C45190564C9D9F1722E83943 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C49AE1E917BF6EA7783F4CAD /* CodexAppServerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerProtocol.swift; sourceTree = "<group>"; };
 		C54C4540AD6F188A2455473F /* ExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionRuntime.swift; sourceTree = "<group>"; };
 		C5941CE8F08FD5986FED12E9 /* QuickActionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsSettingsView.swift; sourceTree = "<group>"; };
-		E20BA0BB09DFAC9C67D184DD /* CustomQuickActionEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomQuickActionEditorSheet.swift; sourceTree = "<group>"; };
 		C5BA06E4CC7E8D40E3285F16 /* KeyCapChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCapChip.swift; sourceTree = "<group>"; };
 		C72AE5D924466E1E80818A98 /* ExtensionStoreSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStoreSheet.swift; sourceTree = "<group>"; };
 		C7B3FC48B58E1005453E7E18 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
@@ -1050,6 +1051,7 @@
 		D28281DFC434C75F8A594635 /* ReleaseFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseFeed.swift; sourceTree = "<group>"; };
 		D29DCDCD85CC097E5E68A319 /* ExtensionDateExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDateExpression.swift; sourceTree = "<group>"; };
 		D2D032AC22E53BB9997E492F /* CalculatorHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorHistoryStore.swift; sourceTree = "<group>"; };
+		D2E1C14C150F3EC6EC5D610B /* BuiltInQuickAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInQuickAction.swift; sourceTree = "<group>"; };
 		D381DD8CB296A6D5CFF90111 /* ClipboardFileKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardFileKind.swift; sourceTree = "<group>"; };
 		D3F82845FDA307DF71676352 /* CalendarAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccess.swift; sourceTree = "<group>"; };
 		D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTSubscription.swift; sourceTree = "<group>"; };
@@ -1757,13 +1759,13 @@
 		6D3312FA1849B303BECA8AEA /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				D2E1C14C150F3EC6EC5D610B /* BuiltInQuickAction.swift */,
+				5ADCDDCEBA1EBB74810BDFC4 /* CustomQuickAction.swift */,
+				60D4D2146CE38403B2DDB072 /* CustomQuickActionStore.swift */,
 				E8A4DEF28F120FE354EB5599 /* QuickAction.swift */,
 				53DBA322BA1F117530075F51 /* QuickActionFailure.swift */,
 				F513217C40F0B8199DC57A35 /* QuickActionPrompt.swift */,
 				C3C83D437500107168E12647 /* QuickActionSettings.swift */,
-				4788C2BF386574C066B0E4A5 /* CustomQuickActionStore.swift */,
-				B975F162A0BC05F814D5221A /* CustomQuickAction.swift */,
-				8DC628CE839801099CCFF01F /* BuiltInQuickAction.swift */,
 				D5870C37FFC77A9B53CA5764 /* TextDiffEngine.swift */,
 			);
 			path = Model;
@@ -1921,6 +1923,7 @@
 				B9B724FD9A867189A6118DF7 /* SpaceGesture.swift */,
 				5A1E7B96668721F12170CD72 /* WindowActionMemory.swift */,
 				E7CB45E85566001834934DF1 /* WindowCommand.swift */,
+				A4B1949D20DAEA3F80649D17 /* WindowCycle.swift */,
 				2DFEC8744A55CB60CA864F19 /* WindowLayout.swift */,
 				D65D1C9A117E443C6DA2BD9E /* WindowLayoutAnchor.swift */,
 				E1FB153A0D53D42771F1CA99 /* WindowLayoutDisplay.swift */,
@@ -2147,9 +2150,9 @@
 		A2B4B3539BD46FDC6F2AE4B5 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				285900BC454E62D2A0706E39 /* CustomQuickActionEditorSheet.swift */,
 				98C29DA5656628B41C17D42A /* QuickActionSettingsStore.swift */,
 				C5941CE8F08FD5986FED12E9 /* QuickActionsSettingsView.swift */,
-				E20BA0BB09DFAC9C67D184DD /* CustomQuickActionEditorSheet.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2845,6 +2848,7 @@
 				4549280508130B232069071E /* BackupSettingsView.swift in Sources */,
 				00C09E86C3FC4738CF74F1F2 /* BackupStaging.swift in Sources */,
 				0820C7539E3328338C3C8FBD /* BarButton.swift in Sources */,
+				ADB8D83A32A5F1CEF11E2DE6 /* BuiltInQuickAction.swift in Sources */,
 				0A238E823704B904EFFB4F22 /* BundleLocalization.swift in Sources */,
 				41C5B5B0E637FAA4AFD4BF13 /* BundleNameCache.swift in Sources */,
 				9E514EA8EB0408653AC3D1D9 /* BundleSignature.swift in Sources */,
@@ -2934,6 +2938,9 @@
 				6E2C2F65456E0981FC548C55 /* CustomCommandArgumentsView.swift in Sources */,
 				11C3F9D5C786EF1D11787E0C /* CustomCommandCoordinator.swift in Sources */,
 				CCC775255627E23DC5B567AE /* CustomCommandEditorSheet.swift in Sources */,
+				EAF55A2080AAF3AC70D4FB93 /* CustomQuickAction.swift in Sources */,
+				1DCD098ECB857BC39B81A8EC /* CustomQuickActionEditorSheet.swift in Sources */,
+				B7205708F8DF13958927843A /* CustomQuickActionStore.swift in Sources */,
 				AB500AC3DEBFF6EB1CE42812 /* DialogController.swift in Sources */,
 				C215695FE671BC591DC99C2B /* DialogPanel.swift in Sources */,
 				9F82DA5A46BB39A6C6DD075D /* DialogRequest.swift in Sources */,
@@ -3159,12 +3166,8 @@
 				1A7F214D77D831C7A223631E /* QuickActionResultView.swift in Sources */,
 				3F3414742ABC6F21D48C2A9E /* QuickActionRunner.swift in Sources */,
 				F9750CE5EC2E7E541F740A15 /* QuickActionSettings.swift in Sources */,
-				6142C52E3F757226CBEA70B9 /* CustomQuickActionStore.swift in Sources */,
-				665DB552AAC70A73932C7E2D /* CustomQuickAction.swift in Sources */,
-				F53A9441B864E8EC55FB42EA /* BuiltInQuickAction.swift in Sources */,
 				78BA4410EAA35ED76D7CFBE8 /* QuickActionSettingsStore.swift in Sources */,
 				3C23AEA2FDDB7BD61278BD77 /* QuickActionsSettingsView.swift in Sources */,
-				01D236D5B6E911B9EC430F0C /* CustomQuickActionEditorSheet.swift in Sources */,
 				EBCDF88CD59A4B6F21F945C6 /* Quicklink.swift in Sources */,
 				BBAB44C0E70AABE70A048889 /* QuicklinkArchive.swift in Sources */,
 				5400114EF68AE70236DF0B94 /* QuicklinkArgumentsAccessory.swift in Sources */,
@@ -3301,6 +3304,7 @@
 				4E5F73461C417BE2B3472E6E /* WindowChrome.swift in Sources */,
 				3FC9140341EE41DF2A8ABCA1 /* WindowCommand.swift in Sources */,
 				FF372D9F3A0FE3671D517589 /* WindowCommandCoordinator.swift in Sources */,
+				DC0295A12EF56EF4C8378623 /* WindowCycle.swift in Sources */,
 				DD25D0E22E5729CF612FA1AE /* WindowDragHandle.swift in Sources */,
 				40B5BD0D7AF5C6CC43798EFF /* WindowInventory.swift in Sources */,
 				0B479A90BA6772D3DCC8009D /* WindowLayout.swift in Sources */,

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -49,7 +49,7 @@ struct SettingsBackup: Codable {
         var windowManagementEnabled: Bool?
         var windowManagementShowInLauncher: Bool?
         var windowGap: Int?
-        var windowCycleOnRepeat: Bool?
+        var windowCycle: String?
         var windowLayoutsShowInLauncher: Bool?
         // Carried, unlike `snippetsEnabled`: opening a link grants no permission class of its own.
         var quicklinksEnabled: Bool?
@@ -139,7 +139,7 @@ extension SettingsBackup {
             windowManagementEnabled: s.windowManagementEnabled,
             windowManagementShowInLauncher: s.windowManagementShowInLauncher,
             windowGap: s.windowGap,
-            windowCycleOnRepeat: s.windowCycleOnRepeat,
+            windowCycle: s.windowCycle.rawValue,
             windowLayoutsShowInLauncher: s.windowLayoutsShowInLauncher,
             quicklinksEnabled: s.quicklinksEnabled,
             quicklinksShowInLauncher: s.quicklinksShowInLauncher,
@@ -361,8 +361,8 @@ extension SettingsBackup {
             settings.windowGap = gap
             count += 1
         }
-        if let flag = s.windowCycleOnRepeat {
-            settings.windowCycleOnRepeat = flag
+        if let raw = s.windowCycle, let cycle = WindowCycle(rawValue: raw) {
+            settings.windowCycle = cycle
             count += 1
         }
         if let flag = s.windowLayoutsShowInLauncher {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -31,7 +31,7 @@ enum SettingsBackupCoverage {
         "windowManagementEnabled": .windowManagementEnabled,
         "windowManagementShowInLauncher": .windowManagementShowInLauncher,
         "windowGap": .windowGap,
-        "windowCycleOnRepeat": .windowCycleOnRepeat,
+        "windowCycle": .windowCycle,
         "windowLayoutsShowInLauncher": .windowLayoutsShowInLauncher,
         "quicklinksEnabled": .quicklinksEnabled,
         "quicklinksShowInLauncher": .quicklinksShowInLauncher,

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -422,9 +422,9 @@ final class AppSettings {
         }
     }
 
-    /// Re-triggering a half steps it through ⅓ and ⅔ instead of re-applying the same frame.
-    var windowCycleOnRepeat: Bool {
-        didSet { defaults.set(windowCycleOnRepeat, forKey: Key.windowCycleOnRepeat.rawValue) }
+    /// What re-triggering a half does: nothing, step its size, or walk it across the displays.
+    var windowCycle: WindowCycle {
+        didSet { defaults.set(windowCycle.rawValue, forKey: Key.windowCycle.rawValue) }
     }
 
     /// Off means fully off, down to a still-registered shortcut opening nothing.
@@ -595,7 +595,8 @@ final class AppSettings {
             || defaults.bool(forKey: Key.windowManagementShowInLauncher.rawValue)
         // Unset reads as 0, which is the intended default anyway — no gap.
         windowGap = defaults.integer(forKey: Key.windowGap.rawValue)
-        windowCycleOnRepeat = defaults.bool(forKey: Key.windowCycleOnRepeat.rawValue)
+        windowCycle =
+            defaults.string(forKey: Key.windowCycle.rawValue).flatMap(WindowCycle.init) ?? .sizes
         windowLayoutsShowInLauncher =
             defaults.object(forKey: Key.windowLayoutsShowInLauncher.rawValue) == nil
             || defaults.bool(forKey: Key.windowLayoutsShowInLauncher.rawValue)

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -596,7 +596,7 @@ final class AppSettings {
         // Unset reads as 0, which is the intended default anyway — no gap.
         windowGap = defaults.integer(forKey: Key.windowGap.rawValue)
         windowCycle =
-            defaults.string(forKey: Key.windowCycle.rawValue).flatMap(WindowCycle.init) ?? .sizes
+            defaults.string(forKey: Key.windowCycle.rawValue).flatMap(WindowCycle.init) ?? .off
         windowLayoutsShowInLauncher =
             defaults.object(forKey: Key.windowLayoutsShowInLauncher.rawValue) == nil
             || defaults.bool(forKey: Key.windowLayoutsShowInLauncher.rawValue)

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -34,7 +34,7 @@ enum AppSettingsKey: String, CaseIterable {
     case windowManagementEnabled = "windowManagementEnabled"
     case windowManagementShowInLauncher = "windowManagementShowInLauncher"
     case windowGap = "windowManagementGap"
-    case windowCycleOnRepeat = "windowManagementCycleOnRepeat"
+    case windowCycle = "windowManagementCycleMode"
     case windowLayoutsShowInLauncher = "windowLayoutsShowInLauncher"
     case quicklinksEnabled = "quicklinksEnabled"
     case quicklinksShowInLauncher = "quicklinksShowInLauncher"

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -355,8 +355,8 @@ enum SettingsSearchCatalog {
             .windowManagementWindowManagement, "Enable window management",
             keywords: ["tile", "accessibility"]),
         .init(
-            .windowManagementOptions, "Cycle sizes on repeat",
-            keywords: ["repeat", "thirds", "halves"]),
+            .windowManagementOptions, "Cycling",
+            keywords: ["repeat", "thirds", "halves", "displays", "monitor", "screens"]),
         .init(
             .windowManagementOptions, "Gap between windows",
             keywords: ["padding", "spacing", "margin", "points"]),

--- a/Tinycast/Features/WindowManagement/Model/WindowActionMemory.swift
+++ b/Tinycast/Features/WindowManagement/Model/WindowActionMemory.swift
@@ -49,7 +49,7 @@ struct WindowActionMemory<Key: Hashable> {
     /// Resolves the cycle step and restore point; `commit` writes once the mover knows what landed.
     func decide(
         key: Key, command: WindowCommand.ID, currentFrame: CGRect, currentScreenID: Int,
-        cycleEnabled: Bool, now: Date
+        cycleLength: Int, now: Date
     ) -> Decision {
         // First sight: capture where it was, so Restore works for a never-moved window.
         guard let record = records[key] else {
@@ -65,14 +65,14 @@ struct WindowActionMemory<Key: Hashable> {
 
         let lastTileCommand =
             WindowPlacementEngine.isTileCommand(record.command) ? record.command : nil
-        let cycles = WindowCommandCatalog.command(id: command)?.cyclesOnRepeat ?? false
         let expired = cycleTimeout.map { now.timeIntervalSince(record.at) > $0 } ?? false
+        // A length of 1 covers both a non-cycling command and cycling switched off entirely.
         let continues =
-            cycleEnabled && cycles && command == record.command
+            cycleLength > 1 && command == record.command
             && currentScreenID == record.screenID && !expired
         return Decision(
-            step: continues ? (record.step + 1) % 3 : 0, restoreFrame: record.restoreFrame,
-            canRestore: true, lastTileCommand: lastTileCommand)
+            step: continues ? (record.step + 1) % cycleLength : 0,
+            restoreFrame: record.restoreFrame, canRestore: true, lastTileCommand: lastTileCommand)
     }
 
     /// Records what actually landed. `appliedFrame` must be read back from the window, not assumed.

--- a/Tinycast/Features/WindowManagement/Model/WindowCommand.swift
+++ b/Tinycast/Features/WindowManagement/Model/WindowCommand.swift
@@ -80,7 +80,7 @@ struct WindowCommand: Identifiable, Hashable, Sendable {
     let sfSymbol: String
     let kind: Kind
     let group: Group
-    /// Only the four halves cycle ½ → ⅓ → ⅔; the rest ignore the step they are handed.
+    /// Only the four halves honour `WindowCycle`; the rest ignore the step they are handed.
     let cyclesOnRepeat: Bool
     /// False for the nudges, so the mover never writes `kAXSizeAttribute` for them.
     let resizes: Bool

--- a/Tinycast/Features/WindowManagement/Model/WindowCycle.swift
+++ b/Tinycast/Features/WindowManagement/Model/WindowCycle.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// What a repeat press of a half does. docs/features/window-management.md#cycling-and-restore
+enum WindowCycle: String, CaseIterable, Identifiable, Sendable {
+    /// Re-apply the same half — the shortcut is idempotent.
+    case off
+    /// Step the half through ⅓ and ⅔ before it returns to ½.
+    case sizes
+    /// Walk the half one slot along the strip of half-slots every display contributes.
+    case displays
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .off: "None"
+        case .sizes: "Cycle ½, ⅓ and ⅔"
+        case .displays: "Cycle displays"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .off: "Triggering a half again re-applies the same frame."
+        case .sizes: "Triggering a half again steps it through a third and two thirds."
+        case .displays:
+            "Triggering a half again walks it to the next half across your displays, wrapping around."
+        }
+    }
+}

--- a/Tinycast/Features/WindowManagement/Model/WindowPlacementEngine.swift
+++ b/Tinycast/Features/WindowManagement/Model/WindowPlacementEngine.swift
@@ -50,6 +50,8 @@ enum WindowPlacementEngine {
         var gap: CGFloat
         /// Cycle position, supplied by `WindowActionMemory` so the geometry itself stays stateless.
         var step: Int
+        /// What the step means: the mode the user picked for a repeat press.
+        var cycle: WindowCycle
         /// Read only by `.restore`.
         var restoreFrame: CGRect?
         /// The tile that last placed this window, so a display move re-derives rather than scales.
@@ -57,13 +59,15 @@ enum WindowPlacementEngine {
 
         init(
             command: WindowCommand.ID, windowFrame: CGRect, screens: [Screen], gap: CGFloat = 0,
-            step: Int = 0, restoreFrame: CGRect? = nil, lastTileCommand: WindowCommand.ID? = nil
+            step: Int = 0, cycle: WindowCycle = .off, restoreFrame: CGRect? = nil,
+            lastTileCommand: WindowCommand.ID? = nil
         ) {
             self.command = command
             self.windowFrame = windowFrame
             self.screens = screens
             self.gap = gap
             self.step = step
+            self.cycle = cycle
             self.restoreFrame = restoreFrame
             self.lastTileCommand = lastTileCommand
         }
@@ -109,15 +113,16 @@ enum WindowPlacementEngine {
             break
         }
 
-        // Non-cycling commands ignore the step, so a stale cycle position can't leak in.
-        let step = command.cyclesOnRepeat ? normalizedStep(input.step) : 0
+        // `cycleLength` is 1 for a non-cycling command, so a stale step can never leak in.
+        let step = wrapped(
+            input.step,
+            into: cycleLength(for: input.command, screens: input.screens, cycle: input.cycle))
 
-        if let fractions = tileFractions(input.command, step: step) {
-            let frame = tile(
-                host.visibleFrame, x0: fractions.x0, x1: fractions.x1, y0: fractions.y0,
-                y1: fractions.y1, gap: gap)
-            return Placement(
-                frame: frame, screenID: host.id, anchor: fractions.anchor, resizes: true)
+        if let half = Half.of(input.command) {
+            return halfPlacement(input, half: half, host: host, step: step)
+        }
+        if let fractions = tileFractions(input.command) {
+            return tilePlacement(fractions, on: host, gap: gap)
         }
 
         let canvas = canvas(host.visibleFrame, gap: gap)
@@ -229,7 +234,7 @@ enum WindowPlacementEngine {
         _ frame: CGRect, from: Screen, to: Screen, gap: CGFloat, lastTile: WindowCommand.ID?
     ) -> CGRect {
         // Exactness beats proportion: an untouched tile re-derives instead of being scaled.
-        if let lastTile, let fractions = tileFractions(lastTile, step: 0) {
+        if let lastTile, let fractions = tileFractions(lastTile) {
             return tile(
                 to.visibleFrame, x0: fractions.x0, x1: fractions.x1, y0: fractions.y0,
                 y1: fractions.y1, gap: sanitizedGap(gap, in: to.visibleFrame))
@@ -280,24 +285,92 @@ enum WindowPlacementEngine {
     private static let oneThird: CGFloat = 1.0 / 3.0
     private static let twoThirds: CGFloat = 2.0 / 3.0
 
-    /// Fractional bounds of a tile command, or `nil`; `step` matters only for the four halves.
-    private static func tileFractions(_ command: WindowCommand.ID, step: Int) -> Fractions? {
-        let cycle: [CGFloat] = [0.5, oneThird, twoThirds]
-        let position = cycle[normalizedStep(step)]
-        switch command {
-        case .leftHalf:
-            return Fractions(x0: 0, x1: position, y0: 0, y1: 1, anchor: .topLeading)
-        case .rightHalf:
-            return Fractions(
-                x0: 1 - position, x1: 1, y0: 0, y1: 1,
-                anchor: Anchor(horizontal: .max, vertical: .min))
-        case .topHalf:
-            return Fractions(x0: 0, x1: 1, y0: 0, y1: position, anchor: .topLeading)
-        case .bottomHalf:
-            return Fractions(
-                x0: 0, x1: 1, y0: 1 - position, y1: 1,
-                anchor: Anchor(horizontal: .min, vertical: .max))
+    /// One of the four halves: the axis it splits, and the edge of that axis it hugs.
+    private struct Half {
+        enum Axis { case horizontal, vertical }
+        enum Edge { case leading, trailing }
 
+        var axis: Axis
+        var edge: Edge
+
+        static func of(_ command: WindowCommand.ID) -> Half? {
+            switch command {
+            case .leftHalf: Half(axis: .horizontal, edge: .leading)
+            case .rightHalf: Half(axis: .horizontal, edge: .trailing)
+            case .topHalf: Half(axis: .vertical, edge: .leading)
+            case .bottomHalf: Half(axis: .vertical, edge: .trailing)
+            default: nil
+            }
+        }
+
+        /// Bounds covering `fraction` of the screen along the axis, pinned to the edge.
+        func fractions(_ fraction: CGFloat) -> Fractions {
+            let leads = edge == .leading
+            let span: (CGFloat, CGFloat) = leads ? (0, fraction) : (1 - fraction, 1)
+            let along: Anchor.Axis = leads ? .min : .max
+            switch axis {
+            case .horizontal:
+                return Fractions(
+                    x0: span.0, x1: span.1, y0: 0, y1: 1,
+                    anchor: Anchor(horizontal: along, vertical: .min))
+            case .vertical:
+                return Fractions(
+                    x0: 0, x1: 1, y0: span.0, y1: span.1,
+                    anchor: Anchor(horizontal: .min, vertical: along))
+            }
+        }
+    }
+
+    /// The sizes a half steps through when size cycling is on.
+    private static let sizeCycle: [CGFloat] = [0.5, oneThird, twoThirds]
+
+    /// Presses before the chain wraps; 1 means this command doesn't cycle at all.
+    static func cycleLength(
+        for command: WindowCommand.ID, screens: [Screen], cycle: WindowCycle
+    ) -> Int {
+        guard WindowCommandCatalog.command(id: command)?.cyclesOnRepeat == true else { return 1 }
+        switch cycle {
+        case .off: return 1
+        case .sizes: return sizeCycle.count
+        // One display makes the display cycle a no-op rather than a left/right flip in place.
+        case .displays: return screens.count > 1 ? screens.count * 2 : 1
+        }
+    }
+
+    /// A half's slot this press: its own edge on the host, or one walked along the display strip.
+    private static func halfPlacement(
+        _ input: Input, half: Half, host: Screen, step: Int
+    ) -> Placement {
+        guard input.cycle == .displays else {
+            return tilePlacement(half.fractions(sizeCycle[step]), on: host, gap: input.gap)
+        }
+        let strip = ordered(input.screens)
+        guard strip.count > 1, let hostIndex = strip.firstIndex(where: { $0.id == host.id }) else {
+            return tilePlacement(half.fractions(0.5), on: host, gap: input.gap)
+        }
+        // Left and Top walk backwards, so one shortcut sweeps the whole desktop in one direction.
+        let leads = half.edge == .leading
+        let slot = wrapped(
+            hostIndex * 2 + (leads ? 0 : 1) + (leads ? -step : step), into: strip.count * 2)
+        let edge: Half.Edge = slot.isMultiple(of: 2) ? .leading : .trailing
+        return tilePlacement(
+            Half(axis: half.axis, edge: edge).fractions(0.5), on: strip[slot / 2], gap: input.gap)
+    }
+
+    private static func tilePlacement(
+        _ fractions: Fractions, on screen: Screen, gap: CGFloat
+    ) -> Placement {
+        let frame = tile(
+            screen.visibleFrame, x0: fractions.x0, x1: fractions.x1, y0: fractions.y0,
+            y1: fractions.y1, gap: sanitizedGap(gap, in: screen.visibleFrame))
+        return Placement(
+            frame: frame, screenID: screen.id, anchor: fractions.anchor, resizes: true)
+    }
+
+    /// Fractional bounds of a tile command at its base position, or `nil` if it isn't one.
+    private static func tileFractions(_ command: WindowCommand.ID) -> Fractions? {
+        if let half = Half.of(command) { return half.fractions(0.5) }
+        switch command {
         case .topLeftQuarter:
             return Fractions(x0: 0, x1: 0.5, y0: 0, y1: 0.5, anchor: .topLeading)
         case .topRightQuarter:
@@ -346,7 +419,7 @@ enum WindowPlacementEngine {
 
     /// Whether the command lands on the fractional grid, which a display move can re-derive.
     static func isTileCommand(_ command: WindowCommand.ID) -> Bool {
-        tileFractions(command, step: 0) != nil
+        tileFractions(command) != nil
     }
 
     /// A tile from fractional bounds of `visible`. See docs/features/window-management.md#geometry.
@@ -437,5 +510,8 @@ enum WindowPlacementEngine {
         return min(gap, min(visible.width, visible.height) / 10)
     }
 
-    private static func normalizedStep(_ step: Int) -> Int { ((step % 3) + 3) % 3 }
+    /// Wraps into `0..<length`, so neither a negative nor an overrun step escapes the cycle.
+    private static func wrapped(_ value: Int, into length: Int) -> Int {
+        ((value % length) + length) % length
+    }
 }

--- a/Tinycast/Features/WindowManagement/Service/WindowMover.swift
+++ b/Tinycast/Features/WindowManagement/Service/WindowMover.swift
@@ -43,7 +43,7 @@ final class WindowMover {
     @discardableResult
     func perform(
         _ command: WindowCommand.ID, target: NSRunningApplication?, gap: CGFloat,
-        cycleOnRepeat: Bool
+        cycle: WindowCycle
     ) -> Bool {
         // Invoked from an explicit user gesture, so prompting for the grant is appropriate here.
         guard Permissions.ensureAccessibility() else { return false }
@@ -79,11 +79,13 @@ final class WindowMover {
         let now = Date()
         let decision = memory.decide(
             key: key, command: command, currentFrame: current, currentScreenID: host.id,
-            cycleEnabled: cycleOnRepeat, now: now)
+            cycleLength: WindowPlacementEngine.cycleLength(
+                for: command, screens: screens, cycle: cycle),
+            now: now)
 
         let input = WindowPlacementEngine.Input(
             command: command, windowFrame: current, screens: screens, gap: gap, step: decision.step,
-            restoreFrame: decision.canRestore ? decision.restoreFrame : nil,
+            cycle: cycle, restoreFrame: decision.canRestore ? decision.restoreFrame : nil,
             lastTileCommand: decision.lastTileCommand)
         guard let placement = WindowPlacementEngine.placement(for: input) else { return false }
 

--- a/Tinycast/Features/WindowManagement/Settings/WindowManagementSettingsView.swift
+++ b/Tinycast/Features/WindowManagement/Settings/WindowManagementSettingsView.swift
@@ -45,11 +45,13 @@ struct WindowManagementSettingsView: View {
     private var options: some View {
         @Bindable var settings = settings
         return Section {
-            Toggle(isOn: $settings.windowCycleOnRepeat) {
-                SettingsRowTitle(.windowManagementOptions, "Cycle sizes on repeat")
-                Text(
-                    "Triggering a half again steps it through a third and two thirds before returning."
-                )
+            Picker(selection: $settings.windowCycle) {
+                ForEach(WindowCycle.allCases) { cycle in
+                    Text(cycle.title).tag(cycle)
+                }
+            } label: {
+                SettingsRowTitle(.windowManagementOptions, "Cycling")
+                Text(settings.windowCycle.detail)
             }
 
             LabeledContent {

--- a/Tinycast/Features/WindowManagement/UI/WindowCommandCoordinator.swift
+++ b/Tinycast/Features/WindowManagement/UI/WindowCommandCoordinator.swift
@@ -31,6 +31,6 @@ final class WindowCommandCoordinator {
         if paletteCoordinator.isVisible { paletteCoordinator.hidePalette(restoreFocus: true) }
         windowMover.perform(
             id, target: target, gap: CGFloat(settings.windowGap),
-            cycleOnRepeat: settings.windowCycleOnRepeat)
+            cycle: settings.windowCycle)
     }
 }

--- a/docs/features/window-management.md
+++ b/docs/features/window-management.md
@@ -136,7 +136,8 @@ Two details carry their weight:
 Rule 1 also delivers the "works for windows Tinycast never moved" requirement: the capture happens in
 `WindowMover.perform` before a single write.
 
-**Cycling covers the four halves only**, and `WindowCycle` picks one of three modes, `.sizes` by default:
+**Cycling covers the four halves only**, and `WindowCycle` picks one of three modes, `.off` by default
+so a repeat press stays idempotent unless asked otherwise:
 
 - **`.sizes`** — ½ → ⅓ → ⅔ in place. Top and Bottom Half cycle through _vertical_ thirds, which have no
   commands of their own (the Thirds group is horizontal), so they are expressed as fractions rather
@@ -264,7 +265,7 @@ quantize to zero and the gesture would do nothing.
   app, and activating an app that lives on another Space pulls that Space forward — a race against the
   gesture that can land on the opposite Space from the one asked for.
 - **Settings** — `windowManagementEnabled` (off), `windowManagementShowInLauncher` (on), `windowGap`
-  (0) and `windowCycle` (`.sizes`). All four ride in settings backups: unlike `snippetsEnabled` they
+  (0) and `windowCycle` (`.off`). All four ride in settings backups: unlike `snippetsEnabled` they
   grant no permission class of their own.
 - **Per-command visibility** reuses `VisibilityStore` as-is; clearing a recorded shortcut is how a
   hotkey is disabled, so there is no separate per-command enabled flag. Window commands deliberately

--- a/docs/features/window-management.md
+++ b/docs/features/window-management.md
@@ -31,6 +31,7 @@ entries and a still-registered shortcut moves nothing.
 | File                                             | Imports                      | Role                                                                |
 | ------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------- |
 | `Model/WindowCommand.swift`          | Foundation                   | Catalog: id, name, symbol, kind, group, `cyclesOnRepeat`, `resizes` |
+| `Model/WindowCycle.swift`            | Foundation                   | The three cycling modes a repeat press can run                      |
 | `Model/WindowPlacementEngine.swift`  | Foundation + CoreGraphics    | **Pure.** Every frame the commands produce                          |
 | `Model/WindowActionMemory.swift`     | Foundation + CoreGraphics    | **Pure.** Per-window cycle position and restore point               |
 | `Model/SpaceGesture.swift`           | Foundation                   | **Pure.** The Dock-swipe field tables and the IOHID payload bytes   |
@@ -43,7 +44,7 @@ entries and a still-registered shortcut moves nothing.
 The feature also owns **[Window Layouts](window-layouts.md)** — saved multi-display arrangements
 applied in one pass. They share this feature's switch, its Accessibility grant and its gap setting.
 
-The first three compile into `Tests/window-command-test.swift` and `SpaceGesture.swift` compiles into
+The first four compile into `Tests/window-command-test.swift` and `SpaceGesture.swift` compiles into
 `Tests/space-gesture-test.swift`, so none of them may gain an AppKit, SwiftUI or `NSScreen`
 dependency, and all must stay pure — `WindowActionMemory` takes `now` as a parameter rather than
 reading a clock. CoreGraphics is needed only because `CGRect`'s `Equatable` conformance lives in that
@@ -116,9 +117,12 @@ cycle state is never hidden inside the geometry. Its rules, in order:
 
 1. No record → step 0, capture the current frame as the restore point, `canRestore: false`.
 2. The frame drifted from `appliedFrame` by more than 2 pt → step 0, **and refresh** the restore point.
-3. A different command, a different display, cycling disabled, a non-cycling command, or a lapsed
-   `cycleTimeout` → step 0.
-4. Otherwise → `(step + 1) % 3`.
+3. A different command, a different display, a `cycleLength` of 1, or a lapsed `cycleTimeout` → step 0.
+4. Otherwise → `(step + 1) % cycleLength`.
+
+`cycleLength` comes from `WindowPlacementEngine.cycleLength(for:screens:cycle:)`, so the memory holds
+no opinion about what a step means: 1 covers cycling switched off *and* a command that never cycles,
+which is why `WindowActionMemory` no longer reads the catalog at all.
 
 Two details carry their weight:
 
@@ -132,9 +136,21 @@ Two details carry their weight:
 Rule 1 also delivers the "works for windows Tinycast never moved" requirement: the capture happens in
 `WindowMover.perform` before a single write.
 
-**Cycling covers the four halves only** (½ → ⅓ → ⅔), and is off by default. Top and Bottom Half cycle
-through _vertical_ thirds, which have no commands of their own — the Thirds group is horizontal — so
-they are expressed as fractions rather than other command IDs.
+**Cycling covers the four halves only**, and `WindowCycle` picks one of three modes, `.sizes` by default:
+
+- **`.sizes`** — ½ → ⅓ → ⅔ in place. Top and Bottom Half cycle through _vertical_ thirds, which have no
+  commands of their own (the Thirds group is horizontal), so they are expressed as fractions rather
+  than as other command IDs.
+- **`.displays`** — every display contributes two half-slots to one strip, ordered left-to-right by
+  `ordered(_:)`. Left and Top walk it backwards, Right and Bottom forwards, both wrapping, so one
+  shortcut sweeps the whole desktop in one direction: on two displays, Left Half gives
+  D1-left → D2-right → D2-left → D1-right. One display makes the mode a quiet no-op — a length of 1 —
+  rather than a left/right flip in place, matching Next Display's own single-display behaviour.
+
+The two are deliberately exclusive rather than composable: a 12-press chain over two displays is not a
+shortcut any more, and Raycast's own setting is the same single choice. `Half` carries the (axis, edge)
+pair that makes both modes one expression — a slot's edge decides which side a ⅓ hugs, so the four
+halves are no longer four hand-written fraction cases.
 
 Growth is bounded three ways: an LRU cap of 64, an `NSWorkspace.didTerminateApplicationNotification`
 observer (the house `NotificationToken` RAII idiom) dropping a quit app's keys, and lazy invalidation
@@ -142,7 +158,7 @@ when a read fails. Nothing is persisted.
 
 ## Applying a placement
 
-`WindowMover.perform(_:target:gap:cycleOnRepeat:)` is the only entry point. `target` is **explicit**
+`WindowMover.perform(_:target:gap:cycle:)` is the only entry point. `target` is **explicit**
 because the palette is frontmost when a command dispatches from it — `WindowCommandCoordinator` passes
 `windowController.previousApp`, the same recorded app the paste path targets, and restores focus to it
 rather than dropping it. It is synchronous: every AX call is a bounded mach round trip capped by a 1s
@@ -248,7 +264,7 @@ quantize to zero and the gesture would do nothing.
   app, and activating an app that lives on another Space pulls that Space forward — a race against the
   gesture that can land on the opposite Space from the one asked for.
 - **Settings** — `windowManagementEnabled` (off), `windowManagementShowInLauncher` (on), `windowGap`
-  (0) and `windowCycleOnRepeat` (off). All four ride in settings backups: unlike `snippetsEnabled` they
+  (0) and `windowCycle` (`.sizes`). All four ride in settings backups: unlike `snippetsEnabled` they
   grant no permission class of their own.
 - **Per-command visibility** reuses `VisibilityStore` as-is; clearing a recorded shortcut is how a
   hotkey is disabled, so there is no separate per-command enabled flag. Window commands deliberately
@@ -260,9 +276,10 @@ quantize to zero and the gesture would do nothing.
 `Tests/window-command-test.swift` (357 assertions) covers the catalog, the AX-space convention lock,
 tiling on divisible and non-divisible screens, off-origin and negative-coordinate displays, gap
 arithmetic including degenerate values, sizing, the Make Larger/Smaller round trip, nudges, display
-moves and wrapping, restore recovery, every `WindowActionMemory` rule, and a fuzz sweep over every
-command × gap × screen × degenerate window frame checking for non-finite output, negative dimensions,
-off-screen results, non-determinism and drift on repeat.
+moves and wrapping, both cycling modes including the strip walk and its wrap, restore recovery, every
+`WindowActionMemory` rule, and a fuzz sweep over every command × gap × screen × cycle × step ×
+degenerate window frame checking for non-finite output, negative dimensions, off-screen results,
+non-determinism and, at step 0, drift on repeat.
 
 `Tests/space-gesture-test.swift` (121 assertions) covers the other pure half: the fixed-point encoding
 and its ±1 floor, both field tables and the sign convention shared between them, the ended-only fling
@@ -278,7 +295,9 @@ verification, particularly:
 2. **A mixed-resolution multi-monitor setup** — the coordinate-flip bug appears nowhere else. Tile on
    the secondary display, then round-trip Next/Previous Display.
 3. Toggle Fullscreen on a window that accepts it and one that refuses it.
-4. Cycling: three presses of Left Half, then drag the window and confirm the next press restarts at ½.
+4. Cycling, in both modes: under `.sizes`, three presses of Left Half, then drag the window and confirm
+   the next press restarts at ½. Under `.displays` on two monitors, four presses of Left Half must
+   visit every half-slot once and return to the first.
 5. Restore on a window Tinycast has never moved.
 6. **Space switching, on the real desktop with three or more Spaces.** Next and Previous each move
    exactly one Space with no visible slide, in and out of a fullscreen Space, and a held shortcut does

--- a/website/content/docs/features/window-management.md
+++ b/website/content/docs/features/window-management.md
@@ -32,12 +32,12 @@ Center · Center Half · Make Larger · Make Smaller · Restore
 
 ## Settings
 
-| Setting                  | Range          | Default |
-| ------------------------ | -------------- | ------- |
-| Enable window management | —              | **Off** |
-| Show in launcher         | —              | On      |
-| Cycle sizes on repeat    | —              | **Off** |
-| Gap between windows      | 0–64 pt, in 2s | **0**   |
+| Setting                  | Range                                       | Default  |
+| ------------------------ | ------------------------------------------- | -------- |
+| Enable window management | —                                           | **Off**  |
+| Show in launcher         | —                                           | On       |
+| Cycling                  | None · Cycle ½, ⅓ and ⅔ · Cycle displays    | **None** |
+| Gap between windows      | 0–64 pt, in 2s                              | **0**    |
 
 Per-command shortcut and visibility live in this same pane — window commands deliberately get no
 launcher pane of their own.
@@ -64,11 +64,16 @@ The usable area already excludes the menu bar, the Dock and the notch.
 
 ## Cycling and Restore
 
-**Cycling** covers the four halves only, stepping ½ → ⅓ → ⅔, and is off by default. Top and Bottom
-Half cycle through vertical thirds.
+**Cycling** covers the four halves only, and is off by default — a repeat press re-applies the same
+frame. Two modes change that:
 
-It restarts at ½ when you move the window yourself (more than 2 pt), on a different command, on a
-different display, after a timeout, or when cycling is off.
+- **Cycle ½, ⅓ and ⅔** steps the half in place. Top and Bottom Half step through vertical thirds.
+- **Cycle displays** walks the half one slot along every half-slot your displays contribute, so one
+  shortcut sweeps the whole desktop. On two displays, Left Half gives Display 1 left → Display 2
+  right → Display 2 left → Display 1 right, then wraps. With a single display it does nothing.
+
+The chain restarts when you move the window yourself (more than 2 pt), on a different command, on a
+different display, or after a timeout.
 
 **Restore is single-level, not a stack.** Left Half → Maximize → Top Right → Restore lands on the
 **original** frame, not the previous one.

--- a/website/content/docs/reference/settings.md
+++ b/website/content/docs/reference/settings.md
@@ -79,7 +79,7 @@ Seven features, all off by default.
 | [File Search](/docs/features/file-search)             | Enable File Search       | Search Scopes, Ignore Patterns                                              |
 | [Notes](/docs/features/notes)                         | Enable Notes             | Per-command visibility and shortcut                                         |
 | [Snippets](/docs/features/snippets)                   | Enable snippets          | Show in launcher, New Snippet, Snippets Folder                              |
-| [Window Management](/docs/features/window-management) | Enable window management | Show in launcher, Cycle sizes on repeat, Gap (0–64 pt, default 0)           |
+| [Window Management](/docs/features/window-management) | Enable window management | Show in launcher, Cycling (**None**), Gap (0–64 pt, default 0)           |
 | [Clipboard](/docs/features/clipboard)                 | _(always on)_            | Keep history for (**3 Months**), Disabled Applications, Clear history       |
 | [Emoji & Symbols](/docs/features/emoji)               | _(always on)_            | Emoji Skin Tone (**Default**)                                               |
 | [Extensions](/docs/extensions)                        | Enable extensions        | Show in launcher, per-command alias and shortcut, package manager, registries, custom search paths, Storage |


### PR DESCRIPTION
## Related issue

Closes #552

## What changed

Window Management's `Cycle sizes on repeat` toggle becomes a **Cycling** picker with three modes, matching Raycast's own setting:

| Mode | Repeat press |
| --- | --- |
| None | re-applies the same frame |
| Cycle ½, ⅓ and ⅔ (default) | steps the size in place — what the old toggle did |
| Cycle displays | walks one slot along the display strip |

**The strip.** Every display contributes two half-slots to one strip, ordered left-to-right by the existing `ordered(_:)`. Left and Top walk it backwards, Right and Bottom forwards, both wrapping, so one shortcut sweeps the whole desktop in one direction. On two displays, Left Half gives exactly the sequence the issue asks for:

```
D1-left → D2-right → D2-left → D1-right → wrap
```

Right Half is the exact mirror. Top and Bottom walk the same strip on their own axis.

Three things in the diff that aren't obvious:

- **A private `Half` type** in `WindowPlacementEngine` carries the `(axis, edge)` pair. A slot's edge decides which side a ⅓ hugs, so both modes are one expression and the four halves stop being four hand-written fraction cases.
- **`WindowActionMemory` takes a `cycleLength` rather than a `Bool`.** A length of 1 covers both cycling switched off *and* a command that never cycles, so the memory no longer reads `WindowCommandCatalog` at all. `cycleLength` comes from the engine, keeping the rule that cycle state never hides inside the geometry.
- **The gap is sanitised against the destination display**, not the one the window started on — a new `tilePlacement` helper owns that, and the non-cycling tiles now share it.

**The modes are exclusive, not composable.** Two independent toggles were the first cut; a 12-press chain over two displays stops being a shortcut, and Raycast's single picker settled it.

**One display makes `Cycle displays` a quiet no-op** — a length of 1 — rather than a left/right flip in place, matching the call Next Display already makes.

## Memory footprint

Not measured. This adds no allocation, no storage and no new long-lived state: one `String` in `UserDefaults` replacing one `Bool`, and pure `CGRect` arithmetic on a path that already ran on every window command. `WindowActionMemory` keeps its LRU cap of 64 and its termination observer untouched.

| Step | Memory |
| --- | --- |
| Idle after launch | not measured |
| Palette open | not measured |
| Feature in use (peak) | not measured |
| Palette closed, settled | not measured |

Leak-tested: no. No new object graph, observer, timer or task.

## Demo

Not attached — the visible change is a Settings row going from a checkbox to a picker, and the behaviour needs two physical monitors to film.

## Drawbacks

- **The old `windowManagementCycleOnRepeat` key is gone**, replaced by `windowManagementCycleMode`. Per the project's no-migration rule there is no shim, so anyone who had the old toggle **off** silently gets the new default (`Cycle ½, ⅓ and ⅔`) on next launch. Reading the old key once would fix that if it's worth the scaffolding.
- **The strip order is `NSScreen`-arrangement order, not physical order.** Displays stacked vertically walk in the same left-to-right sequence as side-by-side ones, which is consistent but not what a vertical arrangement might suggest.
- **A display hotplug mid-chain can land the window in an unexpected slot**, since the step is an index into a strip whose length just changed. The existing same-display guard in `decide` catches the common case; the arrangement-change case is rare enough that restarting the chain wasn't worth a second mechanism.
- **`Cycle displays` and the size cycle can't both be on.** Deliberate, argued above, but it is a capability Rectangle offers and this doesn't.

## Tests & validation

`./Scripts/run-tests.sh` — all 67 harnesses pass. Debug build compiles with no new warnings, `./Scripts/lint.sh` is clean, and the `Features/*/Model/` AppKit grep is empty.

Added to `Tests/window-command-test.swift`, in a new `testDisplayCycle()`:

- `cycleLength` for every mode × two displays, plus the single-display no-op and every non-cycling command under every mode.
- The exact four-step sequence for Left Half and its mirror for Right Half, plus the wrap and a negative step.
- Top/Bottom walking the strip on their own axis.
- One full lap from either starting display visits four distinct frames and reaches both screens.
- The size cycle staying on the host display with a second one plugged in.
- The destination display sanitising the gap, via a deliberately narrow second screen.

Existing coverage was rewritten rather than dropped: every size-cycle assertion now names the mode it runs under, and the memory tests pass a real `cycleLength`. The fuzz sweep gained two dimensions — cycle × step — so it now covers every command × gap × screen × mode × step over the same degenerate frames, with idempotence checked only at step 0 (a cycle exists to move the window).

**Not exercised by hand.** The pure layer is fully covered, but nothing here ran against real AX on a real two-monitor desktop — manual step 4 in `docs/features/window-management.md` § Testing is the one to run before merge.