### PR TITLE
Drag a clipboard entry out into another app

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -128,12 +128,14 @@ run clipboard-test         Tinycast/Features/Clipboard/Model/ClipboardStore.swif
                            Tinycast/Features/Clipboard/Model/ColorValue.swift \
                            Tinycast/Features/Clipboard/Model/ColorFormat.swift \
                            Tinycast/Features/Clipboard/Model/ColorSpaces.swift
-run clipboard-search-test  Tinycast/Features/Clipboard/Model/*.swift
-run clipboard-text-test    Tinycast/Features/Clipboard/Model/*.swift \
+# `Q` is the URL detector a drag payload builds its link with, rather than a second one.
+Q=Tinycast/Features/Quicklinks/Model/QuicklinkDestination.swift
+run clipboard-search-test  Tinycast/Features/Clipboard/Model/*.swift $Q
+run clipboard-text-test    Tinycast/Features/Clipboard/Model/*.swift $Q \
                            Tinycast/Features/Clipboard/Service/ClipboardTextExtractor.swift \
                            Tinycast/Features/Clipboard/Service/ClipboardTextIndexer.swift \
                            Tinycast/Features/Clipboard/Service/ClipboardTextWorker.swift
-run clipboard-worker-test  Tinycast/Features/Clipboard/Model/*.swift \
+run clipboard-worker-test  Tinycast/Features/Clipboard/Model/*.swift $Q \
                            Tinycast/Features/Clipboard/Service/ClipboardTextWorker.swift
 run pasteboard-test        Tinycast/Platform/PasteboardFiles.swift \
                            Tinycast/Features/Clipboard/Model/ClipboardStore.swift \

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		36784C964DB27B94A62EEAA3 /* tinycast.icon in Resources */ = {isa = PBXBuildFile; fileRef = 6621A88681E993D49EEF07A3 /* tinycast.icon */; };
 		36968DFA1E201E681F0BCD42 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1306524F57602D90FCF153C /* Theme.swift */; };
 		36A6FC9C41CDBD4ADA1F8E87 /* AIModelDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68649D40F987D1CD24D1112 /* AIModelDiscovery.swift */; };
+		383A577E1A70AF702C474B0F /* ClipDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6491D532351DEB940B4FBD1A /* ClipDragPayload.swift */; };
 		3891DA96CC148D13893F4494 /* ShortcutCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B235DFF451FF4D52A8E44D00 /* ShortcutCaptureSession.swift */; };
 		3917193B62450F226297B3F1 /* SelectionReveal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648F0F43FEEE537F6451756B /* SelectionReveal.swift */; };
 		39F5A11DD9D7C31AC720D4C0 /* QuicklinksSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC68E042182F7068220BB3 /* QuicklinksSettingsView.swift */; };
@@ -820,6 +821,7 @@
 		63E3B7CDDB6A9D790548648B /* ReleaseArchitecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseArchitecture.swift; sourceTree = "<group>"; };
 		6420FE45699DC3E53907CAE3 /* AIInstructions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInstructions.swift; sourceTree = "<group>"; };
 		648F0F43FEEE537F6451756B /* SelectionReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReveal.swift; sourceTree = "<group>"; };
+		6491D532351DEB940B4FBD1A /* ClipDragPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipDragPayload.swift; sourceTree = "<group>"; };
 		64EC07E163CE4F3D11FE7225 /* SymbolImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolImage.swift; sourceTree = "<group>"; };
 		65F1010FAC9C0EC4DBDE58A8 /* AIRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIRequestBody.swift; sourceTree = "<group>"; };
 		6621A88681E993D49EEF07A3 /* tinycast.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = tinycast.icon; sourceTree = "<group>"; };
@@ -2756,6 +2758,7 @@
 				D381DD8CB296A6D5CFF90111 /* ClipboardFileKind.swift */,
 				682E7F6534CB4014969D98E0 /* ClipboardFilter.swift */,
 				201FCD08ACA933378876385B /* ClipboardStore.swift */,
+				6491D532351DEB940B4FBD1A /* ClipDragPayload.swift */,
 				025D7D760DE2FD02C0D7D9D2 /* ColorFormat.swift */,
 				8756FBB625DFAE931D8D5D9D /* ColorSpaces.swift */,
 				CA9287418DC6C04437FB4BAF /* ColorValue.swift */,
@@ -2986,6 +2989,7 @@
 				52D95C1FF343FCD57D5425A0 /* ChatSession.swift in Sources */,
 				E77BF5D26A6D9E9FC7E82259 /* ChatTranscriptView.swift in Sources */,
 				4E1BFE20BD4308D1EF05A5F2 /* ClipDrag.swift in Sources */,
+				383A577E1A70AF702C474B0F /* ClipDragPayload.swift in Sources */,
 				A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */,
 				40E28FFBE1DDE737D43A7836 /* ClipboardFileKind.swift in Sources */,
 				AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */,

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		4D462D0F116A5C04E4DEFCCF /* PseudoTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6A905C247E0A5C349125EA /* PseudoTerminal.swift */; };
 		4D8C05DD67FAB9F2DA1F31FB /* AIStreamDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0337B056DA2D31772534F1EF /* AIStreamDecoder.swift */; };
 		4DA03A170E95F0D08E3569F9 /* ExtensionColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0266BAF4643A4B5C41B600DE /* ExtensionColors.swift */; };
+		4E1BFE20BD4308D1EF05A5F2 /* ClipDrag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB74C73EB33F368E0890E839 /* ClipDrag.swift */; };
 		4E5F73461C417BE2B3472E6E /* WindowChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D61199EE7B60E91ACBDE2E2 /* WindowChrome.swift */; };
 		4EBFBA1CC7DA9B22C396DBEC /* CommandArgumentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1590A8769EF787763DE189B7 /* CommandArgumentsRow.swift */; };
 		4F231B3551269815753B8C4C /* BackupCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA4145CFBB855DF1699C744 /* BackupCategory.swift */; };
@@ -1100,6 +1101,7 @@
 		DB1752929BA1ACC0BC54865C /* HUDPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDPanel.swift; sourceTree = "<group>"; };
 		DB44DCF1B6B9C9846CFB053D /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		DB5FA545F484D7666E9A5F14 /* RunningAppsMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningAppsMonitor.swift; sourceTree = "<group>"; };
+		DB74C73EB33F368E0890E839 /* ClipDrag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipDrag.swift; sourceTree = "<group>"; };
 		DBD9A72B34E336446F312B30 /* QuicklinkEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuicklinkEditorSheet.swift; sourceTree = "<group>"; };
 		DBED1FDAAD4735FDB4B2453A /* MCPProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPProtocol.swift; sourceTree = "<group>"; };
 		DCBC5A9553716C8F03ED0216 /* SettingsToolbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsToolbarController.swift; sourceTree = "<group>"; };
@@ -1501,6 +1503,7 @@
 				B45A6AB1413A8A08EF7F0A9E /* ClipboardFilterButton.swift */,
 				548C83C4086CD9FB8E85B222 /* ClipboardScreen.swift */,
 				FBF6EF3A2C35F45B82D40968 /* ClipboardView.swift */,
