### PR TITLE
Expand snippets inside a Note

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -301,6 +301,7 @@ run notes-test             Tinycast/Platform/Signposts.swift \
 run notes-editor-test      Tinycast/Platform/Signposts.swift \
                            Tinycast/Platform/Appearance.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/Features/TextInjection/Service/InjectableTextView.swift \
                            Tinycast/Features/Notes/Model/NoteDocument.swift \
                            Tinycast/Features/Notes/UI/NoteTextView.swift \
                            Tinycast/Features/Notes/UI/NoteEditorView.swift

--- a/Tests/snippets-test.swift
+++ b/Tests/snippets-test.swift
@@ -10,6 +10,8 @@ struct SnippetsTests {
     static var passes = 0
 
     static func main() async throws {
+        // The in-process delivery tier drives a real text view, which needs AppKit awake.
+        _ = NSApplication.shared
         testIdentityAndRevision()
         testRaycastImport()
         try testMarkdownCodec()
@@ -24,6 +26,7 @@ struct SnippetsTests {
         testKeywordPolicy()
         testKeywordLifecycle()
         testKeywordListenerLifecycle()
+        testOwnEditorInjection()
 
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)
@@ -594,6 +597,62 @@ struct SnippetsTests {
             backing.string(forType: .string) == "Original")
     }
 
+    /// Our panels never activate, so the frontmost app is not where the typist's caret is.
+    private static func testOwnEditorInjection() {
+        let editor = HarnessEditor(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+
+        // The tap sees the keystroke first, so the view is a character behind at match time.
+        editor.string = "!si"
+        editor.setSelectedRange(NSRange(location: 3, length: 0))
+        check(
+            "a document shorter than the keyword reads as pending, not absent",
+            editor.keywordReplacementState(expectedKeyword: "!sig", keywordLength: 4) == .pending)
+
+        editor.string = "Regards, !si"
+        editor.setSelectedRange(NSRange(location: 12, length: 0))
+        check(
+            "the same stale view behind existing text reads as a mismatch, not a lag",
+            editor.keywordReplacementState(expectedKeyword: "!sig", keywordLength: 4) == .rejected)
+
+        editor.string = "Regards, !sig"
+        editor.setSelectedRange(NSRange(location: 13, length: 0))
+        check(
+            "the keyword resolves once AppKit has delivered the keystroke",
+            editor.keywordReplacementState(expectedKeyword: "!sig", keywordLength: 4)
+                == .matched(NSRange(location: 9, length: 4)))
+
+        editor.inject(InjectedText("Ada Lovelace"), over: NSRange(location: 9, length: 4))
+        check(
+            "a converged keyword is replaced in place",
+            editor.string == "Regards, Ada Lovelace")
+        check(
+            "the caret lands after the text the snippet inserted",
+            editor.selectedRange() == NSRange(location: 21, length: 0))
+
+        editor.string = "Regards, !xyz"
+        editor.setSelectedRange(NSRange(location: 13, length: 0))
+        check(
+            "enough text that is not the keyword is a mismatch, never a wait",
+            editor.keywordReplacementState(expectedKeyword: "!sig", keywordLength: 4) == .rejected)
+
+        editor.string = "wrap me"
+        editor.setSelectedRange(NSRange(location: 0, length: 7))
+        check(
+            "a zero-length keyword takes the selection as its replacement range",
+            editor.keywordReplacementState(expectedKeyword: nil, keywordLength: 0)
+                == .matched(NSRange(location: 0, length: 7)))
+
+        editor.inject(
+            InjectedText("<b></b>", cursorOffsetFromEnd: 4), over: NSRange(location: 0, length: 7))
+        check(
+            "the selection is replaced and the caret honours the template's cursor offset",
+            editor.string == "<b></b>" && editor.selectedRange() == NSRange(location: 3, length: 0))
+
+        check(
+            "the caret offset counts UTF-16 units, not characters",
+            InjectedText("\u{1F1F3}\u{1F1F1} done", cursorOffsetFromEnd: 5).caretPrefixLength == 4)
+    }
+
     private static func testDeliveryQueueAndPasteboard() async throws {
         let queue = DeliveryQueue()
         var order: [String] = []
@@ -650,58 +709,58 @@ struct SnippetsTests {
 
         check(
             "an AX keyword one character behind the event stream remains pending",
-            AccessibilityReplacementPolicy.keywordState(
+            TextReplacementPolicy.keywordState(
                 value: "!tcaxprob",
                 selectedRange: NSRange(location: 9, length: 0),
                 keyword: "!tcaxprobe") == .pending)
         check(
             "a converged AX keyword resolves to its exact replacement range",
-            AccessibilityReplacementPolicy.keywordState(
+            TextReplacementPolicy.keywordState(
                 value: "prefix !tcaxprobe",
                 selectedRange: NSRange(location: 17, length: 0),
                 keyword: "!tcaxprobe") == .matched(NSRange(location: 7, length: 10)))
         check(
             "an AX state with enough text but the wrong suffix is a genuine rejection",
-            AccessibilityReplacementPolicy.keywordState(
+            TextReplacementPolicy.keywordState(
                 value: "prefix !tcaxwrong",
                 selectedRange: NSRange(location: 17, length: 0),
                 keyword: "!tcaxprobe") == .rejected)
         check(
             "an empty editor AX snapshot remains pending instead of becoming a false mismatch",
-            AccessibilityReplacementPolicy.keywordState(
+            TextReplacementPolicy.keywordState(
                 value: "",
                 selectedRange: NSRange(location: 0, length: 0),
                 keyword: "!tcaxprobe") == .pending)
         check(
             "a non-empty selection is a mismatch rather than a lagging caret",
-            AccessibilityReplacementPolicy.keywordState(
+            TextReplacementPolicy.keywordState(
                 value: "prefix !tcaxprobe",
                 selectedRange: NSRange(location: 7, length: 10),
                 keyword: "!tcaxprobe") == .rejected)
         check(
             "AX replacement confirmation requires the observable text to actually change",
-            AccessibilityReplacementPolicy.confirmsReplacement(
+            TextReplacementPolicy.confirmsReplacement(
                 originalValue: "!tcprobe",
                 replacementRange: NSRange(location: 0, length: 8),
                 insertedText: "PROBE_OK",
                 observedValue: "PROBE_OK"))
         check(
             "an AX setter success with unchanged text is not accepted as delivery",
-            !AccessibilityReplacementPolicy.confirmsReplacement(
+            !TextReplacementPolicy.confirmsReplacement(
                 originalValue: "!tcprobe",
                 replacementRange: NSRange(location: 0, length: 8),
                 insertedText: "PROBE_OK",
                 observedValue: "!tcprobe"))
         check(
             "an AX write that lands somewhere unexpected is not accepted as delivery",
-            !AccessibilityReplacementPolicy.confirmsReplacement(
+            !TextReplacementPolicy.confirmsReplacement(
                 originalValue: "keep !tcprobe",
                 replacementRange: NSRange(location: 5, length: 8),
                 insertedText: "PROBE_OK",
                 observedValue: "PROBE_OK !tcprobe"))
         check(
             "an unreadable value after the write is not accepted as delivery",
-            !AccessibilityReplacementPolicy.confirmsReplacement(
+            !TextReplacementPolicy.confirmsReplacement(
                 originalValue: "!tcprobe",
                 replacementRange: NSRange(location: 0, length: 8),
                 insertedText: "PROBE_OK",
@@ -1915,3 +1974,6 @@ private final class FakeSnippetKeywordTapController: SnippetKeywordTapControllin
         state = .absent
     }
 }
+
+/// Stands in for `NoteTextView`: the conformance is the whole opt-in.
+private final class HarnessEditor: NSTextView, InjectableTextView {}

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		303FC5342B61A7862EBC1C32 /* FocusRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9A0079D05A5D9B21A1CFCE /* FocusRelease.swift */; };
 		309320CB6B5424EA558A4823 /* EmojiData.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BE90FB09366A3518C2D4E5 /* EmojiData.generated.swift */; };
 		309B1313B6B40D1342362492 /* CalcEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7817B7A8760B36FDA43F48FC /* CalcEngine.swift */; };
+		30AF44B8B075FFB9080A686D /* InjectionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B2905335C6C050C49ED3E0 /* InjectionTarget.swift */; };
 		30C5B58F3876A5B85BFBBDDF /* ScheduleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590A432CC25ED6372B453BFA /* ScheduleScreen.swift */; };
 		30EA70771C555C136F56BA70 /* FallbackCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C92BDC35B5E26BA8BA4AA /* FallbackCoordinator.swift */; };
 		312BCD2850AFD26E8B532937 /* ExtensionInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = F023729C84682E9231F3D73B /* ExtensionInstaller.swift */; };
@@ -163,6 +164,7 @@
 		46F5D522E6F5470D3694A218 /* RaycastImportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD7591D273A6484DD48018A /* RaycastImportReader.swift */; };
 		478500C6465327947EBD9D61 /* RaycastSnippetImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80806A442BADAC390ECD993 /* RaycastSnippetImport.swift */; };
 		47A443F25878A27DE6DF24AA /* NoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAFF79E9897975CAC5EAC0E /* NoteEditorView.swift */; };
+		47C49821CF6CFABB1B7410E1 /* InjectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CBB4251C94C31DE1BE6937 /* InjectableTextView.swift */; };
 		47C7E1E33C5D70C3DBED15D5 /* CustomCommandArgumentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7F0F7172895889F1AF069 /* CustomCommandArgumentsScreen.swift */; };
 		47E13BC63F8BE11EDF25EA82 /* RootPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A98172AA46F5C0C89C4AB /* RootPaletteView.swift */; };
 		48AE2C9989F8FA2AA99D2D61 /* CalcPercent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B4495E56754B05B5F3551D /* CalcPercent.swift */; };
