### PR TITLE
Hide a launcher result from search via ⌘K

### DIFF
--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -20,61 +20,75 @@ struct AppEntry: Identifiable, Hashable, Sendable {
             case .application:
                 return KindDescriptor(
                     label: "Application", sectionTitle: "Applications",
-                    openVerb: "Open Application", canRevealInFinder: true, isSymbolIcon: false)
+                    openVerb: "Open Application", canHideFromSearch: true,
+                    canRevealInFinder: true, isSymbolIcon: false)
             case .systemSettings:
                 return KindDescriptor(
                     label: "System Setting", sectionTitle: "System Settings",
-                    openVerb: "Open System Setting", canRevealInFinder: true, isSymbolIcon: false)
+                    openVerb: "Open System Setting", canHideFromSearch: true,
+                    canRevealInFinder: true, isSymbolIcon: false)
             case .command:
                 return KindDescriptor(
                     label: "Command", sectionTitle: "Commands",
-                    openVerb: "Run Command", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Run Command", canHideFromSearch: true,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .quickAction:
                 return KindDescriptor(
                     label: "Quick Action", sectionTitle: "Quick Actions",
-                    openVerb: "Run Quick Action", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Run Quick Action", canHideFromSearch: true,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .customCommand:
                 return KindDescriptor(
                     label: "Custom Command", sectionTitle: "Custom Commands",
-                    openVerb: "Run Custom Command", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Run Custom Command", canHideFromSearch: false,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .snippet:
                 return KindDescriptor(
                     label: "Snippet", sectionTitle: "Snippets",
-                    openVerb: "Paste Snippet", canRevealInFinder: true, isSymbolIcon: true)
+                    openVerb: "Paste Snippet", canHideFromSearch: false,
+                    canRevealInFinder: true, isSymbolIcon: true)
             case .systemAction:
                 return KindDescriptor(
                     label: "System Action", sectionTitle: "System Actions",
-                    openVerb: "Run System Action", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Run System Action", canHideFromSearch: true,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .windowCommand:
                 return KindDescriptor(
                     label: "Window Command", sectionTitle: "Window Management",
-                    openVerb: "Move Window", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Move Window", canHideFromSearch: true,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .windowLayout:
                 return KindDescriptor(
                     label: "Window Layout", sectionTitle: "Window Layouts",
-                    openVerb: "Arrange Windows", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Arrange Windows", canHideFromSearch: true,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .quicklink:
                 return KindDescriptor(
                     label: "Quicklink", sectionTitle: "Quicklinks",
-                    openVerb: "Open Quicklink", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Open Quicklink", canHideFromSearch: false,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .extensionCommand:
                 // The label is per-entry, the owning extension's title; this is the fallback.
                 return KindDescriptor(
                     label: "Extension", sectionTitle: "Extensions",
-                    openVerb: "Run Command", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Run Command", canHideFromSearch: false,
+                    canRevealInFinder: false, isSymbolIcon: true)
             case .meeting:
                 return KindDescriptor(
                     label: "Meeting", sectionTitle: "Meetings",
-                    openVerb: "Join Meeting", canRevealInFinder: false, isSymbolIcon: true)
+                    openVerb: "Join Meeting", canHideFromSearch: false,
+                    canRevealInFinder: false, isSymbolIcon: true)
             }
         }
     }
 
-    /// Everything that is fixed per kind. A new `Kind` case fails to build until it names all five.
+    /// Everything that is fixed per kind. A new `Kind` case fails to build until it names all six.
     struct KindDescriptor: Sendable {
         let label: String
         let sectionTitle: String
         let openVerb: String
+        /// Only where Settings lists a per-item checkbox to put it back: a hide is never one-way.
+        let canHideFromSearch: Bool
         let canRevealInFinder: Bool
         let isSymbolIcon: Bool
     }
@@ -166,6 +180,8 @@ struct AppEntry: Identifiable, Hashable, Sendable {
 
     /// Synthetic entries have no file to reveal; a destination is its record's own action.
     var canRevealInFinder: Bool { kind.descriptor.canRevealInFinder }
+
+    var canHideFromSearch: Bool { kind.descriptor.canHideFromSearch }
 
     /// What this row draws, and the only thing any icon path needs to ask.
     var iconSource: EntryIcon { iconOverride ?? defaultIcon }

--- a/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
+++ b/Tinycast/Features/Launcher/UI/AppActionsMenu.swift
@@ -15,7 +15,8 @@ enum AppActionsMenu {
 
     static func content(
         app: AppEntry, searchQuery: String, core: AppCore, running: Bool,
-        favorites: FavoriteActions, onResetRanking: @escaping () -> Void
+        favorites: FavoriteActions, onResetRanking: @escaping () -> Void,
+        onHideFromSearch: @escaping () -> Void
     ) -> PopoverMenuContent {
         var items: [PopoverMenuItem] = [
             PopoverMenuItem(
@@ -23,13 +24,20 @@ enum AppActionsMenu {
                 shortcut: "↵"
             ) { core.launcherCoordinator.launch(app, searchQuery: searchQuery) }
         ]
-        // A query-driven row lives only for its query, so pinning it would favorite nothing.
-        if !CommandCatalog.isQueryDriven(app) {
+        if app.canRevealInFinder {
+            items.append(
+                PopoverMenuItem(title: "Show in Finder", systemImage: "folder", shortcut: "⌘↵") {
+                    core.launcherCoordinator.showInFinder(app)
+                })
+        }
+        // A query-driven row lives only for its query, so no preference could outlive it.
+        let isPersistent = !CommandCatalog.isQueryDriven(app)
+        if isPersistent {
             items.append(
                 PopoverMenuItem(
                     title: favorites.isFavorite ? "Remove from Favorites" : "Add to Favorites",
-                    systemImage: favorites.isFavorite ? "star.slash" : "star", shortcut: "⇧⌘F",
-                    action: favorites.toggle))
+                    systemImage: favorites.isFavorite ? "star.slash" : "star", startsSection: true,
+                    shortcut: "⇧⌘F", action: favorites.toggle))
         }
         if favorites.canMoveUp {
             items.append(
@@ -53,18 +61,17 @@ enum AppActionsMenu {
                     onResetRanking()
                 })
         }
-        if app.canRevealInFinder {
+        if isPersistent, app.canHideFromSearch {
             items.append(
                 PopoverMenuItem(
-                    title: "Show in Finder", systemImage: "folder", startsSection: true, shortcut: "⌘↵"
-                ) {
-                    core.launcherCoordinator.showInFinder(app)
-                })
+                    title: "Hide from Search", systemImage: "eye.slash", shortcut: "⇧⌘H",
+                    action: onHideFromSearch))
         }
         if running, app.kind == .application {
             items.append(
                 PopoverMenuItem(
-                    title: "Restart Application", systemImage: "arrow.clockwise", shortcut: "⌘R"
+                    title: "Restart Application", systemImage: "arrow.clockwise", startsSection: true,
+                    shortcut: "⌘R"
                 ) {
                     core.launcherCoordinator.restart(app)
                 })
@@ -109,10 +116,7 @@ enum AppActionsMenu {
                     core.extensionCoordinator.showExtensionSettings(for: app)
                 })
             items.append(
-                PopoverMenuItem(
-                    title: "Uninstall Extension", systemImage: "trash", startsSection: true,
-                    isDestructive: true
-                ) {
+                PopoverMenuItem(title: "Uninstall Extension", systemImage: "trash", isDestructive: true) {
                     core.extensionCoordinator.confirmUninstall(app)
                 })
         }

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -211,7 +211,8 @@ struct LauncherScreen: PaletteScreen {
                     core.launcherCoordinator.resetRanking(for: app)
                     // Reset can move the item; keep the highlight on the item whose action ran.
                     if let index = rows.firstIndex(of: .entry(app)) { vm.selection = index }
-                })
+                },
+                onHideFromSearch: { _ = hideFromSearch(at: selection) })
         case .fallback(let fallback, let app):
             return FallbackActionsMenu.content(
                 fallback: fallback, entry: app, query: vm.query, core: core)
@@ -315,6 +316,16 @@ struct LauncherScreen: PaletteScreen {
     private func favoriteIndex(of app: AppEntry) -> Int? {
         guard let index = results.firstIndex(of: app), index < favoriteCount else { return nil }
         return index
+    }
+
+    /// ⇧⌘H — the row leaves the list for good, so the highlight takes the place it vacated.
+    func hideFromSearch(at selection: Int) -> Bool {
+        guard let app = entry(at: selection), app.canHideFromSearch,
+            !CommandCatalog.isQueryDriven(app), let index = results.firstIndex(of: app)
+        else { return false }
+        visibility.setItemVisible(false, for: app)
+        select(row: min(index, max(reorderedResults().count - 1, 0)))
+        return true
     }
 
     /// The list reorders under an action; keep the highlight and the scroll on the row that moved.

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -558,6 +558,16 @@ struct RootPaletteView: View {
                 if menuOpen { closeMenus() }
                 return .handled
             }
+            // ⇧⌘H mirrors the Hide from Search row, on that row's own guard, and closes the menu.
+            .onKeyPress(phases: .down) { press in
+                guard press.modifiers.contains(.command), press.modifiers.contains(.shift),
+                    ASCIIKeyboardLayout.matches(press.key, character: "h"),
+                    !isCollapsed, let launcher = screen as? LauncherScreen
+                else { return .ignored }
+                guard launcher.hideFromSearch(at: selection(in: launcher)) else { return .ignored }
+                if menuOpen { closeMenus() }
+                return .handled
+            }
             // Both cases, Shift uppercasing the key; the compact bar shows no target.
             .onKeyPress(phases: .down) { press in
                 guard press.modifiers.contains(.control), press.modifiers.contains(.shift),

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -13,8 +13,9 @@ earliest scope wins).
   `orderedResults` *and* `HotKeyManager.perform`, so `Enable Applications` off stops the per-app chords
   as well as the rows — the guard sits in the one dispatch funnel, the way each feature switch already
   guards its own. The per-item checkbox beside it is the narrow tool: it hides one row and leaves that
-  row's shortcut firing. A new category must be wired into `VisibilityStore.allowsHotKey`, or its
-  chords keep running while its pane reads off.
+  row's shortcut firing, and **Hide from Search** in the ⌘K menu ticks that same checkbox off for the
+  kinds whose pane can tick it back on. A new category must be wired into
+  `VisibilityStore.allowsHotKey`, or its chords keep running while its pane reads off.
 - **One command, one pane, one switch.** `SettingsTab.ownedCommands` is the whole table of which pane
   lists a command's shortcut, alias and launcher checkbox. A feature that names its commands there
   already decides whether they exist, so `Enable Commands` neither lists nor gates them — two switches
@@ -245,8 +246,8 @@ entry is an ordinary `.command`, so `VisibilityStore` still gates it — Command
 and its `url` carries the destination instead of the catalog's `tinycast://` placeholder. Nothing
 learns from it and nothing pins it: `LauncherCoordinator.launch` skips `LauncherRankingStore` for a
 contextual row, the way it already skips a category listing, since a pasted URL is not a term any
-row should rank under; and ⇧⌘F is refused, because a favorite the empty query can never resolve is
-dead state a backup would then carry.
+row should rank under; and ⇧⌘F and ⇧⌘H are both refused, because a favorite — or a hidden-item key —
+the empty query can never resolve is dead state a backup would then carry.
 
 The row prints `AppEntry.subtitle` beside its name — the one field for an entry whose name alone
 can't say what it acts on.
@@ -316,8 +317,10 @@ alias in as a `.userAlias` at rank time, keying its memos on the store's revisio
 A launcher row shows its entry's alias as a small chip after the name, so what a badge-bearing
 result will answer to is visible without opening anything.
 
-Editing lives in Settings only — an alias is one-time configuration like a shortcut or a
-visibility checkbox, not a per-invocation action, so the ⌘K menu stays out of it. Every pane built
+Editing lives in Settings only — an alias is one-time configuration like a shortcut, not a
+per-invocation action, so the ⌘K menu stays out of it. Visibility is the one exception, and only in
+one direction: an unwanted result is noticed while searching, so ⌘K can hide a row, but putting it
+back is still the pane's checkbox. Every pane built
 on `LauncherItemsSection` puts an `AliasField` on each row, dressed like the `ShortcutRecorder`
 beside it; edits store as typed and trim when the field loses focus, and a blank means none. That
 list filters by **membership only**, keeping the index's name order — re-ranking it per keystroke
@@ -629,6 +632,32 @@ it any higher would attach it to `RootPaletteView`'s body and rebuild the whole 
 press, where a row-level read re-runs only the handful of rows the `LazyVStack` has realized. The
 digit each row shows is carried on its `Row` case from the section build, so no row searches for its
 own position.
+
+## Hiding one result
+
+**Hide from Search**, on a result's ⌘K menu and on **⇧⌘H**, writes exactly what the checkbox in
+Settings writes — `VisibilityStore.setItemVisible(false,…)` against the entry's `preferenceKey` — so
+the row leaves
+every search until that checkbox is ticked again. Nothing else moves: the app stays installed, its
+favorite, alias and learned ranking survive the round trip, and its shortcut keeps firing, because
+`allowsHotKey` gates by category and never by item.
+
+The row is offered only where Settings can undo it, and `KindDescriptor.canHideFromSearch` is that
+rule — per kind, and a new `Kind` case has to answer it to compile. Applications, System Settings,
+Commands, Quick Actions, System Actions, Window Commands and Window Layouts each draw a per-row
+checkbox in their pane, so they carry it. Custom commands, quicklinks and snippets do not: their
+panes list a record with its own switches, not a launcher checkbox. An extension's pane has one
+toggle for the whole extension, and it still reads *on* while a single command of it is hidden, so
+that kind stays out too — a hide nothing in Settings can visibly undo is a trap, not a shortcut.
+`AppActionsMenu` adds the query-driven guard the favorites row already uses: a typed URL lives only
+for its query and has no preference to write.
+
+Hiding shrinks the list under the action that ran it, so `LauncherScreen.hideFromSearch(at:)`
+re-reads the order and drops the highlight into the index the row vacated, clamped to what is left —
+the move `selectFavorite` already makes. The palette stays open on the same query, with focus
+untouched. One function answers both the menu row and the chord, and it re-tests eligibility rather
+than trusting the caller, so ⇧⌘H falls through to whatever else wants the press on a row that offers
+no such menu item.
 
 ## Reveal in Finder
 


### PR DESCRIPTION
## Related issue

Closes #567

## What changed

A result's ⌘K menu carries **Hide from Search**, also on **⇧⌘H**. It writes the same per-item preference the Settings checkbox writes — `VisibilityStore.setItemVisible(false,…)` against the entry's `preferenceKey` — so the row leaves every search until that checkbox is ticked again. Nothing else moves: the app stays installed, its favorite, alias and learned ranking survive the round trip, and its shortcut keeps firing, because `allowsHotKey` gates by category and never by item.

Non-obvious parts of the diff:

- **`KindDescriptor` gained `canHideFromSearch`**, so a new `Kind` case has to answer it to compile. The action is offered only where Settings can undo it: applications, System Settings, commands, quick actions, system actions, window commands and window layouts each draw a per-row checkbox in their pane. Custom commands, quicklinks and snippets do not — their panes list a record with its own switches, not a launcher checkbox. An extension's pane has one toggle for the *whole extension*, and its getter (`entryIDs.contains { !hidden }`) still reads **on** while a single command of it is hidden, so that kind stays out too. A hide nothing in Settings can visibly undo is a trap, not a shortcut.
- **No `LauncherCoordinator` hop.** The store write is the whole operation, and `LauncherScreen` already holds `visibility` and already calls `FavoritesStore` directly. Routing through the coordinator would only widen its `unowned core`, which is documented as backup-commands-only.
- **One function answers the menu row and the chord**, and it re-tests eligibility rather than trusting the caller, so ⇧⌘H falls through to whatever else wants the press on a row that offers no such item — the guard-mirrors-the-row rule Quit and Restart already follow.
- **Selection**: hiding shrinks the list under the action that ran it, so the highlight drops into the index the row vacated, clamped to what is left — the move `selectFavorite` already makes. The palette stays open on the same query with focus untouched. Result invalidation was already keyed on `visibility.revision`, so nothing new was needed there.
- **Menu sectioning was wrong before this and is fixed here.** `Show in Finder` carried `startsSection` and sat alone between two separators whenever the app was not running; `Uninstall Extension` did the same after `Configure Extension`. Show in Finder now joins the open row, `Restart` starts the group it shares with `Quit`, and Uninstall Extension joins Configure. Every separator now divides two real groups.

## Memory footprint

Not measured. This adds one menu row, one key handler and one `Bool` per `Kind`; there is no new allocation, cache, task or observer, and nothing retains anything beyond the menu that is already built per open.

| Step                    | Memory      |
| ----------------------- | ----------- |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — no new ownership. The action writes to the existing `VisibilityStore` and returns.

## Demo

Menu structure, rendered offscreen from the shipped `PopoverMenu` (dark, no glass backdrop, so contrast reads low):

```
Alacritty
  Open Application            ↵
  Show in Finder              ⌘↵
  ─────────────────────────────
  Remove from Favorites       ⇧⌘F
  Move Favorite Up            ⌥⌘↑
  Hide from Search            ⇧⌘H
  ─────────────────────────────
  Uninstall Application
```

Before, with the same entry, `Show in Finder` was the only row between those two separators.

## Drawbacks

- **Extension commands cannot be hidden this way**, which is a plausible thing to want. The prerequisite is a per-command row in the Extensions pane; until that exists, offering the action there would hide a command behind a toggle that reads on.
- **Restoring is still a trip to Settings.** That is the issue's own design, and the ⌘K menu deliberately holds no "unhide" — a hidden row is not in the list to select.
- **`Show in Finder` moved** in an already-shipped menu. Muscle memory for its position changes; ⌘↵ does not.
- ⇧⌘H is unclaimed on this surface today, but it is one more chord competing for the palette's key handling.

## Tests & validation

- `./Scripts/run-tests.sh` — all 68 harnesses pass.
- `./Scripts/lint.sh` — clean. `./Scripts/format.sh --check` — clean. Debug build — no new warnings. Pure-layer grep — clean.
- **No harness added.** `AppEntry` lives in an AppKit-importing `Service/` file that no harness compiles; pulling its dependency graph into one to assert a boolean table would cost more than it guards, and the compiler already enforces the exhaustiveness. `symbols-test` covers the catalog but not menu literals, so `eye.slash` was checked separately against `NSImage(systemSymbolName:)`.
- By hand: menu structure verified by rendering the shipped `PopoverMenu` offscreen to PNG with the item list this code now produces, for the running and not-running app cases.
