### PR TITLE
Drop the duplicate security contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Discord
     url: https://discord.gg/v2Eeb4QQy3
     about: Questions, ideas, and general chat.
-  - name: Report a security vulnerability
-    url: https://github.com/abue-ammar/tinycast/security/advisories/new
-    about: Security issues go here privately, not in the tracker.


### PR DESCRIPTION
## Related issue

None — follow-up to #580, which merged before this commit was pushed.

## What changed

Removes the `Report a security vulnerability` entry from `.github/ISSUE_TEMPLATE/config.yml`. It rendered as a second, identical-looking row in the issue chooser, directly under the one GitHub injects on its own because `SECURITY.md` exists.

It was also dead: the URL points at `/security/advisories/new`, and private vulnerability reporting is disabled on this repo, so the link went nowhere.

## Memory footprint

N/A — no app code.

## Demo

Nothing visual in the app changed.

## Drawbacks

The remaining security row comes from GitHub, not from this file, so it cannot be removed here — only by deleting `SECURITY.md`, which this PR does not do.

Separately, and not fixed here: `SECURITY.md` still tells reporters to use **Security → Report a vulnerability**, which is disabled. Either enable private reporting in the repo settings or repoint that file at the email in the README.

## Tests & validation

`config.yml` parses. No Swift changed, so the harnesses are unaffected; `./Scripts/lint.sh` is clean.