@@ -202,6 +204,7 @@
 		552B7230E78D2C05793EC013 /* ExtensionNodeShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A0A3867D1B8E1D3284471 /* ExtensionNodeShims.swift */; };
 		555791AE6CDCF42ECA171B2C /* FavoritesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F1080FB443A1D0616790E /* FavoritesStore.swift */; };
 		55CDBFDB13B816FFFB6CC867 /* MCPTrustPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A724FAAD08B77AA54D080E45 /* MCPTrustPolicy.swift */; };
+		564CB6D0052C9A7C0AF9C9BF /* InProcessInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A73B92320ED5A4F802EE54 /* InProcessInjection.swift */; };
 		5679661058689EC8FF1C5C11 /* PaletteFilterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621B09CB5CF15517D9FDAB5B /* PaletteFilterAction.swift */; };
 		568B7DA6A6C2D24BABF0867A /* ClipboardTextHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DB32B7ACED5BE2BEE7451F /* ClipboardTextHelper.swift */; };
 		56E4958BCEF1FED10B4A796E /* UpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F3D4D06C13288911E8D135 /* UpdateCoordinator.swift */; };
@@ -603,6 +606,7 @@
 		030E67F6AC9A292F385FB5A5 /* ChatCopyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCopyButton.swift; sourceTree = "<group>"; };
 		0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIStreamDecoder.swift; sourceTree = "<group>"; };
 		03757CDEFC14359CAEF4CE93 /* FileSearchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchSession.swift; sourceTree = "<group>"; };
+		03B2905335C6C050C49ED3E0 /* InjectionTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionTarget.swift; sourceTree = "<group>"; };
 		03D29ADBBE565419B1E98281 /* SettingsSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarView.swift; sourceTree = "<group>"; };
 		0437C802C1F3E33E8532A7E3 /* Fallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fallback.swift; sourceTree = "<group>"; };
 		045EC0C36F08176EE0304F49 /* ExtensionFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFormView.swift; sourceTree = "<group>"; };
@@ -708,6 +712,7 @@
 		32733B27AE0BD75742D1394F /* DialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogView.swift; sourceTree = "<group>"; };
 		32D20FAFD9F3CC0E5802A966 /* ExtensionImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionImage.swift; sourceTree = "<group>"; };
 		33994DC2FB0A6B23A403CA29 /* AppLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLauncher.swift; sourceTree = "<group>"; };
+		33A73B92320ED5A4F802EE54 /* InProcessInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProcessInjection.swift; sourceTree = "<group>"; };
 		34F2E06B7C8613EB3096B94B /* CalcToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcToken.swift; sourceTree = "<group>"; };
 		364BEC0805A8F5C39444EAF5 /* SettingsNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationState.swift; sourceTree = "<group>"; };
 		36B6DAC3B9FF387367C3FAB4 /* UninstallSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSession.swift; sourceTree = "<group>"; };
@@ -917,6 +922,7 @@
 		92B4495E56754B05B5F3551D /* CalcPercent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcPercent.swift; sourceTree = "<group>"; };
 		934DBE501F116131DC1BF5CE /* CalcExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcExpressionParser.swift; sourceTree = "<group>"; };
 		936C0D68CC32D90E590F712C /* ExtensionPickerField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPickerField.swift; sourceTree = "<group>"; };
+		93CBB4251C94C31DE1BE6937 /* InjectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectableTextView.swift; sourceTree = "<group>"; };
 		943495E91C0D09B633746515 /* ChatGPTSubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTSubscriptionManager.swift; sourceTree = "<group>"; };
 		94507F8F095D3EBD1A9B3007 /* DialogController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogController.swift; sourceTree = "<group>"; };
 		94D1EA2460590C49B4A66C64 /* AIModelSelectionRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIModelSelectionRows.swift; sourceTree = "<group>"; };
@@ -1698,6 +1704,9 @@
 		5DCDC77D6BA32FC905DA30CF /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				93CBB4251C94C31DE1BE6937 /* InjectableTextView.swift */,
