### PR TITLE
Point would-be contributors at the contributor guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,8 +55,10 @@ body:
     attributes:
       label: Contribution
       description: >
-        Optional. Don't start until the issue is marked `approved` — an unapproved PR is
-        closed automatically.
+        Read
+        [CONTRIBUTING.md](https://github.com/abue-ammar/tinycast/blob/main/CONTRIBUTING.md)
+        before you write a line — it is required reading, and it is what your PR is held to. Don't
+        start until the issue is marked `approved`; an unapproved PR is closed automatically.
       options:
         - label: I'm willing to implement this myself
           required: false

--- a/.github/ISSUE_TEMPLATE/extension_bug.yml
+++ b/.github/ISSUE_TEMPLATE/extension_bug.yml
@@ -91,8 +91,10 @@ body:
     attributes:
       label: Contribution
       description: >
-        Optional. Don't start until the issue is marked `approved` — an unapproved PR is
-        closed automatically.
+        Read
+        [CONTRIBUTING.md](https://github.com/abue-ammar/tinycast/blob/main/CONTRIBUTING.md)
+        before you write a line — it is required reading, and it is what your PR is held to. Don't
+        start until the issue is marked `approved`; an unapproved PR is closed automatically.
       options:
         - label: I'm willing to implement this myself
           required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -24,8 +24,10 @@ body:
     attributes:
       label: Contribution
       description: >
-        Optional. Don't start until the issue is marked `approved` — an unapproved PR is
-        closed automatically.
+        Read
+        [CONTRIBUTING.md](https://github.com/abue-ammar/tinycast/blob/main/CONTRIBUTING.md)
+        before you write a line — it is required reading, and it is what your PR is held to. Don't
+        start until the issue is marked `approved`; an unapproved PR is closed automatically.
       options:
         - label: I'm willing to implement this myself
           required: false


### PR DESCRIPTION
## Related issue

None — wording follow-up to #580.

## What changed

The `Contribution` field on all three issue forms said only that work needs the `approved` label. It now links `CONTRIBUTING.md` and says plainly that it is required reading, so someone ticking "I'm willing to implement this myself" meets the memory budget, the before/after video rule and the rest before they start rather than at review.

## Memory footprint

N/A — no app code.

## Demo

Nothing visual in the app changed.

## Drawbacks

The link is an absolute `blob/main` URL. Issue-form descriptions are rendered outside any repo context, so a relative path would not resolve; the cost is that it breaks if the file is ever renamed.

## Tests & validation

All four files under `.github/ISSUE_TEMPLATE/` parse. No Swift changed; `./Scripts/lint.sh` is clean.

- [ ] open each form and confirm the link renders and resolves