### PR TITLE
Let an unquoted date format keep its spaces

### DIFF
--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -1196,6 +1196,21 @@ struct SnippetsTests {
         check(
             "format still applies with an offset",
             expand("{date offset=\"-1d\" format=\"yyyy-MM-dd\"}").text == "2026-07-23")
+        check(
+            "a bare format needs no quotes",
+            expand("{date format=yyyy-MM-dd}").text == "2026-07-24")
+        check(
+            "a bare format keeps its spaces",
+            expand("{date format=MMMM d, yyyy}").text == "July 24, 2026")
+        check(
+            "a bare value ends at the next parameter",
+            expand("{date format=MMM d offset=+1d}").text == "Jul 25")
+        check(
+            "a bare value trailing another parameter keeps its spaces",
+            expand("{date offset=+1d format=MMM d}").text == "Jul 25")
+        check(
+            "a bare format with no value leaves the token literal",
+            expand("{date format=}").text == "{date format=}")
 
         // UUID comes from the injected source, once per token.
         check("each uuid token draws a fresh value", expand("{uuid}|{uuid}").text == "uuid-1|uuid-2")

--- a/Tinycast/Features/Backup/Service/BackupActions.swift
+++ b/Tinycast/Features/Backup/Service/BackupActions.swift
@@ -13,6 +13,7 @@ enum BackupActions {
         var summary: SettingsBackup.ApplySummary
         var clipboardImported: Int
         var snippetsImported: Int
+        var snippetsNeedEnabling: Bool
         /// Set when the snippet files couldn't be written; the rest of the import still applied.
         var snippetsError: String?
         var quicklinksImported: Int
@@ -178,6 +179,7 @@ enum BackupActions {
             summary: summary,
             clipboardImported: imported,
             snippetsImported: snippetsImported,
+            snippetsNeedEnabling: snippetsImported > 0 && !core.settings.snippetsEnabled,
             snippetsError: snippetsError,
             quicklinksImported: quicklinksImported,
             quicklinksError: quicklinksError,
@@ -230,6 +232,7 @@ enum BackupActions {
         if !imported.isEmpty {
             parts.append("Imported " + imported.joined(separator: ", ") + ".")
         }
+        if summary.snippetsNeedEnabling { parts.append(snippetsNeedEnablingText) }
         parts.append(contentsOf: summary.problems)
         return parts.isEmpty ? nothingImportedText : parts.joined(separator: " ")
     }
@@ -250,6 +253,10 @@ enum BackupActions {
 
     static let nothingImportedText = "Nothing to import from this file."
 
+    /// No import may grant keystroke listening, so say the switch an imported keyword needs is off.
+    private static let snippetsNeedEnablingText =
+        "Turn on Snippets in Settings to use their keywords."
+
     /// One sentence per Raycast category that actually moved, shared by the pane and onboarding.
     static func raycastText(_ outcome: RaycastOutcome) -> String {
         var parts: [String] = []
@@ -261,6 +268,7 @@ enum BackupActions {
             let noun = outcome.snippetsImported == 1 ? "snippet" : "snippets"
             parts.append("Imported \(outcome.snippetsImported) \(noun).")
         }
+        if outcome.snippetsNeedEnabling { parts.append(snippetsNeedEnablingText) }
         if let snippetsError = outcome.snippetsError {
             parts.append("Couldn’t import snippets: \(snippetsError)")
         }

--- a/Tinycast/Features/Backup/Service/BackupApplier.swift
+++ b/Tinycast/Features/Backup/Service/BackupApplier.swift
@@ -7,6 +7,7 @@ enum BackupApplier {
         var settings: SettingsBackup.ApplySummary?
         var clipboard = 0
         var snippets = 0
+        var snippetsNeedEnabling = false
         var notes = 0
         var learning = 0
         /// Reported rather than thrown: a failure here must not abort the categories after it.
@@ -29,6 +30,8 @@ enum BackupApplier {
         if categories.contains(.snippets) {
             do {
                 summary.snippets = try await applySnippets(bundle, to: core)
+                summary.snippetsNeedEnabling =
+                    summary.snippets > 0 && !core.settings.snippetsEnabled
             } catch {
                 summary.problems.append("Couldn't import snippets: \(error.localizedDescription)")
             }

--- a/Tinycast/Features/Snippets/Model/SnippetTemplateEngine.swift
+++ b/Tinycast/Features/Snippets/Model/SnippetTemplateEngine.swift
@@ -604,14 +604,37 @@ enum SnippetTemplateEngine {
                 guard let decoded = decodeQuoted(&remainder) else { return nil }
                 value = decoded
             } else {
-                let bare = remainder.prefix { !$0.isWhitespace }
-                guard !bare.isEmpty else { return nil }
-                remainder = remainder.dropFirst(bare.count)
-                value = String(bare)
+                guard let bare = takeBareValue(&remainder) else { return nil }
+                value = bare
             }
             guard parameters.updateValue(value, forKey: String(key)) == nil else { return nil }
         }
         return ParsedToken(command: String(command).lowercased(), parameters: parameters)
+    }
+
+    /// Runs to the next `key=`, so an unquoted `format=MMM d, yyyy` keeps the spaces Raycast writes.
+    private static func takeBareValue(_ remainder: inout Substring) -> String? {
+        var index = remainder.startIndex
+        var end = remainder.startIndex
+        while index < remainder.endIndex {
+            if remainder[index].isWhitespace {
+                index = remainder[index...].drop(while: \Character.isWhitespace).startIndex
+                if startsParameter(remainder[index...]) { break }
+            } else {
+                index = remainder.index(after: index)
+                end = index
+            }
+        }
+        guard end > remainder.startIndex else { return nil }
+        let value = String(remainder[..<end])
+        remainder = remainder[end...]
+        return value
+    }
+
+    private static func startsParameter(_ text: Substring) -> Bool {
+        let key = text.prefix { !$0.isWhitespace && $0 != "=" }
+        guard !key.isEmpty else { return false }
+        return text.dropFirst(key.count).drop(while: \Character.isWhitespace).first == "="
     }
 
     /// Consumes a quoted value from `remainder`, leaving it positioned after the closing quote.

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -51,7 +51,9 @@ the store and its watchers stop, and the launcher section disappears — while t
 states survive for re-enabling. "Show in launcher" takes the section and the two Snippet commands out
 of the launcher together; keyword expansion and the browser's shortcut keep working.
 `snippetsShowInLauncher` travels in settings backups; `snippetsEnabled` deliberately does not, so an
-import can never enable keystroke listening. `AppCore`'s settings sinks re-project on every change.
+import can never enable keystroke listening — which is why either importer's summary says the switch is
+still off when snippets land, so a dormant keyword doesn't read as a broken one. `AppCore`'s settings
+sinks re-project on every change.
 
 ## Importing from Raycast
 
@@ -124,7 +126,9 @@ so a migrated snippet keeps working.
 | `{snippet:Name}` · `{snippet name="Name"}` | Another snippet resolved by name, then keyword                                                                                                                                                                     |
 | `{cursor}`                                 | Final insertion point                                                                                                                                                                                              |
 
-The editor's **Insert…** menu lists every token above; parameters and modifiers are typed by hand.
+The editor's **Insert…** menu lists every token above; parameters and modifiers are typed by hand. A
+parameter value needs quotes only to carry a `|`: an unquoted one runs to the next `key=`, so
+`{date format=MMMM d, yyyy}` keeps its spaces the way Raycast writes it.
 
 Any value-producing token accepts a modifier pipeline, applied left to right:
 `{clipboard | trim | uppercase}`. The modifiers are `uppercase`, `lowercase`, `trim`,


### PR DESCRIPTION
## Related issue

Closes #532

## What changed

`{date format=…}` already shipped — `{date format=yyyy-MM-dd}` and `{date format=MM/dd/yy}` expand
correctly today. Two things behind the issue did not.

**1. An unquoted value couldn't contain a space.** `parseToken` read a bare value as "up to the next
whitespace", so `{date format=mm dd yy}` saw `dd` as a parameter with no `=`, failed the whole token
and left it in the text verbatim. Raycast writes that form, so a migrated snippet printed its own
placeholder instead of a date.

A bare value now runs to the next `key=` instead. That boundary is unambiguous —
`{date offset=+1d format=MMM d}` still splits where it should — and quotes are needed only to carry a
`|`, which the modifier split claims first.

```
{date format=mm dd yy}          ->  26 20 25        (was literal)
{date format=MMMM d, yyyy}      ->  July 24, 2026   (was literal)
{date format=MMM d offset=+1d}  ->  Jul 25
{time offset=+3h +30m}          ->  11:56 AM        (was literal)
```

It generalises past dates: `{argument name=First Last}` and `{snippet name=My Snippet}` parse now too.

**2. An import never said snippets were switched off.** `snippetsEnabled` is excluded from every
import because it doubles as consent to keystroke listening. The summary didn't mention it, so a user
who imported from Raycast saw "Imported 12 snippets", typed their keyword, and got nothing — which
reads as a failed import rather than a dormant one. That is what the issue thread actually described:
`{date format=yyyy-MM-dd}` with an alias of `!d` imported fine and simply never fired.

Both importers now carry `snippetsNeedEnabling` and append one sentence pointing at the switch. What
lands and when it lands is unchanged; only the silence is gone. The native backup import had the same
defect and gets the same flag.

## Memory footprint

Not measured. Both changes are string parsing and one summary sentence — no new allocation shape, no
retained state, nothing on a hot path.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no — no new ownership, observers or tasks.

## Demo

Nothing visual changed beyond one added sentence in the import summary.

## Drawbacks

The looser grammar accepts a few strings it used to reject, e.g. `{date format=yyyy =bad}` now parses
as a format rather than staying literal. That is the cost of a value that can hold spaces, and it
errs toward expanding what the user meant. Genuinely malformed tokens — `{date format=}`,
`{date bogus=1}`, an unterminated quote — still stay literal, and `snippets-test` pins each one.

The `s/` vs `S/` keyword collision raised in the issue thread is **not** in here. Keywords are matched
case-insensitively on purpose; making them case-sensitive changes expansion for every existing user
and deserves its own issue.

## Tests & validation

`./Scripts/run-tests.sh` — all 67 harnesses pass. Five cases added to `snippets-test`'s
`testDynamicPlaceholders`: a bare format, a bare format with spaces, a bare value ending at the next
parameter, one trailing another parameter, and `{date format=}` staying literal.

Debug build is clean with no new warnings; `./Scripts/lint.sh` is clean.