+				03B2905335C6C050C49ED3E0 /* InjectionTarget.swift */,
+				33A73B92320ED5A4F802EE54 /* InProcessInjection.swift */,
 				74904E7C8CE9B121B32594B9 /* TextInjector.swift */,
 			);
 			path = Service;
@@ -3128,6 +3137,9 @@
 				CA6BA9C381351D0B2CADFB9D /* IconCache.swift in Sources */,
 				3E2E2CFAD5C5731A5F059AD5 /* IconStyleMonitor.swift in Sources */,
 				CB95B0CBF0DFEDFCEA837053 /* ImageThumbnail.swift in Sources */,
+				564CB6D0052C9A7C0AF9C9BF /* InProcessInjection.swift in Sources */,
+				47C49821CF6CFABB1B7410E1 /* InjectableTextView.swift in Sources */,
+				30AF44B8B075FFB9080A686D /* InjectionTarget.swift in Sources */,
 				0A086C5452FD9FCE68AF4E46 /* InputSourceSwitcher.swift in Sources */,
 				6D241F01F4BB98AAE1720330 /* InstalledAI.swift in Sources */,
 				EAFC40D8851C50EB62198C7E /* InstalledAIManager.swift in Sources */,

--- a/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherCoordinator.swift
@@ -126,7 +126,7 @@ final class LauncherCoordinator {
             quicklinkCoordinator.openQuicklink(id: id, values: arguments)
             return
         }
