### PR TITLE
Size the onboarding window to each step

### DIFF
--- a/Tinycast/Features/Onboarding/OnboardingCoordinator.swift
+++ b/Tinycast/Features/Onboarding/OnboardingCoordinator.swift
@@ -10,8 +10,13 @@ final class OnboardingCoordinator {
     init(core: AppCore) {
         self.core = core
         window = AppWindowController(
-            title: "Welcome to Tinycast", contentSize: OnboardingView.windowSize,
+            title: "Welcome to Tinycast", contentSize: OnboardingView.initialSize,
             activation: core.activationPolicy)
+    }
+
+    /// The window takes the height the current step measured, so no step is clipped or padded out.
+    func fit(height: CGFloat) {
+        window.fitContent(width: OnboardingView.width, height: height)
     }
 
     func showOnboarding() {

--- a/Tinycast/Features/Onboarding/OnboardingView.swift
+++ b/Tinycast/Features/Onboarding/OnboardingView.swift
@@ -14,26 +14,35 @@ struct OnboardingView: View {
     private let refreshTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     private static let lastStep = 3
-    /// Fixed content size, so `NSHostingView` can't size the window to its ideal height.
-    static let windowSize = CGSize(width: 520, height: 400)
+    static let width: CGFloat = 520
+    /// Only until the first layout measures the real one, which is what the window then takes.
+    static let initialSize = CGSize(width: width, height: 352)
 
     var body: some View {
         VStack(spacing: Theme.Spacing.lg) {
             hero
             stepContent
-                .frame(maxHeight: .infinity, alignment: .top)
             footer
         }
-        .padding(.top, Theme.Spacing.xxl)
+        // Less on top: the title bar adds 32pt, and the lights must be cleared.
+        .padding(.top, Theme.Spacing.xs)
         .padding([.horizontal, .bottom], Theme.Spacing.xxl)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity)
+        // The ideal height, not the window's, so sizing to it converges instead of feeding back.
+        .fixedSize(horizontal: false, vertical: true)
+        .onGeometryChange(for: CGFloat.self) {
+            $0.size.height
+        } action: {
+            core.onboardingCoordinator.fit(height: $0)
+        }
+        // Only the gradient reaches under the titlebar; the content stays in the safe area.
         .background(
             LinearGradient(
                 colors: [Theme.Colors.sheen, Color.clear],
-                startPoint: .top, endPoint: .center)
+                startPoint: .top, endPoint: .center
+            )
+            .ignoresSafeArea()
         )
-        // Extend under the titlebar, so window height equals the fixed content height.
-        .ignoresSafeArea()
         // Onboarding's shortcut step has a recorder too, and it isn't inside a `SettingsPane`.
         .shortcutRecorderPopoverHost()
         .animation(.easeInOut(duration: 0.2), value: step)


### PR DESCRIPTION
## Related issue

Closes #583

## What changed

The Raycast import step's content — file row, passphrase row, the 11-checkbox grid, Select All and the hint line — measures ~475pt, against a window fixed at 520x400 and not resizable. The `VStack` doesn't clip, so the footer holding **Skip** and **Import** rendered past the bottom edge. Only a sliver of the Import button was visible, and Return was no help since it maps to Import, which stays disabled until a file is picked. The only way out was the red close button, which skips the final "You're all set" step.

Onboarding now measures its own ideal height and sizes the window to it, using the pattern the update window already uses (`UpdateWindowView` → `UpdateCoordinator.fit(height:)` → `AppWindowController.fitContent`):

- `OnboardingCoordinator.fit(height:)` forwards to the existing `fitContent`.
- `OnboardingView` takes its ideal height via `.fixedSize(horizontal: false, vertical: true)` and reports it with `.onGeometryChange`.
- `windowSize` splits into `width` plus an `initialSize` that only holds until the first layout, matching `UpdateWindowView.initialSize`.

The one non-obvious bit: `fitContent` adds the titlebar back onto the measured height, so the content has to be measured *inside* the safe area. Onboarding previously put `.ignoresSafeArea()` on the whole tree to make the window height equal the content height. That moves onto the gradient alone — the sheen still bleeds under the titlebar, the content no longer does — and the top padding drops from `xxl` to `xs` to compensate for the titlebar now sitting above the content rather than behind it.

## Memory footprint

Not measured — no allocation behaviour changed. The diff swaps layout modifiers on an existing view and adds one method that forwards to an existing one; no new types, storage, observers or tasks.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       | n/a    |
| Palette open            | n/a    |
| Feature in use (peak)   | n/a    |
| Palette closed, settled | n/a    |

Leak-tested: n/a — no new retained references.

## Demo

No before/after video. Screen capture isn't permitted for the process I was working from, so I verified geometrically instead: I measured the live window through `CGWindowListCopyWindowInfo` with the wizard pinned to each step in turn.

| Step | Before | After |
| --- | --- | --- |
| 0 — Welcome | 520 × 400 | 520 × 352 |
| 1 — Enable Pasting | 520 × 400 | 520 × 313 |
| 2 — Import from Raycast | 520 × 400 (content ~477) | 520 × 477 |
| 3 — You're all set | 520 × 400 | 520 × 241 |

Step 2 is the bug: 77pt of content lived outside the window. With `.fixedSize` the window height now equals the content's ideal height, so the footer is inside by construction.

## Drawbacks

The window resizes between steps rather than holding one size. I first tried a floor that kept the short steps at the original 400pt so only the import step grew, but it looked worse in practice — every step reading as tall and empty — so the per-step fit is deliberate. It also matches the update window, which already resizes per stage.

Step 3 settles at 241pt, which is short for a 520-wide window. If that reads as too sparse, the fix belongs in that step's content rather than in a height floor.

## Tests & validation

- `./Scripts/run-tests.sh` — all 68 harnesses pass.
- `./Scripts/lint.sh` — clean.
- Debug build compiles with no new warnings.
- By hand: ran the dev build with the onboarding marker removed, pinned to each step in turn, and measured the resulting window.

No harness covers this — the onboarding window is SwiftUI layout, and the harnesses compile `Features/*/Model/` sources that can't import SwiftUI.