+				DB74C73EB33F368E0890E839 /* ClipDrag.swift */,
 				C214E40D42F4812F141C16A8 /* ColorPreview.swift */,
 				89DBFE62B513EC161F194D0A /* ColorSwatch.swift */,
 				E03A52EBF08AD5C44953DBDC /* FilePreviewStage.swift */,
@@ -2982,6 +2985,7 @@
 				3162C31B1971F738F9CE05E9 /* ChatMessage.swift in Sources */,
 				52D95C1FF343FCD57D5425A0 /* ChatSession.swift in Sources */,
 				E77BF5D26A6D9E9FC7E82259 /* ChatTranscriptView.swift in Sources */,
+				4E1BFE20BD4308D1EF05A5F2 /* ClipDrag.swift in Sources */,
 				A320745F576C5915217DF113 /* ClipboardCoordinator.swift in Sources */,
 				40E28FFBE1DDE737D43A7836 /* ClipboardFileKind.swift in Sources */,
 				AD9753D6EAF202B6E31510EB /* ClipboardFilter.swift in Sources */,

--- a/Tinycast/Features/Clipboard/Model/ClipDragPayload.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipDragPayload.swift
@@ -9,8 +9,7 @@ enum ClipDragPayload: Equatable, Sendable {
 }
 
 extension ClipboardItem {
-    /// Derived and never persisted, like `textForm` beside it. `textForm` stays the one answer to
-    /// whether an entry is a link, so the drag and the type filter cannot disagree.
+    /// `textForm` stays the one answer to a link, so the drag and the type filter cannot disagree.
     var dragPayload: ClipDragPayload {
         if let path = imagePath ?? filePath { return .file(URL(fileURLWithPath: path)) }
         let copy = text ?? ""

--- a/Tinycast/Features/Clipboard/Model/ClipDragPayload.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipDragPayload.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// What a row hands to the app it is dropped on.
+enum ClipDragPayload: Equatable, Sendable {
+    case file(URL)
+    /// A browser reads `public.url`, a text field reads the string.
+    case link(URL, String)
+    case text(String)
+}
+
+extension ClipboardItem {
+    /// Derived and never persisted, like `textForm` beside it. `textForm` stays the one answer to
+    /// whether an entry is a link, so the drag and the type filter cannot disagree.
+    var dragPayload: ClipDragPayload {
+        if let path = imagePath ?? filePath { return .file(URL(fileURLWithPath: path)) }
+        let copy = text ?? ""
+        guard textForm == .link else { return .text(copy) }
+        switch QuicklinkDestination.detect(copy) {
+        case .web(let url), .network(let url), .deeplink(let url): return .link(url, copy)
+        case .path, nil: return .text(copy)
+        }
+    }
+}

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -470,6 +470,12 @@ final class ClipboardStore {
         return URL(fileURLWithPath: path)
     }
 
+    /// What a drag hands out: our stored blob for an image, the referenced file for a file entry.
+    /// Nil for text, which stays on the row's own gestures.
+    func dragURL(for item: ClipboardItem) -> URL? {
+        imageURL(for: item) ?? fileURL(for: item)
+    }
+
     /// Display order for `query` under `filter`: pinned entries first, each block newest-first.
     func search(_ query: String, filter: ClipboardFilter) -> [ClipboardItem] {
         // Load-bearing: a settled OCR query changes the answer without `items` changing.

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -470,10 +470,14 @@ final class ClipboardStore {
         return URL(fileURLWithPath: path)
     }
 
-    /// What a drag hands out: our stored blob for an image, the referenced file for a file entry.
-    /// Nil for text, which stays on the row's own gestures.
-    func dragURL(for item: ClipboardItem) -> URL? {
-        imageURL(for: item) ?? fileURL(for: item)
+    /// What a drag hands out, in the flavour the receiver expects. Never nil: every row drags.
+    func dragPayload(for item: ClipboardItem) -> ClipDragPayload {
+        if let url = imageURL(for: item) ?? fileURL(for: item) { return .file(url) }
+        let text = item.text ?? ""
+        guard item.textForm == .link, let url = ClipDragPayload.webURL(from: text) else {
+            return .text(text)
+        }
+        return .link(url, text)
     }
 
     /// Display order for `query` under `filter`: pinned entries first, each block newest-first.

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -470,16 +470,6 @@ final class ClipboardStore {
         return URL(fileURLWithPath: path)
     }
 
-    /// What a drag hands out, in the flavour the receiver expects. Never nil: every row drags.
-    func dragPayload(for item: ClipboardItem) -> ClipDragPayload {
-        if let url = imageURL(for: item) ?? fileURL(for: item) { return .file(url) }
-        let text = item.text ?? ""
-        guard item.textForm == .link, let url = ClipDragPayload.webURL(from: text) else {
-            return .text(text)
-        }
-        return .link(url, text)
-    }
-
     /// Display order for `query` under `filter`: pinned entries first, each block newest-first.
     func search(_ query: String, filter: ClipboardFilter) -> [ClipboardItem] {
         // Load-bearing: a settled OCR query changes the answer without `items` changing.

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -509,7 +509,10 @@ final class ClipboardStore {
         let unpinned = ordinary.filter { !$0.isPinned }
         // OCR-only rows fill what is left of the budget the FTS `LIMIT` gives ordinary ones.
         let remaining = max(0, Self.searchLimit - filter.apply(to: unpinned).count)
-        return pins + unpinned + filter.apply(to: additional.filter { !$0.isPinned }).prefix(remaining)
+        // `Array(…)` spelled out: left open, the type checker reads `prefix` as the `Sequence`
+        // overload and the whole `+` chain stops resolving.
+        let extra = Array(filter.apply(to: additional.filter { !$0.isPinned }).prefix(remaining))
+        return pins + unpinned + extra
     }
 
     private func runSearch(_ q: String) -> [ClipboardItem] {

--- a/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
+++ b/Tinycast/Features/Clipboard/Model/ClipboardStore.swift
@@ -509,8 +509,7 @@ final class ClipboardStore {
         let unpinned = ordinary.filter { !$0.isPinned }
         // OCR-only rows fill what is left of the budget the FTS `LIMIT` gives ordinary ones.
         let remaining = max(0, Self.searchLimit - filter.apply(to: unpinned).count)
-        // `Array(…)` spelled out: left open, the type checker reads `prefix` as the `Sequence`
-        // overload and the whole `+` chain stops resolving.
+        // `Array(…)` spelled out: left open, `prefix` resolves as `Sequence` and the chain fails.
         let extra = Array(filter.apply(to: additional.filter { !$0.isPinned }).prefix(remaining))
         return pins + unpinned + extra
     }

--- a/Tinycast/Features/Clipboard/UI/ClipDrag.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipDrag.swift
@@ -1,12 +1,7 @@
 import AppKit
 import SwiftUI
 
-/// Drags a clipboard entry out to another app.
-///
-/// AppKit rather than SwiftUI's `onDrag`, which takes an `NSItemProvider` and cannot declare the
-/// operation mask. Images live under `imagesDir` on the boot volume, where a same-volume drop
-/// defaults to a move and would carry the blob out of the history. Only an `NSDraggingSource`
-/// answers `.copy`. See docs/features/clipboard.md#dragging-out.
+/// AppKit, not `onDrag`: only an `NSDraggingSource` can force `.copy` over a same-volume move.
 struct ClipDragHandle: NSViewRepresentable {
     /// Read when the drag starts, not when the row draws: resolving it stats the file.
     var payload: () -> ClipDragPayload?
@@ -23,8 +18,7 @@ struct ClipDragHandle: NSViewRepresentable {
 }
 
 extension View {
-    /// The handle owns the press, so it answers the click and the double click too. A SwiftUI tap
-    /// gesture underneath it never sees either.
+    /// The handle owns the press, so a tap gesture underneath never sees click or double click.
     func clipDraggable(
         payload: @escaping () -> ClipDragPayload?,
         onSelect: @escaping () -> Void,
@@ -56,6 +50,14 @@ private final class ClipDragView: NSView, NSDraggingSource {
         self.onSelect = onSelect
         self.onActivate = onActivate
         self.onDropped = onDropped
+    }
+
+    /// Left button only, so the row's right-click catcher underneath still opens the actions menu.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        switch NSApp.currentEvent?.type {
+        case .rightMouseDown, .rightMouseUp, .rightMouseDragged: return nil
+        default: return super.hitTest(point)
+        }
     }
 
     /// Tracks the gesture itself, like `WindowDragHandle`: the hosting view eats the click first.
@@ -116,8 +118,7 @@ private final class ClipDragView: NSView, NSDraggingSource {
         }
     }
 
-    /// Drawn, never snapshotted: SwiftUI renders into layers, so `cacheDisplay` on the row returns
-    /// a transparent bitmap and the drag carries nothing visible.
+    /// Drawn, not snapshotted: SwiftUI draws into layers, so `cacheDisplay` returns a clear bitmap.
     private func dragImage(for payload: ClipDragPayload) -> NSImage {
         switch payload {
         case .file(let url):
@@ -142,19 +143,17 @@ private final class ClipDragView: NSView, NSDraggingSource {
         let text = string.size()
         let size = NSSize(
             width: min(text.width, 320) + inset.width * 2, height: text.height + inset.height * 2)
-        let image = NSImage(size: size)
-        image.lockFocus()
-        NSColor.controlBackgroundColor.withAlphaComponent(0.95).setFill()
-        NSBezierPath(
-            roundedRect: NSRect(origin: .zero, size: size),
-            xRadius: Theme.Radius.thumbnail, yRadius: Theme.Radius.thumbnail
-        ).fill()
-        string.draw(
-            in: NSRect(
-                x: inset.width, y: inset.height, width: size.width - inset.width * 2,
-                height: text.height))
-        image.unlockFocus()
-        return image
+        return NSImage(size: size, flipped: false) { rect in
+            NSColor.controlBackgroundColor.withAlphaComponent(0.95).setFill()
+            NSBezierPath(
+                roundedRect: rect, xRadius: Theme.Radius.thumbnail, yRadius: Theme.Radius.thumbnail
+            ).fill()
+            string.draw(
+                in: NSRect(
+                    x: inset.width, y: inset.height, width: rect.width - inset.width * 2,
+                    height: text.height))
+            return true
+        }
     }
 
     // MARK: - NSDraggingSource

--- a/Tinycast/Features/Clipboard/UI/ClipDrag.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipDrag.swift
@@ -5,8 +5,8 @@ import SwiftUI
 ///
 /// AppKit rather than SwiftUI's `onDrag`, which takes an `NSItemProvider` and cannot declare the
 /// operation mask. Images live under `imagesDir` on the boot volume, where a same-volume drop
-/// defaults to a move and would carry the blob out of the history. Only `NSDraggingSource` can
-/// answer `.copy`.
+/// defaults to a move and would carry the blob out of the history. Only an `NSDraggingSource`
+/// answers `.copy`. See docs/features/clipboard.md#dragging-out.
 struct ClipDragHandle: NSViewRepresentable {
     /// Read when the drag starts, not when the row draws: resolving it stats the file.
     var payload: () -> ClipDragPayload?
@@ -23,7 +23,7 @@ struct ClipDragHandle: NSViewRepresentable {
 }
 
 extension View {
-    /// The handle owns the press, so it answers the click and the double click too — a SwiftUI tap
+    /// The handle owns the press, so it answers the click and the double click too. A SwiftUI tap
     /// gesture underneath it never sees either.
     func clipDraggable(
         payload: @escaping () -> ClipDragPayload?,
@@ -89,7 +89,7 @@ private final class ClipDragView: NSView, NSDraggingSource {
     private func beginDrag(_ payload: ClipDragPayload, with event: NSEvent) {
         let image = dragImage(for: payload)
         let item = NSDraggingItem(pasteboardWriter: pasteboardWriter(for: payload))
-        // Sized to the image and centred on the cursor; the row's shape would stretch a thumbnail.
+        // Sized to the image and centred on the cursor. The row's shape would stretch a thumbnail.
         let origin = convert(event.locationInWindow, from: nil)
         item.setDraggingFrame(
             NSRect(

--- a/Tinycast/Features/Clipboard/UI/ClipDrag.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipDrag.swift
@@ -1,0 +1,133 @@
+import AppKit
+import SwiftUI
+
+/// Drags a clipboard entry out as the file it already is, so an image reaches another app in one
+/// gesture rather than through Reveal in Finder.
+///
+/// An overlay that tracks the gesture itself, like `WindowDragHandle`: the hosting view eats the
+/// click first, and SwiftUI's `onDrag` hands over an `NSItemProvider` with no say in the operation
+/// mask. That say is the point. Images live under `ClipboardStore.imagesDir` on the boot volume,
+/// where a same-volume drop defaults to a **move** — which would carry the blob out of the history
+/// and strand its row. An `NSDraggingSource` answers `.copy` and the entry stays.
+struct ClipDragHandle: NSViewRepresentable {
+    let url: URL
+    var onSelect: () -> Void
+    var onActivate: () -> Void
+    var onDropped: () -> Void
+
+    func makeNSView(context: Context) -> NSView { ClipDragView(url: url) }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let view = nsView as? ClipDragView else { return }
+        view.url = url
+        view.bind(onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
+    }
+}
+
+extension View {
+    /// Marks a row as a drag source for `url`. A row without one keeps its SwiftUI gestures, so a
+    /// text entry behaves exactly as before.
+    func clipDraggable(
+        _ url: URL?,
+        onSelect: @escaping () -> Void,
+        onActivate: @escaping () -> Void,
+        onDropped: @escaping () -> Void
+    ) -> some View {
+        overlay {
+            if let url {
+                ClipDragHandle(
+                    url: url, onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
+            }
+        }
+    }
+}
+
+/// Claims mouse-down, then decides: past the slop it is a drag, otherwise it was the row's click.
+private final class ClipDragView: NSView, NSDraggingSource {
+    /// The slop AppKit itself allows before a press reads as a drag.
+    private static let threshold: CGFloat = 4
+    /// The row thumbnail is already cached at this size, so the preview costs no decode.
+    private static let previewPixel: CGFloat = 64
+
+    var url: URL
+    private var onSelect: (() -> Void)?
+    private var onActivate: (() -> Void)?
+    private var onDropped: (() -> Void)?
+
+    init(url: URL) {
+        self.url = url
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func bind(
+        onSelect: @escaping () -> Void, onActivate: @escaping () -> Void,
+        onDropped: @escaping () -> Void
+    ) {
+        self.onSelect = onSelect
+        self.onActivate = onActivate
+        self.onDropped = onDropped
+    }
+
+    /// The row's own gestures never see this press, so the click they used to handle lands here.
+    override func mouseDown(with event: NSEvent) {
+        guard let window else { return }
+        // On the press, not the release: a drag that starts must carry the row it started on.
+        onSelect?()
+        if event.clickCount == 2 {
+            onActivate?()
+            return
+        }
+        // Deltas off `mouseLocation`, so no view or window coordinate conversion can drift.
+        let start = NSEvent.mouseLocation
+        var passedThreshold = false
+        window.trackEvents(
+            matching: [.leftMouseDragged, .leftMouseUp], timeout: NSEvent.foreverDuration,
+            mode: .eventTracking
+        ) { tracked, stop in
+            guard let tracked, tracked.type != .leftMouseUp else {
+                stop.pointee = true
+                return
+            }
+            let mouse = NSEvent.mouseLocation
+            guard hypot(mouse.x - start.x, mouse.y - start.y) > Self.threshold else { return }
+            passedThreshold = true
+            stop.pointee = true
+        }
+        guard passedThreshold else { return }
+        beginDrag(with: event)
+    }
+
+    /// `NSURL` writes the file URL every receiver understands, from Finder to a browser upload.
+    private func beginDrag(with event: NSEvent) {
+        let item = NSDraggingItem(pasteboardWriter: url as NSURL)
+        item.setDraggingFrame(bounds, contents: dragImage())
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    /// Cache-only lookups: a decode on mouse-down would stall the frame the drag begins on.
+    private func dragImage() -> NSImage {
+        ImageThumbnail.cached(url, maxPixel: Self.previewPixel)
+            ?? FilePreviewThumbnail.cached(url, maxPixel: Self.previewPixel)
+            ?? NSWorkspace.shared.icon(forFile: url.path)
+    }
+
+    // MARK: - NSDraggingSource
+
+    /// Copy, always. The store owns the blob it hands out, and a move would delete it.
+    func draggingSession(
+        _ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .copy
+    }
+
+    /// A drop that landed is a finished errand, so the palette gets out of the way like a paste.
+    func draggingSession(
+        _ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation
+    ) {
+        guard operation != [] else { return }
+        onDropped?()
+    }
+}

--- a/Tinycast/Features/Clipboard/UI/ClipDrag.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipDrag.swift
@@ -1,53 +1,32 @@
 import AppKit
 import SwiftUI
 
-/// What a row hands to the app it is dropped on. The flavours are what receivers actually read:
-/// a file URL for anything on disk, a URL *and* its text for a link, plain text for the rest.
-enum ClipDragPayload: Equatable, Sendable {
-    /// The stored blob for an image, the referenced file for a `.file` entry.
-    case file(URL)
-    /// A browser wants `public.url`, a text field wants the string. Writing both serves either.
-    case link(URL, String)
-    case text(String)
-
-    /// A bare domain is still a link, and a browser rejects one without a scheme, so it gets
-    /// `https://` — the same assumption the address bar makes.
-    static func webURL(from text: String) -> URL? {
-        let token = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !token.isEmpty else { return nil }
-        if token.contains("://") { return URL(string: token) }
-        return URL(string: "https://" + token)
-    }
-}
-
-/// Drags a clipboard entry out to another app, so reaching one costs a gesture rather than Reveal
-/// in Finder or a paste into a scratch window.
+/// Drags a clipboard entry out to another app.
 ///
-/// An overlay that tracks the gesture itself, like `WindowDragHandle`: the hosting view eats the
-/// click first, and SwiftUI's `onDrag` hands over an `NSItemProvider` with no say in the operation
-/// mask. That say is the point. Images live under `ClipboardStore.imagesDir` on the boot volume,
-/// where a same-volume drop defaults to a **move** — which would carry the blob out of the history
-/// and strand its row. An `NSDraggingSource` answers `.copy` and the entry stays.
+/// AppKit rather than SwiftUI's `onDrag`, which takes an `NSItemProvider` and cannot declare the
+/// operation mask. Images live under `imagesDir` on the boot volume, where a same-volume drop
+/// defaults to a move and would carry the blob out of the history. Only `NSDraggingSource` can
+/// answer `.copy`.
 struct ClipDragHandle: NSViewRepresentable {
-    let payload: ClipDragPayload
+    /// Read when the drag starts, not when the row draws: resolving it stats the file.
+    var payload: () -> ClipDragPayload?
     var onSelect: () -> Void
     var onActivate: () -> Void
     var onDropped: () -> Void
 
-    func makeNSView(context: Context) -> NSView { ClipDragView(payload: payload) }
+    func makeNSView(context: Context) -> NSView { ClipDragView() }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        guard let view = nsView as? ClipDragView else { return }
-        view.payload = payload
-        view.bind(onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
+        (nsView as? ClipDragView)?
+            .bind(payload: payload, onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
     }
 }
 
 extension View {
-    /// Marks a row as a drag source. The handle owns the press outright, so it takes the click and
-    /// the double click the row's own gestures used to answer.
+    /// The handle owns the press, so it answers the click and the double click too — a SwiftUI tap
+    /// gesture underneath it never sees either.
     func clipDraggable(
-        _ payload: ClipDragPayload,
+        payload: @escaping () -> ClipDragPayload?,
         onSelect: @escaping () -> Void,
         onActivate: @escaping () -> Void,
         onDropped: @escaping () -> Void
@@ -59,45 +38,35 @@ extension View {
     }
 }
 
-/// Claims mouse-down, then decides: past the slop it is a drag, otherwise it was the row's click.
 private final class ClipDragView: NSView, NSDraggingSource {
-    /// The slop AppKit itself allows before a press reads as a drag.
     private static let threshold: CGFloat = 4
-    /// The row thumbnail is already cached at this size, so the fallback costs no decode.
+    /// The row tile is already cached at this size, so the preview costs no decode.
     private static let previewPixel: CGFloat = 64
 
-    var payload: ClipDragPayload
+    private var payload: (() -> ClipDragPayload?)?
     private var onSelect: (() -> Void)?
     private var onActivate: (() -> Void)?
     private var onDropped: (() -> Void)?
 
-    init(payload: ClipDragPayload) {
-        self.payload = payload
-        super.init(frame: .zero)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError() }
-
     func bind(
-        onSelect: @escaping () -> Void, onActivate: @escaping () -> Void,
-        onDropped: @escaping () -> Void
+        payload: @escaping () -> ClipDragPayload?, onSelect: @escaping () -> Void,
+        onActivate: @escaping () -> Void, onDropped: @escaping () -> Void
     ) {
+        self.payload = payload
         self.onSelect = onSelect
         self.onActivate = onActivate
         self.onDropped = onDropped
     }
 
-    /// The row's own gestures never see this press, so the click they used to handle lands here.
+    /// Tracks the gesture itself, like `WindowDragHandle`: the hosting view eats the click first.
     override func mouseDown(with event: NSEvent) {
         guard let window else { return }
-        // On the press, not the release: a drag that starts must carry the row it started on.
         onSelect?()
         if event.clickCount == 2 {
             onActivate?()
             return
         }
-        // Deltas off `mouseLocation`, so no view or window coordinate conversion can drift.
+        // Deltas off `mouseLocation`, so no coordinate conversion can drift.
         let start = NSEvent.mouseLocation
         var passedThreshold = false
         window.trackEvents(
@@ -113,19 +82,27 @@ private final class ClipDragView: NSView, NSDraggingSource {
             passedThreshold = true
             stop.pointee = true
         }
-        guard passedThreshold else { return }
-        beginDrag(with: event)
+        guard passedThreshold, let payload = payload?() else { return }
+        beginDrag(payload, with: event)
     }
 
-    private func beginDrag(with event: NSEvent) {
-        let item = NSDraggingItem(pasteboardWriter: pasteboardWriter())
-        item.setDraggingFrame(bounds, contents: dragImage())
-        beginDraggingSession(with: [item], event: event, source: self)
+    private func beginDrag(_ payload: ClipDragPayload, with event: NSEvent) {
+        let image = dragImage(for: payload)
+        let item = NSDraggingItem(pasteboardWriter: pasteboardWriter(for: payload))
+        // Sized to the image and centred on the cursor; the row's shape would stretch a thumbnail.
+        let origin = convert(event.locationInWindow, from: nil)
+        item.setDraggingFrame(
+            NSRect(
+                x: origin.x - image.size.width / 2, y: origin.y - image.size.height / 2,
+                width: image.size.width, height: image.size.height),
+            contents: image)
+        let session = beginDraggingSession(with: [item], event: event, source: self)
+        // A refused drop flies back, so a drag that achieved nothing says so.
+        session.animatesToStartingPositionsOnCancelOrFail = true
     }
 
-    /// `NSURL` writes the file URL every receiver understands, from Finder to a browser upload.
     /// A link writes two types from one item, so the receiver takes whichever it reads.
-    private func pasteboardWriter() -> NSPasteboardWriting {
+    private func pasteboardWriter(for payload: ClipDragPayload) -> NSPasteboardWriting {
         switch payload {
         case .file(let url):
             return url as NSURL
@@ -139,38 +116,56 @@ private final class ClipDragView: NSView, NSDraggingSource {
         }
     }
 
-    /// The row as drawn, which is what SwiftUI's own drag preview shows and the only preview a text
-    /// row can have. Converting into the superview keeps a container larger than the row honest.
-    private func dragImage() -> NSImage? {
-        guard let host = superview else { return fallbackImage() }
-        let rect = convert(bounds, to: host)
-        guard !rect.isEmpty, let rep = host.bitmapImageRepForCachingDisplay(in: rect) else {
-            return fallbackImage()
+    /// Drawn, never snapshotted: SwiftUI renders into layers, so `cacheDisplay` on the row returns
+    /// a transparent bitmap and the drag carries nothing visible.
+    private func dragImage(for payload: ClipDragPayload) -> NSImage {
+        switch payload {
+        case .file(let url):
+            // Cache-only: a decode on mouse-down stalls the frame the drag begins on.
+            return ImageThumbnail.cached(url, maxPixel: Self.previewPixel)
+                ?? FilePreviewThumbnail.cached(url, maxPixel: Self.previewPixel)
+                ?? NSWorkspace.shared.icon(forFile: url.path)
+        case .link(_, let text), .text(let text):
+            return Self.textImage(text)
         }
-        host.cacheDisplay(in: rect, to: rep)
-        let image = NSImage(size: rect.size)
-        image.addRepresentation(rep)
-        return image
     }
 
-    /// Cache-only lookups: a decode on mouse-down would stall the frame the drag begins on.
-    private func fallbackImage() -> NSImage? {
-        guard case .file(let url) = payload else { return nil }
-        return ImageThumbnail.cached(url, maxPixel: Self.previewPixel)
-            ?? FilePreviewThumbnail.cached(url, maxPixel: Self.previewPixel)
-            ?? NSWorkspace.shared.icon(forFile: url.path)
+    private static func textImage(_ copy: String) -> NSImage {
+        let line = copy.replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+        let string = NSAttributedString(
+            string: String(line.prefix(60)),
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 12), .foregroundColor: NSColor.labelColor
+            ])
+        let inset = NSSize(width: 10, height: 6)
+        let text = string.size()
+        let size = NSSize(
+            width: min(text.width, 320) + inset.width * 2, height: text.height + inset.height * 2)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.controlBackgroundColor.withAlphaComponent(0.95).setFill()
+        NSBezierPath(
+            roundedRect: NSRect(origin: .zero, size: size),
+            xRadius: Theme.Radius.thumbnail, yRadius: Theme.Radius.thumbnail
+        ).fill()
+        string.draw(
+            in: NSRect(
+                x: inset.width, y: inset.height, width: size.width - inset.width * 2,
+                height: text.height))
+        image.unlockFocus()
+        return image
     }
 
     // MARK: - NSDraggingSource
 
-    /// Copy, always. The store owns the blob it hands out, and a move would delete it.
+    /// Copy, always: the store owns the blob it hands out, and a move would delete it.
     func draggingSession(
         _ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext
     ) -> NSDragOperation {
         .copy
     }
 
-    /// A drop that landed is a finished errand, so the palette gets out of the way like a paste.
     func draggingSession(
         _ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation
     ) {

--- a/Tinycast/Features/Clipboard/UI/ClipDrag.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipDrag.swift
@@ -1,8 +1,27 @@
 import AppKit
 import SwiftUI
 
-/// Drags a clipboard entry out as the file it already is, so an image reaches another app in one
-/// gesture rather than through Reveal in Finder.
+/// What a row hands to the app it is dropped on. The flavours are what receivers actually read:
+/// a file URL for anything on disk, a URL *and* its text for a link, plain text for the rest.
+enum ClipDragPayload: Equatable, Sendable {
+    /// The stored blob for an image, the referenced file for a `.file` entry.
+    case file(URL)
+    /// A browser wants `public.url`, a text field wants the string. Writing both serves either.
+    case link(URL, String)
+    case text(String)
+
+    /// A bare domain is still a link, and a browser rejects one without a scheme, so it gets
+    /// `https://` — the same assumption the address bar makes.
+    static func webURL(from text: String) -> URL? {
+        let token = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { return nil }
+        if token.contains("://") { return URL(string: token) }
+        return URL(string: "https://" + token)
+    }
+}
+
+/// Drags a clipboard entry out to another app, so reaching one costs a gesture rather than Reveal
+/// in Finder or a paste into a scratch window.
 ///
 /// An overlay that tracks the gesture itself, like `WindowDragHandle`: the hosting view eats the
 /// click first, and SwiftUI's `onDrag` hands over an `NSItemProvider` with no say in the operation
@@ -10,34 +29,32 @@ import SwiftUI
 /// where a same-volume drop defaults to a **move** — which would carry the blob out of the history
 /// and strand its row. An `NSDraggingSource` answers `.copy` and the entry stays.
 struct ClipDragHandle: NSViewRepresentable {
-    let url: URL
+    let payload: ClipDragPayload
     var onSelect: () -> Void
     var onActivate: () -> Void
     var onDropped: () -> Void
 
-    func makeNSView(context: Context) -> NSView { ClipDragView(url: url) }
+    func makeNSView(context: Context) -> NSView { ClipDragView(payload: payload) }
 
     func updateNSView(_ nsView: NSView, context: Context) {
         guard let view = nsView as? ClipDragView else { return }
-        view.url = url
+        view.payload = payload
         view.bind(onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
     }
 }
 
 extension View {
-    /// Marks a row as a drag source for `url`. A row without one keeps its SwiftUI gestures, so a
-    /// text entry behaves exactly as before.
+    /// Marks a row as a drag source. The handle owns the press outright, so it takes the click and
+    /// the double click the row's own gestures used to answer.
     func clipDraggable(
-        _ url: URL?,
+        _ payload: ClipDragPayload,
         onSelect: @escaping () -> Void,
         onActivate: @escaping () -> Void,
         onDropped: @escaping () -> Void
     ) -> some View {
         overlay {
-            if let url {
-                ClipDragHandle(
-                    url: url, onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
-            }
+            ClipDragHandle(
+                payload: payload, onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
         }
     }
 }
@@ -46,16 +63,16 @@ extension View {
 private final class ClipDragView: NSView, NSDraggingSource {
     /// The slop AppKit itself allows before a press reads as a drag.
     private static let threshold: CGFloat = 4
-    /// The row thumbnail is already cached at this size, so the preview costs no decode.
+    /// The row thumbnail is already cached at this size, so the fallback costs no decode.
     private static let previewPixel: CGFloat = 64
 
-    var url: URL
+    var payload: ClipDragPayload
     private var onSelect: (() -> Void)?
     private var onActivate: (() -> Void)?
     private var onDropped: (() -> Void)?
 
-    init(url: URL) {
-        self.url = url
+    init(payload: ClipDragPayload) {
+        self.payload = payload
         super.init(frame: .zero)
     }
 
@@ -100,16 +117,46 @@ private final class ClipDragView: NSView, NSDraggingSource {
         beginDrag(with: event)
     }
 
-    /// `NSURL` writes the file URL every receiver understands, from Finder to a browser upload.
     private func beginDrag(with event: NSEvent) {
-        let item = NSDraggingItem(pasteboardWriter: url as NSURL)
+        let item = NSDraggingItem(pasteboardWriter: pasteboardWriter())
         item.setDraggingFrame(bounds, contents: dragImage())
         beginDraggingSession(with: [item], event: event, source: self)
     }
 
+    /// `NSURL` writes the file URL every receiver understands, from Finder to a browser upload.
+    /// A link writes two types from one item, so the receiver takes whichever it reads.
+    private func pasteboardWriter() -> NSPasteboardWriting {
+        switch payload {
+        case .file(let url):
+            return url as NSURL
+        case .link(let url, let text):
+            let item = NSPasteboardItem()
+            item.setString(url.absoluteString, forType: .URL)
+            item.setString(text, forType: .string)
+            return item
+        case .text(let text):
+            return text as NSString
+        }
+    }
+
+    /// The row as drawn, which is what SwiftUI's own drag preview shows and the only preview a text
+    /// row can have. Converting into the superview keeps a container larger than the row honest.
+    private func dragImage() -> NSImage? {
+        guard let host = superview else { return fallbackImage() }
+        let rect = convert(bounds, to: host)
+        guard !rect.isEmpty, let rep = host.bitmapImageRepForCachingDisplay(in: rect) else {
+            return fallbackImage()
+        }
+        host.cacheDisplay(in: rect, to: rep)
+        let image = NSImage(size: rect.size)
+        image.addRepresentation(rep)
+        return image
+    }
+
     /// Cache-only lookups: a decode on mouse-down would stall the frame the drag begins on.
-    private func dragImage() -> NSImage {
-        ImageThumbnail.cached(url, maxPixel: Self.previewPixel)
+    private func fallbackImage() -> NSImage? {
+        guard case .file(let url) = payload else { return nil }
+        return ImageThumbnail.cached(url, maxPixel: Self.previewPixel)
             ?? FilePreviewThumbnail.cached(url, maxPixel: Self.previewPixel)
             ?? NSWorkspace.shared.icon(forFile: url.path)
     }

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -141,8 +141,7 @@ final class ClipboardCoordinator {
         AppLauncher.showInFinder(url)
     }
 
-    /// Nil when there is nothing to hand over, which only a vanished file is — reported by the HUD
-    /// rather than dragged out as a dead path, the same answer Reveal and Open give.
+    /// Nil only for a vanished file, which the HUD reports rather than hand over a dead path.
     func dragPayload(for item: ClipboardItem) -> ClipDragPayload? {
         let payload = item.dragPayload
         guard case .file = payload else { return payload }

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -141,6 +141,19 @@ final class ClipboardCoordinator {
         AppLauncher.showInFinder(url)
     }
 
+    /// Nil when there is nothing to hand over, which only a vanished file is — reported by the HUD
+    /// rather than dragged out as a dead path, the same answer Reveal and Open give.
+    func dragPayload(for item: ClipboardItem) -> ClipDragPayload? {
+        let payload = item.dragPayload
+        guard case .file = payload else { return payload }
+        return clipURL(for: item).map(ClipDragPayload.file)
+    }
+
+    /// A landed drop is a finished errand, so the palette leaves as it does after a paste.
+    func clipDropped() {
+        paletteCoordinator.hidePalette(restoreFocus: false)
+    }
+
     func openClip(_ item: ClipboardItem) {
         guard let url = clipURL(for: item) else { return }
         paletteCoordinator.hidePalette(restoreFocus: false)

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -118,7 +118,8 @@ struct ClipboardScreen: PaletteScreen {
                         if let index = rows.firstIndex(of: item) { vm.selection = index }
                         openActions()
                     },
-                    onDropped: { core.paletteCoordinator.hidePalette(restoreFocus: false) }
+                    onDragPayload: { core.clipboardCoordinator.dragPayload(for: $0) },
+                    onDropped: { core.clipboardCoordinator.clipDropped() }
                 )
                 .frame(width: metrics.size.clipboardListWidth)
                 Rectangle()

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -117,7 +117,8 @@ struct ClipboardScreen: PaletteScreen {
                     onActions: { item in
                         if let index = rows.firstIndex(of: item) { vm.selection = index }
                         openActions()
-                    }
+                    },
+                    onDropped: { core.paletteCoordinator.hidePalette(restoreFocus: false) }
                 )
                 .frame(width: metrics.size.clipboardListWidth)
                 Rectangle()

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -11,7 +11,8 @@ struct ClipboardList: View {
     let onSelect: (ClipboardItem) -> Void
     let onActivate: () -> Void
     let onActions: (ClipboardItem) -> Void
-    /// A dropped entry is a finished errand, so the palette leaves as it does after a paste.
+    /// Nil when the entry has nothing left to hand over, which is reported rather than dragged.
+    let onDragPayload: (ClipboardItem) -> ClipDragPayload?
     let onDropped: () -> Void
     @Environment(ClipboardStore.self) private var store
 
@@ -65,19 +66,13 @@ struct ClipboardList: View {
                             )
                             .selectionFrame(item.id == selectedID)
                             .contentShape(Rectangle())
-                            // Simultaneous gestures, and the light catcher: `.contextMenu` stalls.
-                            .onTapGesture { onSelect(item) }
-                            .simultaneousGesture(
-                                TapGesture(count: 2).onEnded {
-                                    onSelect(item)
-                                    onActivate()
-                                }
-                            )
+                            // The light catcher: `.contextMenu` stalls.
                             .onRightClick { onActions(item) }
-                            // Last, so the drag overlay sits above the right-click catcher and
-                            // claims the left button the gestures above no longer see.
+                            // Last, so it sits above the right-click catcher. It claims the left
+                            // button outright, which is why the click lives here and not in a tap
+                            // gesture underneath.
                             .clipDraggable(
-                                store.dragPayload(for: item),
+                                payload: { onDragPayload(item) },
                                 onSelect: { onSelect(item) },
                                 onActivate: {
                                     onSelect(item)

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -77,7 +77,7 @@ struct ClipboardList: View {
                             // Last, so the drag overlay sits above the right-click catcher and
                             // claims the left button the gestures above no longer see.
                             .clipDraggable(
-                                store.dragURL(for: item),
+                                store.dragPayload(for: item),
                                 onSelect: { onSelect(item) },
                                 onActivate: {
                                     onSelect(item)

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -68,9 +68,6 @@ struct ClipboardList: View {
                             .contentShape(Rectangle())
                             // The light catcher: `.contextMenu` stalls.
                             .onRightClick { onActions(item) }
-                            // Last, so it sits above the right-click catcher. It claims the left
-                            // button outright, which is why the click lives here and not in a tap
-                            // gesture underneath.
                             .clipDraggable(
                                 payload: { onDragPayload(item) },
                                 onSelect: { onSelect(item) },

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -11,6 +11,8 @@ struct ClipboardList: View {
     let onSelect: (ClipboardItem) -> Void
     let onActivate: () -> Void
     let onActions: (ClipboardItem) -> Void
+    /// A dropped entry is a finished errand, so the palette leaves as it does after a paste.
+    let onDropped: () -> Void
     @Environment(ClipboardStore.self) private var store
 
     private enum Row: Identifiable {
@@ -72,6 +74,17 @@ struct ClipboardList: View {
                                 }
                             )
                             .onRightClick { onActions(item) }
+                            // Last, so the drag overlay sits above the right-click catcher and
+                            // claims the left button the gestures above no longer see.
+                            .clipDraggable(
+                                store.dragURL(for: item),
+                                onSelect: { onSelect(item) },
+                                onActivate: {
+                                    onSelect(item)
+                                    onActivate()
+                                },
+                                onDropped: onDropped
+                            )
                         }
                     }
                 }

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -375,7 +375,9 @@ copy-only for the reverse reason: the path is the user's own file, and Tinycast 
 first.** The overlay owns the whole press: select on the way down, activate on a double click, and
 start the session once the pointer passes 4pt of slop. A press that stays inside the slop was a
 click, which is why the handle takes `onSelect` and `onActivate` instead of sitting beside a tap
-gesture that would never fire.
+gesture that would never fire. It declines the right button in `hitTest`, the mirror of what
+`RightClickCatcher` does with the left one — an overlay that answers every event would sit on top of
+the actions catcher and silently swallow the menu.
 
 **The payload resolves on mouse-down, not on every row render.**
 `ClipboardCoordinator.dragPayload` stats the file first, so a vanished one raises the HUD rather

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -354,3 +354,33 @@ Nothing ever autoplays — arrow-keying a list of twenty videos must not start t
 blob, a file already gone at export time is counted missing, and a restore drops a row whose path
 does not exist on this Mac — the same thing the Raycast import already does for an image path.
 Carrying file bytes would make a backup unbounded and defeat the point of referencing in place.
+
+## Dragging out
+
+An image or file row is a drag source for the file it already is (`ClipDrag.swift`), so reaching
+another app costs one gesture instead of Reveal in Finder and a second drag. `ClipboardStore.dragURL`
+is the payload rule and the whole of it: the stored blob for an image, the referenced path for a
+file, **nil for text** — a text row keeps its SwiftUI gestures untouched.
+
+**Copy, always — this is the reason the drag is AppKit and not `onDrag`.** `imagesDir` lives in
+Application Support, on the boot volume, which is the same volume as almost every drop target. A
+file-URL drag there defaults to a *move*, and a move carries the blob out of the history and strands
+its row. Only an `NSDraggingSource` can answer `sourceOperationMaskFor` at all, and `ClipDragView`
+answers `.copy` for every context. SwiftUI's `onDrag` takes an `NSItemProvider` and nothing else, so
+it cannot make that promise. A `.file` row is copy-only for the same reason turned outward: the path
+is the user's own file, and Tinycast must not move it out from under them.
+
+**It claims mouse-down, like `WindowDragHandle` does, because the hosting view eats the click
+first.** So the overlay owns the whole press: select on the way down, activate on a double click,
+and start the session once the pointer passes 4pt of slop. Below the slop nothing happened but a
+click, which is what the row's own `onTapGesture` used to do and why the handle takes `onSelect` and
+`onActivate` rather than sitting beside them.
+
+The drag preview is `cached` only, never `load` — a decode on mouse-down stalls the frame the drag
+begins on. The row tile is already warm at 64px, which is exactly what the preview asks for, and a
+miss falls through to the file's own icon.
+
+**A landed drop hides the palette**, the same ending a paste has, through `onDropped`. A cancelled
+drag (`operation == []`) leaves it up, because nothing was accomplished. The session outliving the
+panel is safe for the reason the player teardown above is delicate: `orderOut` leaves the SwiftUI
+tree mounted, and the pasteboard holds the URL from the moment the session begins.

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -357,30 +357,39 @@ Carrying file bytes would make a backup unbounded and defeat the point of refere
 
 ## Dragging out
 
-An image or file row is a drag source for the file it already is (`ClipDrag.swift`), so reaching
-another app costs one gesture instead of Reveal in Finder and a second drag. `ClipboardStore.dragURL`
-is the payload rule and the whole of it: the stored blob for an image, the referenced path for a
-file, **nil for text** — a text row keeps its SwiftUI gestures untouched.
+Every row is a drag source (`ClipDrag.swift`), so reaching another app costs one gesture instead of
+Reveal in Finder and a second drag. `ClipboardItem.dragPayload` says in what flavour: the file URL
+for an image or a referenced file, a URL and its text for a link, plain text for the rest. It is
+derived and never persisted, like `textForm` beside it, and `textForm` stays the one answer to
+whether an entry is a link, so the drag and the type filter cannot disagree.
+`QuicklinkDestination.detect` builds the URL rather than a second parser.
 
-**Copy, always — this is the reason the drag is AppKit and not `onDrag`.** `imagesDir` lives in
-Application Support, on the boot volume, which is the same volume as almost every drop target. A
-file-URL drag there defaults to a *move*, and a move carries the blob out of the history and strands
-its row. Only an `NSDraggingSource` can answer `sourceOperationMaskFor` at all, and `ClipDragView`
-answers `.copy` for every context. SwiftUI's `onDrag` takes an `NSItemProvider` and nothing else, so
-it cannot make that promise. A `.file` row is copy-only for the same reason turned outward: the path
-is the user's own file, and Tinycast must not move it out from under them.
+**Copy, always. That is why the drag is AppKit and not `onDrag`.** `imagesDir` lives in Application
+Support, on the boot volume, which is the same volume as almost every drop target. A file-URL drag
+there defaults to a move, and a move carries the blob out of the history and strands its row. Only
+an `NSDraggingSource` can answer `sourceOperationMaskFor`, and `ClipDragView` answers `.copy` for
+every context. SwiftUI's `onDrag` takes an `NSItemProvider` and nothing else. A `.file` row is
+copy-only for the reverse reason: the path is the user's own file, and Tinycast must not move it.
 
 **It claims mouse-down, like `WindowDragHandle` does, because the hosting view eats the click
-first.** So the overlay owns the whole press: select on the way down, activate on a double click,
-and start the session once the pointer passes 4pt of slop. Below the slop nothing happened but a
-click, which is what the row's own `onTapGesture` used to do and why the handle takes `onSelect` and
-`onActivate` rather than sitting beside them.
+first.** The overlay owns the whole press: select on the way down, activate on a double click, and
+start the session once the pointer passes 4pt of slop. A press that stays inside the slop was a
+click, which is why the handle takes `onSelect` and `onActivate` instead of sitting beside a tap
+gesture that would never fire.
 
-The drag preview is `cached` only, never `load` — a decode on mouse-down stalls the frame the drag
-begins on. The row tile is already warm at 64px, which is exactly what the preview asks for, and a
-miss falls through to the file's own icon.
+**The payload resolves on mouse-down, not on every row render.**
+`ClipboardCoordinator.dragPayload` stats the file first, so a vanished one raises the HUD rather
+than handing another app a dead path, the same answer Reveal and Open give. That is one stat per
+drag instead of one per row per frame.
 
-**A landed drop hides the palette**, the same ending a paste has, through `onDropped`. A cancelled
-drag (`operation == []`) leaves it up, because nothing was accomplished. The session outliving the
-panel is safe for the reason the player teardown above is delicate: `orderOut` leaves the SwiftUI
-tree mounted, and the pasteboard holds the URL from the moment the session begins.
+**Previews are drawn, never snapshotted.** SwiftUI renders into layers, so `cacheDisplay` on the row
+returns a transparent bitmap and the drag carries nothing the eye can follow. A file uses the row
+tile, `cached` only and never `load`, because a decode on mouse-down stalls the frame the drag
+begins on. A link or a copy gets a drawn text tile. The dragging frame is sized to that image and
+centred on the cursor, since the row's own shape would stretch a thumbnail.
+
+**A landed drop hides the palette**, the ending a paste has, through `clipDropped()`. A cancelled
+drag leaves it up and animates back to the row it came from, so a drag that achieved nothing says
+so. The session outliving the panel is safe for the reason the player teardown above is delicate:
+`orderOut` leaves the SwiftUI tree mounted, and the pasteboard holds the payload from the moment the
+session begins.


### PR DESCRIPTION
## Related issue

Closes #544

## What changed

A clipboard row is now a drag source. Press, move four points, and the entry goes to whatever is under the cursor: an image or file as a file URL, a link as `public.url` plus its string, plain text as a string.

The one non-obvious thing is copy versus move. `imagesDir` sits in Application Support on the boot volume, which is the same volume as almost every drop target, so a file-URL drop there defaults to a move. That carries the blob out of the history and leaves the row pointing at nothing. Only `NSDraggingSource` can answer `sourceOperationMaskFor` with `.copy`, and SwiftUI's `onDrag` takes an `NSItemProvider` and nothing else. So `ClipDragHandle` is an AppKit overlay that tracks the gesture itself, the same shape as `WindowDragHandle`.

The overlay claims the left button outright, so it answers the click and the double click too. The row's `onTapGesture` and its double-tap `simultaneousGesture` are deleted rather than left underneath, where they would never fire.

It reuses what is there rather than adding vocabulary:

- `textForm` still decides what counts as a link, so the drag and the type filter cannot disagree.
- `QuicklinkDestination.detect` builds the URL.
- `ClipboardCoordinator.dragPayload(for:)` stats the file first, so a vanished one raises the HUD instead of handing another app a dead path.
- The preview is drawn, not snapshotted. SwiftUI renders into layers, so `cacheDisplay` on the row returns a transparent bitmap. A file uses the thumbnail already cached at 64 px, a link or text gets a drawn tile.

One commit is unrelated to the feature. `ClipboardStore.search` had a bare `prefix(_:)` inside a `+` chain, which the Command Line Tools Swift 6.2.1 type checker resolves to the `Sequence` overload and then fails the whole expression. Spelling out `Array(...)` fixes it and changes no behavior. Without it four harnesses cannot compile outside Xcode.

## Memory footprint

Not measured. There is no Xcode on the machine this was written on, so there is no Instruments run and no leak test.

What the code does allocate: one `NSView` per visible row, and one `NSImage` per drag that lives for the length of the gesture. The file preview reads the thumbnail cache only and never decodes on mouse-down. Nothing is retained after `draggingSession(_:endedAt:operation:)` returns.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested: no

## Demo

Not recorded yet.

## Drawbacks

- The overlay owns the left button for the whole row. Any future left-click gesture on a clipboard row has to go through `clipDraggable` instead of a SwiftUI gesture.
- The drag preview is drawn rather than a copy of the row, so it does not match the row pixel for pixel.
- A drop that lands hides the palette, the same as a paste. A cancelled drag leaves it up.
- `.copy` is returned for every context, including inside the app. There is no in-app drop target today.

## Tests & validation

`Scripts/run-tests.sh`, all 68 harnesses pass. Three of them glob `Clipboard/Model/*.swift` and now compile `ClipDragPayload.swift`, so the script passes `QuicklinkDestination.swift` alongside them. No cases were added.

SwiftLint and the purity grep are clean. `docs/features/clipboard.md` has a "Dragging out" section.

By hand, against a local build: dragging an image into Finder and into a browser. Links, text, and the drawn previews are not yet hand-tested.