-        let previous = windowController.previousApp
+        let previous = windowController.previousTarget
         paletteCoordinator.hidePalette(restoreFocus: false)
         switch app.kind {
         case .application:
@@ -136,7 +136,7 @@ final class LauncherCoordinator {
             AppLauncher.openSettingsPane(bundleID: bundleID)
         case .snippet:
             let snippetID = String(app.id.dropFirst("snippet:".count))
-            snippetCoordinator.expandSnippet(id: snippetID, targetApp: previous)
+            snippetCoordinator.expandSnippet(id: snippetID, target: previous)
         case .command, .quickAction, .customCommand, .systemAction, .windowCommand, .windowLayout,
             .quicklink, .extensionCommand, .meeting:
             break  // handled above

--- a/Tinycast/Features/Notes/UI/NoteTextView.swift
+++ b/Tinycast/Features/Notes/UI/NoteTextView.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 @MainActor
-final class NoteTextView: NSTextView {
+final class NoteTextView: NSTextView, InjectableTextView {
     var editorUndoManager: UndoManager?
 
     override var undoManager: UndoManager? { editorUndoManager }

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkCoordinator.swift
@@ -75,14 +75,14 @@ final class QuicklinkCoordinator {
         guard settings.quicklinksEnabled, let quicklink = store.quicklink(id: id),
             quicklink.isEnabled
         else { return }
-        // With the palette closed a shortcut still reads the selection from the frontmost app.
+        // With the palette closed a shortcut still reads the selection from wherever the caret is.
         let target =
             windowController.isVisible
-            ? windowController.previousApp : NSWorkspace.shared.frontmostApplication
+            ? windowController.previousTarget : InjectionTarget.current()
         let encoding: SnippetTemplateEngine.ValueEncoding =
             QuicklinkDestination.usesURLEncoding(quicklink.link) ? .percentEncoding : .none
         var context = injector.captureExpansionContext(
-            targetApp: target, clipboardHistory: clipboardHistory())
+            target: target, clipboardHistory: clipboardHistory())
 
         // An unreadable selection is missing, not empty: substitute the clipboard, or take the field.
         if context.selection.isEmpty, SnippetTemplateEngine.usesSelection(quicklink.link) {

--- a/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
+++ b/Tinycast/Features/Snippets/Service/SnippetKeywordListener.swift
@@ -127,7 +127,7 @@ final class SnippetKeywordListener: HealthCheckable {
     @ObservationIgnored private var policy = SnippetKeywordPolicy()
     @ObservationIgnored private var onUserActivity: (() -> Void)?
     @ObservationIgnored
-    private var onMatch: ((StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void)?
+    private var onMatch: ((StoredSnippet.ID, String, Int, InjectionTarget?) -> Void)?
     private var sessionActive = true
     private var loggedTapFailure = false
 
@@ -164,7 +164,7 @@ final class SnippetKeywordListener: HealthCheckable {
 
     func start(
         onUserActivity: @escaping () -> Void,
-        onMatch: @escaping (StoredSnippet.ID, String, Int, NSRunningApplication?) -> Void
+        onMatch: @escaping (StoredSnippet.ID, String, Int, InjectionTarget?) -> Void
     ) {
         self.onUserActivity = onUserActivity
         self.onMatch = onMatch
@@ -328,11 +328,8 @@ final class SnippetKeywordListener: HealthCheckable {
             isDeleteBackward: keyCode == kVK_Delete)
         if input != .ignored { onUserActivity?() }
         guard let match = policy.process(input, at: now()) else { return }
-        onMatch?(
-            match.snippetID,
-            match.keyword,
-            match.deletionCount,
-            NSWorkspace.shared.frontmostApplication)
+        // Sampled here, with the keystroke: by delivery the reader may have moved on.
+        onMatch?(match.snippetID, match.keyword, match.deletionCount, InjectionTarget.current())
     }
 
     private static let resetKeyCodes: Set<Int> = [

--- a/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
@@ -126,14 +126,13 @@ final class SnippetCoordinator {
         // `beginAutomaticExpansion` is the gate, so this callback doesn't re-check anything.
         listener.start(
             onUserActivity: { [weak self] in self?.injector.cancelAutomaticExpansion() },
-            onMatch: { [weak self] id, keyword, keywordLength, targetApp in
+            onMatch: { [weak self] id, keyword, keywordLength, target in
                 guard let self,
-                    let generation = self.injector.beginAutomaticExpansion(
-                        targetApp: targetApp)
+                    let generation = self.injector.beginAutomaticExpansion(target: target)
                 else { return }
                 self.expandSnippet(
                     id: id,
-                    targetApp: targetApp,
+                    target: target,
                     expectedKeyword: keyword,
                     keywordLength: keywordLength,
                     automaticGeneration: generation)
@@ -155,14 +154,15 @@ final class SnippetCoordinator {
 
     /// The browser's ↵. The target has to be read before the panel hides, as the launcher's does.
     func expandSnippetFromPalette(id: StoredSnippet.ID) {
-        let target = windowController.previousApp
-        paletteCoordinator.hidePalette(restoreFocus: false)
-        expandSnippet(id: id, targetApp: target)
+        let target = windowController.previousTarget
+        // One of our own editors is only reachable again once the palette hands key back to it.
+        paletteCoordinator.hidePalette(restoreFocus: target?.ownEditor != nil)
+        expandSnippet(id: id, target: target)
     }
 
     func expandSnippet(
         id: StoredSnippet.ID,
-        targetApp: NSRunningApplication?,
+        target: InjectionTarget?,
         expectedKeyword: String? = nil,
         keywordLength: Int = 0,
         automaticGeneration: UInt? = nil
@@ -171,16 +171,16 @@ final class SnippetCoordinator {
         guard let record = records.first(where: { $0.id == id }) else {
             injector.cancelArgumentPrompt(
                 automaticGeneration: automaticGeneration,
-                targetApp: targetApp)
+                target: target)
             return
         }
         // Only the interactive path needs this: it must fail before the prompt, not after.
         if automaticGeneration == nil {
-            guard injector.prepareInteractiveExpansion(targetApp: targetApp) else { return }
+            guard injector.prepareInteractiveExpansion(target: target) else { return }
         }
         let confirmation = record.snippet.showsConfirmation ? "Inserted \(record.snippet.name)" : nil
         let context = injector.captureExpansionContext(
-            targetApp: targetApp,
+            target: target,
             clipboardHistory: clipboardHistoryForExpansion())
         let result = SnippetTemplateEngine.expand(
             record,
@@ -192,7 +192,7 @@ final class SnippetCoordinator {
                 records: records,
                 context: context,
                 missingArgs: result.missingArguments,
-                targetApp: targetApp,
+                target: target,
                 expectedKeyword: expectedKeyword,
                 keywordLength: keywordLength,
                 automaticGeneration: automaticGeneration,
@@ -201,7 +201,7 @@ final class SnippetCoordinator {
         }
         completeSnippetExpansion(
             result,
-            targetApp: targetApp,
+            target: target,
             expectedKeyword: expectedKeyword,
             keywordLength: keywordLength,
             automaticGeneration: automaticGeneration,
@@ -213,7 +213,7 @@ final class SnippetCoordinator {
         records: [StoredSnippet],
         context: SnippetTemplateEngine.ExpansionContext,
         missingArgs: [SnippetTemplateEngine.MissingArgument],
-        targetApp: NSRunningApplication?,
+        target: InjectionTarget?,
         expectedKeyword: String?,
         keywordLength: Int,
         automaticGeneration: UInt?,
@@ -226,7 +226,7 @@ final class SnippetCoordinator {
         else {
             injector.cancelArgumentPrompt(
                 automaticGeneration: automaticGeneration,
-                targetApp: targetApp)
+                target: target)
             return
         }
 
@@ -237,7 +237,7 @@ final class SnippetCoordinator {
             userArguments: arguments)
         completeSnippetExpansion(
             result,
-            targetApp: targetApp,
+            target: target,
             expectedKeyword: expectedKeyword,
             keywordLength: keywordLength,
             automaticGeneration: automaticGeneration,
@@ -246,7 +246,7 @@ final class SnippetCoordinator {
 
     private func completeSnippetExpansion(
         _ result: SnippetTemplateEngine.ExpansionResult,
-        targetApp: NSRunningApplication?,
+        target: InjectionTarget?,
         expectedKeyword: String?,
         keywordLength: Int,
         automaticGeneration: UInt?,
@@ -254,7 +254,7 @@ final class SnippetCoordinator {
     ) {
         injector.deliver(
             InjectedText(result.text, cursorOffsetFromEnd: result.cursorOffsetFromEnd),
-            targetApp: targetApp,
+            target: target,
             expectedKeyword: expectedKeyword,
             keywordLength: keywordLength,
             automaticGeneration: automaticGeneration,

--- a/Tinycast/Features/TextInjection/Service/InProcessInjection.swift
+++ b/Tinycast/Features/TextInjection/Service/InProcessInjection.swift
@@ -1,0 +1,25 @@
+import AppKit
+
+/// The in-process delivery tier: our own view needs no grant, no pasteboard and no event posting.
+extension InjectableTextView {
+    /// Where the typed keyword sits — `.pending` until AppKit has handed us the keystroke itself.
+    func keywordReplacementState(
+        expectedKeyword: String?, keywordLength: Int
+    ) -> TextReplacementPolicy.KeywordState {
+        let selection = selectedRange()
+        guard keywordLength > 0 else { return .matched(selection) }
+        guard let expectedKeyword, expectedKeyword.count == keywordLength else { return .rejected }
+        return TextReplacementPolicy.keywordState(
+            value: string, selectedRange: selection, keyword: expectedKeyword)
+    }
+
+    /// Replaces `range` and leaves the caret where the text asks, undoable in the view's own manager.
+    @MainActor
+    func inject(_ injected: InjectedText, over range: NSRange) {
+        // The argument prompt runs modally mid-expansion, so take the caret back before writing.
+        if let window, window.firstResponder !== self { window.makeFirstResponder(self) }
+        insertText(injected.text, replacementRange: range)
+        setSelectedRange(NSRange(location: range.location + injected.caretPrefixLength, length: 0))
+        scrollRangeToVisible(selectedRange())
+    }
+}

--- a/Tinycast/Features/TextInjection/Service/InjectableTextView.swift
+++ b/Tinycast/Features/TextInjection/Service/InjectableTextView.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+/// Opt-in: a view that adopts this accepts injected text written straight into it, in process.
+protocol InjectableTextView where Self: NSTextView {}
+
+extension InjectableTextView {
+    var injectableSelection: String {
+        (string as NSString).substring(with: selectedRange())
+    }
+}

--- a/Tinycast/Features/TextInjection/Service/InjectionTarget.swift
+++ b/Tinycast/Features/TextInjection/Service/InjectionTarget.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+/// Where injected text is going — another app over events, or one of our own editors in process.
+enum InjectionTarget {
+    case external(NSRunningApplication)
+    case ownEditor(any InjectableTextView)
+
+    /// Where the keystrokes land: our panels never activate, so the frontmost app is not it.
+    @MainActor
+    static func current() -> InjectionTarget? {
+        guard let keyWindow = NSApp.keyWindow else {
+            return NSWorkspace.shared.frontmostApplication.map(InjectionTarget.external)
+        }
+        return (keyWindow.firstResponder as? any InjectableTextView).map(InjectionTarget.ownEditor)
+    }
+
+    /// What the palette covered when it was summoned: one of our editors, or the app behind it.
+    @MainActor
+    static func behindPalette(
+        ownWindow: NSWindow?, app: NSRunningApplication?
+    ) -> InjectionTarget? {
+        if let editor = ownWindow?.firstResponder as? any InjectableTextView {
+            return .ownEditor(editor)
+        }
+        return app.map(InjectionTarget.external)
+    }
+
+    /// Hands the caret back — after a modal argument prompt, or an expansion that went nowhere.
+    @MainActor
+    func restoreFocus() {
+        switch self {
+        case .external(let app):
+            guard !app.isTerminated else { return }
+            app.activate()
+        case .ownEditor(let editor):
+            editor.window?.makeFirstResponder(editor)
+        }
+    }
+
+    var externalApp: NSRunningApplication? {
+        guard case .external(let app) = self else { return nil }
+        return app
+    }
+
+    var ownEditor: (any InjectableTextView)? {
+        guard case .ownEditor(let editor) = self else { return nil }
+        return editor
+    }
+}

--- a/Tinycast/Features/TextInjection/Service/TextInjector.swift
+++ b/Tinycast/Features/TextInjection/Service/TextInjector.swift
@@ -11,6 +11,12 @@ struct InjectedText: Equatable, Sendable {
         self.text = text
         self.cursorOffsetFromEnd = cursorOffsetFromEnd
     }
+
+    /// UTF-16 distance from the start of the inserted text to where the caret should land.
+    var caretPrefixLength: Int {
+        let offset = min(max(cursorOffsetFromEnd ?? 0, 0), text.count)
+        return text[..<text.index(text.endIndex, offsetBy: -offset)].utf16.count
+    }
 }
 
 enum AccessibilityReplacement: Equatable {
@@ -22,8 +28,8 @@ enum AccessibilityReplacement: Equatable {
     var fallsBackToEvents: Bool { self == .unavailable }
 }
 
-/// The two judgements the Accessibility tier makes, kept pure so the harness can drive both.
-enum AccessibilityReplacementPolicy {
+/// The two judgements a replacement makes, kept pure so the harness can drive both tiers.
+enum TextReplacementPolicy {
     enum KeywordState: Equatable {
         case matched(NSRange)
         case pending
@@ -108,30 +114,25 @@ final class TextInjector {
     /// A paste is still in flight, or we still hold the pasteboard it borrowed.
     var isDelivering: Bool { !deliveryQueue.isIdle || activePasteboardLease != nil }
 
-    func prepareInteractiveExpansion(targetApp: NSRunningApplication?) -> Bool {
-        guard targetAcceptsInjection(targetApp), Permissions.ensureAccessibility() else {
-            activate(targetApp)
+    func prepareInteractiveExpansion(target: InjectionTarget?) -> Bool {
+        if let editor = target?.ownEditor { return editor.isEditable }
+        guard targetAcceptsInjection(target?.externalApp), Permissions.ensureAccessibility() else {
+            target?.restoreFocus()
             return false
         }
         return true
     }
 
-    func beginAutomaticExpansion(
-        targetApp: NSRunningApplication?
-    ) -> AutomaticGeneration? {
+    func beginAutomaticExpansion(target: InjectionTarget?) -> AutomaticGeneration? {
         cancelAutomaticExpansion()
-        guard
-            automaticExpansionIsAllowed(
-                generation: automaticGeneration,
-                targetApp: targetApp)
-        else { return nil }
+        guard expansionIsAllowed(generation: automaticGeneration, target: target) else { return nil }
         return automaticGeneration
     }
 
-    func cancelAutomaticExpansion(targetApp: NSRunningApplication? = nil) {
+    func cancelAutomaticExpansion(target: InjectionTarget? = nil) {
         automaticGeneration &+= 1
         deliveryQueue.cancelAutomatic()
-        activate(targetApp)
+        target?.restoreFocus()
     }
 
     func prepareForTermination() {
@@ -142,12 +143,12 @@ final class TextInjector {
 
     func cancelArgumentPrompt(
         automaticGeneration: AutomaticGeneration?,
-        targetApp: NSRunningApplication?
+        target: InjectionTarget?
     ) {
         if automaticGeneration != nil {
-            cancelAutomaticExpansion(targetApp: targetApp)
+            cancelAutomaticExpansion(target: target)
         } else {
-            activate(targetApp)
+            target?.restoreFocus()
         }
     }
 
@@ -161,7 +162,7 @@ final class TextInjector {
         return true
     }
 
-    func automaticExpansionIsAllowed(
+    private func automaticExpansionIsAllowed(
         generation: AutomaticGeneration,
         targetApp: NSRunningApplication?
     ) -> Bool {
@@ -173,13 +174,28 @@ final class TextInjector {
         return true
     }
 
+    /// In process there is nothing to grant, activate or post: our own view is the whole contract.
+    private func expansionIsAllowed(
+        generation: AutomaticGeneration,
+        target: InjectionTarget?
+    ) -> Bool {
+        switch target {
+        case .ownEditor(let editor):
+            return generation == automaticGeneration && settings.snippetsEnabled && editor.isEditable
+        case .external(let app):
+            return automaticExpansionIsAllowed(generation: generation, targetApp: app)
+        case nil:
+            return false
+        }
+    }
+
     func captureExpansionContext(
-        targetApp: NSRunningApplication?,
+        target: InjectionTarget?,
         clipboardHistory: [String]
     ) -> SnippetTemplateEngine.ExpansionContext {
         SnippetTemplateEngine.ExpansionContext(
             clipboardHistory: clipboardHistory,
-            selection: selectedText(in: targetApp) ?? "",
+            selection: selection(in: target),
             now: Date(),
             calendar: Calendar.current,
             locale: Locale.current,
@@ -194,7 +210,8 @@ final class TextInjector {
         onFailed: @escaping @MainActor () -> Void = {}
     ) {
         deliver(
-            InjectedText(text), targetApp: targetApp, expectedKeyword: nil, keywordLength: 0,
+            InjectedText(text), target: targetApp.map(InjectionTarget.external),
+            expectedKeyword: nil, keywordLength: 0,
             automaticGeneration: nil, onDelivered: onDelivered, onFailed: onFailed)
     }
 
@@ -244,22 +261,19 @@ final class TextInjector {
 
     func deliver(
         _ injected: InjectedText,
-        targetApp: NSRunningApplication?,
+        target: InjectionTarget?,
         expectedKeyword: String?,
         keywordLength: Int,
         automaticGeneration: AutomaticGeneration?,
         onDelivered: @escaping @MainActor () -> Void = {},
         onFailed: @escaping @MainActor () -> Void = {}
     ) {
+        let targetApp = target?.externalApp
         activate(targetApp)
         if let automaticGeneration {
-            guard
-                automaticExpansionIsAllowed(
-                    generation: automaticGeneration,
-                    targetApp: targetApp)
-            else { return }
+            guard expansionIsAllowed(generation: automaticGeneration, target: target) else { return }
         } else {
-            guard prepareInteractiveExpansion(targetApp: targetApp) else {
+            guard prepareInteractiveExpansion(target: target) else {
                 onFailed()
                 return
             }
@@ -267,14 +281,65 @@ final class TextInjector {
 
         deliveryQueue.enqueue(isAutomatic: automaticGeneration != nil) { [weak self] in
             guard let self else { return }
+            let completion = DeliveryCompletion(onDelivered: onDelivered, onFailed: onFailed)
+            if let editor = target?.ownEditor {
+                await self.deliverInProcess(
+                    injected,
+                    into: editor,
+                    expectedKeyword: expectedKeyword,
+                    keywordLength: keywordLength,
+                    automaticGeneration: automaticGeneration,
+                    completion: completion)
+                return
+            }
             await self.performDelivery(
                 injected,
                 targetApp: targetApp,
                 expectedKeyword: expectedKeyword,
                 keywordLength: keywordLength,
                 automaticGeneration: automaticGeneration,
-                completion: DeliveryCompletion(onDelivered: onDelivered, onFailed: onFailed))
+                completion: completion)
         }
+    }
+
+    /// Needs no grant, activation or pasteboard, but the keyword still converges on Rule 2.
+    private func deliverInProcess(
+        _ injected: InjectedText,
+        into editor: any InjectableTextView,
+        expectedKeyword: String?,
+        keywordLength: Int,
+        automaticGeneration: AutomaticGeneration?,
+        completion: DeliveryCompletion
+    ) async {
+        defer { completion.settle() }
+        for _ in 0..<Self.convergenceAttempts {
+            // The tap runs ahead of AppKit, so looking before the wait reads a stale view as a miss.
+            if keywordLength > 0 {
+                guard await wait(for: Self.convergenceInterval) else { return }
+            }
+            guard inProcessDeliveryIsAllowed(automaticGeneration: automaticGeneration, editor: editor)
+            else { return }
+            switch editor.keywordReplacementState(
+                expectedKeyword: expectedKeyword, keywordLength: keywordLength)
+            {
+            case .matched(let range):
+                editor.inject(injected, over: range)
+                completion.confirm()
+                return
+            case .rejected:
+                return
+            case .pending:
+                continue
+            }
+        }
+    }
+
+    private func inProcessDeliveryIsAllowed(
+        automaticGeneration: AutomaticGeneration?,
+        editor: any InjectableTextView
+    ) -> Bool {
+        guard let automaticGeneration else { return editor.isEditable }
+        return expansionIsAllowed(generation: automaticGeneration, target: .ownEditor(editor))
     }
 
     private func performDelivery(
@@ -590,7 +655,7 @@ final class TextInjector {
 
         let observed = stringValue(in: target.element)
         guard
-            AccessibilityReplacementPolicy.confirmsReplacement(
+            TextReplacementPolicy.confirmsReplacement(
                 originalValue: target.value,
                 replacementRange: target.replacementRange,
                 insertedText: injected.text,
@@ -601,11 +666,9 @@ final class TextInjector {
             return observed == target.value ? .unavailable : .rejected
         }
 
-        let cursorOffset = min(injected.cursorOffsetFromEnd ?? 0, injected.text.count)
-        let cursorIndex = injected.text.index(injected.text.endIndex, offsetBy: -cursorOffset)
-        let insertedPrefixLength = injected.text[..<cursorIndex].utf16.count
         _ = setSelectedRange(
-            NSRange(location: target.replacementRange.location + insertedPrefixLength, length: 0),
+            NSRange(
+                location: target.replacementRange.location + injected.caretPrefixLength, length: 0),
             in: target.element)
         return .delivered
     }
@@ -617,19 +680,19 @@ final class TextInjector {
         keywordLength: Int,
         automaticGeneration: AutomaticGeneration?
     ) async -> AccessibilityTargetState {
-        for attempt in 0..<Self.accessibilityConvergenceAttempts {
+        for attempt in 0..<Self.convergenceAttempts {
             let state = inspectAccessibilityTarget(
                 in: targetApp,
                 expectedKeyword: expectedKeyword,
                 keywordLength: keywordLength)
             guard case .pending = state else { return state }
-            guard attempt < Self.accessibilityConvergenceAttempts - 1,
+            guard attempt < Self.convergenceAttempts - 1,
                 automaticGeneration != nil,
                 deliveryIsAllowed(
                     automaticGeneration: automaticGeneration,
                     targetApp: targetApp,
                     promptForInteractiveAccessibility: false),
-                await wait(for: Self.accessibilityConvergenceInterval)
+                await wait(for: Self.convergenceInterval)
             else { return .unavailable }
         }
         return .unavailable
@@ -657,7 +720,7 @@ final class TextInjector {
                     replacementRange: originalRange))
         }
         guard let expectedKeyword, expectedKeyword.count == keywordLength else { return .rejected }
-        switch AccessibilityReplacementPolicy.keywordState(
+        switch TextReplacementPolicy.keywordState(
             value: value, selectedRange: originalRange, keyword: expectedKeyword)
         {
         case .matched(let replacementRange):
@@ -683,9 +746,9 @@ final class TextInjector {
         return CFGetTypeID(value) == AXTextMarkerRangeGetTypeID()
     }
 
-    /// A renderer converges in single-digit milliseconds; past this it was never going to.
-    private static let accessibilityConvergenceAttempts = 8
-    private static let accessibilityConvergenceInterval = Duration.milliseconds(5)
+    /// A renderer, or AppKit handing us our own keystroke, converges in single-digit milliseconds.
+    private static let convergenceAttempts = 8
+    private static let convergenceInterval = Duration.milliseconds(5)
 
     private func waitForPasteConfirmation(
         previousState: AccessibilityTextState?,
@@ -784,6 +847,14 @@ final class TextInjector {
     private func activate(_ targetApp: NSRunningApplication?) {
         guard targetApp?.isTerminated == false else { return }
         targetApp?.activate()
+    }
+
+    private func selection(in target: InjectionTarget?) -> String {
+        switch target {
+        case .ownEditor(let editor): return editor.injectableSelection
+        case .external(let app): return selectedText(in: app) ?? ""
+        case nil: return ""
+        }
     }
 
     private func selectedText(in targetApp: NSRunningApplication?) -> String? {

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -39,6 +39,11 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     var isVisible: Bool { panel?.isVisible ?? false }
 
+    /// What the palette covered when it was summoned, for anything it expands into on dismissal.
+    var previousTarget: InjectionTarget? {
+        InjectionTarget.behindPalette(ownWindow: previousOwnWindow, app: previousApp)
+    }
+
     func show() {
         Signposts.interval("PaletteWindowController.show") {
             // Summoned over one of our own windows: there is no external paste or focus target.

--- a/docs/features/notes.md
+++ b/docs/features/notes.md
@@ -26,6 +26,10 @@ commands and global shortcuts can show, search, or extend the collection.
   window shows its empty state and Create Note still works from there.
 - **The user owns the window size.** AppKit resizes and autosaves the frame; the controller only
   clamps it to the floor below which the title bar's own parts collide.
+- **The editor is the one surface snippets expand into.** `NoteTextView` adopts `InjectableTextView`,
+  so a typed keyword — and the Snippets browser's ↵ — is written straight into the text storage
+  rather than posted as events at whichever app happens to be frontmost. Nothing else in Tinycast
+  adopts it: see [snippets.md](snippets.md#text-delivery-and-pasteboard-safety).
 
 ## Storage and identity
 

--- a/docs/features/quick-actions.md
+++ b/docs/features/quick-actions.md
@@ -30,8 +30,8 @@ provider protocol and the connections behind it.
   through `DialogController` first and then calls `Permissions.ensureAccessibility()`, the pattern
   `SnippetCoordinator.setSnippetsEnabled` established. Everything else — a shortcut press, a
   delivery — uses `isAccessibilityTrusted()` and degrades to a HUD.
-- **Tinycast is never the target.** `QuickActionRunner.selection(in:using:)` refuses our own bundle
-  identifier, and `TextInjector.targetAcceptsInjection` refuses it again before every event post,
+- **Tinycast is never an event target.** `QuickActionRunner.selection(in:using:)` refuses our own
+  bundle identifier, and `TextInjector.targetAcceptsInjection` refuses it again before every event post,
   along with anything raised while Secure Event Input is up. A shortcut pressed with Settings
   frontmost, or in a password field, does nothing and says so.
 - **One run at a time.** Two overlapping runs would race for one selection, and the second would

--- a/docs/features/snippets.md
+++ b/docs/features/snippets.md
@@ -16,6 +16,12 @@ another app.
 - **All of `Model/` and `Service/` compiles into `snippets-test`** (it globs both), so the model, Markdown
   serializer, template engine, repository and keyword policies stay Foundation-only, and the AppKit files
   there keep their dependencies to what the harness can stub.
+- **Expansion goes where the caret is, which is not the frontmost application.** Our panels are
+  non-activating, so a key window of ours receives the keystrokes while `frontmostApplication` still
+  names the app behind it. `InjectionTarget.current()` resolves the destination from
+  `NSApp.keyWindow` first, and only falls back to the frontmost app when no window of ours holds key.
+  A key window of ours that is *not* an `InjectableTextView` — the palette's own search field, a
+  Settings form — resolves to no target at all, so a keyword typed there expands nowhere.
 - The on-disk Markdown format is user-authored and user-editable — an interchange format, not an internal
   one.
 
@@ -192,8 +198,9 @@ inactivity. It is capped at 256 characters. Keywords are matched case-insensitiv
 duplicates resolve by file identity. Tinycast-tagged synthetic events are ignored.
 
 Immediately before deleting a matched keyword and before inserting its expansion, automatic delivery
-re-checks consent, both permissions, Secure Event Input, the captured target app, and cancellation
-generation. A failed gate leaves the typed keyword untouched.
+re-checks consent, both permissions, Secure Event Input, the captured target, and cancellation
+generation. A failed gate leaves the typed keyword untouched. Delivery into one of our own editors
+gates on consent and the generation alone: there is nothing to grant, activate or post.
 
 ## Search Snippets
 
@@ -242,7 +249,23 @@ not report completion and therefore cannot show it.
 
 ## Text delivery and pasteboard safety
 
-Delivery is one contract, in this order, and every clause below is a rule in it.
+There are two delivery tiers, and the target picks which one runs.
+
+`InjectionTarget.ownEditor` is one of our own views — today only `NoteTextView`, which opts in by
+adopting `InjectableTextView`. It is written in process with `insertText(_:replacementRange:)`:
+undoable in the editor's own `UndoManager`, and needing no Accessibility grant, no pasteboard lease,
+no app activation and no event posting. Rules 1, 3 and 4 below do not apply — our own storage is
+authoritative, so there is nothing to sniff for and nothing to read back.
+
+**Rule 2 applies to it more sharply than to any renderer.** The tap is `headInsertEventTap`, so it
+fires *before* AppKit delivers the keystroke to our own view: the first look is always one character
+stale. `.pending` only covers a document shorter than the keyword; with anything typed before it, the
+same staleness reads as `.rejected` and fails closed. So this tier **leads with the wait** — it sleeps
+one convergence interval before it inspects at all, then polls on the shared budget. In practice the
+keyword has landed after a single 5 ms pass.
+
+`InjectionTarget.external` is another application, and it takes the contract below, in this order,
+where every clause is a rule in it.
 
 1. The focused element exposes `AXSelectedTextMarkerRange` → a renderer surface. Skip Accessibility.
 2. The keyword is not at the caret yet → wait, up to 40 ms. Never arrives → events. Wrong → refuse.
@@ -258,7 +281,7 @@ marker range is the reliable tell, so those targets never take the Accessibility
 `accessibilityTextState` skips them for the same reason: a value that never moves cannot confirm a
 paste either.
 
-**Rule 2: too little text is not the same as the wrong text.** `AccessibilityReplacementPolicy`
+**Rule 2: too little text is not the same as the wrong text.** `TextReplacementPolicy`
 `.pending` means the value is shorter than the keyword — the renderer has not caught up — and is
 retried for up to eight 5 ms passes. `.rejected` means there was enough text and it was not the
 keyword, which is a genuine mismatch and stops delivery. Only an automatic expansion waits; an


### PR DESCRIPTION
## Related issue

Closes #528

## What changed

Snippet keywords did nothing inside a Note. The cause was the destination, not the delivery.

`TextInjector` resolved its target from `NSWorkspace.frontmostApplication`. Every Tinycast panel is
`.nonactivatingPanel`, so with the Note key, the frontmost application is still the one behind it —
measured, not assumed: with the Note focused, `NSApp.keyWindow` was `NotesPanel` while
`frontmostApplication` reported the editor behind it. The expansion was being posted as events at
*that* app.

- **`InjectionTarget`** is now the destination: `.external(app)` or `.ownEditor(view)`, resolved from
  `NSApp.keyWindow` first and only falling back to the frontmost app when no window of ours holds key.
  A key window of ours that is *not* an `InjectableTextView` — the palette's search field, a Settings
  form — resolves to no target at all, so a keyword typed there no longer expands into whatever sits
  behind it.
- **`InjectableTextView`** is the opt-in, and `NoteTextView` is its only adopter. It is deliberately a
  separate file from the injection logic so `notes-editor-test` can compile the conformance without
  pulling in the whole injector.
- **In-process tier** writes with `insertText(_:replacementRange:)`, so the note's own `UndoManager`,
  `textDidChange` and autosave all fire. No Accessibility grant, pasteboard lease, app activation or
  event posting.
- The Snippets browser's ↵ and the launcher's snippet row reach a focused Note too, via
  `PaletteWindowController.previousTarget`.

The non-obvious part is the timing. The tap is a `headInsertEventTap`, so it fires *before* AppKit
hands the keystroke to our own view — the first look at the text storage is always one character
stale. `TextReplacementPolicy.pending` only covers a document shorter than the keyword; with anything
typed before it, the same staleness reads as `.rejected` and fails closed. So this tier **leads with
the wait**: one convergence interval before it inspects at all, then the shared budget. Instrumented,
the keyword lands after a single 5 ms pass (`attempt 0: pending chars=2` → `attempt 1: matched({0,3})
chars=3`).

Two pieces of cleanup fell out of having a second tier: `AccessibilityReplacementPolicy` is now
`TextReplacementPolicy` (both tiers use it), and the caret maths both tiers had is now
`InjectedText.caretPrefixLength` instead of being written twice.

## Memory footprint

Not measured — no profiling run for this change. The in-process tier allocates strictly less than the
path it replaces: no pasteboard lease, no synthesized `CGEvent` groups, no AX round trips.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no. The one new retained reference is `InjectionTarget.ownEditor`, held only for the
duration of a single delivery.

## Demo

No recording. The visible change is a keyword expanding in place inside a Note where nothing happened
before.

## Drawbacks

- Expansion into our own editor now costs at least one 5 ms convergence pass, because the tap is
  guaranteed to run ahead of AppKit's own delivery. Unavoidable at this layer, and imperceptible.
- `InjectableTextView` is opt-in by conformance, so a future editor surface that wants snippets has to
  adopt it. That is deliberate: the palette's search field must *not* get expansion.
- `SnippetArgumentsPrompt` still uses `NSAlert`, which the repo's own rule forbids. Pre-existing, left
  alone here rather than widened into this change.

## Tests & validation

`./Scripts/run-tests.sh` — all 68 harnesses pass. `./Scripts/lint.sh` clean, `./Scripts/format.sh
--check` clean, Debug build with no new warnings.

Added to `snippets-test` (7 checks): a document shorter than the keyword reads as `.pending`; the same
stale view *behind existing text* reads as `.rejected` — the case that makes the lead-with-the-wait
necessary; converged replacement in place; caret after inserted text; wrong-suffix mismatch; a
zero-length keyword taking the selection; cursor-offset placement; UTF-16 caret maths.

By hand, against a Debug build: `!t1` typed on its own in a Note, and typed after existing text
(`Regards, !t1`) — the second is the case an earlier version of this fix silently failed, caught by
the new `.rejected` test.
