### PR TITLE
Let a bare backspace fall to the root search

### DIFF
--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -280,7 +280,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         panel.onFieldEditorFocused = { [weak self] context in
             self?.core.inputSourceSwitcher.applySession(to: context)
         }
-        // Backspace in an empty search takes the same back step Escape does.
+        // Backspace takes Escape's back step but never closes: a root screen falls to the launcher.
         panel.onBareBackspace = { [weak self] in
             guard let core = self?.core, core.palette.query.isEmpty else { return false }
             // A form field owns the key: the text it deletes is the field's, not a query's.
@@ -300,7 +300,10 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             if core.palette.mode == .ai, core.aiChatCoordinator.removeLastAttachment() {
                 return true
             }
-            return core.palette.pop()
+            if core.palette.pop() { return true }
+            guard core.palette.mode != .launcher else { return false }
+            core.palette.prepare(mode: .launcher)
+            return true
         }
         installPasteMonitor()
         // Handled at the panel: the field editor or a missing main menu eats these first.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -137,8 +137,10 @@ top, which would throw away the very selection being restored.
 leaves: an extension screen exits itself first (it keeps a stack the palette cannot see), then a
 pushed screen pops, and a root hides the palette. A focused inline argument field is a rung above the
 query, so Escape hands focus back to the search field first — the query that found the command is
-still there to be cleared by the next press. A bare backspace in an empty field takes the same step,
-and ⌘⎋ skips the whole stack for a fresh root search without closing the window.
+still there to be cleared by the next press. A bare backspace in an empty field takes the same step
+**but never closes**: on a root screen summoned by its own hotkey it falls to the root search, which
+is the step Escape would have taken had that screen been reached by typing its name. ⌘⎋ skips the
+whole stack for that same root search from any depth.
 
 `EscapeKeyBehavior` (General settings) can trade the walk back for the old behavior: under
 `closeAndPopToRoot` an empty field closes the window and resets it immediately, whatever Pop to Root


### PR DESCRIPTION
## Related issue

Closes #

## What changed

A screen summoned by its own hotkey is a root, so `onBareBackspace` ended at `palette.pop()`, which
returned `false` and did nothing at all. ⌥V then backspace sat there: the one back edge in the
palette with no step left to take, while Escape closed and ⌘⎋ reset.

It now prepares the launcher when there is nothing to pop — the step Escape would have taken had the
screen been reached by typing its name at the root. Backspace still never closes the window; that
stays Escape's alone. The launcher itself returns `false`, so the key keeps its ordinary meaning at
the root rather than swallowing a press that reads as an edit.

The non-obvious part is what the new branch does *not* have to clean up. Every screen that owns work
— uninstall, file search, a running extension, a half-filled argument form — cancels it from
`onChange(of: vm.mode)` in `RootPaletteView`, so leaving through `prepare(mode: .launcher)` tears
those down the same way every other exit does. The earlier guards in the closure still run first, so
the argument form walks back an answer per press and an extension pops its own stack before any of
this is reached.

## Memory footprint

Unchanged — no new state, no allocation; the change is one `prepare` call on an existing path.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — nothing retained, no new closure, task or observer.

## Demo

No visual change: a key that did nothing now performs a screen change the palette already had.

## Drawbacks

Backspace and Escape no longer agree at the bottom of the stack, which the docs used to state
outright as "takes the same step". That divergence is the fix — a key that walks back should not
close a window — but it is a real asymmetry, now written down in
`docs/features/palette.md` rather than left for the next reader to discover.

## Tests & validation

`./Scripts/run-tests.sh` — all 67 harnesses pass. No harness covers this: `onBareBackspace` is an
AppKit closure on `PaletteWindowController`, which the standalone harnesses cannot build.
`./Scripts/lint.sh` clean, Debug build with no new warnings.

By hand: ⌥V then backspace lands on the root search; backspace again does nothing, as it should.
Escape from that same clipboard still closes, ⌘⎋ still resets from any depth, a clipboard reached by
typing "Clipboard History" still pops back to the search that found it, and a backspace inside an
extension's form still deletes text instead of leaving the screen.