### PR TITLE
Scale the palette with an Interface Size setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,8 @@ feature's doc, under its own `## Invariants`.
   control, so it must never be able to force a change on a launcher surface.
   **Duplicating a view or a piece of layout maths to keep it here is the correct trade**, and the one
   place the no-duplication rule yields. What *is* shared: `Theme`'s base tokens (spacing, radius,
-  colour), `PopoverMenuItem` as a data shape, and `Platform/`. What is never shared: anything with
+  colour), `InterfaceMetrics` as the view over those same base tokens, `PopoverMenuItem` as a data
+  shape, and `Platform/`. What is never shared: anything with
   "how an extension looks or moves" in it. `ExtensionActionsPanel` and `ExtensionGridGeometry` exist
   precisely because the palette's own menu and the emoji grid must stay free to change without them.
 - **`AppEntry.Kind` is the only thing that says what an entry is.** One case per launcher section and

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -158,9 +158,17 @@ run palette-selection-test Tinycast/Features/PaletteRowIndex.swift \
                            Tinycast/Features/Emoji/Model/EmojiGridGeometry.swift
 run appearance-test        Tinycast/Platform/Appearance.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
                            Tinycast/Features/Settings/AppAppearance.swift
+run interface-size-test    Tinycast/Platform/Appearance.swift \
+                           Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
+                           Tinycast/Features/Settings/InterfaceSize.swift \
+                           Tinycast/Features/Extensions/Model/ExtensionFormMetrics.swift
 run palette-placement-test Tinycast/Platform/Appearance.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
+                           Tinycast/Features/Settings/InterfaceSize.swift \
                            Tinycast/Palette/PalettePlacement.swift
 run scroll-reveal-test     Tinycast/DesignSystem/Scrolling/SelectionReveal.swift
 run redaction-test         Tinycast/DesignSystem/RedactedPlaceholder.swift
@@ -231,6 +239,7 @@ run hotkey-test            Tinycast/Features/HotKeys/Model/DoubleTapModifier.swi
                            Tinycast/Features/WindowManagement/Model/WindowCommand.swift
 run callout-test           Tinycast/Platform/Appearance.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
                            Tinycast/Features/HotKeys/UI/CalloutPlacement.swift
 run icon-cache-test        Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift
@@ -241,6 +250,7 @@ run ext-icon-test          Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift \
                            Tinycast/Platform/Compression/Zlib.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
                            Tinycast/Features/Extensions/Model/ExtensionBootConfig.swift \
                            Tinycast/Features/Extensions/Model/ExtensionLaunchType.swift \
                            Tinycast/Features/Extensions/Model/ExtensionManifest.swift \
@@ -301,6 +311,7 @@ run notes-test             Tinycast/Platform/Signposts.swift \
 run notes-editor-test      Tinycast/Platform/Signposts.swift \
                            Tinycast/Platform/Appearance.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
                            Tinycast/Features/TextInjection/Service/InjectableTextView.swift \
                            Tinycast/Features/Notes/Model/NoteDocument.swift \
                            Tinycast/Features/Notes/UI/NoteTextView.swift \
@@ -349,6 +360,7 @@ run slow ext-test          -parse-as-library \
                            Tinycast/Platform/Appearance.swift \
                            Tinycast/Platform/Images/IconCache.swift \
                            Tinycast/DesignSystem/Theme.swift \
+                           Tinycast/DesignSystem/InterfaceMetrics.swift \
                            $E/Model/ExtensionBootConfig.swift \
                            $E/Model/ExtensionLaunchType.swift \
                            $E/Model/ExtensionFormField.swift \

--- a/Tests/ext-form-test.swift
+++ b/Tests/ext-form-test.swift
@@ -96,40 +96,40 @@ struct ExtensionFormTests {
     static func popoverGeometry() {
         print("\n# popover geometry")
 
-        let pitch = ExtensionFormMetrics.popoverRowHeight + ExtensionFormMetrics.popoverRowSpacing
+        let pitch = ExtensionFormMetrics.base.popoverRowHeight + ExtensionFormMetrics.base.popoverRowSpacing
         check(
             "three rows measure exactly three rows",
-            ExtensionFormMetrics.popoverListHeight(rows: 3)
-                == pitch * 3 - ExtensionFormMetrics.popoverRowSpacing)
-        check("no rows measure nothing", ExtensionFormMetrics.popoverListHeight(rows: 0) == 0)
+            ExtensionFormMetrics.base.popoverListHeight(rows: 3)
+                == pitch * 3 - ExtensionFormMetrics.base.popoverRowSpacing)
+        check("no rows measure nothing", ExtensionFormMetrics.base.popoverListHeight(rows: 0) == 0)
         check(
             "a long list caps at the visible rows",
-            ExtensionFormMetrics.popoverListHeight(rows: 40)
-                == ExtensionFormMetrics.popoverRowsMaxHeight)
+            ExtensionFormMetrics.base.popoverListHeight(rows: 40)
+                == ExtensionFormMetrics.base.popoverRowsMaxHeight)
         check(
             "the cap is a half row, so it reads as scrollable",
-            ExtensionFormMetrics.popoverVisibleRows
-                != ExtensionFormMetrics.popoverVisibleRows
+            ExtensionFormMetrics.base.popoverVisibleRows
+                != ExtensionFormMetrics.base.popoverVisibleRows
                 .rounded())
         check(
             "a search row adds its own height",
-            ExtensionFormMetrics.popoverHeight(rows: 3, hasSearchField: true)
-                - ExtensionFormMetrics.popoverHeight(rows: 3, hasSearchField: false)
-                == ExtensionFormMetrics.popoverSearchHeight)
+            ExtensionFormMetrics.base.popoverHeight(rows: 3, hasSearchField: true)
+                - ExtensionFormMetrics.base.popoverHeight(rows: 3, hasSearchField: false)
+                == ExtensionFormMetrics.base.popoverSearchHeight)
         check(
             "a section heading takes room of its own",
-            ExtensionFormMetrics.popoverListHeight(rows: 4, headers: 2)
-                - ExtensionFormMetrics.popoverListHeight(rows: 4)
-                == (ExtensionFormMetrics.popoverSectionHeaderHeight
-                    + ExtensionFormMetrics.popoverRowSpacing) * 2)
+            ExtensionFormMetrics.base.popoverListHeight(rows: 4, headers: 2)
+                - ExtensionFormMetrics.base.popoverListHeight(rows: 4)
+                == (ExtensionFormMetrics.base.popoverSectionHeaderHeight
+                    + ExtensionFormMetrics.base.popoverRowSpacing) * 2)
         check(
             "and a headed list still caps at the visible rows",
-            ExtensionFormMetrics.popoverListHeight(rows: 40, headers: 6)
-                == ExtensionFormMetrics.popoverRowsMaxHeight)
+            ExtensionFormMetrics.base.popoverListHeight(rows: 40, headers: 6)
+                == ExtensionFormMetrics.base.popoverRowsMaxHeight)
         check(
             "an empty list still measures the row it draws, since the panel is sized to this",
-            ExtensionFormMetrics.popoverHeight(rows: 0, hasSearchField: false)
-                == ExtensionFormMetrics.popoverRowHeight + ExtensionFormMetrics.popoverPadding * 2)
+            ExtensionFormMetrics.base.popoverHeight(rows: 0, hasSearchField: false)
+                == ExtensionFormMetrics.base.popoverRowHeight + ExtensionFormMetrics.base.popoverPadding * 2)
     }
 
     static func popoverPlacement() {
@@ -137,30 +137,30 @@ struct ExtensionFormTests {
 
         let control = CGRect(x: 0, y: 100, width: 360, height: 32)
 
-        let below = ExtensionFormMetrics.placement(
+        let below = ExtensionFormMetrics.base.placement(
             anchor: control, popoverHeight: 200, containerHeight: 600)
         check("it opens downward when there is room", !below.flipped)
         check(
             "and sits one gap under the control",
-            below.y == control.maxY + ExtensionFormMetrics.popoverGap)
+            below.y == control.maxY + ExtensionFormMetrics.base.popoverGap)
 
         // A control near the bottom of a tall form: no room under it, plenty over it.
         let low = CGRect(x: 0, y: 500, width: 360, height: 32)
-        let above = ExtensionFormMetrics.placement(
+        let above = ExtensionFormMetrics.base.placement(
             anchor: low, popoverHeight: 200, containerHeight: 600)
         check("it flips up when the bottom would cut it off", above.flipped)
         check(
             "and sits one gap over the control",
-            above.y == low.minY - ExtensionFormMetrics.popoverGap - 200)
+            above.y == low.minY - ExtensionFormMetrics.base.popoverGap - 200)
 
         // Taller than the container either way; showing its start beats showing its middle.
-        let cramped = ExtensionFormMetrics.placement(
+        let cramped = ExtensionFormMetrics.base.placement(
             anchor: low, popoverHeight: 500, containerHeight: 300)
         check("a list taller than the form still starts on screen", cramped.y >= 0)
         check("and does not claim to have flipped", !cramped.flipped)
 
         // Exactly enough room below is still room: the rule may not flip on a tie.
-        let exact = ExtensionFormMetrics.placement(
+        let exact = ExtensionFormMetrics.base.placement(
             anchor: control, popoverHeight: 100, containerHeight: 238)
         check("a list that exactly fits opens downward", !exact.flipped)
     }

--- a/Tests/interface-size-test.swift
+++ b/Tests/interface-size-test.swift
@@ -1,0 +1,292 @@
+import AppKit
+import SwiftUI
+
+/// Against the real `Theme`, so `.standard` can never drift from what the app ships today.
+@main
+@MainActor
+struct InterfaceSizeTests {
+    static var failures = 0
+    static var passes = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if condition() {
+            passes += 1
+        } else {
+            failures += 1
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func expect(_ actual: CGFloat, _ expected: CGFloat, _ message: String) {
+        expect(abs(actual - expected) < 0.001, "\(message) — got \(actual), want \(expected)")
+    }
+
+    static func main() {
+        theDefaultIsThemeVerbatim()
+        fontsKeepTheirFace()
+        everySizeRounds()
+        sizesGrow()
+        derivationsHold()
+        theEnumIsWellFormed()
+
+        print("\(passes) passed, \(failures) failed")
+        if failures > 0 { exit(1) }
+    }
+
+    // MARK: - Identity at the default size
+
+    /// Every member, so a mistyped `Theme` reference in `InterfaceMetrics` cannot ship silently.
+    static func theDefaultIsThemeVerbatim() {
+        let m = InterfaceMetrics.standard
+        expect(m.scale, 1, "the default scale is 1")
+
+        expect(m.spacing.xxs, Theme.Spacing.xxs, "spacing.xxs")
+        expect(m.spacing.xs, Theme.Spacing.xs, "spacing.xs")
+        expect(m.spacing.sm, Theme.Spacing.sm, "spacing.sm")
+        expect(m.spacing.md, Theme.Spacing.md, "spacing.md")
+        expect(m.spacing.lg, Theme.Spacing.lg, "spacing.lg")
+        expect(m.spacing.xl, Theme.Spacing.xl, "spacing.xl")
+        expect(m.spacing.xxl, Theme.Spacing.xxl, "spacing.xxl")
+        expect(m.spacing.xxxl, Theme.Spacing.xxxl, "spacing.xxxl")
+        expect(
+            m.spacing.sectionHeaderBottom, Theme.Spacing.sectionHeaderBottom,
+            "spacing.sectionHeaderBottom")
+        expect(m.spacing.sectionSpacing, Theme.Spacing.sectionSpacing, "spacing.sectionSpacing")
+        expect(
+            m.spacing.chatTranscriptBottom, Theme.Spacing.chatTranscriptBottom,
+            "spacing.chatTranscriptBottom")
+        expect(
+            m.spacing.chatFollowTailSlack, Theme.Spacing.chatFollowTailSlack,
+            "spacing.chatFollowTailSlack")
+
+        expect(m.radius.panel, Theme.Radius.panel, "radius.panel")
+        expect(m.radius.row, Theme.Radius.row, "radius.row")
+        expect(m.radius.menu, Theme.Radius.menu, "radius.menu")
+        expect(m.radius.menuRow, Theme.Radius.menuRow, "radius.menuRow")
+        expect(m.radius.barControl, Theme.Radius.barControl, "radius.barControl")
+        expect(m.radius.menuPanel, Theme.Radius.menuPanel, "radius.menuPanel")
+        expect(m.radius.dialog, Theme.Radius.dialog, "radius.dialog")
+        expect(m.radius.thumbnail, Theme.Radius.thumbnail, "radius.thumbnail")
+        expect(m.radius.glyph, Theme.Radius.glyph, "radius.glyph")
+        expect(m.radius.attachmentChip, Theme.Radius.attachmentChip, "radius.attachmentChip")
+        expect(m.radius.card, Theme.Radius.card, "radius.card")
+        expect(m.radius.keyCap, Theme.Radius.keyCap, "radius.keyCap")
+
+        expect(m.size.panelWidth, Theme.Size.panelWidth, "size.panelWidth")
+        expect(m.size.panelHeight, Theme.Size.panelHeight, "size.panelHeight")
+        expect(m.size.headerHeight, Theme.Size.headerHeight, "size.headerHeight")
+        expect(m.size.headerIconSlot, Theme.Size.headerIconSlot, "size.headerIconSlot")
+        expect(m.size.headerPadding, Theme.Size.headerPadding, "size.headerPadding")
+        expect(m.size.compactHeight, Theme.Size.compactHeight, "size.compactHeight")
+        expect(m.size.bottomBarHeight, Theme.Size.bottomBarHeight, "size.bottomBarHeight")
+        expect(m.size.barButtonHeight, Theme.Size.barButtonHeight, "size.barButtonHeight")
+        expect(m.size.rowIcon, Theme.Size.rowIcon, "size.rowIcon")
+        expect(m.size.keyCap, Theme.Size.keyCap, "size.keyCap")
+        expect(m.size.compactKeyCap, Theme.Size.compactKeyCap, "size.compactKeyCap")
+        expect(m.size.heroKeyCap, Theme.Size.heroKeyCap, "size.heroKeyCap")
+        expect(m.size.menuButton, Theme.Size.menuButton, "size.menuButton")
+        expect(m.size.checkbox, Theme.Size.checkbox, "size.checkbox")
+        expect(m.size.menuWidth, Theme.Size.menuWidth, "size.menuWidth")
+        expect(
+            m.size.clipboardFilterMenuWidth, Theme.Size.clipboardFilterMenuWidth,
+            "size.clipboardFilterMenuWidth")
+        expect(m.size.menuIcon, Theme.Size.menuIcon, "size.menuIcon")
+        expect(m.size.menuBrandIcon, Theme.Size.menuBrandIcon, "size.menuBrandIcon")
+        expect(m.size.barBrandIcon, Theme.Size.barBrandIcon, "size.barBrandIcon")
+        expect(m.size.menuRowSpacing, Theme.Size.menuRowSpacing, "size.menuRowSpacing")
+        expect(m.size.menuSectionHeader, Theme.Size.menuSectionHeader, "size.menuSectionHeader")
+        expect(m.size.menuRowHeight, Theme.Size.menuRowHeight, "size.menuRowHeight")
+        expect(m.size.menuRowsMaxHeight, Theme.Size.menuRowsMaxHeight, "size.menuRowsMaxHeight")
+        expect(m.size.clipboardListWidth, Theme.Size.clipboardListWidth, "size.clipboardListWidth")
+        expect(
+            m.size.clipboardMediaHeight, Theme.Size.clipboardMediaHeight, "size.clipboardMediaHeight")
+        expect(
+            m.size.clipboardPreviewPixel, Theme.Size.clipboardPreviewPixel,
+            "size.clipboardPreviewPixel")
+        expect(m.size.emojiCell, Theme.Size.emojiCell, "size.emojiCell")
+        expect(m.size.formLabelWidth, Theme.Size.formLabelWidth, "size.formLabelWidth")
+        expect(m.size.argumentPromptWidth, Theme.Size.argumentPromptWidth, "size.argumentPromptWidth")
+        expect(m.size.markdownListMarker, Theme.Size.markdownListMarker, "size.markdownListMarker")
+        expect(m.size.markdownQuoteBar, Theme.Size.markdownQuoteBar, "size.markdownQuoteBar")
+        expect(m.size.chatMessageAction, Theme.Size.chatMessageAction, "size.chatMessageAction")
+        expect(m.size.chatImageThumb, Theme.Size.chatImageThumb, "size.chatImageThumb")
+        expect(m.size.chatAttachmentGlyph, Theme.Size.chatAttachmentGlyph, "size.chatAttachmentGlyph")
+        expect(m.size.chatAttachmentThumb, Theme.Size.chatAttachmentThumb, "size.chatAttachmentThumb")
+        expect(
+            m.size.chatAttachmentRemove, Theme.Size.chatAttachmentRemove, "size.chatAttachmentRemove")
+        expect(m.size.chatAttachmentInset, Theme.Size.chatAttachmentInset, "size.chatAttachmentInset")
+        expect(m.size.quickActionPanel, Theme.Size.quickActionPanel, "size.quickActionPanel")
+        expect(
+            m.size.quickActionHeaderIcon, Theme.Size.quickActionHeaderIcon,
+            "size.quickActionHeaderIcon")
+        expect(
+            m.size.quickActionScrollFade, Theme.Size.quickActionScrollFade,
+            "size.quickActionScrollFade")
+        expect(m.size.quickActionPanelBody, Theme.Size.quickActionPanelBody, "size.quickActionPanelBody")
+        expect(
+            m.size.quickActionPanelMinBody, Theme.Size.quickActionPanelMinBody,
+            "size.quickActionPanelMinBody")
+        expect(m.size.dialogWidth, Theme.Size.dialogWidth, "size.dialogWidth")
+        expect(m.size.dialogIcon, Theme.Size.dialogIcon, "size.dialogIcon")
+        expect(m.size.hudMaxWidth, Theme.Size.hudMaxWidth, "size.hudMaxWidth")
+        expect(m.size.hudWidth, Theme.Size.hudWidth, "size.hudWidth")
+        expect(m.size.hudHeight, Theme.Size.hudHeight, "size.hudHeight")
+        expect(m.size.volumeTrackHeight, Theme.Size.volumeTrackHeight, "size.volumeTrackHeight")
+        expect(m.size.volumeKnob, Theme.Size.volumeKnob, "size.volumeKnob")
+        expect(m.size.volumeReadout, Theme.Size.volumeReadout, "size.volumeReadout")
+
+        expect(m.typography.searchFieldSize, Theme.Typography.searchFieldSize, "typography.searchField")
+        expect(
+            m.typography.searchFieldNSFont == Theme.Typography.searchFieldNSFont,
+            "typography.searchFieldNSFont is the Theme font itself")
+        expect(
+            m.typography.chipNSFont == Theme.Typography.chipNSFont,
+            "typography.chipNSFont is the Theme font itself")
+
+        // Extensions duplicates the mechanism rather than importing it, so it is checked here too.
+        expect(ExtensionFormMetrics.base.scale, 1, "the form metrics base is unscaled")
+    }
+
+    // MARK: - Fonts
+
+    /// `.headline` is Bold and `.caption2` Medium: a size-and-weight rebuild would lighten both.
+    static func fontsKeepTheirFace() {
+        for size in InterfaceSize.allCases {
+            let metrics = size.metrics
+            for style in [NSFont.TextStyle.body, .callout, .subheadline, .headline, .caption2] {
+                let base = NSFont.preferredFont(forTextStyle: style)
+                let scaled = NSFont(
+                    descriptor: base.fontDescriptor,
+                    size: (base.pointSize * size.scale).rounded())
+                expect(scaled != nil, "\(style.rawValue) rebuilds from its own descriptor")
+                expect(
+                    scaled?.familyName == base.familyName,
+                    "\(style.rawValue) keeps its family at \(size.rawValue)")
+                expect(
+                    scaled?.fontName == base.fontName,
+                    "\(style.rawValue) keeps its face at \(size.rawValue)")
+            }
+            expect(
+                metrics.typography.searchFieldSize
+                    == (Theme.Typography.searchFieldSize * size.scale).rounded(),
+                "the search field's stated size scales at \(size.rawValue)")
+        }
+    }
+
+    // MARK: - Rounding and growth
+
+    static func everySizeRounds() {
+        for size in InterfaceSize.allCases {
+            let m = size.metrics
+            for (name, value) in lengths(m) {
+                expect(
+                    value == value.rounded(),
+                    "\(name) lands on a whole point at \(size.rawValue) — got \(value)")
+            }
+        }
+    }
+
+    /// Weakly, not strictly: a 2pt gap rounds to 2 at 1.1, which is the only way to draw it.
+    static func sizesGrow() {
+        let ordered = [InterfaceSize.standard, .large, .larger]
+        for (smaller, larger) in zip(ordered, ordered.dropFirst()) {
+            let a = lengths(smaller.metrics)
+            let b = lengths(larger.metrics)
+            for (index, entry) in a.enumerated() {
+                expect(
+                    b[index].1 >= entry.1,
+                    "\(entry.0) never shrinks from \(smaller.rawValue) to \(larger.rawValue)")
+            }
+            expect(
+                larger.metrics.size.panelWidth > smaller.metrics.size.panelWidth,
+                "the panel is wider at \(larger.rawValue)")
+            expect(smaller.scale < larger.scale, "\(larger.rawValue) scales further")
+        }
+    }
+
+    /// A derived token composes scaled parts; scaling the result would disagree by a point.
+    static func derivationsHold() {
+        for size in InterfaceSize.allCases {
+            let m = size.metrics
+            expect(
+                m.size.compactHeight, m.size.headerHeight + m.size.headerPadding * 2,
+                "the compact bar is the header in symmetric slack at \(size.rawValue)")
+            expect(
+                m.size.menuRowHeight, m.size.menuIcon + m.spacing.md * 2,
+                "a menu row is its glyph slot plus breathing room at \(size.rawValue)")
+
+            let form = ExtensionFormMetrics(scale: size.scale)
+            expect(
+                form.popoverRowsMaxHeight
+                    == (form.popoverVisibleRows * (form.popoverRowHeight + form.popoverRowSpacing))
+                    .rounded(),
+                "a form popover still caps on a whole row at \(size.rawValue)")
+        }
+    }
+
+    static func theEnumIsWellFormed() {
+        expect(InterfaceSize.standard.scale == 1, "the default size changes nothing")
+        expect(InterfaceSize(rawValue: "huge") == nil, "an unknown raw value is rejected")
+        expect(
+            InterfaceSize.allCases.count == Set(InterfaceSize.allCases.map(\.title)).count,
+            "every size has its own title")
+    }
+
+    /// Every scalable length, paired with its name, so one loop covers rounding and growth.
+    static func lengths(_ m: InterfaceMetrics) -> [(String, CGFloat)] {
+        [
+            ("spacing.xxs", m.spacing.xxs), ("spacing.xs", m.spacing.xs),
+            ("spacing.sm", m.spacing.sm), ("spacing.md", m.spacing.md),
+            ("spacing.lg", m.spacing.lg), ("spacing.xl", m.spacing.xl),
+            ("spacing.xxl", m.spacing.xxl), ("spacing.xxxl", m.spacing.xxxl),
+            ("spacing.sectionHeaderBottom", m.spacing.sectionHeaderBottom),
+            ("spacing.sectionSpacing", m.spacing.sectionSpacing),
+            ("spacing.chatTranscriptBottom", m.spacing.chatTranscriptBottom),
+            ("spacing.chatFollowTailSlack", m.spacing.chatFollowTailSlack),
+            ("radius.panel", m.radius.panel), ("radius.row", m.radius.row),
+            ("radius.menu", m.radius.menu), ("radius.menuRow", m.radius.menuRow),
+            ("radius.barControl", m.radius.barControl), ("radius.menuPanel", m.radius.menuPanel),
+            ("radius.dialog", m.radius.dialog), ("radius.thumbnail", m.radius.thumbnail),
+            ("radius.glyph", m.radius.glyph), ("radius.attachmentChip", m.radius.attachmentChip),
+            ("radius.card", m.radius.card), ("radius.keyCap", m.radius.keyCap),
+            ("size.panelWidth", m.size.panelWidth), ("size.panelHeight", m.size.panelHeight),
+            ("size.headerHeight", m.size.headerHeight),
+            ("size.headerIconSlot", m.size.headerIconSlot),
+            ("size.headerPadding", m.size.headerPadding),
+            ("size.compactHeight", m.size.compactHeight),
+            ("size.bottomBarHeight", m.size.bottomBarHeight),
+            ("size.barButtonHeight", m.size.barButtonHeight), ("size.rowIcon", m.size.rowIcon),
+            ("size.keyCap", m.size.keyCap), ("size.compactKeyCap", m.size.compactKeyCap),
+            ("size.heroKeyCap", m.size.heroKeyCap), ("size.menuButton", m.size.menuButton),
+            ("size.checkbox", m.size.checkbox), ("size.menuWidth", m.size.menuWidth),
+            ("size.clipboardFilterMenuWidth", m.size.clipboardFilterMenuWidth),
+            ("size.menuIcon", m.size.menuIcon), ("size.menuBrandIcon", m.size.menuBrandIcon),
+            ("size.barBrandIcon", m.size.barBrandIcon),
+            ("size.menuSectionHeader", m.size.menuSectionHeader),
+            ("size.menuRowHeight", m.size.menuRowHeight),
+            ("size.menuRowsMaxHeight", m.size.menuRowsMaxHeight),
+            ("size.clipboardListWidth", m.size.clipboardListWidth),
+            ("size.clipboardMediaHeight", m.size.clipboardMediaHeight),
+            ("size.emojiCell", m.size.emojiCell), ("size.formLabelWidth", m.size.formLabelWidth),
+            ("size.argumentPromptWidth", m.size.argumentPromptWidth),
+            ("size.markdownListMarker", m.size.markdownListMarker),
+            ("size.markdownQuoteBar", m.size.markdownQuoteBar),
+            ("size.chatMessageAction", m.size.chatMessageAction),
+            ("size.chatImageThumb", m.size.chatImageThumb),
+            ("size.chatAttachmentGlyph", m.size.chatAttachmentGlyph),
+            ("size.chatAttachmentThumb", m.size.chatAttachmentThumb),
+            ("size.chatAttachmentRemove", m.size.chatAttachmentRemove),
+            ("size.chatAttachmentInset", m.size.chatAttachmentInset),
+            ("size.quickActionPanel", m.size.quickActionPanel),
+            ("size.quickActionHeaderIcon", m.size.quickActionHeaderIcon),
+            ("size.quickActionScrollFade", m.size.quickActionScrollFade),
+            ("size.quickActionPanelBody", m.size.quickActionPanelBody),
+            ("size.quickActionPanelMinBody", m.size.quickActionPanelMinBody),
+            ("size.dialogWidth", m.size.dialogWidth), ("size.dialogIcon", m.size.dialogIcon),
+            ("size.hudMaxWidth", m.size.hudMaxWidth), ("size.hudWidth", m.size.hudWidth),
+            ("size.hudHeight", m.size.hudHeight),
+            ("size.volumeTrackHeight", m.size.volumeTrackHeight),
+            ("size.volumeKnob", m.size.volumeKnob), ("size.volumeReadout", m.size.volumeReadout)
+        ]
+    }
+}

--- a/Tests/palette-placement-test.swift
+++ b/Tests/palette-placement-test.swift
@@ -8,9 +8,10 @@ struct PalettePlacementTests {
     static var failures = 0
     static var passes = 0
 
-    // Exactly what `PaletteWindowController` passes.
-    static let width = Theme.Size.panelWidth
-    static let graspable = CGSize(width: width, height: Theme.Size.compactHeight)
+    // Exactly what `PaletteWindowController` passes, at the size the user picked.
+    static let metrics = InterfaceMetrics.standard
+    static let width = metrics.size.panelWidth
+    static let graspable = CGSize(width: width, height: metrics.size.compactHeight)
     static let minimumVisible = Theme.Size.paletteMinimumVisible
     static let snap = Theme.Size.paletteSnapDistance
     static let topFraction = Theme.Size.paletteTopMarginFraction
@@ -49,6 +50,7 @@ struct PalettePlacementTests {
         restoringPartlyOffscreen()
         snapping()
         tokenGrammar()
+        everyInterfaceSize()
 
         print("\(passes) passed, \(failures) failed")
         if failures > 0 { exit(1) }
@@ -66,7 +68,7 @@ struct PalettePlacementTests {
 
         // The panel grows downward from the anchor, so a full-height list must still fit.
         expect(
-            anchor.y - Theme.Size.panelHeight > laptop.minY,
+            anchor.y - metrics.size.panelHeight > laptop.minY,
             "an expanded palette clears the bottom of the screen it opened on")
 
         // A screen offset from the origin must not shift the panel off it.
@@ -160,5 +162,42 @@ struct PalettePlacementTests {
             snap * 2 < width,
             "the snap zone is narrower than the panel, so it can't swallow every drop")
         expect(topFraction > 0 && topFraction < 1, "the top margin is a real fraction of the screen")
+    }
+
+    // MARK: - The same rules at every Interface Size
+
+    /// The largest palette still has to land on the smallest display Tinycast supports.
+    static let smallest = CGRect(x: 0, y: 0, width: 1440, height: 875)
+
+    static func everyInterfaceSize() {
+        for size in InterfaceSize.allCases {
+            let metrics = size.metrics
+            let width = metrics.size.panelWidth
+            let label = "at \(size.rawValue)"
+
+            for screen in [laptop, external, smallest] {
+                let anchor = PalettePlacement.defaultAnchor(
+                    in: screen, width: width, topMarginFraction: topFraction)
+                expect(anchor.x, screen.midX - width / 2, "the panel stays centred \(label)")
+                expect(
+                    anchor.y - metrics.size.panelHeight > screen.minY,
+                    "an expanded palette clears the bottom of a \(Int(screen.width))pt display \(label)"
+                )
+            }
+
+            // The wider bar needs more of itself on screen, so a stored edge position can lapse.
+            let graspable = CGSize(width: width, height: metrics.size.compactHeight)
+            let sliver = CGPoint(x: laptop.maxX - minimumVisible, y: 900)
+            expect(
+                PalettePlacement.restored(
+                    sliver, graspable: graspable, visibleFrames: [laptop],
+                    minimumVisible: minimumVisible) != nil,
+                "the minimum sliver is still grabbable \(label)")
+            expect(
+                PalettePlacement.restored(
+                    CGPoint(x: laptop.maxX, y: 900), graspable: graspable,
+                    visibleFrames: [laptop], minimumVisible: minimumVisible) == nil,
+                "a bar dragged fully past the right edge is dropped \(label)")
+        }
     }
 }

--- a/Tinycast.xcodeproj/project.pbxproj
+++ b/Tinycast.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 		CA6BA9C381351D0B2CADFB9D /* IconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CBCCE63360E4590CF5884A /* IconCache.swift */; };
 		CAE4C44A9D2EC4AC51FD3150 /* UninstallTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBAD0766FF9BFC6A4396474 /* UninstallTarget.swift */; };
 		CB95B0CBF0DFEDFCEA837053 /* ImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6775BBA0FC6F134296606 /* ImageThumbnail.swift */; };
+		CB9A463B71829D219F5AD477 /* InterfaceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8EEC4B5B30644A7EAA117 /* InterfaceMetrics.swift */; };
 		CBE647056A15F49DF0711ECD /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */; };
 		CC984C9647779469629461E7 /* LauncherItemsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A2ACAEC4D2D25D3112634 /* LauncherItemsSection.swift */; };
 		CC9A286B77E32C22B21A22BE /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */; };
@@ -539,6 +540,7 @@
 		EEBE3490872F3A8D0400AC56 /* MenuSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2967B06D3E059BFB9F30DF /* MenuSearchList.swift */; };
 		F03DB7A7898F0388E821FDBB /* AppleIntelligenceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B5C0B83C3645AC90639B85 /* AppleIntelligenceProvider.swift */; };
 		F13789E3732E844EE7584561 /* ColorValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9287418DC6C04437FB4BAF /* ColorValue.swift */; };
+		F289967F8DE039B6E1C3BE12 /* InterfaceSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C9F1A20CBB32EBB9629A4F /* InterfaceSize.swift */; };
 		F37AC0478A0A96243E833900 /* MCPCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFFF4B2F2BF476AD9B111B9 /* MCPCoordinator.swift */; };
 		F3E0C5D483CC854D63448A4B /* UpdateReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76460C2D60828CC79F0CE972 /* UpdateReadiness.swift */; };
 		F44DA0C81285A90138E13A7B /* ChatGPTSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43E5D47E198B86901D75515 /* ChatGPTSubscription.swift */; };
@@ -848,6 +850,7 @@
 		7592579B976CA7BCA03E2815 /* CalcValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcValue.swift; sourceTree = "<group>"; };
 		761B2A5D0CBD3930939ABA5C /* QuickActionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionRunner.swift; sourceTree = "<group>"; };
 		76460C2D60828CC79F0CE972 /* UpdateReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateReadiness.swift; sourceTree = "<group>"; };
+		76C9F1A20CBB32EBB9629A4F /* InterfaceSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceSize.swift; sourceTree = "<group>"; };
 		7732FB0ED92C8FBFE22599CE /* ExtensionStoreResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionStoreResponse.swift; sourceTree = "<group>"; };
 		77A29ED24604BE67E562B07D /* WindowLayoutInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowLayoutInspector.swift; sourceTree = "<group>"; };
 		780B32AF98BA3A51D2F0E8B4 /* BackupBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBundle.swift; sourceTree = "<group>"; };
@@ -1142,6 +1145,7 @@
 		EE1C64977153EF104F583008 /* CalcTokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcTokenizer.swift; sourceTree = "<group>"; };
 		EEAFF79E9897975CAC5EAC0E /* NoteEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorView.swift; sourceTree = "<group>"; };
 		EF202236034AB044CA846B60 /* WindowLayoutsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowLayoutsSection.swift; sourceTree = "<group>"; };
+		EFF8EEC4B5B30644A7EAA117 /* InterfaceMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceMetrics.swift; sourceTree = "<group>"; };
 		F023729C84682E9231F3D73B /* ExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstaller.swift; sourceTree = "<group>"; };
 		F0311153A4A3557C6FFEAAAB /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		F044A6A0C3C1CEC53D46497A /* ClipboardTextWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardTextWorker.swift; sourceTree = "<group>"; };
@@ -1404,6 +1408,7 @@
 				16F1DA610F3D792F6B08AFE5 /* Scrolling */,
 				4395BACF833C810961A248F0 /* BarButton.swift */,
 				08279257B0F5995E86FF2C03 /* EntryIconView.swift */,
+				EFF8EEC4B5B30644A7EAA117 /* InterfaceMetrics.swift */,
 				C5BA06E4CC7E8D40E3285F16 /* KeyCapChip.swift */,
 				4FAE24CC14F7DFECD1BD7FB1 /* PopoverMenu.swift */,
 				131B15F5EF86A067FA6C36D7 /* RedactedPlaceholder.swift */,
@@ -2579,6 +2584,7 @@
 				7F64F4362989516482853CDB /* AppSettings.swift */,
 				384485BD1794D25503534525 /* AppSettingsKey.swift */,
 				920FAC043BC3887B6D2C314D /* EscapeKeyBehavior.swift */,
+				76C9F1A20CBB32EBB9629A4F /* InterfaceSize.swift */,
 				C41B7D28CD2AF8AD14DA6FC3 /* SettingsAnchor.swift */,
 				8CBD6D8BC6951A482BDF6169 /* SettingsCoordinator.swift */,
 				C845A6718CFBD1AFE93BA903 /* SettingsDetailView.swift */,
@@ -3145,6 +3151,8 @@
 				EAFC40D8851C50EB62198C7E /* InstalledAIManager.swift in Sources */,
 				2E9CDC24A175FE8AAE4F03D9 /* InstalledAIStream.swift in Sources */,
 				B17B6FE6F8DE23D815E3C5BB /* InstalledCLIProvider.swift in Sources */,
+				CB9A463B71829D219F5AD477 /* InterfaceMetrics.swift in Sources */,
+				F289967F8DE039B6E1C3BE12 /* InterfaceSize.swift in Sources */,
 				CD52F594782DD51D5B3D4CE8 /* JSONValue.swift in Sources */,
 				8855C67C7EE196E3F9EDE778 /* KeyCapChip.swift in Sources */,
 				AE3144FCC55FADC48955D17A /* KeyShortcut.swift in Sources */,

--- a/Tinycast/App/AppCore.swift
+++ b/Tinycast/App/AppCore.swift
@@ -170,7 +170,7 @@ final class AppCore {
     @ObservationIgnored private lazy var windowController = PaletteWindowController(core: self)
     @ObservationIgnored private lazy var messageHUD = MessageHUDController(settings: settings)
     /// Every confirmation, report and prompt; it also stops a held hotkey stacking them.
-    private let dialogs = DialogController()
+    @ObservationIgnored private lazy var dialogs = DialogController(settings: settings)
     private let healthTicker = HealthTicker()
 
     private init() {
@@ -515,6 +515,7 @@ final class AppCore {
             { _ = $0.snippetsShowInLauncher },
             reproject: { $0.snippetCoordinator.applySnippetsLauncherPresence() })
         track({ _ = $0.appearance }, reproject: { $0.applyAppearance() })
+        track({ _ = $0.interfaceSize }, reproject: { $0.windowController.applyInterfaceSize() })
     }
 
     /// `.system` resolves to `nil`, so AppKit follows macOS with nothing polling.

--- a/Tinycast/DesignSystem/BarButton.swift
+++ b/Tinycast/DesignSystem/BarButton.swift
@@ -5,13 +5,13 @@ enum BarButtonChrome {
     case capsule
     case rounded
 
-    var shape: AnyShape {
+    func shape(_ metrics: InterfaceMetrics) -> AnyShape {
         switch self {
         case .capsule:
             return AnyShape(Capsule())
         case .rounded:
             return AnyShape(
-                RoundedRectangle(cornerRadius: Theme.Radius.barControl, style: .continuous))
+                RoundedRectangle(cornerRadius: metrics.radius.barControl, style: .continuous))
         }
     }
 }
@@ -22,13 +22,14 @@ struct BarButton<Label: View>: View {
     let action: () -> Void
     @ViewBuilder let label: Label
     @State private var hovered = false
+    @Environment(\.metrics) private var metrics
 
     var body: some View {
-        let shape = chrome.shape
+        let shape = chrome.shape(metrics)
         return Button(action: action) {
             label
-                .padding(.horizontal, Theme.Spacing.md)
-                .frame(height: Theme.Size.barButtonHeight)
+                .padding(.horizontal, metrics.spacing.md)
+                .frame(height: metrics.size.barButtonHeight)
                 .contentShape(shape)
                 .background(shape.fill(hovered ? Theme.Colors.rowHover : Color.clear))
         }
@@ -44,6 +45,7 @@ struct HeaderMenuButton: View {
     let isOpen: Bool
     let help: String
     let action: () -> Void
+    @Environment(\.metrics) private var metrics
 
     init(
         title: String, icon: PopoverMenuIcon, isOpen: Bool, help: String,
@@ -65,29 +67,29 @@ struct HeaderMenuButton: View {
 
     var body: some View {
         BarButton(chrome: .rounded, action: action) {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 switch icon {
                 case .blank:
                     EmptyView()
                 case .symbol(let name):
                     Image(systemName: name)
-                        .font(Theme.Typography.bar)
+                        .font(metrics.typography.bar)
                         .symbolRenderingMode(.hierarchical)
                 case .asset(let name):
                     Image(name)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: Theme.Size.barBrandIcon, height: Theme.Size.barBrandIcon)
+                        .frame(width: metrics.size.barBrandIcon, height: metrics.size.barBrandIcon)
                 case .file(let path):
                     MenuFileIcon(path: path)
                 }
                 Text(title)
-                    .font(Theme.Typography.bar)
+                    .font(metrics.typography.bar)
                     .lineLimit(1)
                     .truncationMode(.middle)
                 // Points at the menu it opens, the way a native pop-up's chevron does.
                 Image(systemName: isOpen ? "chevron.up" : "chevron.down")
-                    .font(Theme.Typography.disclosure)
+                    .font(metrics.typography.disclosure)
             }
             .foregroundStyle(Theme.Colors.textSecondary)
         }

--- a/Tinycast/DesignSystem/EntryIconView.swift
+++ b/Tinycast/DesignSystem/EntryIconView.swift
@@ -6,6 +6,7 @@ struct EntryIconView: View {
     /// Only `.file` needs it, and only the launcher has one to give.
     var fileURL: URL = URL(fileURLWithPath: "/")
     @State private var image: NSImage?
+    @Environment(\.metrics) private var metrics
 
     init(source: EntryIcon, fileURL: URL = URL(fileURLWithPath: "/")) {
         self.source = source
@@ -18,7 +19,7 @@ struct EntryIconView: View {
             if let image {
                 Image(nsImage: image).resizable()
             } else {
-                RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                     .fill(Theme.Colors.iconPlaceholder)
             }
         }

--- a/Tinycast/DesignSystem/InterfaceMetrics.swift
+++ b/Tinycast/DesignSystem/InterfaceMetrics.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// `Theme`'s palette geometry at the user's Interface Size; `.standard` is `Theme` verbatim.
+struct InterfaceMetrics: Equatable, Sendable {
+    static let standard = InterfaceMetrics(scale: 1)
+
+    let scale: CGFloat
+
+    var spacing: Spacing { Spacing(scale: scale) }
+    var radius: Radius { Radius(scale: scale) }
+    var size: Size { Size(scale: scale) }
+    var typography: Typography { Typography(scale: scale) }
+
+    /// For a tuned length a surface owns itself, where `Theme` states no token for it.
+    func scaled(_ value: CGFloat) -> CGFloat { scaledPoints(value, scale) }
+
+    struct Spacing: Equatable, Sendable {
+        let scale: CGFloat
+
+        var xxs: CGFloat { scaledPoints(Theme.Spacing.xxs, scale) }
+        var xs: CGFloat { scaledPoints(Theme.Spacing.xs, scale) }
+        var sm: CGFloat { scaledPoints(Theme.Spacing.sm, scale) }
+        var md: CGFloat { scaledPoints(Theme.Spacing.md, scale) }
+        var lg: CGFloat { scaledPoints(Theme.Spacing.lg, scale) }
+        var xl: CGFloat { scaledPoints(Theme.Spacing.xl, scale) }
+        var xxl: CGFloat { scaledPoints(Theme.Spacing.xxl, scale) }
+        var xxxl: CGFloat { scaledPoints(Theme.Spacing.xxxl, scale) }
+        var sectionHeaderBottom: CGFloat { scaledPoints(Theme.Spacing.sectionHeaderBottom, scale) }
+        var sectionSpacing: CGFloat { scaledPoints(Theme.Spacing.sectionSpacing, scale) }
+        var chatTranscriptBottom: CGFloat { scaledPoints(Theme.Spacing.chatTranscriptBottom, scale) }
+        var chatFollowTailSlack: CGFloat { scaledPoints(Theme.Spacing.chatFollowTailSlack, scale) }
+    }
+
+    struct Radius: Equatable, Sendable {
+        let scale: CGFloat
+
+        var panel: CGFloat { scaledPoints(Theme.Radius.panel, scale) }
+        var row: CGFloat { scaledPoints(Theme.Radius.row, scale) }
+        var menu: CGFloat { scaledPoints(Theme.Radius.menu, scale) }
+        var menuRow: CGFloat { scaledPoints(Theme.Radius.menuRow, scale) }
+        var barControl: CGFloat { scaledPoints(Theme.Radius.barControl, scale) }
+        var menuPanel: CGFloat { scaledPoints(Theme.Radius.menuPanel, scale) }
+        var dialog: CGFloat { scaledPoints(Theme.Radius.dialog, scale) }
+        var thumbnail: CGFloat { scaledPoints(Theme.Radius.thumbnail, scale) }
+        var glyph: CGFloat { scaledPoints(Theme.Radius.glyph, scale) }
+        var attachmentChip: CGFloat { scaledPoints(Theme.Radius.attachmentChip, scale) }
+        var card: CGFloat { scaledPoints(Theme.Radius.card, scale) }
+        var keyCap: CGFloat { scaledPoints(Theme.Radius.keyCap, scale) }
+    }
+
+    struct Size: Equatable, Sendable {
+        let scale: CGFloat
+
+        var panelWidth: CGFloat { scaledPoints(Theme.Size.panelWidth, scale) }
+        var panelHeight: CGFloat { scaledPoints(Theme.Size.panelHeight, scale) }
+        var headerHeight: CGFloat { scaledPoints(Theme.Size.headerHeight, scale) }
+        var headerIconSlot: CGFloat { scaledPoints(Theme.Size.headerIconSlot, scale) }
+        var headerPadding: CGFloat { scaledPoints(Theme.Size.headerPadding, scale) }
+        /// Derived, not scaled: the compact bar must stay exactly the header in symmetric slack.
+        var compactHeight: CGFloat { headerHeight + headerPadding * 2 }
+        var bottomBarHeight: CGFloat { scaledPoints(Theme.Size.bottomBarHeight, scale) }
+        var barButtonHeight: CGFloat { scaledPoints(Theme.Size.barButtonHeight, scale) }
+        var rowIcon: CGFloat { scaledPoints(Theme.Size.rowIcon, scale) }
+        var keyCap: CGFloat { scaledPoints(Theme.Size.keyCap, scale) }
+        var compactKeyCap: CGFloat { scaledPoints(Theme.Size.compactKeyCap, scale) }
+        var heroKeyCap: CGFloat { scaledPoints(Theme.Size.heroKeyCap, scale) }
+        var menuButton: CGFloat { scaledPoints(Theme.Size.menuButton, scale) }
+        var checkbox: CGFloat { scaledPoints(Theme.Size.checkbox, scale) }
+
+        var menuWidth: CGFloat { scaledPoints(Theme.Size.menuWidth, scale) }
+        var clipboardFilterMenuWidth: CGFloat { scaledPoints(Theme.Size.clipboardFilterMenuWidth, scale) }
+        var menuIcon: CGFloat { scaledPoints(Theme.Size.menuIcon, scale) }
+        var menuBrandIcon: CGFloat { scaledPoints(Theme.Size.menuBrandIcon, scale) }
+        var barBrandIcon: CGFloat { scaledPoints(Theme.Size.barBrandIcon, scale) }
+        var menuRowSpacing: CGFloat { scaledPoints(Theme.Size.menuRowSpacing, scale) }
+        var menuSectionHeader: CGFloat { scaledPoints(Theme.Size.menuSectionHeader, scale) }
+        /// Derived like `Theme`'s, so the row cap still counts whole rows at every size.
+        var menuRowHeight: CGFloat { menuIcon + Spacing(scale: scale).md * 2 }
+        var menuRowsMaxHeight: CGFloat {
+            (Theme.Size.menuVisibleRows * (menuRowHeight + menuRowSpacing)).rounded()
+        }
+
+        var clipboardListWidth: CGFloat { scaledPoints(Theme.Size.clipboardListWidth, scale) }
+        var clipboardMediaHeight: CGFloat { scaledPoints(Theme.Size.clipboardMediaHeight, scale) }
+        var clipboardPreviewPixel: CGFloat { scaledPoints(Theme.Size.clipboardPreviewPixel, scale) }
+        var emojiCell: CGFloat { scaledPoints(Theme.Size.emojiCell, scale) }
+        var formLabelWidth: CGFloat { scaledPoints(Theme.Size.formLabelWidth, scale) }
+        var argumentPromptWidth: CGFloat { scaledPoints(Theme.Size.argumentPromptWidth, scale) }
+
+        var markdownListMarker: CGFloat { scaledPoints(Theme.Size.markdownListMarker, scale) }
+        var markdownQuoteBar: CGFloat { scaledPoints(Theme.Size.markdownQuoteBar, scale) }
+        var chatMessageAction: CGFloat { scaledPoints(Theme.Size.chatMessageAction, scale) }
+        var chatImageThumb: CGFloat { scaledPoints(Theme.Size.chatImageThumb, scale) }
+        var chatAttachmentGlyph: CGFloat { scaledPoints(Theme.Size.chatAttachmentGlyph, scale) }
+        var chatAttachmentThumb: CGFloat { scaledPoints(Theme.Size.chatAttachmentThumb, scale) }
+        var chatAttachmentRemove: CGFloat { scaledPoints(Theme.Size.chatAttachmentRemove, scale) }
+        var chatAttachmentInset: CGFloat { scaledPoints(Theme.Size.chatAttachmentInset, scale) }
+
+        var quickActionPanel: CGFloat { scaledPoints(Theme.Size.quickActionPanel, scale) }
+        var quickActionHeaderIcon: CGFloat { scaledPoints(Theme.Size.quickActionHeaderIcon, scale) }
+        var quickActionScrollFade: CGFloat { scaledPoints(Theme.Size.quickActionScrollFade, scale) }
+        var quickActionPanelBody: CGFloat { scaledPoints(Theme.Size.quickActionPanelBody, scale) }
+        var quickActionPanelMinBody: CGFloat { scaledPoints(Theme.Size.quickActionPanelMinBody, scale) }
+
+        var dialogWidth: CGFloat { scaledPoints(Theme.Size.dialogWidth, scale) }
+        var dialogIcon: CGFloat { scaledPoints(Theme.Size.dialogIcon, scale) }
+        var hudMaxWidth: CGFloat { scaledPoints(Theme.Size.hudMaxWidth, scale) }
+        var hudWidth: CGFloat { scaledPoints(Theme.Size.hudWidth, scale) }
+        var hudHeight: CGFloat { scaledPoints(Theme.Size.hudHeight, scale) }
+        var volumeTrackHeight: CGFloat { scaledPoints(Theme.Size.volumeTrackHeight, scale) }
+        var volumeKnob: CGFloat { scaledPoints(Theme.Size.volumeKnob, scale) }
+        var volumeReadout: CGFloat { scaledPoints(Theme.Size.volumeReadout, scale) }
+    }
+
+    /// `NSFont` is the only public source of a text style's size and face.
+    struct Typography: Sendable {
+        let scale: CGFloat
+
+        var searchFieldSize: CGFloat { scaledPoints(Theme.Typography.searchFieldSize, scale) }
+        var searchField: Font {
+            scale == 1
+                ? Theme.Typography.searchField
+                : .system(size: searchFieldSize, weight: .regular)
+        }
+        /// Isolated because `Theme`'s twin is, not because resolving a font needs main.
+        @MainActor var searchFieldNSFont: NSFont {
+            scale == 1
+                ? Theme.Typography.searchFieldNSFont
+                : NSFont.systemFont(ofSize: searchFieldSize, weight: .regular)
+        }
+        var headerIcon: Font {
+            scale == 1
+                ? Theme.Typography.headerIcon
+                : .system(size: scaledPoints(18, scale), weight: .medium)
+        }
+
+        var rowTitle: Font { font(Theme.Typography.rowTitle, .body) }
+        var rowTrailing: Font { font(Theme.Typography.rowTrailing, .callout) }
+        var sectionHeader: Font { font(Theme.Typography.sectionHeader, .subheadline, .medium) }
+        var panelTitle: Font { font(Theme.Typography.panelTitle, .headline) }
+        var calcResult: Font { font(Theme.Typography.calcResult, .title1) }
+        var keyCap: Font { font(Theme.Typography.keyCap, .caption1) }
+        var compactKeyCap: Font { font(Theme.Typography.compactKeyCap, .caption2) }
+        var heroKeyCap: Font { font(Theme.Typography.heroKeyCap, .body) }
+        var markdownHeading1: Font { font(Theme.Typography.markdownHeading1, .title2, .semibold) }
+        var markdownHeading2: Font { font(Theme.Typography.markdownHeading2, .title3, .semibold) }
+        var markdownHeading3: Font { font(Theme.Typography.markdownHeading3, .headline) }
+        var code: Font {
+            scale == 1
+                ? Theme.Typography.code
+                : .system(size: nsFont(.callout).pointSize, design: .monospaced)
+        }
+        var inlineCode: Font { font(Theme.Typography.inlineCode, .body).monospaced() }
+        var bar: Font { font(Theme.Typography.bar, .callout, .medium) }
+        var chip: Font { font(Theme.Typography.chip, .callout) }
+        @MainActor var chipNSFont: NSFont { scale == 1 ? Theme.Typography.chipNSFont : nsFont(.callout) }
+        var disclosure: Font { font(Theme.Typography.disclosure, .caption1, .semibold) }
+        var menuRow: Font { font(Theme.Typography.menuRow, .body) }
+        var menuShortcut: Font { font(Theme.Typography.menuShortcut, .callout) }
+        var menuIcon: Font { font(Theme.Typography.menuIcon, .body) }
+
+        /// Composed like `Theme`'s own: the style carries the face, an explicit weight overrides it.
+        private func font(
+            _ base: Font, _ style: NSFont.TextStyle, _ weight: Font.Weight? = nil
+        )
+            -> Font
+        {
+            guard scale != 1 else { return base }
+            let scaled = Font(nsFont(style))
+            return weight.map(scaled.weight) ?? scaled
+        }
+
+        /// Its own descriptor, so `.headline` stays Bold and `.caption2` Medium rather than lightening.
+        private func nsFont(_ style: NSFont.TextStyle) -> NSFont {
+            let base = NSFont.preferredFont(forTextStyle: style)
+            guard scale != 1 else { return base }
+            return NSFont(descriptor: base.fontDescriptor, size: scaledPoints(base.pointSize, scale)) ?? base
+        }
+    }
+}
+
+/// Whole points: a fractional row pitch lands keycap edges and the dissolve mask off-pixel.
+private func scaledPoints(_ value: CGFloat, _ scale: CGFloat) -> CGFloat {
+    scale == 1 ? value : (value * scale).rounded()
+}
+
+extension EnvironmentValues {
+    /// `.standard` by default, so a shared `DesignSystem` view outside the palette never scales.
+    @Entry var metrics = InterfaceMetrics.standard
+}

--- a/Tinycast/DesignSystem/KeyCapChip.swift
+++ b/Tinycast/DesignSystem/KeyCapChip.swift
@@ -13,19 +13,20 @@ struct KeyCapChip: View {
         case standard
         case hero
 
-        var side: CGFloat {
+        func side(_ metrics: InterfaceMetrics) -> CGFloat {
             switch self {
-            case .compact: Theme.Size.compactKeyCap
-            case .standard: Theme.Size.keyCap
-            case .hero: Theme.Size.heroKeyCap
+            case .compact: metrics.size.compactKeyCap
+            case .standard: metrics.size.keyCap
+            case .hero: metrics.size.heroKeyCap
             }
         }
 
-        var font: Font {
+        @MainActor
+        func font(_ metrics: InterfaceMetrics) -> Font {
             switch self {
-            case .compact: Theme.Typography.compactKeyCap
-            case .standard: Theme.Typography.keyCap
-            case .hero: Theme.Typography.heroKeyCap
+            case .compact: metrics.typography.compactKeyCap
+            case .standard: metrics.typography.keyCap
+            case .hero: metrics.typography.heroKeyCap
             }
         }
     }
@@ -33,18 +34,19 @@ struct KeyCapChip: View {
     let text: String
     var style: Style = .filled
     var scale: Scale = .standard
+    @Environment(\.metrics) private var metrics
 
     /// "↵" falls back to another face that seats high, so nudge it render-only.
     private static let returnGlyphDrop: CGFloat = 1.1
 
     var body: some View {
-        let shape = RoundedRectangle(cornerRadius: Theme.Radius.keyCap, style: .continuous)
+        let shape = RoundedRectangle(cornerRadius: metrics.radius.keyCap, style: .continuous)
         Text(text)
-            .font(scale.font)
+            .font(scale.font(metrics))
             .foregroundStyle(Theme.Colors.textSecondary)
             .offset(y: text == "↵" ? Self.returnGlyphDrop : 0)
-            .padding(.horizontal, Theme.Spacing.xs)
-            .frame(minWidth: scale.side, minHeight: scale.side)
+            .padding(.horizontal, metrics.spacing.xs)
+            .frame(minWidth: scale.side(metrics), minHeight: scale.side(metrics))
             .background {
                 switch style {
                 case .filled: shape.fill(Theme.Colors.controlSurface)

--- a/Tinycast/DesignSystem/PopoverMenu.swift
+++ b/Tinycast/DesignSystem/PopoverMenu.swift
@@ -69,42 +69,43 @@ struct PopoverMenu: View {
     let items: [PopoverMenuItem]
     @Binding var selection: Int
     /// Fixed, never intrinsic: a width tracking the longest row would jitter as rows change.
-    var width: CGFloat = Theme.Size.menuWidth
+    var width: CGFloat?
     let onActivate: (Int) -> Void
 
     /// The palette arms this only once the pointer has moved of its own accord.
     @Environment(PaletteState.self) private var palette
+    @Environment(\.metrics) private var metrics
     /// Set by the pointer so the reveal can tell its own move from a keyboard one.
     @State private var pointerSelection: Int?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Size.menuRowSpacing) {
+        VStack(alignment: .leading, spacing: metrics.size.menuRowSpacing) {
             if let header { headerLabel(header) }
             rows
         }
-        .padding(Theme.Spacing.sm)
-        .frame(width: width)
+        .padding(metrics.spacing.sm)
+        .frame(width: width ?? metrics.size.menuWidth)
         .glassEffect(
-            .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)
+            .regular, in: RoundedRectangle(cornerRadius: metrics.radius.menuPanel, style: .continuous)
         )
     }
 
     private func headerLabel(_ text: String) -> some View {
         Text(text)
-            .font(Theme.Typography.sectionHeader)
+            .font(metrics.typography.sectionHeader)
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .truncationMode(.tail)
-            .padding(.horizontal, Theme.Spacing.lg)
-            .padding(.top, Theme.Spacing.xs)
-            .padding(.bottom, Theme.Spacing.xs / 2)
+            .padding(.horizontal, metrics.spacing.lg)
+            .padding(.top, metrics.spacing.xs)
+            .padding(.bottom, metrics.spacing.xs / 2)
     }
 
     /// Rows alone scroll, under a header that keeps naming what they act on.
     private var rows: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(alignment: .leading, spacing: Theme.Size.menuRowSpacing) {
+                VStack(alignment: .leading, spacing: metrics.size.menuRowSpacing) {
                     // Index-as-id is stable: a menu's rows never reorder while it is open.
                     ForEach(items.indices, id: \.self) { index in
                         VStack(alignment: .leading, spacing: 0) {
@@ -120,8 +121,8 @@ struct PopoverMenu: View {
                                 Rectangle()
                                     .fill(Theme.Colors.separator)
                                     .frame(height: Theme.Size.hairline)
-                                    .padding(.horizontal, Theme.Spacing.md)
-                                    .offset(y: -Theme.Size.menuRowSpacing)
+                                    .padding(.horizontal, metrics.spacing.md)
+                                    .offset(y: -metrics.size.menuRowSpacing)
                                     .allowsHitTesting(false)
                                     .accessibilityHidden(true)
                             }
@@ -149,29 +150,29 @@ struct PopoverMenu: View {
     private var viewportHeight: CGFloat {
         let rows = CGFloat(items.count)
         var contentHeight =
-            rows * Theme.Size.menuRowHeight + max(rows - 1, 0) * Theme.Size.menuRowSpacing
+            rows * metrics.size.menuRowHeight + max(rows - 1, 0) * metrics.size.menuRowSpacing
         for (index, item) in items.enumerated() where item.sectionTitle != nil {
-            contentHeight += Theme.Size.menuSectionHeader + Theme.Spacing.xxs
-            if index > 0 { contentHeight += Theme.Spacing.md }
+            contentHeight += metrics.size.menuSectionHeader + metrics.spacing.xxs
+            if index > 0 { contentHeight += metrics.spacing.md }
         }
-        return min(contentHeight, Theme.Size.menuRowsMaxHeight)
+        return min(contentHeight, metrics.size.menuRowsMaxHeight)
     }
 
     /// Tighter below than above, so a header belongs to the rows under it, not between two groups.
     private func sectionLabel(_ title: String, isFirst: Bool) -> some View {
         Text(title)
-            .font(Theme.Typography.sectionHeader)
+            .font(metrics.typography.sectionHeader)
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .truncationMode(.tail)
             .frame(
-                maxWidth: .infinity, minHeight: Theme.Size.menuSectionHeader,
-                maxHeight: Theme.Size.menuSectionHeader, alignment: .leading
+                maxWidth: .infinity, minHeight: metrics.size.menuSectionHeader,
+                maxHeight: metrics.size.menuSectionHeader, alignment: .leading
             )
             // `md`, matching a row's own inset, so header and icon share one edge.
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.top, isFirst ? 0 : Theme.Spacing.md)
-            .padding(.bottom, Theme.Spacing.xxs)
+            .padding(.horizontal, metrics.spacing.md)
+            .padding(.top, isFirst ? 0 : metrics.spacing.md)
+            .padding(.bottom, metrics.spacing.xxs)
     }
 
     /// Armed only once the pointer has moved of its own accord, so a scroll past it lights nothing.
@@ -187,67 +188,68 @@ private struct PopoverMenuRow: View {
     let item: PopoverMenuItem
     let selected: Bool
     let onActivate: () -> Void
+    @Environment(\.metrics) private var metrics
 
     var body: some View {
         Button(action: onActivate) {
             // `sm`, not `lg`: the icon slot carries its own slack, so the gap reads wider.
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 if item.isLoading {
                     ProgressView()
                         .controlSize(.small)
-                        .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
+                        .frame(width: metrics.size.menuIcon, height: metrics.size.menuIcon)
                 } else {
                     switch item.icon {
                     case .blank:
                         EmptyView()
                     case .symbol(let name):
                         Image(systemName: name)
-                            .font(Theme.Typography.menuIcon)
+                            .font(metrics.typography.menuIcon)
                             .symbolRenderingMode(.hierarchical)
                             .foregroundStyle(item.isDestructive ? Color.red : Color.secondary)
-                            .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
+                            .frame(width: metrics.size.menuIcon, height: metrics.size.menuIcon)
                     case .asset(let name):
                         Image(name)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .foregroundStyle(item.isDestructive ? Color.red : Color.secondary)
-                            .frame(width: Theme.Size.menuBrandIcon, height: Theme.Size.menuBrandIcon)
-                            .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
+                            .frame(width: metrics.size.menuBrandIcon, height: metrics.size.menuBrandIcon)
+                            .frame(width: metrics.size.menuIcon, height: metrics.size.menuIcon)
                     case .file(let path):
                         MenuFileIcon(path: path)
                     }
                 }
                 Text(item.title)
-                    .font(Theme.Typography.menuRow)
+                    .font(metrics.typography.menuRow)
                     .foregroundStyle(item.isDestructive ? Color.red : Color.primary)
                     .lineLimit(1)
-                Spacer(minLength: Theme.Spacing.sm)
+                Spacer(minLength: metrics.spacing.sm)
                 if let detail = item.detail {
                     Text(detail)
                         // Smaller than the title it trails: a stated value, not a second label.
-                        .font(Theme.Typography.keyCap)
+                        .font(metrics.typography.keyCap)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         // A notation opens with what identifies it, so the tail is what can go.
                         .truncationMode(.tail)
                 }
                 if let shortcut = item.shortcut {
-                    HStack(spacing: Theme.Spacing.xxs) {
+                    HStack(spacing: metrics.spacing.xxs) {
                         ForEach(Array(shortcut.enumerated()), id: \.offset) { _, glyph in
                             KeyCapChip(text: String(glyph), style: .outline)
                         }
                     }
                 }
             }
-            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.horizontal, metrics.spacing.md)
             // Stated, not padded: the height maths above counts rows, so a row is one exact height.
             .frame(
-                maxWidth: .infinity, minHeight: Theme.Size.menuRowHeight,
-                maxHeight: Theme.Size.menuRowHeight, alignment: .leading
+                maxWidth: .infinity, minHeight: metrics.size.menuRowHeight,
+                maxHeight: metrics.size.menuRowHeight, alignment: .leading
             )
             .contentShape(Rectangle())
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.menuRow, style: .continuous)
                     .fill(selected ? Theme.Colors.menuHover : Color.clear)
             )
         }
@@ -260,6 +262,7 @@ private struct PopoverMenuRow: View {
 struct MenuFileIcon: View {
     let path: String
     @State private var image: NSImage?
+    @Environment(\.metrics) private var metrics
 
     init(path: String) {
         self.path = path
@@ -274,7 +277,7 @@ struct MenuFileIcon: View {
                 Color.clear
             }
         }
-        .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
+        .frame(width: metrics.size.menuIcon, height: metrics.size.menuIcon)
         .task(id: IconRequest(path)) {
             guard image == nil else { return }
             image = await IconCache.loadAsync(forFile: path)

--- a/Tinycast/DesignSystem/Scrolling/EdgeDissolve.swift
+++ b/Tinycast/DesignSystem/Scrolling/EdgeDissolve.swift
@@ -3,10 +3,13 @@ import SwiftUI
 /// Scroll-driven edge mask for a list underlapping the palette's floating bars. See `docs/ui.md`.
 struct EdgeDissolveMask: ViewModifier {
     /// Band lengths: the bar's height plus its overshoot into the list — 32px top, 28px bottom.
-    var topFade: CGFloat = Theme.Size.headerHeight + Theme.Size.headerPadding + 32
-    var bottomFade: CGFloat = Theme.Size.bottomBarHeight + 28
+    private var topFade: CGFloat {
+        metrics.size.headerHeight + metrics.size.headerPadding + metrics.scaled(32)
+    }
+    private var bottomFade: CGFloat { metrics.size.bottomBarHeight + metrics.scaled(28) }
     private static let topMinAlpha: CGFloat = 0.15
     private static let bottomMinAlpha: CGFloat = 0.25
+    @Environment(\.metrics) private var metrics
 
     /// How much content is hidden beyond each edge, 0 when the list rests against it.
     @State private var topDistance: CGFloat = 0

--- a/Tinycast/DesignSystem/Theme.swift
+++ b/Tinycast/DesignSystem/Theme.swift
@@ -162,6 +162,8 @@ enum Theme {
         static let settingsDetailMinimum: CGFloat = 420
         static let settingsRowIcon: CGFloat = 20
         static let paletteTransparencySlider: CGFloat = 190
+        /// One "Aa" segment of the Interface Size control; three sit in a grouped row's trailing slot.
+        static let interfaceSizeSegment: CGFloat = 40
         /// The sidebar's search field; matches a grouped `Form` row's control height.
         static let settingsSearchField: CGFloat = 28
         /// The layout editor. Height is stated so selecting an entry cannot resize the sheet.

--- a/Tinycast/DesignSystem/Tooltip.swift
+++ b/Tinycast/DesignSystem/Tooltip.swift
@@ -4,6 +4,7 @@ import SwiftUI
 private struct TooltipModifier: ViewModifier {
     let text: String?
     @State private var hovered = false
+    @Environment(\.metrics) private var metrics
 
     func body(content: Content) -> some View {
         content
@@ -11,14 +12,14 @@ private struct TooltipModifier: ViewModifier {
             .overlay(alignment: .top) {
                 if let text, hovered {
                     Text(text)
-                        .font(Theme.Typography.keyCap)
+                        .font(metrics.typography.keyCap)
                         .foregroundStyle(Theme.Colors.textSecondary)
-                        .padding(.horizontal, Theme.Spacing.sm)
-                        .padding(.vertical, Theme.Spacing.xxs)
+                        .padding(.horizontal, metrics.spacing.sm)
+                        .padding(.vertical, metrics.spacing.xxs)
                         .background(Capsule().fill(Theme.Colors.controlSurface))
                         .overlay(Capsule().strokeBorder(Theme.Colors.border, lineWidth: 1))
                         .fixedSize()
-                        .offset(y: -Theme.Spacing.xxl)
+                        .offset(y: -metrics.spacing.xxl)
                         .transition(.opacity)
                         .allowsHitTesting(false)
                 }

--- a/Tinycast/Features/AI/UI/AIScreen.swift
+++ b/Tinycast/Features/AI/UI/AIScreen.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// AI chat as one native palette screen: the search field is its composer.
 struct AIScreen: PaletteScreen {
     let vm: PaletteState
+    let metrics: InterfaceMetrics
     let chat: AIChatState
     let settings: AISettingsStore
     let coordinator: AIChatCoordinator
@@ -74,13 +75,13 @@ struct AIScreen: PaletteScreen {
         let addressed = coordinator.addressedServer(in: vm.query)
         guard !attachments.isEmpty || addressed != nil else { return nil }
         let width =
-            PendingAttachmentsChips.width(for: attachments)
-            + (addressed.map { ComposerChip.width(of: "@\($0.slug)") } ?? 0)
+            PendingAttachmentsChips.width(for: attachments, metrics)
+            + (addressed.map { ComposerChip.width(of: "@\($0.slug)", metrics) } ?? 0)
         return PaletteHeaderAccessory(
-            width: width + Theme.Size.menuWidth,
+            width: width + metrics.size.menuWidth,
             fieldNames: [], firstIncompleteField: nil,
             view: AnyView(
-                HStack(spacing: Theme.Spacing.sm) {
+                HStack(spacing: metrics.spacing.sm) {
                     if let addressed {
                         ComposerChip(symbol: "wrench.and.screwdriver", label: "@\(addressed.slug)")
                     }
@@ -129,12 +130,14 @@ private struct AIChatView: View {
 }
 
 private struct AIEmptyState: View {
+
+    @Environment(\.metrics) private var metrics
     let message: String?
     let canConfigure: Bool
     let onConfigure: () -> Void
 
     var body: some View {
-        VStack(spacing: Theme.Spacing.md) {
+        VStack(spacing: metrics.spacing.md) {
             Image(systemName: "sparkles")
                 .font(.largeTitle)
                 .symbolRenderingMode(.hierarchical)
@@ -143,55 +146,57 @@ private struct AIEmptyState: View {
                 .foregroundStyle(.secondary)
             if let message {
                 Text(message)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .multilineTextAlignment(.center)
                 if canConfigure { Button("Configure AI", action: onConfigure) }
             } else {
-                HStack(spacing: Theme.Spacing.sm) {
+                HStack(spacing: metrics.spacing.sm) {
                     Text("Send a message")
                     KeyCapChip(text: "↵")
                 }
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textTertiary)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, Theme.Spacing.xxl)
+        .padding(.horizontal, metrics.spacing.xxl)
     }
 }
 
 /// The MCP `@server` pill: a glyph and a word, unchanged by what attachments do.
 private struct ComposerChip: View {
+    @Environment(\.metrics) private var metrics
     let symbol: String
     let label: String
 
     /// Load-bearing: `RootPaletteView.searchFieldWidth(for:)` shrinks the field by exactly this.
-    static func width(of label: String) -> CGFloat {
-        let font = Theme.Typography.chipNSFont
+    static func width(of label: String, _ metrics: InterfaceMetrics) -> CGFloat {
+        let font = metrics.typography.chipNSFont
         let text = (label as NSString).size(withAttributes: [.font: font]).width
-        return Theme.Size.chatAttachmentGlyph + text + Theme.Spacing.md * 3
+        return metrics.size.chatAttachmentGlyph + text + metrics.spacing.md * 3
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             Image(systemName: symbol)
-                .font(Theme.Typography.chip)
+                .font(metrics.typography.chip)
                 .symbolRenderingMode(.hierarchical)
-                .frame(width: Theme.Size.chatAttachmentGlyph)
+                .frame(width: metrics.size.chatAttachmentGlyph)
             Text(label)
-                .font(Theme.Typography.chip)
+                .font(metrics.typography.chip)
                 .lineLimit(1)
         }
         .foregroundStyle(Theme.Colors.textSecondary)
-        .padding(.horizontal, Theme.Spacing.sm)
-        .padding(.vertical, Theme.Spacing.xxs)
+        .padding(.horizontal, metrics.spacing.sm)
+        .padding(.vertical, metrics.spacing.xxs)
         .background(Capsule().fill(Theme.Colors.controlSurface))
     }
 }
 
 /// A staged file: an image states itself, a document names itself, and either can be taken back.
 private struct AttachmentChip: View {
+    @Environment(\.metrics) private var metrics
     let attachment: ChatAttachment
     let onRemove: () -> Void
 
@@ -208,27 +213,27 @@ private struct AttachmentChip: View {
         return "\(head)…\(tail)"
     }
 
-    static func width(for attachment: ChatAttachment) -> CGFloat {
+    static func width(for attachment: ChatAttachment, _ metrics: InterfaceMetrics) -> CGFloat {
         let text = (Self.shortened(attachment.name) as NSString).size(
-            withAttributes: [.font: Theme.Typography.chipNSFont]
+            withAttributes: [.font: metrics.typography.chipNSFont]
         ).width
-        return Theme.Size.chatAttachmentInset * 2 + Theme.Size.chatAttachmentThumb
-            + Theme.Spacing.sm + text + Theme.Spacing.sm + Theme.Size.chatAttachmentRemove
+        return metrics.size.chatAttachmentInset * 2 + metrics.size.chatAttachmentThumb
+            + metrics.spacing.sm + text + metrics.spacing.sm + metrics.size.chatAttachmentRemove
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             leading
             Text(Self.shortened(attachment.name))
-                .font(Theme.Typography.chip)
+                .font(metrics.typography.chip)
                 .lineLimit(1)
                 .foregroundStyle(Theme.Colors.textSecondary)
             Button(action: onRemove) {
                 Image(systemName: "xmark")
                     .font(.system(size: 9, weight: .semibold))
                     .frame(
-                        width: Theme.Size.chatAttachmentRemove,
-                        height: Theme.Size.chatAttachmentRemove
+                        width: metrics.size.chatAttachmentRemove,
+                        height: metrics.size.chatAttachmentRemove
                     )
                     .foregroundStyle(hovered ? Theme.Colors.textPrimary : Theme.Colors.textTertiary)
                     .contentShape(Rectangle())
@@ -237,10 +242,10 @@ private struct AttachmentChip: View {
             .help("Remove \(attachment.name)")
         }
         // Inset under the inner gap, so the thumbnail reads as filling the pill.
-        .padding(.horizontal, Theme.Size.chatAttachmentInset)
-        .padding(.vertical, Theme.Size.chatAttachmentInset)
+        .padding(.horizontal, metrics.size.chatAttachmentInset)
+        .padding(.vertical, metrics.size.chatAttachmentInset)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.attachmentChip, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.attachmentChip, style: .continuous)
                 .fill(Theme.Colors.controlSurface)
         )
         .onHover { hovered = $0 }
@@ -254,18 +259,19 @@ private struct AttachmentChip: View {
             ComposerThumbnail(data: attachment.preview, id: attachment.id)
         case .pdf, .text:
             Image(systemName: attachment.kind == .pdf ? "doc.richtext" : "doc.plaintext")
-                .font(Theme.Typography.chip)
+                .font(metrics.typography.chip)
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(Theme.Colors.textSecondary)
                 .frame(
-                    width: Theme.Size.chatAttachmentThumb,
-                    height: Theme.Size.chatAttachmentThumb)
+                    width: metrics.size.chatAttachmentThumb,
+                    height: metrics.size.chatAttachmentThumb)
         }
     }
 }
 
 /// Decoded once per attachment: `ForEach` keys on its id, so a per-keystroke re-render reuses it.
 private struct ComposerThumbnail: View {
+    @Environment(\.metrics) private var metrics
     let data: Data?
     let id: UUID
 
@@ -277,18 +283,19 @@ private struct ComposerThumbnail: View {
                 Image(nsImage: image).resizable().scaledToFill()
             } else {
                 Image(systemName: "photo")
-                    .font(Theme.Typography.chip)
+                    .font(metrics.typography.chip)
                     .symbolRenderingMode(.hierarchical)
             }
         }
-        .frame(width: Theme.Size.chatAttachmentThumb, height: Theme.Size.chatAttachmentThumb)
-        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
+        .frame(width: metrics.size.chatAttachmentThumb, height: metrics.size.chatAttachmentThumb)
+        .clipShape(RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous))
         .task(id: id) { image = data.flatMap(NSImage.init(data:)) }
     }
 }
 
 /// Staged files follow the typed text; past two they become a count, the width being the field's.
 private struct PendingAttachmentsChips: View {
+    @Environment(\.metrics) private var metrics
     let attachments: [ChatAttachment]
     let onRemove: (UUID) -> Void
 
@@ -304,32 +311,32 @@ private struct PendingAttachmentsChips: View {
         return hidden > 0 ? "+\(hidden)" : nil
     }
 
-    static func width(for attachments: [ChatAttachment]) -> CGFloat {
-        var total = visible(attachments).reduce(0) { $0 + AttachmentChip.width(for: $1) }
-        total += CGFloat(max(0, visible(attachments).count - 1)) * Theme.Spacing.xs
+    static func width(for attachments: [ChatAttachment], _ metrics: InterfaceMetrics) -> CGFloat {
+        var total = visible(attachments).reduce(0) { $0 + AttachmentChip.width(for: $1, metrics) }
+        total += CGFloat(max(0, visible(attachments).count - 1)) * metrics.spacing.xs
         if let label = overflowLabel(attachments) {
             let text = (label as NSString).size(
-                withAttributes: [.font: Theme.Typography.chipNSFont]
+                withAttributes: [.font: metrics.typography.chipNSFont]
             ).width
-            total += Theme.Spacing.xs + text + Theme.Spacing.sm * 2
+            total += metrics.spacing.xs + text + metrics.spacing.sm * 2
         }
         return total
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             ForEach(Self.visible(attachments)) { attachment in
                 AttachmentChip(attachment: attachment) { onRemove(attachment.id) }
             }
             if let label = Self.overflowLabel(attachments) {
                 Text(label)
-                    .font(Theme.Typography.chip)
+                    .font(metrics.typography.chip)
                     .foregroundStyle(Theme.Colors.textTertiary)
-                    .padding(.horizontal, Theme.Spacing.sm)
-                    .padding(.vertical, Theme.Spacing.xs)
+                    .padding(.horizontal, metrics.spacing.sm)
+                    .padding(.vertical, metrics.spacing.xs)
                     .background(
                         RoundedRectangle(
-                            cornerRadius: Theme.Radius.attachmentChip, style: .continuous
+                            cornerRadius: metrics.radius.attachmentChip, style: .continuous
                         ).fill(Theme.Colors.controlSurface)
                     )
                     .help("\(attachments.count) files attached")

--- a/Tinycast/Features/AI/UI/ChatCopyButton.swift
+++ b/Tinycast/Features/AI/UI/ChatCopyButton.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ChatCopyButton: View {
+
+    @Environment(\.metrics) private var metrics
     let text: String
     var subject = "Message"
 
@@ -15,9 +17,9 @@ struct ChatCopyButton: View {
             copiedAt = Date()
         } label: {
             Image(systemName: copied ? "checkmark" : "square.on.square")
-                .font(Theme.Typography.keyCap)
+                .font(metrics.typography.keyCap)
                 .foregroundStyle(tint)
-                .frame(width: Theme.Size.chatMessageAction, height: Theme.Size.chatMessageAction)
+                .frame(width: metrics.size.chatMessageAction, height: metrics.size.chatMessageAction)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Tinycast/Features/AI/UI/ChatHistoryScreen.swift
+++ b/Tinycast/Features/AI/UI/ChatHistoryScreen.swift
@@ -7,6 +7,7 @@ struct ChatHistoryScreen: PaletteScreen {
     let coordinator: AIChatCoordinator
     let vm: PaletteState
     let openActions: () -> Void
+    let metrics: InterfaceMetrics
 
     var rows: [ChatConversation] { history.search(vm.query) }
     let primaryActionTitle = "Open Chat"
@@ -64,7 +65,7 @@ struct ChatHistoryScreen: PaletteScreen {
                         openActions()
                     }
                 )
-                .frame(width: Theme.Size.clipboardListWidth)
+                .frame(width: metrics.size.clipboardListWidth)
                 Rectangle().fill(Theme.Colors.separator).frame(width: Theme.Size.hairline)
                 ChatHistoryPreview(history: history, chat: chat, conversationID: selected?.id)
             }

--- a/Tinycast/Features/AI/UI/ChatHistoryView.swift
+++ b/Tinycast/Features/AI/UI/ChatHistoryView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ChatHistoryList: View {
+
+    @Environment(\.metrics) private var metrics
     let results: [ChatConversation]
     let selectedID: ChatConversation.ID?
     let scroll: ScrollIntent
@@ -65,9 +67,9 @@ struct ChatHistoryList: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -81,6 +83,8 @@ struct ChatHistoryList: View {
 }
 
 private struct ChatHistoryRow: View {
+
+    @Environment(\.metrics) private var metrics
     let conversation: ChatConversation
     let selected: Bool
     @State private var hovered = false
@@ -92,35 +96,35 @@ private struct ChatHistoryRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
-            RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+        HStack(spacing: metrics.spacing.lg) {
+            RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
                 .fill(Theme.Colors.controlSurface)
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 .overlay(
                     Image(systemName: "bubble.left")
                         .font(.system(size: 12))
                         .symbolRenderingMode(.hierarchical)
                         .foregroundStyle(.secondary))
-            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+            VStack(alignment: .leading, spacing: metrics.spacing.xxs) {
                 Text(conversation.title)
-                    .font(Theme.Typography.rowTitle)
+                    .font(metrics.typography.rowTitle)
                     .lineLimit(1)
                 if !conversation.preview.isEmpty {
                     Text(conversation.preview)
-                        .font(Theme.Typography.keyCap)
+                        .font(metrics.typography.keyCap)
                         .foregroundStyle(Theme.Colors.textTertiary)
                         .lineLimit(1)
                 }
             }
             Spacer(minLength: 0)
             Text(conversation.updatedAt.formatted(date: .omitted, time: .shortened))
-                .font(Theme.Typography.keyCap)
+                .font(metrics.typography.keyCap)
                 .foregroundStyle(Theme.Colors.textTertiary)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous).fill(fill)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous).fill(fill)
         )
         .armedHover($hovered)
     }

--- a/Tinycast/Features/AI/UI/ChatTranscriptView.swift
+++ b/Tinycast/Features/AI/UI/ChatTranscriptView.swift
@@ -2,6 +2,8 @@ import AppKit
 import SwiftUI
 
 struct ChatTranscriptView: View {
+
+    @Environment(\.metrics) private var metrics
     let messages: [ChatMessage]
     let status: String?
     let usage: AIUsage?
@@ -21,7 +23,7 @@ struct ChatTranscriptView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 // Not lazy: every anchored jump and the end test measure an estimated height
-                VStack(spacing: Theme.Spacing.xl) {
+                VStack(spacing: metrics.spacing.xl) {
                     ForEach(messages) { message in
                         ChatMessageView(
                             message: message,
@@ -31,17 +33,17 @@ struct ChatTranscriptView: View {
                     }
                     if let total = usage?.totalTokens {
                         Text("\(total.formatted()) tokens")
-                            .font(Theme.Typography.rowTrailing)
+                            .font(metrics.typography.rowTrailing)
                             .foregroundStyle(Theme.Colors.textTertiary)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                     }
                     Color.clear
-                        .frame(height: Theme.Spacing.xxs)
+                        .frame(height: metrics.spacing.xxs)
                         .id("ai-transcript-tail")
                 }
-                .padding(.horizontal, Theme.Spacing.xxl)
-                .padding(.top, Theme.Spacing.xl)
-                .padding(.bottom, Theme.Spacing.chatTranscriptBottom)
+                .padding(.horizontal, metrics.spacing.xxl)
+                .padding(.top, metrics.spacing.xl)
+                .padding(.bottom, metrics.spacing.chatTranscriptBottom)
             }
             .edgeDissolve()
             .thinScrollbar()
@@ -53,7 +55,7 @@ struct ChatTranscriptView: View {
                     // The offset rests at `-insetTop`, so the end is that far past offset plus band
                     atEnd: geometry.contentOffset.y + geometry.containerSize.height
                         + geometry.contentInsets.top
-                        >= geometry.contentSize.height - Theme.Spacing.chatFollowTailSlack)
+                        >= geometry.contentSize.height - metrics.spacing.chatFollowTailSlack)
             } action: { old, new in
                 // The offset is the only signal every device gives; the end wins, tested first
                 if new.atEnd {
@@ -70,7 +72,7 @@ struct ChatTranscriptView: View {
                     followsTail = true
                     follow(proxy, always: true)
                 }
-                .padding(.bottom, Theme.Spacing.lg)
+                .padding(.bottom, metrics.spacing.lg)
                 .opacity(followsTail ? 0 : 1)
                 .allowsHitTesting(!followsTail)
                 .animation(.easeOut(duration: Theme.Duration.chatFooter), value: followsTail)
@@ -87,15 +89,16 @@ struct ChatTranscriptView: View {
 
 /// A fast reply outruns a reader scrolling toward it, so this asks for the tail, not chases it.
 private struct ResumeFollowingButton: View {
+    @Environment(\.metrics) private var metrics
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Label("Jump to Latest", systemImage: "arrow.down")
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textSecondary)
-                .padding(.horizontal, Theme.Spacing.lg)
-                .padding(.vertical, Theme.Spacing.sm)
+                .padding(.horizontal, metrics.spacing.lg)
+                .padding(.vertical, metrics.spacing.sm)
                 .background(.ultraThinMaterial, in: Capsule())
                 .overlay(Capsule().strokeBorder(Theme.Colors.border))
         }
@@ -104,6 +107,8 @@ private struct ResumeFollowingButton: View {
 }
 
 private struct ChatMessageView: View {
+
+    @Environment(\.metrics) private var metrics
     let message: ChatMessage
     let status: String?
 
@@ -111,8 +116,8 @@ private struct ChatMessageView: View {
 
     var body: some View {
         HStack {
-            if message.role == .user { Spacer(minLength: Theme.Spacing.xxl) }
-            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: Theme.Spacing.xxs) {
+            if message.role == .user { Spacer(minLength: metrics.spacing.xxl) }
+            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: metrics.spacing.xxs) {
                 content
                 if message.state != .streaming { footer }
             }
@@ -126,25 +131,25 @@ private struct ChatMessageView: View {
                     hovered = false
                 }
             }
-            if message.role == .assistant { Spacer(minLength: Theme.Spacing.xxl) }
+            if message.role == .assistant { Spacer(minLength: metrics.spacing.xxl) }
         }
     }
 
     /// Laid out at rest and only faded in, so a hover cannot reflow the transcript
     private var footer: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             if message.role == .user { timestamp }
             ChatCopyButton(text: message.text)
             if message.role == .assistant { timestamp }
         }
         .opacity(hovered ? 1 : 0)
         // A reply's footer hugs the same `sm` edge as its text.
-        .padding(.horizontal, message.role == .user ? Theme.Spacing.md : Theme.Spacing.sm)
+        .padding(.horizontal, message.role == .user ? metrics.spacing.md : metrics.spacing.sm)
     }
 
     private var timestamp: some View {
         Text(message.sentAt.formatted(date: .omitted, time: .shortened))
-            .font(Theme.Typography.keyCap)
+            .font(metrics.typography.keyCap)
             .foregroundStyle(Theme.Colors.textTertiary)
     }
 
@@ -152,38 +157,38 @@ private struct ChatMessageView: View {
         if message.text.isEmpty, message.searches.isEmpty, message.toolUses.isEmpty,
             message.state == .streaming
         {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 ProgressView().controlSize(.small)
                 if let status { Text(status).foregroundStyle(.secondary) }
             }
-            .padding(Theme.Spacing.md)
+            .padding(metrics.spacing.md)
         } else {
             bubbleContent
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .foregroundStyle(message.state == .failed ? Theme.Colors.destructive : .primary)
                 .textSelection(.enabled)
                 // The user bubble is inset because it carries a fill; a reply clears the chevron
-                .padding(.horizontal, message.role == .user ? Theme.Spacing.xl : Theme.Spacing.sm)
-                .padding(.vertical, Theme.Spacing.md)
+                .padding(.horizontal, message.role == .user ? metrics.spacing.xl : metrics.spacing.sm)
+                .padding(.vertical, metrics.spacing.md)
                 .background(
-                    RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                    RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                         .fill(message.role == .user ? Theme.Colors.controlSurface : Color.clear)
                 )
         }
     }
 
     private var bubbleContent: some View {
-        VStack(alignment: message.role == .user ? .trailing : .leading, spacing: Theme.Spacing.sm) {
+        VStack(alignment: message.role == .user ? .trailing : .leading, spacing: metrics.spacing.sm) {
             if !message.images.isEmpty {
                 // Wider than the stack's own rhythm: two 96pt tiles at `sm` read as one blob.
-                HStack(spacing: Theme.Spacing.xl) {
+                HStack(spacing: metrics.spacing.xl) {
                     ForEach(message.images, id: \.self) { image in
-                        ChatImageThumbnail(image: image, edge: Theme.Size.chatImageThumb)
+                        ChatImageThumbnail(image: image, edge: metrics.size.chatImageThumb)
                     }
                 }
             }
             if !message.documents.isEmpty {
-                HStack(spacing: Theme.Spacing.md) {
+                HStack(spacing: metrics.spacing.md) {
                     ForEach(message.documents, id: \.self) { document in
                         ChatDocumentChip(document: document)
                     }
@@ -198,7 +203,7 @@ private struct ChatMessageView: View {
     /// Only a reply is markdown — what the user typed is shown back exactly as they typed it.
     @ViewBuilder private var rendered: some View {
         if message.role == .assistant {
-            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+            VStack(alignment: .leading, spacing: metrics.spacing.lg) {
                 ForEach(Array(message.segments.enumerated()), id: \.offset) { _, segment in
                     switch segment {
                     case .text(let text):
@@ -218,22 +223,23 @@ private struct ChatMessageView: View {
 
 /// A sent document names itself: its bytes went to the model, not into the transcript's prose.
 private struct ChatDocumentChip: View {
+    @Environment(\.metrics) private var metrics
     let document: AIDocument
 
     private var isPDF: Bool { document.mimeType == AIAttachmentPolicy.pdfMIMEType }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             Image(systemName: isPDF ? "doc.richtext" : "doc.plaintext")
-                .font(Theme.Typography.chip)
+                .font(metrics.typography.chip)
                 .symbolRenderingMode(.hierarchical)
             Text(document.name)
-                .font(Theme.Typography.chip)
+                .font(metrics.typography.chip)
                 .lineLimit(1)
         }
         .foregroundStyle(Theme.Colors.textSecondary)
-        .padding(.horizontal, Theme.Spacing.sm)
-        .padding(.vertical, Theme.Spacing.xxs)
+        .padding(.horizontal, metrics.spacing.sm)
+        .padding(.vertical, metrics.spacing.xxs)
         .background(Capsule().fill(Theme.Colors.controlSurface))
         .accessibilityLabel("Attached file \(document.name)")
     }
@@ -241,6 +247,7 @@ private struct ChatDocumentChip: View {
 
 /// Decoded once per image off the render path; a streaming transcript re-renders every flush.
 struct ChatImageThumbnail: View {
+    @Environment(\.metrics) private var metrics
     let image: AIImage
     let edge: CGFloat
     @State private var decoded: NSImage?
@@ -256,17 +263,18 @@ struct ChatImageThumbnail: View {
             }
         }
         .frame(width: edge, height: edge)
-        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous))
         .task(id: image) { decoded = NSImage(data: image.data) }
     }
 }
 
 /// A tool call inside a reply; the same row grammar the search one uses, with its own glyph.
 private struct ChatToolRow: View {
+    @Environment(\.metrics) private var metrics
     let use: ChatToolUse
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             switch use.state {
             case .running:
                 ProgressView().controlSize(.small)
@@ -277,7 +285,7 @@ private struct ChatToolRow: View {
                     .foregroundStyle(Theme.Colors.destructive)
             }
             Text(use.label)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .lineLimit(1)
         }
         .foregroundStyle(Theme.Colors.textSecondary)
@@ -287,29 +295,30 @@ private struct ChatToolRow: View {
     /// Sized by the row's own font, like the search row beside it, not by a symbol point size.
     private func glyph(_ name: String) -> some View {
         Image(systemName: name)
-            .font(Theme.Typography.rowTrailing)
+            .font(metrics.typography.rowTrailing)
             .symbolRenderingMode(.hierarchical)
     }
 }
 
 /// A web search inside a reply: live while it runs, a record of what it looked up once done.
 private struct ChatSearchRow: View {
+    @Environment(\.metrics) private var metrics
     let search: ChatSearch
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             if search.isComplete {
                 Image(systemName: "globe")
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .symbolRenderingMode(.hierarchical)
             } else {
                 ProgressView().controlSize(.small)
             }
             Text(search.isComplete ? "Searched web" : "Searching web")
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
             if let query = search.query, !query.isEmpty {
                 Text("· \(query)")
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .lineLimit(1)
             }

--- a/Tinycast/Features/AI/UI/MarkdownCodeView.swift
+++ b/Tinycast/Features/AI/UI/MarkdownCodeView.swift
@@ -2,34 +2,35 @@ import SwiftUI
 
 /// Lines soft-wrap: a second scroll view would fight the transcript's own dissolve.
 struct MarkdownCodeView: View {
+    @Environment(\.metrics) private var metrics
     let language: String?
     let text: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            HStack(spacing: Theme.Spacing.md) {
+        VStack(alignment: .leading, spacing: metrics.spacing.sm) {
+            HStack(spacing: metrics.spacing.md) {
                 if let language {
                     Text(language)
-                        .font(Theme.Typography.keyCap)
+                        .font(metrics.typography.keyCap)
                         .foregroundStyle(Theme.Colors.textTertiary)
                 }
                 Spacer(minLength: 0)
                 ChatCopyButton(text: text, subject: "Code")
             }
             Text(text)
-                .font(Theme.Typography.code)
+                .font(metrics.typography.code)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, Theme.Spacing.xl)
-        .padding(.vertical, Theme.Spacing.lg)
+        .padding(.horizontal, metrics.spacing.xl)
+        .padding(.vertical, metrics.spacing.lg)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                 .fill(Theme.Colors.cardFill)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                 .stroke(Theme.Colors.cardStroke))
     }
 }

--- a/Tinycast/Features/AI/UI/MarkdownInline.swift
+++ b/Tinycast/Features/AI/UI/MarkdownInline.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Inline markdown for one block. `Text` renders emphasis on its own but not code or strikethrough.
 enum MarkdownInline {
-    static func attributed(_ source: String) -> AttributedString {
+    static func attributed(_ source: String, _ metrics: InterfaceMetrics) -> AttributedString {
         var options = AttributedString.MarkdownParsingOptions()
         options.interpretedSyntax = .inlineOnlyPreservingWhitespace
         options.failurePolicy = .returnPartiallyParsedIfPossible
@@ -12,7 +12,7 @@ enum MarkdownInline {
         let intents = text.runs.compactMap { run in run.inlinePresentationIntent.map { ($0, run.range) } }
         for (intent, range) in intents {
             if intent.contains(.code) {
-                text[range].font = Theme.Typography.inlineCode
+                text[range].font = metrics.typography.inlineCode
                 text[range].backgroundColor = Theme.Colors.controlSurface
             }
             if intent.contains(.strikethrough) { text[range].strikethroughStyle = .single }
@@ -20,11 +20,11 @@ enum MarkdownInline {
         return text
     }
 
-    static func headingFont(_ level: Int) -> Font {
+    static func headingFont(_ level: Int, _ metrics: InterfaceMetrics) -> Font {
         switch level {
-        case 1: Theme.Typography.markdownHeading1
-        case 2: Theme.Typography.markdownHeading2
-        default: Theme.Typography.markdownHeading3
+        case 1: metrics.typography.markdownHeading1
+        case 2: metrics.typography.markdownHeading2
+        default: metrics.typography.markdownHeading3
         }
     }
 }

--- a/Tinycast/Features/AI/UI/MarkdownTableView.swift
+++ b/Tinycast/Features/AI/UI/MarkdownTableView.swift
@@ -1,17 +1,19 @@
 import SwiftUI
 
 struct MarkdownTableView: View {
+
+    @Environment(\.metrics) private var metrics
     let table: MarkdownBlock.Table
 
     var body: some View {
         Grid(
-            alignment: .leadingFirstTextBaseline, horizontalSpacing: Theme.Spacing.xl,
-            verticalSpacing: Theme.Spacing.sm
+            alignment: .leadingFirstTextBaseline, horizontalSpacing: metrics.spacing.xl,
+            verticalSpacing: metrics.spacing.sm
         ) {
             GridRow {
                 ForEach(Array(table.header.enumerated()), id: \.offset) { column, cell in
-                    Text(MarkdownInline.attributed(cell))
-                        .font(Theme.Typography.sectionHeader)
+                    Text(MarkdownInline.attributed(cell, metrics))
+                        .font(metrics.typography.sectionHeader)
                         .foregroundStyle(Theme.Colors.textSecondary)
                         .gridColumnAlignment(alignment(at: column))
                 }
@@ -26,7 +28,7 @@ struct MarkdownTableView: View {
             ForEach(Array(table.rows.enumerated()), id: \.offset) { _, row in
                 GridRow {
                     ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
-                        Text(MarkdownInline.attributed(cell))
+                        Text(MarkdownInline.attributed(cell, metrics))
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }
@@ -34,13 +36,13 @@ struct MarkdownTableView: View {
         }
         // Given only a width, Grid measures a wrapping row a line short of what it draws.
         .fixedSize(horizontal: false, vertical: true)
-        .padding(Theme.Spacing.xl)
+        .padding(metrics.spacing.xl)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                 .fill(Theme.Colors.cardFill)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                 .stroke(Theme.Colors.cardStroke))
     }
 

--- a/Tinycast/Features/AI/UI/MarkdownView.swift
+++ b/Tinycast/Features/AI/UI/MarkdownView.swift
@@ -2,15 +2,16 @@ import SwiftUI
 
 /// Renders parsed markdown; the body is erased so a nested list cannot make `Body` circular.
 struct MarkdownView: View {
+    @Environment(\.metrics) private var metrics
     let blocks: [MarkdownBlock]
-    var spacing = Theme.Spacing.lg
+    var spacing: CGFloat?
 
     var body: AnyView {
         AnyView(
-            VStack(alignment: .leading, spacing: spacing) {
+            VStack(alignment: .leading, spacing: spacing ?? metrics.spacing.lg) {
                 ForEach(Array(blocks.enumerated()), id: \.offset) { offset, block in
                     MarkdownBlockView(block: block)
-                        .padding(.top, offset > 0 && block.isHeading ? Theme.Spacing.sm : 0)
+                        .padding(.top, offset > 0 && block.isHeading ? metrics.spacing.sm : 0)
                 }
             })
     }
@@ -25,16 +26,17 @@ extension MarkdownBlock {
 }
 
 private struct MarkdownBlockView: View {
+    @Environment(\.metrics) private var metrics
     let block: MarkdownBlock
 
     var body: some View {
         switch block {
         case .heading(let level, let text):
-            Text(MarkdownInline.attributed(text))
-                .font(MarkdownInline.headingFont(level))
+            Text(MarkdownInline.attributed(text, metrics))
+                .font(MarkdownInline.headingFont(level, metrics))
                 .fixedSize(horizontal: false, vertical: true)
         case .paragraph(let text):
-            Text(MarkdownInline.attributed(text))
+            Text(MarkdownInline.attributed(text, metrics))
                 .fixedSize(horizontal: false, vertical: true)
         case .bulletList(let items):
             MarkdownListView(items: items, start: nil)
@@ -55,17 +57,19 @@ private struct MarkdownBlockView: View {
 }
 
 private struct MarkdownListView: View {
+
+    @Environment(\.metrics) private var metrics
     let items: [MarkdownBlock.Item]
     /// Nil for a bulleted list; otherwise the number the first item counts from.
     let start: Int?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+        VStack(alignment: .leading, spacing: metrics.spacing.xs) {
             ForEach(Array(items.enumerated()), id: \.offset) { offset, item in
-                HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.sm) {
+                HStack(alignment: .firstTextBaseline, spacing: metrics.spacing.sm) {
                     marker(at: offset, checked: item.checked)
-                        .frame(minWidth: Theme.Size.markdownListMarker, alignment: .trailing)
-                    MarkdownView(blocks: item.blocks, spacing: Theme.Spacing.xs)
+                        .frame(minWidth: metrics.size.markdownListMarker, alignment: .trailing)
+                    MarkdownView(blocks: item.blocks, spacing: metrics.spacing.xs)
                 }
             }
         }
@@ -96,13 +100,15 @@ private struct MarkdownListView: View {
 }
 
 private struct MarkdownQuoteView: View {
+
+    @Environment(\.metrics) private var metrics
     let blocks: [MarkdownBlock]
 
     var body: some View {
-        HStack(alignment: .top, spacing: Theme.Spacing.lg) {
-            RoundedRectangle(cornerRadius: Theme.Radius.keyCap, style: .continuous)
+        HStack(alignment: .top, spacing: metrics.spacing.lg) {
+            RoundedRectangle(cornerRadius: metrics.radius.keyCap, style: .continuous)
                 .fill(Theme.Colors.border)
-                .frame(width: Theme.Size.markdownQuoteBar)
+                .frame(width: metrics.size.markdownQuoteBar)
             MarkdownView(blocks: blocks)
                 .foregroundStyle(Theme.Colors.textSecondary)
         }

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -30,6 +30,7 @@ struct SettingsBackup: Codable {
         var popToRootSeconds: Int?
         var escapeKeyBehavior: String?
         var appearance: String?
+        var interfaceSize: String?
         var paletteTransparency: Int?
         var compactMode: Bool?
         var showFavoritesInCompactMode: Bool?
@@ -123,6 +124,7 @@ extension SettingsBackup {
             popToRootSeconds: s.popToRootTimeout.rawValue,
             escapeKeyBehavior: s.escapeKeyBehavior.rawValue,
             appearance: s.appearance.rawValue,
+            interfaceSize: s.interfaceSize.rawValue,
             paletteTransparency: s.paletteTransparency,
             compactMode: s.compactMode,
             showFavoritesInCompactMode: s.showFavoritesInCompactMode,
@@ -290,6 +292,10 @@ extension SettingsBackup {
         }
         if let raw = s.escapeKeyBehavior, let behavior = EscapeKeyBehavior(rawValue: raw) {
             settings.escapeKeyBehavior = behavior
+            count += 1
+        }
+        if let raw = s.interfaceSize, let size = InterfaceSize(rawValue: raw) {
+            settings.interfaceSize = size
             count += 1
         }
         if let raw = s.appearance, let appearance = AppAppearance(rawValue: raw) {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -15,6 +15,7 @@ enum SettingsBackupCoverage {
         "popToRootSeconds": .popToRootTimeout,
         "escapeKeyBehavior": .escapeKeyBehavior,
         "appearance": .appearance,
+        "interfaceSize": .interfaceSize,
         "paletteTransparency": .paletteTransparency,
         "compactMode": .compactMode,
         "showFavoritesInCompactMode": .showFavoritesInCompactMode,

--- a/Tinycast/Features/Calculator/UI/CalculatorCardView.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorCardView.swift
@@ -25,6 +25,7 @@ enum CalcMemo {
 
 /// The inline answer card above the app results; selectable like a row, Enter copies.
 struct CalculatorCard: View {
+    @Environment(\.metrics) private var metrics
     let result: CalcResult
     let selected: Bool
 
@@ -45,7 +46,7 @@ struct CalculatorCard: View {
                 }
                 .fixedSize(horizontal: false, vertical: true)
             case .error(let message):
-                HStack(spacing: Theme.Spacing.md) {
+                HStack(spacing: metrics.spacing.md) {
                     Image(systemName: "exclamationmark.triangle")
                         .symbolRenderingMode(.hierarchical)
                     Text(message)
@@ -56,8 +57,8 @@ struct CalculatorCard: View {
                 .frame(maxWidth: .infinity)
             }
         }
-        .padding(.horizontal, Theme.Spacing.xl)
-        .padding(.vertical, Theme.Spacing.xxxl)
+        .padding(.horizontal, metrics.spacing.xl)
+        .padding(.vertical, metrics.spacing.xxxl)
         .leadCard(selected: selected)
     }
 }

--- a/Tinycast/Features/Calculator/UI/CalculatorHistoryView.swift
+++ b/Tinycast/Features/Calculator/UI/CalculatorHistoryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Past calculations, shaped like `ClipboardList`; both sides per row, so no preview pane.
 struct CalculatorHistoryList: View {
+    @Environment(\.metrics) private var metrics
     let results: [CalcHistoryEntry]
     let selectedID: CalcHistoryEntry.ID?
     /// Changes only when the list should scroll, so mouse selection never yanks the position.
@@ -70,7 +71,7 @@ struct CalculatorHistoryList: View {
                                 .contentShape(Rectangle())
                                 .onTapGesture(perform: onActivateCalc)
                                 .onRightClick(perform: onCalcActions)
-                                .padding(.bottom, Theme.Spacing.xs)
+                                .padding(.bottom, metrics.spacing.xs)
                                 .selectionFrame(calcSelected)
                         case .entry(let entry):
                             CalcHistoryRow(entry: entry, selected: entry.id == selectedID)
@@ -87,9 +88,9 @@ struct CalculatorHistoryList: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -103,6 +104,8 @@ struct CalculatorHistoryList: View {
 }
 
 private struct CalcHistoryRow: View {
+
+    @Environment(\.metrics) private var metrics
     let entry: CalcHistoryEntry
     let selected: Bool
     @State private var hovered = false
@@ -114,10 +117,10 @@ private struct CalcHistoryRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
-            RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+        HStack(spacing: metrics.spacing.lg) {
+            RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
                 .fill(Theme.Colors.controlSurface)
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 .overlay(
                     Image(systemName: "plus.forwardslash.minus")
                         .font(.system(size: 12))
@@ -125,19 +128,19 @@ private struct CalcHistoryRow: View {
                         .foregroundStyle(.secondary)
                 )
             Text(entry.expression)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
-            Spacer(minLength: Theme.Spacing.xl)
+            Spacer(minLength: metrics.spacing.xl)
             Text(entry.result)
-                .font(Theme.Typography.rowTitle.weight(.semibold))
+                .font(metrics.typography.rowTitle.weight(.semibold))
                 .lineLimit(1)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)

--- a/Tinycast/Features/Calendar/UI/EventDraftFields.swift
+++ b/Tinycast/Features/Calendar/UI/EventDraftFields.swift
@@ -9,20 +9,21 @@ final class EventDraftState {
 
 /// The New Event dialog's controls: a title, then when and how long, as chips.
 struct EventDraftFields: View {
+    @Environment(\.metrics) private var metrics
     @Bindable var state: EventDraftState
     @FocusState private var focused: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+        VStack(alignment: .leading, spacing: metrics.spacing.xl) {
             TextField("", text: $state.draft.title, prompt: Text("Event title"))
                 .textFieldStyle(.plain)
                 .labelsHidden()
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .focused($focused)
-                .padding(.horizontal, Theme.Spacing.lg)
-                .frame(height: Theme.Size.barButtonHeight)
+                .padding(.horizontal, metrics.spacing.lg)
+                .frame(height: metrics.size.barButtonHeight)
                 .background(
-                    RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                    RoundedRectangle(cornerRadius: metrics.radius.menu, style: .continuous)
                         .fill(Theme.Colors.controlSurface))
             ChipRow(
                 label: "Starts", values: EventDraft.startOffsets,
@@ -37,17 +38,18 @@ struct EventDraftFields: View {
 
 /// Our own chips: a menu-style `Picker` drops an AppKit popover onto a vibrancy surface.
 private struct ChipRow: View {
+    @Environment(\.metrics) private var metrics
     let label: String
     let values: [Int]
     let title: (Int) -> String
     @Binding var selection: Int
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.md) {
+        HStack(spacing: metrics.spacing.md) {
             Text(label)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textSecondary)
-                .frame(width: Theme.Size.dialogIcon, alignment: .leading)
+                .frame(width: metrics.size.dialogIcon, alignment: .leading)
             ForEach(values, id: \.self) { value in
                 Chip(title: title(value), selected: value == selection) { selection = value }
             }
@@ -57,6 +59,8 @@ private struct ChipRow: View {
 }
 
 private struct Chip: View {
+
+    @Environment(\.metrics) private var metrics
     let title: String
     let selected: Bool
     let onTap: () -> Void
@@ -71,10 +75,10 @@ private struct Chip: View {
     var body: some View {
         Button(action: onTap) {
             Text(title)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(selected ? Theme.Colors.textPrimary : Theme.Colors.textSecondary)
-                .padding(.horizontal, Theme.Spacing.lg)
-                .frame(height: Theme.Size.barButtonHeight)
+                .padding(.horizontal, metrics.spacing.lg)
+                .frame(height: metrics.size.barButtonHeight)
                 .contentShape(Capsule())
                 .background(Capsule().fill(fill))
         }

--- a/Tinycast/Features/Calendar/UI/MeetingCardView.swift
+++ b/Tinycast/Features/Calendar/UI/MeetingCardView.swift
@@ -2,40 +2,41 @@ import SwiftUI
 
 /// The join card above the launcher results; selectable like a row, Enter joins.
 struct MeetingCard: View {
+    @Environment(\.metrics) private var metrics
     let meeting: MeetingEvent
     let now: Date
     let selected: Bool
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xl) {
+        HStack(spacing: metrics.spacing.xl) {
             SymbolImage(
                 name: meeting.link?.provider.sfSymbol ?? "calendar",
-                size: Theme.Size.headerIconSlot
+                size: metrics.size.headerIconSlot
             )
             .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            VStack(alignment: .leading, spacing: metrics.spacing.xs) {
                 Text(meeting.title)
-                    .font(Theme.Typography.calcResult.weight(.semibold))
+                    .font(metrics.typography.calcResult.weight(.semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
                 Text(subtitle)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
-            Spacer(minLength: Theme.Spacing.md)
+            Spacer(minLength: metrics.spacing.md)
             Text(UpcomingWindow.countdown(to: meeting.start, now: now))
-                .font(Theme.Typography.rowTitle.weight(.medium))
+                .font(metrics.typography.rowTitle.weight(.medium))
                 .lineLimit(1)
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.vertical, Theme.Spacing.xxs)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.vertical, metrics.spacing.xxs)
                 .background(
-                    RoundedRectangle(cornerRadius: Theme.Radius.keyCap, style: .continuous)
+                    RoundedRectangle(cornerRadius: metrics.radius.keyCap, style: .continuous)
                         .fill(Theme.Colors.controlSurface)
                 )
         }
-        .padding(.horizontal, Theme.Spacing.xl)
-        .padding(.vertical, Theme.Spacing.xxl)
+        .padding(.horizontal, metrics.spacing.xl)
+        .padding(.vertical, metrics.spacing.xxl)
         .leadCard(selected: selected)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(

--- a/Tinycast/Features/Calendar/UI/ScheduleView.swift
+++ b/Tinycast/Features/Calendar/UI/ScheduleView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// The My Schedule list, bucketed into Today and Tomorrow.
 struct ScheduleList: View {
+    @Environment(\.metrics) private var metrics
     let results: [MeetingEvent]
     let selectedID: MeetingEvent.ID?
     let now: Date
@@ -59,9 +60,9 @@ struct ScheduleList: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -74,6 +75,8 @@ struct ScheduleList: View {
 }
 
 private struct MeetingRow: View {
+
+    @Environment(\.metrics) private var metrics
     let meeting: MeetingEvent
     let now: Date
     let selected: Bool
@@ -86,25 +89,25 @@ private struct MeetingRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             SymbolImage(
-                name: meeting.link?.provider.sfSymbol ?? "calendar", size: Theme.Size.rowIcon * 0.7
+                name: meeting.link?.provider.sfSymbol ?? "calendar", size: metrics.size.rowIcon * 0.7
             )
-            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+            .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
             .foregroundStyle(meeting.isInProgress(now: now) ? Theme.Colors.brand : .secondary)
             Text(meeting.title)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
-            Spacer(minLength: Theme.Spacing.md)
+            Spacer(minLength: metrics.spacing.md)
             Text(trailing)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -5,6 +5,8 @@ struct ClipboardScreen: PaletteScreen {
     let store: ClipboardStore
     let core: AppCore
     let vm: PaletteState
+
+    private var metrics: InterfaceMetrics { core.settings.interfaceSize.metrics }
     let openActions: () -> Void
     let scrollToFollow: () -> Void
 
@@ -117,7 +119,7 @@ struct ClipboardScreen: PaletteScreen {
                         openActions()
                     }
                 )
-                .frame(width: Theme.Size.clipboardListWidth)
+                .frame(width: metrics.size.clipboardListWidth)
                 Rectangle()
                     .fill(Theme.Colors.separator)
                     .frame(width: 1)

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -2,6 +2,8 @@ import AppKit
 import SwiftUI
 
 struct ClipboardList: View {
+
+    @Environment(\.metrics) private var metrics
     let results: [ClipboardItem]
     let selectedID: ClipboardItem.ID?
     /// Changes only when the list should scroll, so mouse selection never yanks it.
@@ -73,9 +75,9 @@ struct ClipboardList: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -118,6 +120,8 @@ enum DateBucket: Int {
 }
 
 private struct ClipboardRow: View {
+
+    @Environment(\.metrics) private var metrics
     let item: ClipboardItem
     let selected: Bool
     let imageURL: URL?
@@ -134,24 +138,24 @@ private struct ClipboardRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             thumbnail(item.colorValue)
             Text(previewText)
-                .font(Theme.Typography.menuRow)
+                .font(metrics.typography.menuRow)
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
             if let slot, palette.commandHeld {
-                HStack(spacing: Theme.Spacing.xxs) {
+                HStack(spacing: metrics.spacing.xxs) {
                     KeyCapChip(text: "⌘", style: .outline)
                     KeyCapChip(text: String(slot), style: .outline)
                 }
             }
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)
@@ -175,7 +179,7 @@ private struct ClipboardRow: View {
             // A colour states itself, so it takes the tile a glyph would otherwise fill.
             if let color {
                 ColorSwatch(color: color)
-                    .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                    .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
             } else {
                 glyphTile("doc.text")
             }
@@ -184,9 +188,9 @@ private struct ClipboardRow: View {
                 image
                     .resizable()
                     .scaledToFill()
-                    .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                    .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                     .clipShape(
-                        RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
+                        RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous))
             } placeholder: {
                 glyphTile("photo")
             }
@@ -195,9 +199,9 @@ private struct ClipboardRow: View {
                 image
                     .resizable()
                     .scaledToFill()
-                    .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                    .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                     .clipShape(
-                        RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
+                        RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous))
             } placeholder: {
                 glyphTile(fileKind.systemImage)
             }
@@ -212,9 +216,9 @@ private struct ClipboardRow: View {
 
     /// A symbol on a rounded tile, sized so text and image rows share one shape.
     private func glyphTile(_ systemName: String) -> some View {
-        RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+        RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
             .fill(Theme.Colors.controlSurface)
-            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+            .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
             .overlay(
                 Image(systemName: systemName)
                     .font(.system(size: 12))
@@ -278,6 +282,8 @@ private struct AsyncThumbnail<Content: View, Placeholder: View>: View {
 }
 
 struct ClipboardPreview: View {
+
+    @Environment(\.metrics) private var metrics
     let item: ClipboardItem?
     @Environment(ClipboardStore.self) private var store
 
@@ -309,16 +315,16 @@ struct ClipboardPreview: View {
                 }
             }
         case .image:
-            AsyncThumbnail(url: store.imageURL(for: item), maxPixel: Theme.Size.clipboardPreviewPixel) {
+            AsyncThumbnail(url: store.imageURL(for: item), maxPixel: metrics.size.clipboardPreviewPixel) {
                 image in
                 image
                     .resizable()
                     .scaledToFit()
                     .clipShape(
-                        RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                        RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                     )
                     .overlay(
-                        RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                        RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                             .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
                     )
             } placeholder: {
@@ -333,6 +339,7 @@ struct ClipboardPreview: View {
 
 /// The "Information" block; disk-touching details are gathered off the main actor.
 private struct ClipboardInfoSection: View {
+    @Environment(\.metrics) private var metrics
     let item: ClipboardItem
     let imageURL: URL?
 
@@ -363,17 +370,17 @@ private struct ClipboardInfoSection: View {
     }()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+        VStack(alignment: .leading, spacing: metrics.spacing.sm) {
             Text("Information")
-                .font(Theme.Typography.sectionHeader)
+                .font(metrics.typography.sectionHeader)
                 .foregroundStyle(.secondary)
             VStack(spacing: 0) {
                 let rows = self.rows
                 ForEach(rows) { row in
                     if row.id != rows.first?.id { Divider() }
-                    HStack(spacing: Theme.Spacing.sm) {
+                    HStack(spacing: metrics.spacing.sm) {
                         Text(row.label).foregroundStyle(.secondary)
-                        Spacer(minLength: Theme.Spacing.lg)
+                        Spacer(minLength: metrics.spacing.lg)
                         if let icon = row.icon {
                             Image(nsImage: icon)
                                 .resizable()
@@ -382,11 +389,11 @@ private struct ClipboardInfoSection: View {
                         Text(row.value).lineLimit(1).truncationMode(.middle)
                     }
                     .font(.callout)
-                    .padding(.vertical, Theme.Spacing.sm)
+                    .padding(.vertical, metrics.spacing.sm)
                 }
             }
         }
-        .padding(.top, Theme.Spacing.xl)
+        .padding(.top, metrics.spacing.xl)
         .task(id: item.id) { await loadDetails() }
     }
 

--- a/Tinycast/Features/Clipboard/UI/ColorPreview.swift
+++ b/Tinycast/Features/Clipboard/UI/ColorPreview.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// A colour entry's preview: the colour and the copied text, the notations being ⌘K's business.
 struct ColorPreview: View {
+    @Environment(\.metrics) private var metrics
     let color: ColorValue
     let text: String
 
@@ -9,8 +10,8 @@ struct ColorPreview: View {
     private static let swatchSize = CGSize(width: 220, height: 130)
 
     var body: some View {
-        VStack(spacing: Theme.Spacing.lg) {
-            ColorSwatch(color: color, cornerRadius: Theme.Radius.card)
+        VStack(spacing: metrics.spacing.lg) {
+            ColorSwatch(color: color, cornerRadius: metrics.radius.card)
                 .frame(width: Self.swatchSize.width, height: Self.swatchSize.height)
             Text(text)
                 .font(.system(.subheadline, design: .monospaced))
@@ -19,6 +20,6 @@ struct ColorPreview: View {
                 .truncationMode(.middle)
         }
         .frame(maxWidth: .infinity)
-        .padding(.top, Theme.Spacing.xxl)
+        .padding(.top, metrics.spacing.xxl)
     }
 }

--- a/Tinycast/Features/Clipboard/UI/ColorSwatch.swift
+++ b/Tinycast/Features/Clipboard/UI/ColorSwatch.swift
@@ -2,12 +2,14 @@ import SwiftUI
 
 /// The one place a colour is drawn, over the checkerboard that makes its alpha visible.
 struct ColorSwatch: View {
+    @Environment(\.metrics) private var metrics
     let color: ColorValue
-    var cornerRadius: CGFloat = Theme.Radius.thumbnail
+    var cornerRadius: CGFloat?
 
     /// A colour is content, not chrome, so it carries the same hairline a thumbnail does.
     var body: some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        let shape = RoundedRectangle(
+            cornerRadius: cornerRadius ?? metrics.radius.thumbnail, style: .continuous)
         shape
             .fill(Theme.Colors.controlSurface)
             // Built only where there is alpha, else every row pays for a Canvas nothing can see.

--- a/Tinycast/Features/Clipboard/UI/FilePreviewStage.swift
+++ b/Tinycast/Features/Clipboard/UI/FilePreviewStage.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 /// The preview pane's stage for a referenced file: a poster frame, or a player for media.
 struct FilePreviewStage: View {
+    @Environment(\.metrics) private var metrics
     let path: String
 
     /// One stat, off the render path: `body` re-runs per keystroke and must not touch the disk.
@@ -26,7 +27,7 @@ struct FilePreviewStage: View {
         case .some where kind.isPlayable: MediaPreviewPlayer(url: url, isAudio: kind == .audio)
         default:
             FileThumbnailStage(
-                url: url, maxPixel: Theme.Size.clipboardPreviewPixel, glyph: kind.systemImage)
+                url: url, maxPixel: metrics.size.clipboardPreviewPixel, glyph: kind.systemImage)
         }
     }
 
@@ -43,13 +44,14 @@ struct FilePreviewStage: View {
 
 /// The recorded path is still the answer to "where was it?", so the row keeps it and says this.
 private struct MissingFileStage: View {
+    @Environment(\.metrics) private var metrics
     var body: some View {
-        VStack(spacing: Theme.Spacing.sm) {
+        VStack(spacing: metrics.spacing.sm) {
             Image(systemName: "doc.badge.exclamationmark")
                 .font(.system(.largeTitle))
                 .symbolRenderingMode(.hierarchical)
             Text("File is no longer available")
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
         }
         .foregroundStyle(.tertiary)
         .frame(maxWidth: .infinity)
@@ -58,6 +60,7 @@ private struct MissingFileStage: View {
 
 /// A still, framed exactly as the image preview is, so every preview kind is one shape.
 private struct FileThumbnailStage: View {
+    @Environment(\.metrics) private var metrics
     let url: URL
     let maxPixel: CGFloat
     let glyph: String
@@ -70,9 +73,9 @@ private struct FileThumbnailStage: View {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
-                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous))
                     .overlay(
-                        RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                        RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
                             .strokeBorder(Theme.Colors.cardStroke, lineWidth: 1)
                     )
             } else {
@@ -95,6 +98,7 @@ private struct FileThumbnailStage: View {
 
 /// Owns the `AVPlayer`. Never autoplays: arrow-keying a list must not start twenty decodes.
 private struct MediaPreviewPlayer: View {
+    @Environment(\.metrics) private var metrics
     let url: URL
     let isAudio: Bool
 
@@ -110,8 +114,8 @@ private struct MediaPreviewPlayer: View {
     var body: some View {
         PlayerSurface(player: player)
             .background { if isAudio { AudioPoster(url: url) } }
-            .frame(height: Theme.Size.clipboardMediaHeight)
-            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+            .frame(height: metrics.size.clipboardMediaHeight)
+            .clipShape(RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous))
             .task(id: PlaybackKey(url: url, isVisible: palette.isVisible)) {
                 stop()
                 guard palette.isVisible else { return }

--- a/Tinycast/Features/CustomCommands/UI/CustomCommandArgumentsView.swift
+++ b/Tinycast/Features/CustomCommands/UI/CustomCommandArgumentsView.swift
@@ -2,34 +2,35 @@ import SwiftUI
 
 /// The command it will run, and one row per value it still wants.
 struct CustomCommandArgumentsView: View {
+    @Environment(\.metrics) private var metrics
     let session: CustomCommandArgumentSession
 
     private static let markSize: CGFloat = 11
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+        VStack(alignment: .leading, spacing: metrics.spacing.lg) {
             if let command = session.command {
                 header(command)
             }
-            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: metrics.spacing.sm) {
                 ForEach(Array(session.progress.enumerated()), id: \.offset) { index, entry in
                     row(entry.argument, value: entry.value, position: index + 1)
                 }
             }
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, Theme.Spacing.md * 2)
-        .padding(.top, Theme.Spacing.md)
-        .padding(.bottom, Theme.Spacing.lg)
+        .padding(.horizontal, metrics.spacing.md * 2)
+        .padding(.top, metrics.spacing.md)
+        .padding(.bottom, metrics.spacing.lg)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private func header(_ command: CustomCommand) -> some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+        VStack(alignment: .leading, spacing: metrics.spacing.xs) {
             Text(command.name)
-                .font(Theme.Typography.rowTitle.weight(.semibold))
+                .font(metrics.typography.rowTitle.weight(.semibold))
             Text(command.command)
-                .font(Theme.Typography.code)
+                .font(metrics.typography.code)
                 .foregroundStyle(Theme.Colors.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -40,25 +41,25 @@ struct CustomCommandArgumentsView: View {
     private func row(
         _ argument: CustomCommandArgument, value: String?, position: Int
     ) -> some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             Image(systemName: value == nil ? "circle" : "checkmark.circle.fill")
                 .font(.system(size: Self.markSize))
                 .foregroundStyle(value == nil ? Theme.Colors.textTertiary : Theme.Colors.success)
             Text("$\(position)")
-                .font(Theme.Typography.code)
+                .font(metrics.typography.code)
                 .foregroundStyle(Theme.Colors.textTertiary)
             Text(argument.name)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textSecondary)
             if let value {
                 Text(value.isEmpty ? "—" : value)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .lineLimit(1)
                     .truncationMode(.middle)
             } else if argument.isOptional {
                 Text("optional")
-                    .font(Theme.Typography.keyCap)
+                    .font(metrics.typography.keyCap)
                     .foregroundStyle(Theme.Colors.textTertiary)
             }
             Spacer(minLength: 0)

--- a/Tinycast/Features/Emoji/UI/EmojiGridView.swift
+++ b/Tinycast/Features/Emoji/UI/EmojiGridView.swift
@@ -57,6 +57,8 @@ private enum EmojiGridItem: Identifiable {
 }
 
 struct EmojiGridView: View {
+
+    @Environment(\.metrics) private var metrics
     let sections: [EmojiGridSection]
     /// Flat selection index across all sections, as in the list modes.
     let selection: Int
@@ -118,9 +120,9 @@ struct EmojiGridView: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -135,6 +137,7 @@ struct EmojiGridView: View {
 
 /// One grid row, owning all interaction for its cells. See docs/features/emoji.md#rendering.
 private struct EmojiGridRowView: View {
+    @Environment(\.metrics) private var metrics
     let row: EmojiGridRow
     let selection: Int
     let tone: EmojiSkinTone
@@ -157,7 +160,7 @@ private struct EmojiGridRowView: View {
                     )
                 } else {
                     // Empty trailing slots keep a partial last row aligned with the full rows.
-                    Color.clear.frame(maxWidth: .infinity, minHeight: Theme.Size.emojiCell)
+                    Color.clear.frame(maxWidth: .infinity, minHeight: metrics.size.emojiCell)
                 }
             }
         }
@@ -206,6 +209,7 @@ private struct EmojiGridRowView: View {
 
 /// Pure content: no gestures, overlays or hover tracking. See docs/features/emoji.md#rendering.
 private struct EmojiCell: View {
+    @Environment(\.metrics) private var metrics
     let glyph: String
     let selected: Bool
     let hovered: Bool
@@ -220,9 +224,9 @@ private struct EmojiCell: View {
         Text(glyph)
             .font(.system(size: 30))
             .frame(maxWidth: .infinity)
-            .frame(height: Theme.Size.emojiCell)
+            .frame(height: metrics.size.emojiCell)
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                     .fill(fill)
             )
     }

--- a/Tinycast/Features/Extensions/Model/ExtensionFormMetrics.swift
+++ b/Tinycast/Features/Extensions/Model/ExtensionFormMetrics.swift
@@ -1,53 +1,59 @@
 import Foundation
 
 /// The geometry every form control shares; pure, so a harness drives the placement rule.
-enum ExtensionFormMetrics {
+struct ExtensionFormMetrics {
+    /// `Theme` at the default Interface Size, for the pure placement rule and its harness.
+    static let base = ExtensionFormMetrics(scale: 1)
+
+    /// Owned here rather than in `DesignSystem`: an extension never moves a launcher surface.
+    let scale: CGFloat
+
     /// One control's width and height, in the proportions an extension's form is authored against.
-    static let controlWidth: CGFloat = 360
-    static let controlHeight: CGFloat = 32
+    var controlWidth: CGFloat { scaled(360) }
+    var controlHeight: CGFloat { scaled(32) }
     /// A text area is a control that grew: same width and chrome, several lines tall.
-    static let textAreaHeight: CGFloat = 78
+    var textAreaHeight: CGFloat { scaled(78) }
     /// Inset of a control's own text from its rounded edge.
-    static let textInset: CGFloat = 10
+    var textInset: CGFloat { scaled(10) }
     /// One top inset everywhere, so a field and a text area start their text on one line.
-    static let verticalInset: CGFloat = 7
+    var verticalInset: CGFloat { scaled(7) }
     /// `NSTextView`'s line-fragment padding, taken off so its text aligns with a field's.
-    static let textViewGutter: CGFloat = 5
+    var textViewGutter: CGFloat { scaled(5) }
     /// The box a checkbox draws, and the gap to the label beside it.
-    static let checkboxSize: CGFloat = 14
+    var checkboxSize: CGFloat { scaled(14) }
     /// The gap between one labelled row and the next, tuned by eye rather than derived.
-    static let rowSpacing: CGFloat = 18
+    var rowSpacing: CGFloat { scaled(18) }
     /// The gap a separator adds on each side, so a group reads apart from the one before it.
-    static let separatorSpacing: CGFloat = 4
+    var separatorSpacing: CGFloat { scaled(4) }
     /// Room above the first row and below the last, so neither touches the bars.
-    static let formVerticalPadding: CGFloat = 16
+    var formVerticalPadding: CGFloat { scaled(16) }
     /// The gap between a control and the popover it opens, on whichever side it opens.
-    static let popoverGap: CGFloat = 6
+    var popoverGap: CGFloat { scaled(6) }
     /// The ⌘K panel's pitch, restated: a launcher change must never move a form.
-    static let popoverRowHeight: CGFloat = 36
-    static let popoverRowSpacing: CGFloat = 1
+    var popoverRowHeight: CGFloat { scaled(36) }
+    var popoverRowSpacing: CGFloat { 1 }
     /// A section heading inside a picker's list; shorter than a row, since it is a label.
-    static let popoverSectionHeaderHeight: CGFloat = 24
+    var popoverSectionHeaderHeight: CGFloat { scaled(24) }
     /// Six rows and half of the seventh, so a long list reads as scrollable rather than clipped.
-    static let popoverVisibleRows: CGFloat = 6.5
+    var popoverVisibleRows: CGFloat { 6.5 }
     /// The search or expression row a popover opens with, where it has one.
-    static let popoverSearchHeight: CGFloat = 30
+    var popoverSearchHeight: CGFloat { scaled(30) }
     /// The drawn caret that stands in for a field editor the control never gets.
-    static let caretWidth: CGFloat = 1
-    static let caretHeight: CGFloat = 15
-    static let caretBlink: TimeInterval = 0.5
+    var caretWidth: CGFloat { 1 }
+    var caretHeight: CGFloat { scaled(15) }
+    var caretBlink: TimeInterval { 0.5 }
     /// How far left of an empty field's prompt its caret stands, as the field editor's does.
-    static let caretPromptGap: CGFloat = 2
+    var caretPromptGap: CGFloat { scaled(2) }
     /// `Theme.Spacing.sm` on every side, matching the ⌘K panel's own inset.
-    static let popoverPadding: CGFloat = 6
+    var popoverPadding: CGFloat { scaled(6) }
 
     /// Rounded: a half-row of an odd pitch lands the popover's edge on a half pixel.
-    static var popoverRowsMaxHeight: CGFloat {
+    var popoverRowsMaxHeight: CGFloat {
         (popoverVisibleRows * (popoverRowHeight + popoverRowSpacing)).rounded()
     }
 
     /// Exact, because every row is one known height: no measuring pass, and no greedy scroll view.
-    static func popoverListHeight(rows: Int, headers: Int = 0) -> CGFloat {
+    func popoverListHeight(rows: Int, headers: Int = 0) -> CGFloat {
         guard rows > 0 else { return 0 }
         let pitch = popoverRowHeight + popoverRowSpacing
         let headings = CGFloat(headers) * (popoverSectionHeaderHeight + popoverRowSpacing)
@@ -56,7 +62,7 @@ enum ExtensionFormMetrics {
     }
 
     /// The whole popover, list plus whatever chrome sits above it.
-    static func popoverHeight(rows: Int, hasSearchField: Bool, headers: Int = 0) -> CGFloat {
+    func popoverHeight(rows: Int, hasSearchField: Bool, headers: Int = 0) -> CGFloat {
         // The panel is sized to this, so an empty list must still measure the row it draws.
         let list = rows > 0 ? popoverListHeight(rows: rows, headers: headers) : popoverRowHeight
         let search = hasSearchField ? popoverSearchHeight : 0
@@ -72,7 +78,7 @@ enum ExtensionFormMetrics {
     }
 
     /// Below the control when it fits, else above it; clamped so it can never leave the container.
-    static func placement(
+    func placement(
         anchor: CGRect, popoverHeight: CGFloat, containerHeight: CGFloat
     ) -> Placement {
         let below = anchor.maxY + popoverGap
@@ -86,5 +92,10 @@ enum ExtensionFormMetrics {
         }
         // Taller than the container either way: show its start, which is where the selection is.
         return Placement(y: max(0, min(below, containerHeight - popoverHeight)), flipped: false)
+    }
+
+    /// Whole points, matching `InterfaceMetrics`: a fractional pitch lands a row edge off-pixel.
+    private func scaled(_ value: CGFloat) -> CGFloat {
+        scale == 1 ? value : (value * scale).rounded()
     }
 }

--- a/Tinycast/Features/Extensions/UI/CommandArgumentsRow.swift
+++ b/Tinycast/Features/Extensions/UI/CommandArgumentsRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// The inline argument fields beside the search field; their own `FocusState`, Tab hands over.
 struct CommandArgumentsRow: View {
+    @Environment(\.metrics) private var metrics
     let arguments: [ExtensionCommandArgument]
     /// The selected command's glyph, drawn as a leading chip so the fields read as belonging to it.
     let icon: EntryIcon?
@@ -12,9 +13,10 @@ struct CommandArgumentsRow: View {
     let onSubmit: () -> Void
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             if let icon {
-                EntryIconView(source: icon).frame(width: Self.height, height: Self.height)
+                EntryIconView(source: icon)
+                    .frame(width: Self.height(metrics), height: Self.height(metrics))
             }
             ForEach(arguments, id: \.name) { argument in
                 ArgumentField(
@@ -28,17 +30,24 @@ struct CommandArgumentsRow: View {
         }
     }
 
-    static let height: CGFloat = 26
+    static func height(_ metrics: InterfaceMetrics) -> CGFloat { metrics.scaled(26) }
 
     /// The header shrinks the search field to exactly the room left over.
-    static func totalWidth(for arguments: [ExtensionCommandArgument], hasIcon: Bool) -> CGFloat {
-        let fields = arguments.reduce(0) { $0 + fieldWidth(for: $1) }
-        let gaps = CGFloat(arguments.count + (hasIcon ? 0 : -1)) * Theme.Spacing.xs
-        return fields + gaps + (hasIcon ? height : 0)
+    static func totalWidth(
+        for arguments: [ExtensionCommandArgument], hasIcon: Bool, metrics: InterfaceMetrics
+    ) -> CGFloat {
+        let fields = arguments.reduce(0) { $0 + fieldWidth(for: $1, metrics: metrics) }
+        let gaps = CGFloat(arguments.count + (hasIcon ? 0 : -1)) * metrics.spacing.xs
+        return fields + gaps + (hasIcon ? height(metrics) : 0)
     }
 
-    static func fieldWidth(for argument: ExtensionCommandArgument) -> CGFloat {
-        min(max(CGFloat(argument.placeholder.count) * 7 + 20, 62), 150)
+    static func fieldWidth(
+        for argument: ExtensionCommandArgument, metrics: InterfaceMetrics
+    )
+        -> CGFloat
+    {
+        let placeholder = CGFloat(argument.placeholder.count) * metrics.scaled(7)
+        return min(max(placeholder + metrics.scaled(20), metrics.scaled(62)), metrics.scaled(150))
     }
 
     /// The order Tab walks: search field (nil) → each argument → back to the search field.
@@ -52,6 +61,8 @@ struct CommandArgumentsRow: View {
 }
 
 private struct ArgumentField: View {
+
+    @Environment(\.metrics) private var metrics
     let argument: ExtensionCommandArgument
     @Binding var text: String
     let isFocused: Bool
@@ -64,19 +75,19 @@ private struct ArgumentField: View {
             prompt: Text(argument.placeholder).foregroundStyle(Theme.Colors.textTertiary)
         )
         .textFieldStyle(.plain)
-        .font(Theme.Typography.rowTrailing)
+        .font(metrics.typography.rowTrailing)
         .tint(.white)
         .onSubmit(onSubmit)
         .multilineTextAlignment(.center)
         // Sized to the placeholder so a three-argument command still fits.
-        .frame(width: CommandArgumentsRow.fieldWidth(for: argument))
-        .padding(.horizontal, Theme.Spacing.sm)
-        .frame(height: CommandArgumentsRow.height)
+        .frame(width: CommandArgumentsRow.fieldWidth(for: argument, metrics: metrics))
+        .padding(.horizontal, metrics.spacing.sm)
+        .frame(height: CommandArgumentsRow.height(metrics))
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous).fill(fill)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous).fill(fill)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .strokeBorder(stroke, lineWidth: 1)
         )
         .onHover { hovered = $0 }

--- a/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionActionsPanel.swift
@@ -1,18 +1,21 @@
 import SwiftUI
 
 /// File-scoped so a row and the cap that counts rows read one number.
-private enum Metrics {
-    static let width: CGFloat = 300
+private struct Metrics {
+    /// Owned here rather than in `DesignSystem`: an extension never moves a launcher surface.
+    let interface: InterfaceMetrics
+
+    var width: CGFloat { interface.scaled(300) }
     /// The glyph slot plus its breathing room — the tallest thing a row contains.
-    static let rowHeight: CGFloat = Theme.Size.menuIcon + Theme.Spacing.md * 2
-    static let rowSpacing: CGFloat = 1
+    var rowHeight: CGFloat { interface.size.menuIcon + interface.spacing.md * 2 }
+    var rowSpacing: CGFloat { 1 }
     /// Six rows and half of the seventh, so a long panel reads as scrollable rather than clipped.
-    static let visibleRows: CGFloat = 6.5
+    var visibleRows: CGFloat { 6.5 }
     /// Rounded: a fractional height lands the glass edge on a half pixel.
-    static var maxHeight: CGFloat { (visibleRows * (rowHeight + rowSpacing)).rounded() }
+    var maxHeight: CGFloat { (visibleRows * (rowHeight + rowSpacing)).rounded() }
 
     /// Exact, because every row is one known height: no measuring pass, and no greedy scroll view.
-    static func height(rows: Int) -> CGFloat {
+    func height(rows: Int) -> CGFloat {
         min(CGFloat(rows) * (rowHeight + rowSpacing) - rowSpacing, maxHeight)
     }
 }
@@ -27,6 +30,7 @@ struct ExtensionActionItem {
 
 /// The ⌘K panel of a running command; not `PopoverMenu`, because it scrolls.
 struct ExtensionActionsPanel: View {
+    @Environment(\.metrics) private var metrics
     var header: String?
     let items: [ExtensionActionItem]
     @Binding var selection: Int
@@ -37,22 +41,24 @@ struct ExtensionActionsPanel: View {
     /// A hovered row is already visible, so scrolling would drag the list under it.
     @State private var hoverSelection: Int?
 
+    private var panel: Metrics { Metrics(interface: metrics) }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
             if let header {
                 Text(header)
-                    .font(Theme.Typography.sectionHeader)
+                    .font(metrics.typography.sectionHeader)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .padding(.horizontal, Theme.Spacing.lg)
-                    .padding(.top, Theme.Spacing.xs)
-                    .padding(.bottom, Theme.Spacing.xs / 2)
+                    .padding(.horizontal, metrics.spacing.lg)
+                    .padding(.top, metrics.spacing.xs)
+                    .padding(.bottom, metrics.spacing.xs / 2)
             }
             // The header stays put while rows move under it.
             ScrollViewReader { proxy in
                 ScrollView {
-                    VStack(alignment: .leading, spacing: Metrics.rowSpacing) {
+                    VStack(alignment: .leading, spacing: panel.rowSpacing) {
                         // Index-as-id is stable: a panel's rows never reorder while it is open.
                         ForEach(items.indices, id: \.self) { index in
                             ExtensionActionRow(
@@ -65,7 +71,7 @@ struct ExtensionActionsPanel: View {
                         }
                     }
                 }
-                .frame(height: Metrics.height(rows: items.count))
+                .frame(height: panel.height(rows: items.count))
                 // Without this a panel shorter than the cap rubber-bands against nothing.
                 .scrollBounceBehavior(.basedOnSize)
                 // `never`, not `hidden`: hidden still lets AppKit claim the scroller's gutter.
@@ -80,10 +86,10 @@ struct ExtensionActionsPanel: View {
                 }
             }
         }
-        .padding(Theme.Spacing.sm)
-        .frame(width: Metrics.width)
+        .padding(metrics.spacing.sm)
+        .frame(width: panel.width)
         .glassEffect(
-            .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)
+            .regular, in: RoundedRectangle(cornerRadius: metrics.radius.menuPanel, style: .continuous)
         )
     }
 
@@ -97,36 +103,39 @@ struct ExtensionActionsPanel: View {
 
 /// Its own row, not the palette's: that one is file-private.
 private struct ExtensionActionRow: View {
+    @Environment(\.metrics) private var metrics
     let item: ExtensionActionItem
     let selected: Bool
     let onActivate: () -> Void
 
+    private var panel: Metrics { Metrics(interface: metrics) }
+
     var body: some View {
         Button(action: onActivate) {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 icon
                 Text(item.title)
-                    .font(Theme.Typography.menuRow)
+                    .font(metrics.typography.menuRow)
                     .foregroundStyle(item.isDestructive ? Color.red : Color.primary)
                     .lineLimit(1)
-                Spacer(minLength: Theme.Spacing.sm)
+                Spacer(minLength: metrics.spacing.sm)
                 if let shortcut = item.shortcut {
-                    HStack(spacing: Theme.Spacing.xxs) {
+                    HStack(spacing: metrics.spacing.xxs) {
                         ForEach(Array(shortcut.enumerated()), id: \.offset) { _, glyph in
                             KeyCapChip(text: String(glyph), style: .outline)
                         }
                     }
                 }
             }
-            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.horizontal, metrics.spacing.md)
             // Fixed, not padded: the height maths above counts rows, so a row is one exact height.
             .frame(
-                maxWidth: .infinity, minHeight: Metrics.rowHeight, maxHeight: Metrics.rowHeight,
+                maxWidth: .infinity, minHeight: panel.rowHeight, maxHeight: panel.rowHeight,
                 alignment: .leading
             )
             .contentShape(Rectangle())
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.menuRow, style: .continuous)
                     .fill(selected ? Theme.Colors.menuHover : Color.clear)
             )
         }
@@ -138,12 +147,12 @@ private struct ExtensionActionRow: View {
     private var icon: some View {
         if case .symbol(let name) = item.icon.source {
             Image(systemName: name)
-                .font(Theme.Typography.menuIcon)
+                .font(metrics.typography.menuIcon)
                 .symbolRenderingMode(item.icon.tint == nil ? .hierarchical : .monochrome)
                 .foregroundStyle(item.icon.tint ?? Color.secondary)
-                .frame(width: Theme.Size.menuIcon, height: Theme.Size.menuIcon)
+                .frame(width: metrics.size.menuIcon, height: metrics.size.menuIcon)
         } else {
-            ExtensionIconView(resolved: item.icon, size: Theme.Size.menuIcon)
+            ExtensionIconView(resolved: item.icon, size: metrics.size.menuIcon)
         }
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionArgumentsAccessory.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionArgumentsAccessory.swift
@@ -9,6 +9,7 @@ enum ExtensionArgumentsAccessory {
         coordinator: ExtensionCoordinator,
         values: @escaping (String) -> Binding<String>,
         focus: FocusState<String?>.Binding,
+        metrics: InterfaceMetrics,
         onSubmit: @escaping () -> Void
     ) -> PaletteHeaderAccessory? {
         guard let entry, let arguments = coordinator.commandArguments(for: entry),
@@ -17,7 +18,7 @@ enum ExtensionArgumentsAccessory {
 
         let icon = entry.iconSource
         return PaletteHeaderAccessory(
-            width: CommandArgumentsRow.totalWidth(for: arguments, hasIcon: true),
+            width: CommandArgumentsRow.totalWidth(for: arguments, hasIcon: true, metrics: metrics),
             fieldNames: arguments.map(\.name),
             firstIncompleteField: arguments.first {
                 $0.required && values($0.name).wrappedValue.isEmpty

--- a/Tinycast/Features/Extensions/UI/ExtensionCaret.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCaret.swift
@@ -2,16 +2,18 @@ import SwiftUI
 
 /// A drawn caret: the one field editor belongs to the search field, not to these controls.
 struct ExtensionCaret: View {
+    @Environment(\.metrics) private var metrics
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
     /// Restarted from here on every edit, so typing shows the caret as a field editor does.
     let phase: Date
 
     var body: some View {
         // Driven by the timeline, not a stored timer: a `body` per keystroke would restart one.
-        TimelineView(.periodic(from: phase, by: ExtensionFormMetrics.caretBlink)) { context in
+        TimelineView(.periodic(from: phase, by: form.caretBlink)) { context in
             RoundedRectangle(cornerRadius: 0.5, style: .continuous)
                 .fill(Theme.Colors.textPrimary)
-                .frame(width: ExtensionFormMetrics.caretWidth)
-                .frame(height: ExtensionFormMetrics.caretHeight)
+                .frame(width: form.caretWidth)
+                .frame(height: form.caretHeight)
                 .opacity(Self.isLit(context.date, from: phase) ? 1 : 0)
         }
         .accessibilityHidden(true)
@@ -19,14 +21,16 @@ struct ExtensionCaret: View {
 
     /// AppKit's own rate: lit for the first half of each period, dark for the second.
     private static func isLit(_ now: Date, from phase: Date) -> Bool {
-        let period = ExtensionFormMetrics.caretBlink * 2
+        let period = ExtensionFormMetrics.base.caretBlink * 2
         let elapsed = now.timeIntervalSince(phase).truncatingRemainder(dividingBy: period)
-        return elapsed < ExtensionFormMetrics.caretBlink
+        return elapsed < ExtensionFormMetrics.base.caretBlink
     }
 }
 
 /// The text a control-with-list is searched by; the caret overlays the insertion point.
 struct ExtensionQueryText: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     let query: String
     let prompt: String
     /// Bumped by the control whenever the query changes, which relights the caret.
@@ -35,13 +39,13 @@ struct ExtensionQueryText: View {
     var body: some View {
         // No slot of its own: a field editor's caret sits over the text's edge, not beside it.
         Text(query.isEmpty ? prompt : query)
-            .font(Theme.Typography.rowTitle)
+            .font(metrics.typography.rowTitle)
             .foregroundStyle(query.isEmpty ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
             .lineLimit(1)
             .truncationMode(.head)
             .overlay(alignment: query.isEmpty ? .leading : .trailing) {
                 ExtensionCaret(phase: phase)
-                    .offset(x: query.isEmpty ? -ExtensionFormMetrics.caretPromptGap : 0)
+                    .offset(x: query.isEmpty ? -form.caretPromptGap : 0)
             }
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionCommandView.swift
@@ -60,6 +60,7 @@ struct ExtensionCommandView: View {
 
 /// The stack trace is kept: it is the only debugging signal an author gets.
 struct ExtensionFailureView: View {
+    @Environment(\.metrics) private var metrics
     let message: String
 
     private var headline: String {
@@ -72,12 +73,12 @@ struct ExtensionFailureView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
-                HStack(spacing: Theme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: metrics.spacing.md) {
+                HStack(spacing: metrics.spacing.sm) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundStyle(.orange)
                     Text(headline)
-                        .font(Theme.Typography.rowTitle)
+                        .font(metrics.typography.rowTitle)
                         .textSelection(.enabled)
                 }
                 if let detail {
@@ -88,7 +89,7 @@ struct ExtensionFailureView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(Theme.Spacing.lg)
+            .padding(metrics.spacing.lg)
             .hideNativeScrollers()
         }
         .thinScrollbar()
@@ -97,22 +98,25 @@ struct ExtensionFailureView: View {
 
 /// `showHUD` is a separate window: a no-view command closes the palette first.
 struct ExtensionFeedbackOverlay: View {
+    @Environment(\.metrics) private var metrics
     let toasts: [ExtensionToast]
     let onToastAction: (String) -> Void
 
     var body: some View {
-        VStack(spacing: Theme.Spacing.xs) {
+        VStack(spacing: metrics.spacing.xs) {
             ForEach(toasts) { toast in
                 ToastRow(toast: toast, onAction: onToastAction)
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
         }
-        .padding(.bottom, Theme.Size.bottomBarHeight)
-        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.bottom, metrics.size.bottomBarHeight)
+        .padding(.horizontal, metrics.spacing.md)
         .animation(.easeOut(duration: 0.16), value: toasts.map(\.id))
     }
 
     private struct ToastRow: View {
+
+        @Environment(\.metrics) private var metrics
         let toast: ExtensionToast
         let onAction: (String) -> Void
 
@@ -125,30 +129,30 @@ struct ExtensionFeedbackOverlay: View {
         }
 
         var body: some View {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 Image(systemName: icon.name)
                     .foregroundStyle(icon.tint)
                     .symbolEffect(.rotate, isActive: toast.style == .animated)
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(toast.title).font(Theme.Typography.bar).lineLimit(1)
+                    Text(toast.title).font(metrics.typography.bar).lineLimit(1)
                     if let message = toast.message, !message.isEmpty {
                         Text(message)
-                            .font(Theme.Typography.rowTrailing)
+                            .font(metrics.typography.rowTrailing)
                             .foregroundStyle(.secondary)
                             .lineLimit(2)
                     }
                 }
-                Spacer(minLength: Theme.Spacing.sm)
+                Spacer(minLength: metrics.spacing.sm)
                 if let action = toast.primaryAction {
                     Button(action.title) { onAction(action.token) }
                         .buttonStyle(.plain)
-                        .font(Theme.Typography.bar)
+                        .font(metrics.typography.bar)
                         .foregroundStyle(.tint)
                 }
             }
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, Theme.Spacing.sm)
-            .frosted(in: RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous))
+            .padding(.horizontal, metrics.spacing.md)
+            .padding(.vertical, metrics.spacing.sm)
+            .frosted(in: RoundedRectangle(cornerRadius: metrics.radius.menu, style: .continuous))
         }
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionDateField.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionDateField.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// `Form.DatePicker`: presets plus an expression, typed into the control itself.
 struct ExtensionDateField: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     let node: RenderNode
     let index: Int?
     @FocusState.Binding var focus: Int?
@@ -104,22 +106,22 @@ struct ExtensionDateField: View {
     }
 
     private var control: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             Image(systemName: "calendar")
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textSecondary)
             // While the list is open the control is the expression field, caret and all.
             if open {
                 ExtensionQueryText(query: query, prompt: "tomorrow at 10am", phase: typedAt)
             } else {
                 Text(label)
-                    .font(Theme.Typography.rowTitle)
+                    .font(metrics.typography.rowTitle)
                     .foregroundStyle(
                         value == nil ? Theme.Colors.textTertiary : Theme.Colors.textPrimary
                     )
                     .lineLimit(1)
             }
-            Spacer(minLength: Theme.Spacing.sm)
+            Spacer(minLength: metrics.spacing.sm)
             ExtensionDisclosureChevron(open: open, flipped: flipped)
         }
         .extensionFieldChrome(focused: isFocused, open: open, hovered: hovered)
@@ -139,7 +141,7 @@ struct ExtensionDateField: View {
 
     /// The panel's own height, which the placement rule then seats above or below the control.
     private var listHeight: CGFloat {
-        ExtensionFormMetrics.popoverHeight(rows: suggestions.count, hasSearchField: false)
+        form.popoverHeight(rows: suggestions.count, hasSearchField: false)
     }
 
     /// What the hosted list draws; a change to any of it re-pushes the panel's tree.

--- a/Tinycast/Features/Extensions/UI/ExtensionDetailView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// The `Detail` screen, and the pane a `List` shows when `isShowingDetail` is on.
 struct ExtensionDetailBody: View {
+    @Environment(\.metrics) private var metrics
     let markdown: String?
     let metadata: RenderNode?
     let isLoading: Bool
@@ -9,7 +10,7 @@ struct ExtensionDetailBody: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            VStack(alignment: .leading, spacing: metrics.spacing.md) {
                 if isLoading && (markdown ?? "").isEmpty {
                     Text("Loading…").foregroundStyle(.secondary)
                 }
@@ -24,8 +25,8 @@ struct ExtensionDetailBody: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Theme.Spacing.lg)
-            .padding(.vertical, Theme.Spacing.md)
+            .padding(.horizontal, metrics.spacing.lg)
+            .padding(.vertical, metrics.spacing.md)
             .hideNativeScrollers()
         }
         .edgeDissolve()
@@ -35,17 +36,18 @@ struct ExtensionDetailBody: View {
 
 /// `Detail.Metadata` — label / link / tag-list / separator rows.
 struct ExtensionMetadataView: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let metadata: RenderNode
     let assetsPath: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+        VStack(alignment: .leading, spacing: metrics.spacing.sm) {
             ForEach(metadata.children) { child in
                 switch child.type {
                 case "Detail.Metadata.Label":
                     row(title: child.string("title")) {
-                        HStack(spacing: Theme.Spacing.xs) {
+                        HStack(spacing: metrics.spacing.xs) {
                             if let icon = child.props["icon"] {
                                 ExtensionIconView(
                                     resolved: ExtensionImage.resolve(
@@ -53,7 +55,7 @@ struct ExtensionMetadataView: View {
                                     size: 14)
                             }
                             Text(labelText(child))
-                                .font(Theme.Typography.rowTitle)
+                                .font(metrics.typography.rowTitle)
                                 .textSelection(.enabled)
                         }
                     }
@@ -61,9 +63,9 @@ struct ExtensionMetadataView: View {
                     row(title: child.string("title")) {
                         if let target = child.string("target"), let url = URL(string: target) {
                             Link(child.string("text") ?? target, destination: url)
-                                .font(Theme.Typography.rowTitle)
+                                .font(metrics.typography.rowTitle)
                         } else {
-                            Text(child.string("text") ?? "").font(Theme.Typography.rowTitle)
+                            Text(child.string("text") ?? "").font(metrics.typography.rowTitle)
                         }
                     }
                 case "Detail.Metadata.TagList":
@@ -91,7 +93,7 @@ struct ExtensionMetadataView: View {
         VStack(alignment: .leading, spacing: 2) {
             if let title, !title.isEmpty {
                 Text(title)
-                    .font(Theme.Typography.sectionHeader)
+                    .font(metrics.typography.sectionHeader)
                     .foregroundStyle(.secondary)
             }
             content()
@@ -100,13 +102,15 @@ struct ExtensionMetadataView: View {
 }
 
 private struct ExtensionTagListView: View {
+
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let tags: [RenderNode]
     let assetsPath: String?
 
     var body: some View {
         // Wrapping matters here: a metadata tag list is frequently longer than the pane is wide.
-        FlowLayout(spacing: Theme.Spacing.xs) {
+        FlowLayout(spacing: metrics.spacing.xs) {
             ForEach(tags) { tag in
                 let color =
                     ExtensionImage.color(tag.props["color"], isDark: isDark) ?? Theme.Colors.textSecondary
@@ -117,10 +121,10 @@ private struct ExtensionTagListView: View {
                             size: 12)
                     }
                     Text(tag.string("text") ?? "")
-                        .font(Theme.Typography.rowTrailing)
+                        .font(metrics.typography.rowTrailing)
                 }
                 .foregroundStyle(color)
-                .padding(.horizontal, Theme.Spacing.xs)
+                .padding(.horizontal, metrics.spacing.xs)
                 .padding(.vertical, 2)
                 .background(
                     RoundedRectangle(cornerRadius: 4, style: .continuous).fill(color.opacity(0.16))
@@ -178,6 +182,7 @@ struct FlowLayout: Layout {
 
 /// Inline styling comes from `AttributedString`; block structure is laid out here.
 struct ExtensionMarkdownView: View {
+    @Environment(\.metrics) private var metrics
     let markdown: String
 
     private enum Block: Identifiable {
@@ -205,32 +210,32 @@ struct ExtensionMarkdownView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+        VStack(alignment: .leading, spacing: metrics.spacing.sm) {
             ForEach(Self.parse(markdown)) { block in
                 switch block {
                 case .heading(let level, let text):
                     Text(inline(text))
                         .font(.system(size: headingSize(level), weight: .semibold))
-                        .padding(.top, Theme.Spacing.xs)
+                        .padding(.top, metrics.spacing.xs)
                 case .paragraph(let text):
                     Text(inline(text))
-                        .font(Theme.Typography.rowTitle)
+                        .font(metrics.typography.rowTitle)
                         .textSelection(.enabled)
                 case .bullet(let text):
-                    HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+                    HStack(alignment: .top, spacing: metrics.spacing.sm) {
                         Text("•").foregroundStyle(.secondary)
-                        Text(inline(text)).font(Theme.Typography.rowTitle)
+                        Text(inline(text)).font(metrics.typography.rowTitle)
                     }
                 case .numbered(let index, let text):
-                    HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+                    HStack(alignment: .top, spacing: metrics.spacing.sm) {
                         Text("\(index).").foregroundStyle(.secondary).monospacedDigit()
-                        Text(inline(text)).font(Theme.Typography.rowTitle)
+                        Text(inline(text)).font(metrics.typography.rowTitle)
                     }
                 case .quote(let text):
-                    HStack(spacing: Theme.Spacing.sm) {
+                    HStack(spacing: metrics.spacing.sm) {
                         Rectangle().fill(Theme.Colors.separator).frame(width: 2)
                         Text(inline(text))
-                            .font(Theme.Typography.rowTitle)
+                            .font(metrics.typography.rowTitle)
                             .foregroundStyle(.secondary)
                     }
                 case .code(let text):
@@ -238,11 +243,11 @@ struct ExtensionMarkdownView: View {
                         Text(text)
                             .font(.system(.callout, design: .monospaced))
                             .textSelection(.enabled)
-                            .padding(Theme.Spacing.sm)
+                            .padding(metrics.spacing.sm)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
-                        RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                        RoundedRectangle(cornerRadius: metrics.radius.menu, style: .continuous)
                             .fill(ExtensionColors.detailCardFill)
                     )
                     .hideNativeScrollers()
@@ -375,6 +380,7 @@ extension String {
 
 /// An image inside a Detail's markdown, capped so a large asset can't push the layout around.
 private struct ExtensionMarkdownImage: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let url: URL
     @State private var image: NSImage?
@@ -390,9 +396,9 @@ private struct ExtensionMarkdownImage: View {
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: 220)
-                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: metrics.radius.menu, style: .continuous))
             } else {
-                RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.menu, style: .continuous)
                     .fill(ExtensionColors.detailCardFill)
                     .frame(height: 120)
             }

--- a/Tinycast/Features/Extensions/UI/ExtensionFieldChrome.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionFieldChrome.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// The one control surface a form draws, kept here rather than in `DesignSystem`.
 struct ExtensionFieldChrome: ViewModifier {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     var focused: Bool
     /// A control that opens a popover keeps its focused edge while the popover has the keyboard.
     var open = false
@@ -11,27 +13,27 @@ struct ExtensionFieldChrome: ViewModifier {
     var multiline = false
 
     private var height: CGFloat {
-        multiline ? ExtensionFormMetrics.textAreaHeight : ExtensionFormMetrics.controlHeight
+        multiline ? form.textAreaHeight : form.controlHeight
     }
 
     func body(content: Content) -> some View {
         content
-            .padding(.horizontal, ExtensionFormMetrics.textInset)
+            .padding(.horizontal, form.textInset)
             // One inset either way, so a text area's first line sits where a field's does.
-            .padding(.vertical, ExtensionFormMetrics.verticalInset)
+            .padding(.vertical, form.verticalInset)
             .frame(
-                width: ExtensionFormMetrics.controlWidth, height: height,
+                width: form.controlWidth, height: height,
                 alignment: multiline ? .topLeading : .leading
             )
             .background(
                 RoundedRectangle(
-                    cornerRadius: Theme.Radius.row, style: .continuous
+                    cornerRadius: metrics.radius.row, style: .continuous
                 )
                 .fill(fill)
             )
             .overlay(
                 RoundedRectangle(
-                    cornerRadius: Theme.Radius.row, style: .continuous
+                    cornerRadius: metrics.radius.row, style: .continuous
                 )
                 .strokeBorder(stroke, lineWidth: 1)
             )
@@ -62,13 +64,14 @@ extension View {
 
 /// The chevron a control that opens a popover carries, pointing the way it will open.
 struct ExtensionDisclosureChevron: View {
+    @Environment(\.metrics) private var metrics
     let open: Bool
     var flipped = false
 
     var body: some View {
         // Closed it always points down; open, it points back at the list it dropped.
         Image(systemName: pointsUp ? "chevron.up" : "chevron.down")
-            .font(Theme.Typography.disclosure)
+            .font(metrics.typography.disclosure)
             .foregroundStyle(Theme.Colors.textSecondary)
     }
 
@@ -77,6 +80,8 @@ struct ExtensionDisclosureChevron: View {
 
 /// One row of a picker popover: an optional icon, a title, and a trailing detail.
 struct ExtensionPickerRow: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     let title: String
     var detail: String?
     var icon: ExtensionImage.Resolved?
@@ -87,35 +92,35 @@ struct ExtensionPickerRow: View {
 
     var body: some View {
         Button(action: onActivate) {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 if let icon {
-                    ExtensionIconView(resolved: icon, size: Theme.Size.menuIcon)
+                    ExtensionIconView(resolved: icon, size: metrics.size.menuIcon)
                 }
                 Text(title)
-                    .font(Theme.Typography.menuRow)
+                    .font(metrics.typography.menuRow)
                     .lineLimit(1)
-                Spacer(minLength: Theme.Spacing.sm)
+                Spacer(minLength: metrics.spacing.sm)
                 if let detail {
                     Text(detail)
-                        .font(Theme.Typography.menuShortcut)
+                        .font(metrics.typography.menuShortcut)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
                 if checked {
                     Image(systemName: "checkmark")
-                        .font(Theme.Typography.disclosure)
+                        .font(metrics.typography.disclosure)
                         .foregroundStyle(Theme.Colors.textSecondary)
                 }
             }
-            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.horizontal, metrics.spacing.md)
             // Stated, not padded: the height maths counts rows, so a row is one exact height.
             .frame(
-                maxWidth: .infinity, minHeight: ExtensionFormMetrics.popoverRowHeight,
-                maxHeight: ExtensionFormMetrics.popoverRowHeight, alignment: .leading
+                maxWidth: .infinity, minHeight: form.popoverRowHeight,
+                maxHeight: form.popoverRowHeight, alignment: .leading
             )
             .contentShape(Rectangle())
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.menuRow, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.menuRow, style: .continuous)
                     .fill(selected ? Theme.Colors.menuHover : Color.clear)
             )
         }

--- a/Tinycast/Features/Extensions/UI/ExtensionFormView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionFormView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// React owns the values; every edit dispatches back and the re-render draws it.
 struct ExtensionFormView: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     let screen: ExtensionScreen
     let assetsPath: String?
     /// The focused field, as the flat index the palette navigates with.
@@ -17,14 +19,14 @@ struct ExtensionFormView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(alignment: .leading, spacing: ExtensionFormMetrics.rowSpacing) {
+                VStack(alignment: .leading, spacing: form.rowSpacing) {
                     ForEach(screen.fields) { field in
                         row(field)
                     }
                 }
                 // Centred as a block; the label column and controls keep their own widths.
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, ExtensionFormMetrics.formVerticalPadding)
+                .padding(.vertical, form.formVerticalPadding)
                 // Behind the fields, so a press on bare form closes an open list as a menu's does.
                 .background {
                     Color.clear.contentShape(Rectangle())
@@ -80,17 +82,17 @@ struct ExtensionFormView: View {
             Rectangle()
                 .fill(Theme.Colors.separator)
                 .frame(maxWidth: .infinity, minHeight: 1, maxHeight: 1)
-                .padding(.vertical, ExtensionFormMetrics.separatorSpacing)
+                .padding(.vertical, form.separatorSpacing)
 
         case "Form.Description":
             labelled(field, showTitle: field.string("title") != nil) {
                 Text(field.string("text") ?? "")
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
                     // Bare text still takes a control's height, so its label sits level.
-                    .padding(.vertical, ExtensionFormMetrics.verticalInset)
-                    .frame(minHeight: ExtensionFormMetrics.controlHeight, alignment: .leading)
+                    .padding(.vertical, form.verticalInset)
+                    .frame(minHeight: form.controlHeight, alignment: .leading)
             }
 
         case "Form.TextField", "Form.PasswordField":
@@ -164,7 +166,7 @@ struct ExtensionFormView: View {
         default:
             labelled(field) {
                 Text("\(field.type) isn't supported yet")
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
             }
         }
@@ -175,32 +177,32 @@ struct ExtensionFormView: View {
     private func labelled<Content: View>(
         _ field: RenderNode, showTitle: Bool = true, @ViewBuilder content: () -> Content
     ) -> some View {
-        HStack(alignment: .top, spacing: Theme.Spacing.md) {
-            HStack(spacing: Theme.Spacing.xxs) {
+        HStack(alignment: .top, spacing: metrics.spacing.md) {
+            HStack(spacing: metrics.spacing.xxs) {
                 Spacer(minLength: 0)
                 Text(showTitle ? (field.string("title") ?? "") : "")
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textSecondary)
                     .multilineTextAlignment(.trailing)
                 // The info marker Raycast draws beside a label that carries one.
                 if let info = field.string("info"), !info.isEmpty {
                     Image(systemName: "info.circle")
-                        .font(Theme.Typography.disclosure)
+                        .font(metrics.typography.disclosure)
                         .foregroundStyle(Theme.Colors.textTertiary)
                         .help(info)
                         // The control carries this text as its hint, so the glyph is decoration.
                         .accessibilityHidden(true)
                 }
             }
-            .frame(width: Theme.Size.formLabelWidth, alignment: .trailing)
+            .frame(width: metrics.size.formLabelWidth, alignment: .trailing)
             // Centred on a control's height but free to grow, so a long label wraps.
-            .frame(minHeight: ExtensionFormMetrics.controlHeight)
+            .frame(minHeight: form.controlHeight)
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            VStack(alignment: .leading, spacing: metrics.spacing.xs) {
                 content()
                 if let error = field.string("error"), !error.isEmpty {
                     Text(error)
-                        .font(Theme.Typography.rowTrailing)
+                        .font(metrics.typography.rowTrailing)
                         .foregroundStyle(.red)
                         // Spoken by the control it belongs to, so this text is its echo.
                         .accessibilityHidden(true)
@@ -208,16 +210,17 @@ struct ExtensionFormView: View {
             }
         }
         .frame(
-            width: Theme.Size.formLabelWidth + Theme.Spacing.md
-                + ExtensionFormMetrics.controlWidth
+            width: metrics.size.formLabelWidth + metrics.spacing.md
+                + form.controlWidth
         )
         .frame(maxWidth: .infinity)
-        .offset(x: -(Theme.Size.formLabelWidth + Theme.Spacing.md) / 2)
+        .offset(x: -(metrics.size.formLabelWidth + metrics.spacing.md) / 2)
     }
 }
 
 /// Local state absorbs typing so the caret never jumps; a programmatic reset wins.
 private struct ExtensionTextField: View {
+    @Environment(\.metrics) private var metrics
     let node: RenderNode
     let secure: Bool
     let index: Int?
@@ -238,7 +241,7 @@ private struct ExtensionTextField: View {
             }
         }
         .textFieldStyle(.plain)
-        .font(Theme.Typography.rowTitle)
+        .font(metrics.typography.rowTitle)
         .focused($focus, equals: index)
         .extensionFieldChrome(focused: focus == index, hovered: hovered)
         .onHover { hovered = $0 }
@@ -273,6 +276,10 @@ private struct ExtensionTextField: View {
 }
 
 private struct ExtensionTextArea: View {
+
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+
+    @Environment(\.metrics) private var metrics
     let node: RenderNode
     let index: Int?
     @FocusState.Binding var focus: Int?
@@ -285,10 +292,10 @@ private struct ExtensionTextArea: View {
 
     var body: some View {
         TextEditor(text: $text)
-            .font(Theme.Typography.rowTitle)
+            .font(metrics.typography.rowTitle)
             .scrollContentBackground(.hidden)
             // The text system insets its own line fragments, which the chrome's inset then repeats.
-            .padding(.horizontal, -ExtensionFormMetrics.textViewGutter)
+            .padding(.horizontal, -form.textViewGutter)
             .focused($focus, equals: index)
             .extensionFieldChrome(focused: focus == index, hovered: hovered, multiline: true)
             .onHover { hovered = $0 }
@@ -298,10 +305,10 @@ private struct ExtensionTextArea: View {
             .overlay(alignment: .topLeading) {
                 if text.isEmpty {
                     Text(node.string("placeholder") ?? "")
-                        .font(Theme.Typography.rowTitle)
+                        .font(metrics.typography.rowTitle)
                         .foregroundStyle(Theme.Colors.textTertiary)
-                        .padding(.horizontal, ExtensionFormMetrics.textInset)
-                        .padding(.vertical, ExtensionFormMetrics.verticalInset)
+                        .padding(.horizontal, form.textInset)
+                        .padding(.vertical, form.verticalInset)
                         .allowsHitTesting(false)
                 }
             }
@@ -324,6 +331,8 @@ private struct ExtensionTextArea: View {
 
 /// Its own control, not `Toggle`: a `Toggle` takes focus only under Full Keyboard Access.
 private struct ExtensionCheckbox: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     let node: RenderNode
     let index: Int?
     @FocusState.Binding var focus: Int?
@@ -334,16 +343,16 @@ private struct ExtensionCheckbox: View {
     private var isOn: Bool { node.bool("value") ?? false }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             box
             Text(node.string("label") ?? "")
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .foregroundStyle(Theme.Colors.textPrimary)
                 .lineLimit(1)
             Spacer(minLength: 0)
         }
-        .frame(width: ExtensionFormMetrics.controlWidth, alignment: .leading)
-        .frame(height: ExtensionFormMetrics.controlHeight)
+        .frame(width: form.controlWidth, alignment: .leading)
+        .frame(height: form.controlHeight)
         .contentShape(Rectangle())
         .focusable()
         .focused($focus, equals: index)
@@ -376,8 +385,8 @@ private struct ExtensionCheckbox: View {
                 }
             }
             .frame(
-                width: ExtensionFormMetrics.checkboxSize,
-                height: ExtensionFormMetrics.checkboxSize)
+                width: form.checkboxSize,
+                height: form.checkboxSize)
     }
 
     private var borderColor: Color {
@@ -394,6 +403,8 @@ private struct ExtensionCheckbox: View {
 }
 
 private struct ExtensionFilePicker: View {
+
+    @Environment(\.metrics) private var metrics
     let node: RenderNode
     let index: Int?
     @FocusState.Binding var focus: Int?
@@ -409,12 +420,12 @@ private struct ExtensionFilePicker: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             Image(systemName: "doc")
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textSecondary)
             Text(label)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .foregroundStyle(paths.isEmpty ? Theme.Colors.textTertiary : Theme.Colors.textPrimary)
                 .lineLimit(1)
             Spacer(minLength: 0)

--- a/Tinycast/Features/Extensions/UI/ExtensionImage.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionImage.swift
@@ -381,16 +381,20 @@ extension ExtensionImage {
 
 /// A resolved icon at row size; an unresolvable one draws the faint tile, so rows never jump.
 struct ExtensionIconView: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let resolved: ExtensionImage.Resolved?
-    var size: CGFloat = Theme.Size.rowIcon
+    var size: CGFloat?
     /// Opt-in, and off for row icons: a playing GIF at 24pt is noise in a long list.
     var animates = false
     @State private var loaded: NSImage?
 
+    /// Row size unless a caller states one, which only the ⌘K panel's 20pt slot does.
+    private var side: CGFloat { size ?? metrics.size.rowIcon }
+
     var body: some View {
         content
-            .frame(width: size, height: size)
+            .frame(width: side, height: side)
             .clipShape(shape)
             // Keyed on appearance too: an inline SVG's palette resolves at decode.
             .task(id: ExtensionImage.LoadKey(source: resolved?.source, isDark: isDark)) {
@@ -403,14 +407,14 @@ struct ExtensionIconView: View {
         switch resolved?.source {
         case .symbol(let name):
             Image(systemName: name)
-                .font(.system(size: size * 0.62, weight: .regular))
+                .font(.system(size: side * 0.62, weight: .regular))
                 .symbolRenderingMode(resolved?.tint == nil ? .hierarchical : .monochrome)
                 .foregroundStyle(resolved?.tint ?? Theme.Colors.textSecondary)
-                .frame(width: size, height: size)
+                .frame(width: side, height: side)
         case .glyph(let text):
             Text(text)
-                .font(.system(size: size * 0.72))
-                .frame(width: size, height: size)
+                .font(.system(size: side * 0.72))
+                .frame(width: side, height: side)
         case .file, .fileIcon, .remote, .inline:
             if let loaded {
                 // Only a multi-frame image pays for `NSImageView`; a still stays on SwiftUI's path.
@@ -433,14 +437,14 @@ struct ExtensionIconView: View {
     }
 
     private var placeholder: some View {
-        RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+        RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
             .fill(Theme.Colors.iconPlaceholder)
     }
 
     private var shape: AnyShape {
         resolved?.isCircular == true
             ? AnyShape(Circle())
-            : AnyShape(RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous))
     }
 
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionListPanel.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListPanel.swift
@@ -85,7 +85,7 @@ struct ExtensionListPlacement: Equatable {
 
     /// The shipped rule in screen space; the palette's frame stays the room a list may fill.
     @MainActor
-    init?(anchor: CGRect, in window: NSWindow, height: CGFloat) {
+    init?(anchor: CGRect, in window: NSWindow, height: CGFloat, form: ExtensionFormMetrics) {
         guard let contentHeight = window.contentView?.bounds.height else { return nil }
         let host = window.frame
         // SwiftUI reports the control top-left down; AppKit reads the window bottom-left up.
@@ -93,14 +93,14 @@ struct ExtensionListPlacement: Equatable {
             NSRect(
                 x: anchor.minX, y: contentHeight - anchor.maxY, width: anchor.width,
                 height: anchor.height))
-        let placement = ExtensionFormMetrics.placement(
+        let placement = form.placement(
             anchor: CGRect(
                 x: control.minX, y: host.maxY - control.maxY, width: control.width,
                 height: control.height),
             popoverHeight: height, containerHeight: host.height)
         frame = NSRect(
             x: control.minX, y: host.maxY - placement.y - height,
-            width: ExtensionFormMetrics.controlWidth, height: height)
+            width: form.controlWidth, height: height)
         flipped = placement.flipped
     }
 }
@@ -142,6 +142,8 @@ private struct ExtensionListPanelModifier<List: View, Revision: Equatable>: View
     @State private var host: NSWindow?
     @State private var anchor: CGRect = .zero
     @Environment(PaletteState.self) private var palette
+    @Environment(\.metrics) private var metrics
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
 
     private struct Key: Equatable {
         let open: Bool
@@ -168,13 +170,15 @@ private struct ExtensionListPanelModifier<List: View, Revision: Equatable>: View
 
     private func sync() {
         guard open, let host, anchor.width > 0,
-            let placement = ExtensionListPlacement(anchor: anchor, in: host, height: height)
+            let placement = ExtensionListPlacement(
+                anchor: anchor, in: host, height: height, form: form)
         else {
             controller.hide()
             return
         }
         if flipped != placement.flipped { flipped = placement.flipped }
-        let root = AnyView(list().environment(palette))
+        // Forwarded, not re-derived: a child window must never disagree with its parent.
+        let root = AnyView(list().environment(palette).environment(\.metrics, metrics))
         controller.present(root, frame: placement.frame, parent: host, palette: palette)
     }
 }

--- a/Tinycast/Features/Extensions/UI/ExtensionListView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Row order comes from `ExtensionScreen`, so the palette's flat index matches the draw.
 struct ExtensionListView: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let screen: ExtensionScreen
     let selection: Int
@@ -19,7 +20,7 @@ struct ExtensionListView: View {
             } else if screen.showsDetail {
                 HStack(spacing: 0) {
                     rowList
-                        .frame(width: Theme.Size.clipboardListWidth)
+                        .frame(width: metrics.size.clipboardListWidth)
                     Rectangle().fill(Theme.Colors.separator).frame(width: 1)
                     detailPane
                 }
@@ -36,21 +37,21 @@ struct ExtensionListView: View {
         if screen.isLoading {
             EmptyResults(text: "Loading…")
         } else if let empty = screen.emptyView {
-            VStack(spacing: Theme.Spacing.md) {
+            VStack(spacing: metrics.spacing.md) {
                 ExtensionIconView(
                     resolved: ExtensionImage.resolve(
                         empty.props["icon"], assetsPath: assetsPath, isDark: isDark),
                     size: 42)
                 Text(empty.string("title") ?? "Nothing here")
-                    .font(Theme.Typography.rowTitle)
+                    .font(metrics.typography.rowTitle)
                 if let description = empty.string("description") {
                     Text(description)
-                        .font(Theme.Typography.rowTrailing)
+                        .font(metrics.typography.rowTrailing)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                 }
             }
-            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.horizontal, metrics.spacing.xl)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             EmptyResults(text: "No results")
@@ -83,9 +84,9 @@ struct ExtensionListView: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -107,8 +108,8 @@ struct ExtensionListView: View {
             grid(
                 layout: layout,
                 tileWidth: layout.tileWidth(
-                    inWidth: geometry.size.width - Theme.Spacing.md * 2,
-                    spacing: Theme.Spacing.sm))
+                    inWidth: geometry.size.width - metrics.spacing.md * 2,
+                    spacing: metrics.spacing.sm))
         }
     }
 
@@ -117,9 +118,9 @@ struct ExtensionListView: View {
             ScrollView {
                 LazyVGrid(
                     columns: Array(
-                        repeating: GridItem(.flexible(), spacing: Theme.Spacing.sm),
+                        repeating: GridItem(.flexible(), spacing: metrics.spacing.sm),
                         count: layout.columns),
-                    spacing: Theme.Spacing.sm
+                    spacing: metrics.spacing.sm
                 ) {
                     ForEach(screen.items) { item in
                         ExtensionGridCell(
@@ -135,9 +136,9 @@ struct ExtensionListView: View {
                         .selectionFrame(item.index == selection)
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -164,6 +165,7 @@ struct ExtensionListView: View {
 
 /// One `List.Item`: icon, title, subtitle, then its accessories right-aligned.
 private struct ExtensionItemRow: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let node: RenderNode
     let selected: Bool
@@ -178,29 +180,29 @@ private struct ExtensionItemRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             ExtensionIconView(
                 resolved: ExtensionImage.resolve(node.props["icon"], assetsPath: assetsPath, isDark: isDark))
             Text(node.string("title") ?? "")
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
                 // A detail list is 290pt wide, and an accessory would otherwise win the squeeze.
                 .layoutPriority(1)
             if !compact, let subtitle = node.string("subtitle"), !subtitle.isEmpty {
                 Text(subtitle)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
-            Spacer(minLength: Theme.Spacing.sm)
+            Spacer(minLength: metrics.spacing.sm)
             // Raycast draws the accessories it is given, and a quota row's signal is all in them.
             ExtensionAccessoriesView(
                 accessories: node.array("accessories"), assetsPath: assetsPath)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous).fill(fill)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous).fill(fill)
         )
         .armedHover($hovered)
     }
@@ -208,12 +210,13 @@ private struct ExtensionItemRow: View {
 
 /// `List.Item.Accessory` values: text, a tag, a date, an icon, or a combination.
 struct ExtensionAccessoriesView: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let accessories: [RenderValue]
     let assetsPath: String?
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             ForEach(Array(accessories.enumerated()), id: \.offset) { _, accessory in
                 if let fields = accessory.objectValue {
                     accessoryView(fields)
@@ -224,7 +227,7 @@ struct ExtensionAccessoriesView: View {
 
     @ViewBuilder
     private func accessoryView(_ fields: [String: RenderValue]) -> some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             if let icon = fields["icon"] {
                 ExtensionIconView(
                     resolved: ExtensionImage.resolve(icon, assetsPath: assetsPath, isDark: isDark), size: 13)
@@ -234,7 +237,7 @@ struct ExtensionAccessoriesView: View {
             }
             if let text = ExtensionAccessoriesView.label(fields["text"]) {
                 Text(text)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(
                         ExtensionImage.color(fields["text"]?.objectValue?["color"], isDark: isDark)
                             ?? Theme.Colors.textSecondary
@@ -243,7 +246,7 @@ struct ExtensionAccessoriesView: View {
             }
             if let date = ExtensionAccessoriesView.date(fields["date"]) {
                 Text(date, format: .relative(presentation: .numeric))
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textSecondary)
                     .lineLimit(1)
             }
@@ -263,9 +266,9 @@ struct ExtensionAccessoriesView: View {
         if let text {
             let color = ExtensionImage.color(fields?["color"], isDark: isDark) ?? Theme.Colors.textSecondary
             Text(text)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(color)
-                .padding(.horizontal, Theme.Spacing.xs)
+                .padding(.horizontal, metrics.spacing.xs)
                 .padding(.vertical, 1)
                 .background(
                     RoundedRectangle(cornerRadius: 4, style: .continuous)
@@ -291,6 +294,7 @@ struct ExtensionAccessoriesView: View {
 
 /// One `Grid.Item`: content sized to the tile the `Grid`'s props ask for, title underneath.
 private struct ExtensionGridCell: View {
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     let node: RenderNode
     let selected: Bool
@@ -320,16 +324,16 @@ private struct ExtensionGridCell: View {
     }
 
     var body: some View {
-        VStack(spacing: Theme.Spacing.xs) {
+        VStack(spacing: metrics.spacing.xs) {
             tile
             if let title = node.string("title") {
                 Text(title)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .lineLimit(1)
             }
             if let subtitle = node.string("subtitle") {
                 Text(subtitle)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -357,7 +361,7 @@ private struct ExtensionGridCell: View {
 
     /// Filling content shares the tile's corner; inset artwork is small enough to need a tighter one.
     private var contentRadius: Double {
-        layout.inset == .zero ? ExtensionGridLayout.tileRadius : Theme.Radius.thumbnail
+        layout.inset == .zero ? ExtensionGridLayout.tileRadius : metrics.radius.thumbnail
     }
 
     /// `content` is an `ImageLike` or `{value, tooltip}` wrapping one — both `resolve`'s job.

--- a/Tinycast/Features/Extensions/UI/ExtensionPickerField.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionPickerField.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// `Form.Dropdown` and `Form.TagPicker`: one control, typing and caret in the field itself.
 struct ExtensionPickerField: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     let items: [ExtensionPickerItem]
     /// Every value currently held; a dropdown has one, a tag picker any number.
     let chosen: [String]
@@ -137,7 +139,7 @@ struct ExtensionPickerField: View {
     }
 
     private var control: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             if let leadingIcon, query.isEmpty {
                 ExtensionIconView(resolved: leadingIcon, size: 14)
             }
@@ -146,24 +148,24 @@ struct ExtensionPickerField: View {
                 // A multi-select keeps its chosen values in view while the query is typed.
                 if allowsMultipleSelection, !chosen.isEmpty {
                     Text(label)
-                        .font(Theme.Typography.rowTitle)
+                        .font(metrics.typography.rowTitle)
                         .foregroundStyle(Theme.Colors.textSecondary)
                         .lineLimit(1)
                         .layoutPriority(-1)
                     Text("·")
-                        .font(Theme.Typography.rowTitle)
+                        .font(metrics.typography.rowTitle)
                         .foregroundStyle(Theme.Colors.textTertiary)
                 }
                 ExtensionQueryText(query: query, prompt: "Search…", phase: typedAt)
             } else {
                 Text(label)
-                    .font(Theme.Typography.rowTitle)
+                    .font(metrics.typography.rowTitle)
                     .foregroundStyle(
                         chosen.isEmpty ? Theme.Colors.textTertiary : Theme.Colors.textPrimary
                     )
                     .lineLimit(1)
             }
-            Spacer(minLength: Theme.Spacing.sm)
+            Spacer(minLength: metrics.spacing.sm)
             ExtensionDisclosureChevron(open: open, flipped: flipped)
         }
         .extensionFieldChrome(focused: isFocused, open: open, hovered: hovered)
@@ -184,7 +186,7 @@ struct ExtensionPickerField: View {
 
     /// The panel's own height, which the placement rule then seats above or below the control.
     private var listHeight: CGFloat {
-        ExtensionFormMetrics.popoverHeight(
+        form.popoverHeight(
             rows: matches.count, hasSearchField: false, headers: sectionCount)
     }
 

--- a/Tinycast/Features/Extensions/UI/ExtensionPickerList.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionPickerList.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// The results a picker drops, styled as the ⌘K panel; the control above owns the query.
 struct ExtensionPickerList: View {
+    private var form: ExtensionFormMetrics { ExtensionFormMetrics(scale: metrics.scale) }
+    @Environment(\.metrics) private var metrics
     @Environment(\.isDarkAppearance) private var isDark
     /// Read for `hoverHighlightArmed`: a list landing under the pointer must light no row.
     @Environment(PaletteState.self) private var palette
@@ -12,19 +14,19 @@ struct ExtensionPickerList: View {
     let assetsPath: String?
     /// Fixed, never intrinsic, so the list cannot jitter as its rows change. A form's picker
     /// matches the field above it; a header dropdown hangs off a chip and drops narrower.
-    var width: CGFloat = ExtensionFormMetrics.controlWidth
+    var width: CGFloat?
     let onSelect: (Int) -> Void
     /// Moves the highlight under the pointer, so mouse and keyboard share one selection.
     let onHighlight: (Int) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: ExtensionFormMetrics.popoverRowSpacing) {
+        VStack(alignment: .leading, spacing: form.popoverRowSpacing) {
             list
         }
-        .padding(Theme.Spacing.sm)
-        .frame(width: width)
+        .padding(metrics.spacing.sm)
+        .frame(width: width ?? form.controlWidth)
         .glassEffect(
-            .regular, in: RoundedRectangle(cornerRadius: Theme.Radius.menuPanel, style: .continuous)
+            .regular, in: RoundedRectangle(cornerRadius: metrics.radius.menuPanel, style: .continuous)
         )
     }
 
@@ -32,14 +34,14 @@ struct ExtensionPickerList: View {
     private var list: some View {
         if items.isEmpty {
             Text("No matches")
-                .font(Theme.Typography.menuRow)
+                .font(metrics.typography.menuRow)
                 .foregroundStyle(.secondary)
-                .padding(.horizontal, Theme.Spacing.lg)
-                .frame(height: ExtensionFormMetrics.popoverRowHeight, alignment: .leading)
+                .padding(.horizontal, metrics.spacing.lg)
+                .frame(height: form.popoverRowHeight, alignment: .leading)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    VStack(alignment: .leading, spacing: ExtensionFormMetrics.popoverRowSpacing) {
+                    VStack(alignment: .leading, spacing: form.popoverRowSpacing) {
                         ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                             if let section = item.section, section != sectionBefore(index) {
                                 sectionHeader(section)
@@ -59,7 +61,7 @@ struct ExtensionPickerList: View {
                     }
                 }
                 .frame(
-                    height: ExtensionFormMetrics.popoverListHeight(
+                    height: form.popoverListHeight(
                         rows: items.count, headers: headerCount)
                 )
                 // Without this a list shorter than the cap rubber-bands against nothing.
@@ -74,11 +76,11 @@ struct ExtensionPickerList: View {
 
     private func sectionHeader(_ title: String) -> some View {
         Text(title)
-            .font(Theme.Typography.sectionHeader)
+            .font(metrics.typography.sectionHeader)
             .foregroundStyle(.secondary)
             .lineLimit(1)
-            .padding(.horizontal, Theme.Spacing.lg)
-            .frame(height: ExtensionFormMetrics.popoverSectionHeaderHeight, alignment: .leading)
+            .padding(.horizontal, metrics.spacing.lg)
+            .frame(height: form.popoverSectionHeaderHeight, alignment: .leading)
     }
 
     /// The section of the row before this one, so only the first of a run draws its heading.

--- a/Tinycast/Features/Extensions/UI/ExtensionSearchAccessoryButton.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionSearchAccessoryButton.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// The extension's search-bar dropdown, drawn as a header control. Not `HeaderMenuButton`: the
 /// choice it states carries an extension's own icon, which `PopoverMenuIcon` cannot name.
 struct ExtensionSearchAccessoryButton: View {
+    @Environment(\.metrics) private var metrics
     /// Room for a long choice beside its icon and tick, without a form field's 360pt sprawl.
     static let listWidth: CGFloat = 240
 
@@ -18,12 +19,12 @@ struct ExtensionSearchAccessoryButton: View {
 
     var body: some View {
         BarButton(chrome: .rounded, action: action) {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 if let icon {
-                    ExtensionIconView(resolved: icon, size: Theme.Size.menuIcon)
+                    ExtensionIconView(resolved: icon, size: metrics.size.menuIcon)
                 }
                 Text(accessory.title(for: value) ?? "")
-                    .font(Theme.Typography.bar)
+                    .font(metrics.typography.bar)
                     .lineLimit(1)
                     .truncationMode(.middle)
                 // The panel always drops below the header, so it never points back up flipped.

--- a/Tinycast/Features/FileSearch/UI/FileSearchList.swift
+++ b/Tinycast/Features/FileSearch/UI/FileSearchList.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct FileSearchList: View {
+
+    @Environment(\.metrics) private var metrics
     let results: [FileSearchResult]
     let selectedID: FileSearchResult.ID?
     let scroll: ScrollIntent
@@ -24,9 +26,9 @@ struct FileSearchList: View {
                             .onRightClick { onActions(result) }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -40,6 +42,8 @@ struct FileSearchList: View {
 }
 
 private struct FileSearchRow: View {
+
+    @Environment(\.metrics) private var metrics
     let result: FileSearchResult
     let selected: Bool
     @State private var image: NSImage?
@@ -58,30 +62,30 @@ private struct FileSearchRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             Group {
                 if let image {
                     Image(nsImage: image).resizable()
                 } else {
-                    RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                    RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
                         .fill(Theme.Colors.iconPlaceholder)
                 }
             }
-            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+            .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
             Text(result.name)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
-            Spacer(minLength: Theme.Spacing.md)
+            Spacer(minLength: metrics.spacing.md)
             Text(result.parentPath)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)

--- a/Tinycast/Features/Launcher/UI/AppIconView.swift
+++ b/Tinycast/Features/Launcher/UI/AppIconView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Row icon decoding off the main thread; warm icons seed synchronously, so no flash.
 struct AppIconView: View {
+    @Environment(\.metrics) private var metrics
     let app: AppEntry
     @State private var image: NSImage?
 
@@ -24,7 +25,7 @@ struct AppIconView: View {
             if let image {
                 Image(nsImage: image).resizable()
             } else {
-                RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                     .fill(Theme.Colors.iconPlaceholder)
             }
         }

--- a/Tinycast/Features/Launcher/UI/ColorCard.swift
+++ b/Tinycast/Features/Launcher/UI/ColorCard.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// The launcher's colour card, built from the calculator card's parts so it reads as one answer.
 struct ColorCard: View {
+    @Environment(\.metrics) private var metrics
     let color: ColorValue
     let selected: Bool
 
@@ -19,14 +20,14 @@ struct ColorCard: View {
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(.tertiary)
             // Stretched to the value column rather than sized: no notation is a fixed height.
-            ColorSwatch(color: color, cornerRadius: Theme.Radius.card)
+            ColorSwatch(color: color, cornerRadius: metrics.radius.card)
                 .frame(width: Self.swatchWidth)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
         }
         .fixedSize(horizontal: false, vertical: true)
-        .padding(.horizontal, Theme.Spacing.xl)
-        .padding(.vertical, Theme.Spacing.xxxl)
+        .padding(.horizontal, metrics.spacing.xl)
+        .padding(.vertical, metrics.spacing.xxxl)
         .leadCard(selected: selected)
     }
 }

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct LauncherList: View {
+
+    @Environment(\.metrics) private var metrics
     let results: [AppEntry]
     /// The flat row id the screen has selected, not an entry id: a fallback can repeat a result.
     let selectedRowID: String?
@@ -144,7 +146,7 @@ struct LauncherList: View {
                                         .contentShape(Rectangle())
                                         .onTapGesture(perform: onActivateCard)
                                         .onRightClick(perform: onCardActions)
-                                        .padding(.bottom, Theme.Spacing.xs)
+                                        .padding(.bottom, metrics.spacing.xs)
                                         .selectionFrame(cardSelected)
                                 case .app(let app, let slot):
                                     AppRow(
@@ -169,9 +171,9 @@ struct LauncherList: View {
                                 }
                             }
                         }
-                        .padding(.horizontal, Theme.Spacing.md)
-                        .padding(.top, Theme.Spacing.xs)
-                        .padding(.bottom, Theme.Spacing.md)
+                        .padding(.horizontal, metrics.spacing.md)
+                        .padding(.top, metrics.spacing.xs)
+                        .padding(.bottom, metrics.spacing.md)
                         .hideNativeScrollers()
                         .scrollOriginAnchor()
                     }
@@ -204,6 +206,8 @@ private struct LeadCardView: View {
 }
 
 private struct AppRow: View {
+
+    @Environment(\.metrics) private var metrics
     let app: AppEntry
     let selected: Bool
     let running: Bool
@@ -231,9 +235,9 @@ private struct AppRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             AppIconView(app: app)
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 .overlay(alignment: .bottom) {
                     if running {
                         Circle()
@@ -243,27 +247,27 @@ private struct AppRow: View {
                     }
                 }
             Text(app.name)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
             if let subtitle = app.subtitle {
                 Text(subtitle)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
             if let alias = aliases.alias(for: app.preferenceKey) {
                 Text(alias)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .padding(.horizontal, Theme.Spacing.sm)
-                    .padding(.vertical, Theme.Spacing.xxs)
+                    .padding(.horizontal, metrics.spacing.sm)
+                    .padding(.vertical, metrics.spacing.xxs)
                     .background(
-                        RoundedRectangle(cornerRadius: Theme.Radius.menu, style: .continuous)
+                        RoundedRectangle(cornerRadius: metrics.radius.menu, style: .continuous)
                             .fill(Theme.Colors.controlSurface))
             }
             if let caps = shortcutCaps {
-                HStack(spacing: Theme.Spacing.xxs) {
+                HStack(spacing: metrics.spacing.xxs) {
                     ForEach(Array(caps.enumerated()), id: \.offset) { _, cap in
                         KeyCapChip(text: cap, style: .outline)
                     }
@@ -272,24 +276,24 @@ private struct AppRow: View {
             Spacer()
             if let refresh = app.backgroundRefresh {
                 ExtensionRefreshIndicator(state: refresh)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
             }
             // Holding ⌘ turns the trailing label into the chord that launches this row.
             if let slot, palette.commandHeld {
-                HStack(spacing: Theme.Spacing.xxs) {
+                HStack(spacing: metrics.spacing.xxs) {
                     KeyCapChip(text: "⌘", style: .outline)
                     KeyCapChip(text: String(slot), style: .outline)
                 }
             } else {
                 Text(app.kindLabel)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)

--- a/Tinycast/Features/Launcher/UI/LauncherScreen.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherScreen.swift
@@ -144,7 +144,8 @@ struct LauncherScreen: PaletteScreen {
         return ExtensionArgumentsAccessory.make(
             entry: entry, coordinator: core.extensionCoordinator,
             values: { name in headerFieldBinding(entry: entry, name: name) },
-            focus: focus, onSubmit: { activate(at: selection) })
+            focus: focus, metrics: core.settings.interfaceSize.metrics,
+            onSubmit: { activate(at: selection) })
     }
 
     private func headerFieldBinding(entry: AppEntry, name: String) -> Binding<String> {

--- a/Tinycast/Features/Launcher/UI/LeadCard.swift
+++ b/Tinycast/Features/Launcher/UI/LeadCard.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Fill and hover for every lead card, so none can answer a selection differently from another.
 private struct LeadCardChrome: ViewModifier {
+    @Environment(\.metrics) private var metrics
     let selected: Bool
     @State private var hovered = false
 
@@ -13,7 +14,7 @@ private struct LeadCardChrome: ViewModifier {
     }
 
     private var shape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+        RoundedRectangle(cornerRadius: metrics.radius.card, style: .continuous)
     }
 
     private var fill: Color {
@@ -32,37 +33,39 @@ extension View {
 
 /// One side of a two-column lead card: a value line with an optional word-name badge beneath.
 struct LeadCardColumn: View {
+    @Environment(\.metrics) private var metrics
     let text: AttributedString
     let badge: String?
     var weight: Font.Weight = .medium
 
     var body: some View {
-        VStack(spacing: Theme.Spacing.md) {
+        VStack(spacing: metrics.spacing.md) {
             Text(text)
-                .font(Theme.Typography.calcResult.weight(weight))
+                .font(metrics.typography.calcResult.weight(weight))
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
             if let badge { LeadCardBadge(text: badge) }
         }
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.horizontal, metrics.spacing.md)
     }
 }
 
 /// The pill a lead card states its kind in — the calculator's unit, a colour's notation.
 private struct LeadCardBadge: View {
+    @Environment(\.metrics) private var metrics
     let text: String
 
     var body: some View {
         Text(text)
-            .font(Theme.Typography.keyCap)
+            .font(metrics.typography.keyCap)
             .lineLimit(1)
             .minimumScaleFactor(0.6)
             .foregroundStyle(.secondary)
-            .padding(.horizontal, Theme.Spacing.sm)
-            .padding(.vertical, Theme.Spacing.xxs)
+            .padding(.horizontal, metrics.spacing.sm)
+            .padding(.vertical, metrics.spacing.xxs)
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.keyCap, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.keyCap, style: .continuous)
                     .fill(Theme.Colors.controlSurface)
             )
     }

--- a/Tinycast/Features/Launcher/UI/SectionHeader.swift
+++ b/Tinycast/Features/Launcher/UI/SectionHeader.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Section label above a group of rows, shared by every palette list.
 struct SectionHeader: View {
+    @Environment(\.metrics) private var metrics
     let title: String
     /// The first header hugs the top; later ones get spacing above, reading as below.
     var isFirst = false
@@ -10,7 +11,7 @@ struct SectionHeader: View {
     var configureHelp = "Configure…"
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        HStack(spacing: metrics.spacing.sm) {
             Text(title)
                 .lineLimit(1)
             if let configure {
@@ -24,10 +25,10 @@ struct SectionHeader: View {
             }
             Spacer(minLength: 0)
         }
-        .font(Theme.Typography.sectionHeader)
+        .font(metrics.typography.sectionHeader)
         .foregroundStyle(.secondary)
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.top, isFirst ? Theme.Spacing.xs : Theme.Spacing.sectionSpacing)
-        .padding(.bottom, Theme.Spacing.sectionHeaderBottom)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.top, isFirst ? metrics.spacing.xs : metrics.spacing.sectionSpacing)
+        .padding(.bottom, metrics.spacing.sectionHeaderBottom)
     }
 }

--- a/Tinycast/Features/MenuSearch/UI/MenuSearchList.swift
+++ b/Tinycast/Features/MenuSearch/UI/MenuSearchList.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct MenuSearchList: View {
+
+    @Environment(\.metrics) private var metrics
     let items: [MenuSearchItem]
     let targetName: String
     let iconURL: URL?
@@ -30,9 +32,9 @@ struct MenuSearchList: View {
                             .onTapGesture { onActivate(item) }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -54,6 +56,8 @@ struct MenuSearchList: View {
 }
 
 private struct MenuSearchRow: View {
+
+    @Environment(\.metrics) private var metrics
     let item: MenuSearchItem
     let icon: NSImage?
     let selected: Bool
@@ -66,38 +70,38 @@ private struct MenuSearchRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             Group {
                 if let icon {
                     Image(nsImage: icon).resizable()
                 } else {
-                    RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                    RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
                         .fill(Theme.Colors.iconPlaceholder)
                 }
             }
-            .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+            .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
             Text(item.title)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
-            Spacer(minLength: Theme.Spacing.md)
+            Spacer(minLength: metrics.spacing.md)
             Text(item.displayPath)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
             let caps = item.shortcut?.keycaps ?? []
             if !caps.isEmpty {
-                HStack(spacing: Theme.Spacing.xxs) {
+                HStack(spacing: metrics.spacing.xxs) {
                     ForEach(caps, id: \.self) { cap in
                         KeyCapChip(text: cap, style: .outline)
                     }
                 }
             }
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)

--- a/Tinycast/Features/QuickActions/UI/QuickActionCoordinator.swift
+++ b/Tinycast/Features/QuickActions/UI/QuickActionCoordinator.swift
@@ -289,6 +289,7 @@ final class QuickActionCoordinator {
     private func present(_ state: QuickActionPanelState, target: NSRunningApplication?) {
         panels.present(
             state,
+            metrics: settings.interfaceSize.metrics,
             languages: offeredLanguages,
             onRetranslate: { [weak self] language in
                 state.targetLanguage = language

--- a/Tinycast/Features/QuickActions/UI/QuickActionPanelController.swift
+++ b/Tinycast/Features/QuickActions/UI/QuickActionPanelController.swift
@@ -16,6 +16,7 @@ final class QuickActionPanelController: NSObject, NSWindowDelegate {
 
     func present(
         _ state: QuickActionPanelState,
+        metrics: InterfaceMetrics,
         languages: [Locale.Language],
         onRetranslate: @escaping (Locale.Language) -> Void,
         onDownloaded: @escaping () -> Void,
@@ -36,12 +37,13 @@ final class QuickActionPanelController: NSObject, NSWindowDelegate {
                 onCancel: { [weak self] in self?.dismiss() },
                 onRetranslate: { [weak self] in self?.onRetranslate?($0) },
                 onDownloaded: { [weak self] in self?.onDownloaded?() },
-                onHeight: { [weak self] in self?.resize(toHeight: $0) }))
+                onHeight: { [weak self] in self?.resize(toHeight: $0) }
+            ).environment(\.metrics, metrics))
         // The controller owns the frame; without this the top edge drifts as the reply grows.
         hosting.sizingOptions = []
         // Its tallest, so the first frame is never short; the view reports the real height at once.
         hosting.setFrameSize(
-            NSSize(width: Theme.Size.quickActionPanel, height: Theme.Size.quickActionPanelBody))
+            NSSize(width: metrics.size.quickActionPanel, height: metrics.size.quickActionPanelBody))
 
         let panel = QuickActionPanel(content: hosting)
         panel.delegate = self

--- a/Tinycast/Features/QuickActions/UI/QuickActionResultView.swift
+++ b/Tinycast/Features/QuickActions/UI/QuickActionResultView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 @preconcurrency import Translation
 
 struct QuickActionResultView: View {
+
+    @Environment(\.metrics) private var metrics
     let state: QuickActionPanelState
     let languages: [Locale.Language]
     let onReplace: () -> Void
@@ -21,7 +23,7 @@ struct QuickActionResultView: View {
         ScrollView {
             body(for: state.phase)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, Theme.Spacing.xxl)
+                .padding(.horizontal, metrics.spacing.xxl)
                 // A `ScrollView` has no ideal height, so the frame below is set, not merely capped.
                 .fixedSize(horizontal: false, vertical: true)
                 // Measured before the insets, so `isScrollable` cannot depend on its own answer.
@@ -37,10 +39,10 @@ struct QuickActionResultView: View {
         .mask(scrollFade)
         .overlay(alignment: .top) { measured(header) { headerHeight = $0 } }
         .overlay(alignment: .bottom) { measured(footer) { footerHeight = $0 } }
-        .frame(width: Theme.Size.quickActionPanel, height: panelHeight)
+        .frame(width: metrics.size.quickActionPanel, height: panelHeight)
         .background(Theme.Colors.panelScrim)
         .background(VisualEffectView())
-        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.dialog, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: metrics.radius.dialog, style: .continuous))
         .panelEntrance()
         // Reported, not measured: the frame above is ours, so reading it back would feed itself.
         .onChange(of: panelHeight, initial: true) { onHeight(panelHeight) }
@@ -59,7 +61,7 @@ struct QuickActionResultView: View {
 
     /// Clears the bar and its ramp, so the first line is opaque until it scrolls into the gradient.
     private func inset(_ bar: CGFloat) -> CGFloat {
-        bar + (isScrollable ? Theme.Size.quickActionScrollFade : 0)
+        bar + (isScrollable ? metrics.size.quickActionScrollFade : 0)
     }
 
     /// A mask, not `scrollEdgeEffectStyle`: its material composited to nothing over this vibrancy.
@@ -82,50 +84,50 @@ struct QuickActionResultView: View {
 
     private func ramp(from start: Color, to end: Color) -> some View {
         LinearGradient(colors: [start, end], startPoint: .top, endPoint: .bottom)
-            .frame(height: Theme.Size.quickActionScrollFade)
+            .frame(height: metrics.size.quickActionScrollFade)
     }
 
-    private var isScrollable: Bool { contentHeight > Theme.Size.quickActionPanelBody }
+    private var isScrollable: Bool { contentHeight > metrics.size.quickActionPanelBody }
 
     private var panelHeight: CGFloat {
         let chrome = headerHeight + footerHeight
         return min(
-            max(contentHeight + chrome, chrome + Theme.Size.quickActionPanelMinBody),
-            chrome + Theme.Size.quickActionPanelBody)
+            max(contentHeight + chrome, chrome + metrics.size.quickActionPanelMinBody),
+            chrome + metrics.size.quickActionPanelBody)
     }
 
     private var header: some View {
-        HStack(spacing: Theme.Spacing.md) {
+        HStack(spacing: metrics.spacing.md) {
             // Only the title run drags: the handle is an overlay, and would eat the menu's clicks.
-            HStack(spacing: Theme.Spacing.sm) {
-                SymbolImage(name: state.action.symbol, size: Theme.Size.quickActionHeaderIcon)
+            HStack(spacing: metrics.spacing.sm) {
+                SymbolImage(name: state.action.symbol, size: metrics.size.quickActionHeaderIcon)
                     .foregroundStyle(Theme.Colors.textSecondary)
                 Text(state.action.title)
-                    .font(Theme.Typography.panelTitle)
-                Spacer(minLength: Theme.Spacing.md)
+                    .font(metrics.typography.panelTitle)
+                Spacer(minLength: metrics.spacing.md)
             }
             .windowDraggable(true)
             if state.action == .translate, !languages.isEmpty { languageMenu }
         }
-        .padding(.horizontal, Theme.Spacing.xxl)
-        .padding(.top, Theme.Spacing.xl)
-        .padding(.bottom, Theme.Spacing.lg)
+        .padding(.horizontal, metrics.spacing.xxl)
+        .padding(.top, metrics.spacing.xl)
+        .padding(.bottom, metrics.spacing.lg)
     }
 
     @ViewBuilder
     private func body(for phase: QuickActionPanelState.Phase) -> some View {
         switch phase {
         case .running where state.output.isEmpty:
-            HStack(spacing: Theme.Spacing.md) {
+            HStack(spacing: metrics.spacing.md) {
                 ProgressView().controlSize(.small)
                 Text("Working…").foregroundStyle(Theme.Colors.textSecondary)
             }
-            .font(Theme.Typography.rowTitle)
+            .font(metrics.typography.rowTitle)
         case .running, .finished:
             output
         case .failed(let message):
             Label(message, systemImage: "exclamationmark.triangle")
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .foregroundStyle(Theme.Colors.textSecondary)
         case .needsLanguageDownload:
             downloadPrompt
@@ -148,8 +150,8 @@ struct QuickActionResultView: View {
     /// A result is a paragraph to read rather than a row label, so it is led like one.
     private func prose(_ text: Text) -> some View {
         text
-            .font(Theme.Typography.rowTitle)
-            .lineSpacing(Theme.Spacing.xs)
+            .font(metrics.typography.rowTitle)
+            .lineSpacing(metrics.spacing.xs)
             .textSelection(.enabled)
     }
 
@@ -172,9 +174,9 @@ struct QuickActionResultView: View {
     }
 
     private var downloadPrompt: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+        VStack(alignment: .leading, spacing: metrics.spacing.xl) {
             Text("\(TextTranslator.displayName(of: state.targetLanguage)) hasn't been downloaded yet.")
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .foregroundStyle(Theme.Colors.textSecondary)
             Button("Download") {
                 download = TranslationSession.Configuration(
@@ -195,8 +197,8 @@ struct QuickActionResultView: View {
     }
 
     private var footer: some View {
-        HStack(spacing: Theme.Spacing.md) {
-            Spacer(minLength: Theme.Spacing.md)
+        HStack(spacing: metrics.spacing.md) {
+            Spacer(minLength: metrics.spacing.md)
             Button("Dismiss", action: onCancel)
             Button("Copy", action: onCopy).disabled(!state.canReplace)
             Button("Replace", action: onReplace)
@@ -204,7 +206,7 @@ struct QuickActionResultView: View {
                 .disabled(!state.canReplace)
         }
         .controlSize(.large)
-        .padding(.horizontal, Theme.Spacing.xxl)
-        .padding(.vertical, Theme.Spacing.xl)
+        .padding(.horizontal, metrics.spacing.xxl)
+        .padding(.vertical, metrics.spacing.xl)
     }
 }

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsAccessory.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsAccessory.swift
@@ -14,6 +14,7 @@ enum QuicklinkArgumentsAccessory {
         onSubmit: @escaping () -> Void
     ) -> PaletteHeaderAccessory? {
         guard let quicklink else { return nil }
+        let metrics = core.settings.interfaceSize.metrics
         let arguments = core.quicklinkCoordinator.promptedArguments(for: quicklink)
         guard !arguments.isEmpty else { return nil }
 
@@ -21,7 +22,8 @@ enum QuicklinkArgumentsAccessory {
         let symbol = placement == .afterQuery ? quicklink.symbol : nil
         let value = { (name: String) in binding(quicklink: quicklink, name: name, vm: vm) }
         return PaletteHeaderAccessory(
-            width: QuicklinkArgumentsRow.totalWidth(for: arguments, hasIcon: symbol != nil),
+            width: QuicklinkArgumentsRow.totalWidth(
+                for: arguments, hasIcon: symbol != nil, metrics: metrics),
             fieldNames: arguments.map(\.name),
             firstIncompleteField: arguments.first { value($0.name).wrappedValue.isEmpty }?.name,
             optionsMenu: { name in

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsRow.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkArgumentsRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// The inline argument fields beside the search field, one per `{argument}` the link declares.
 struct QuicklinkArgumentsRow: View {
+    @Environment(\.metrics) private var metrics
     let arguments: [SnippetTemplateEngine.MissingArgument]
     /// The quicklink's glyph, anchoring the strip to the row; nil where that row is already listed.
     let symbol: String?
@@ -16,11 +17,11 @@ struct QuicklinkArgumentsRow: View {
     @State private var visited: Set<String> = []
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             if let symbol {
                 Image(nsImage: IconCache.symbolIcon(named: symbol))
                     .resizable()
-                    .frame(width: Self.height, height: Self.height)
+                    .frame(width: Self.height(metrics), height: Self.height(metrics))
             }
             ForEach(arguments, id: \.name) { argument in
                 if argument.options.isEmpty {
@@ -49,24 +50,29 @@ struct QuicklinkArgumentsRow: View {
         }
     }
 
-    static let height: CGFloat = 26
+    static func height(_ metrics: InterfaceMetrics) -> CGFloat { metrics.scaled(26) }
 
     /// The header shrinks the search field to exactly the room left over.
     static func totalWidth(
-        for arguments: [SnippetTemplateEngine.MissingArgument], hasIcon: Bool
+        for arguments: [SnippetTemplateEngine.MissingArgument], hasIcon: Bool,
+        metrics: InterfaceMetrics
     ) -> CGFloat {
-        let fields = arguments.reduce(0) { $0 + fieldWidth(for: $1) }
-        let gaps = CGFloat(arguments.count + (hasIcon ? 0 : -1)) * Theme.Spacing.xs
-        return fields + gaps + (hasIcon ? height : 0)
+        let fields = arguments.reduce(0) { $0 + fieldWidth(for: $1, metrics: metrics) }
+        let gaps = CGFloat(arguments.count + (hasIcon ? 0 : -1)) * metrics.spacing.xs
+        return fields + gaps + (hasIcon ? height(metrics) : 0)
     }
 
-    static func fieldWidth(for argument: SnippetTemplateEngine.MissingArgument) -> CGFloat {
-        min(max(CGFloat(argument.name.count) * 7 + 34, 72), 160)
+    static func fieldWidth(
+        for argument: SnippetTemplateEngine.MissingArgument, metrics: InterfaceMetrics
+    ) -> CGFloat {
+        let name = CGFloat(argument.name.count) * metrics.scaled(7)
+        return min(max(name + metrics.scaled(34), metrics.scaled(72)), metrics.scaled(160))
     }
 }
 
 /// Shared chrome, so a typed field and a chosen one read as the same control.
 private struct ArgumentFieldChrome: ViewModifier {
+    @Environment(\.metrics) private var metrics
     let argument: SnippetTemplateEngine.MissingArgument
     let isFocused: Bool
     /// Visited, left, and still empty — the only state that earns a warning edge.
@@ -75,14 +81,14 @@ private struct ArgumentFieldChrome: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .frame(width: QuicklinkArgumentsRow.fieldWidth(for: argument))
-            .padding(.horizontal, Theme.Spacing.sm)
-            .frame(height: QuicklinkArgumentsRow.height)
+            .frame(width: QuicklinkArgumentsRow.fieldWidth(for: argument, metrics: metrics))
+            .padding(.horizontal, metrics.spacing.sm)
+            .frame(height: QuicklinkArgumentsRow.height(metrics))
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous).fill(fill)
+                RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous).fill(fill)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                     .strokeBorder(stroke, lineWidth: 1)
             )
             .onHover { hovered = $0 }
@@ -104,6 +110,8 @@ private struct ArgumentFieldChrome: ViewModifier {
 }
 
 private struct ArgumentField: View {
+
+    @Environment(\.metrics) private var metrics
     let argument: SnippetTemplateEngine.MissingArgument
     @Binding var text: String
     let isFocused: Bool
@@ -117,7 +125,7 @@ private struct ArgumentField: View {
             prompt: Text(argument.name).foregroundStyle(Theme.Colors.textTertiary)
         )
         .textFieldStyle(.plain)
-        .font(Theme.Typography.rowTrailing)
+        .font(metrics.typography.rowTrailing)
         .tint(Theme.Colors.textPrimary)
         .onSubmit(onSubmit)
         .multilineTextAlignment(.center)
@@ -130,6 +138,7 @@ private struct ArgumentField: View {
 
 /// An `options=` argument: the value is picked from the palette's own menu, never typed.
 private struct ArgumentChoiceField: View {
+    @Environment(\.metrics) private var metrics
     let argument: SnippetTemplateEngine.MissingArgument
     @Binding var text: String
     let isFocused: Bool
@@ -138,9 +147,9 @@ private struct ArgumentChoiceField: View {
     @State private var hovered = false
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xxs) {
+        HStack(spacing: metrics.spacing.xxs) {
             Text(text.isEmpty ? argument.name : text)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(
                     text.isEmpty ? Theme.Colors.textTertiary : Theme.Colors.textPrimary
                 )

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListScreen.swift
@@ -5,6 +5,8 @@ struct QuicklinkListScreen: PaletteScreen {
     let store: QuicklinkStore
     let core: AppCore
     let vm: PaletteState
+
+    private var metrics: InterfaceMetrics { core.settings.interfaceSize.metrics }
     let openActions: () -> Void
     /// Opens the palette's own menu for an `options=` field, keyed by argument name.
     let openArgumentOptions: (String) -> Void
@@ -94,7 +96,7 @@ struct QuicklinkListScreen: PaletteScreen {
                         openActions()
                     }
                 )
-                .frame(width: Theme.Size.clipboardListWidth)
+                .frame(width: metrics.size.clipboardListWidth)
                 Rectangle().fill(Theme.Colors.separator).frame(width: Theme.Size.hairline)
                 QuicklinkPreview(quicklink: selected)
             }

--- a/Tinycast/Features/Quicklinks/UI/QuicklinkListView.swift
+++ b/Tinycast/Features/Quicklinks/UI/QuicklinkListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 /// The Search Quicklinks screen: the whole library, pinned entries first.
 struct QuicklinkList: View {
+    @Environment(\.metrics) private var metrics
     let results: [Quicklink]
     let selectedID: Quicklink.ID?
     /// Changes only when the list should scroll, so mouse selection never yanks the position.
@@ -68,9 +69,9 @@ struct QuicklinkList: View {
                         }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -83,6 +84,8 @@ struct QuicklinkList: View {
 }
 
 private struct QuicklinkRow: View {
+
+    @Environment(\.metrics) private var metrics
     let quicklink: Quicklink
     let selected: Bool
     @Environment(HotKeyManager.self) private var hotKeys
@@ -96,38 +99,38 @@ private struct QuicklinkRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             Image(nsImage: IconCache.symbolIcon(named: quicklink.symbol))
                 .resizable()
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
-            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
+            VStack(alignment: .leading, spacing: metrics.spacing.xxs) {
                 Text(quicklink.name)
-                    .font(Theme.Typography.rowTitle)
+                    .font(metrics.typography.rowTitle)
                     .lineLimit(1)
                 Text(quicklink.link)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Spacer(minLength: Theme.Spacing.lg)
+            Spacer(minLength: metrics.spacing.lg)
             if !quicklink.showsInRootSearch {
                 Image(systemName: "eye.slash")
                     .font(.system(size: 10))
                     .foregroundStyle(Theme.Colors.textTertiary)
             }
             if let keycaps = hotKeys.binding(for: .quicklink(id: quicklink.id))?.keycaps {
-                HStack(spacing: Theme.Spacing.xxs) {
+                HStack(spacing: metrics.spacing.xxs) {
                     ForEach(Array(keycaps.enumerated()), id: \.offset) { _, cap in
                         KeyCapChip(text: cap, style: .outline)
                     }
                 }
             }
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)
@@ -136,6 +139,7 @@ private struct QuicklinkRow: View {
 
 /// The detail pane beside the list, the way Search Snippets previews the snippet it highlights.
 struct QuicklinkPreview: View {
+    @Environment(\.metrics) private var metrics
     let quicklink: Quicklink?
 
     var body: some View {
@@ -144,7 +148,7 @@ struct QuicklinkPreview: View {
                 Spacer(minLength: 0)
                 SymbolImage(name: quicklink.symbol, size: Self.glyphSize)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, Theme.Spacing.xl)
+                    .padding(.vertical, metrics.spacing.xl)
                 Spacer(minLength: 0)
                 QuicklinkInfoSection(quicklink: quicklink)
             }
@@ -161,6 +165,7 @@ struct QuicklinkPreview: View {
 
 /// The "Information" block; everything in it is already in memory, so nothing is gathered off-main.
 private struct QuicklinkInfoSection: View {
+    @Environment(\.metrics) private var metrics
     let quicklink: Quicklink
     @Environment(HotKeyManager.self) private var hotKeys
     @Environment(AppIndex.self) private var appIndex
@@ -200,24 +205,24 @@ private struct QuicklinkInfoSection: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+        VStack(alignment: .leading, spacing: metrics.spacing.sm) {
             Text("Information")
-                .font(Theme.Typography.sectionHeader)
+                .font(metrics.typography.sectionHeader)
                 .foregroundStyle(.secondary)
             VStack(spacing: 0) {
                 let rows = self.rows
                 ForEach(rows) { row in
                     if row.id != rows.first?.id { Divider() }
-                    HStack(spacing: Theme.Spacing.sm) {
+                    HStack(spacing: metrics.spacing.sm) {
                         Text(row.label).foregroundStyle(.secondary)
-                        Spacer(minLength: Theme.Spacing.lg)
+                        Spacer(minLength: metrics.spacing.lg)
                         Text(row.value).lineLimit(1).truncationMode(.middle)
                     }
-                    .font(Theme.Typography.keyCap)
-                    .padding(.vertical, Theme.Spacing.xs)
+                    .font(metrics.typography.keyCap)
+                    .padding(.vertical, metrics.spacing.xs)
                 }
             }
         }
-        .padding(.vertical, Theme.Spacing.md)
+        .padding(.vertical, metrics.spacing.md)
     }
 }

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -191,6 +191,11 @@ final class AppSettings {
         didSet { defaults.set(appearance.rawValue, forKey: Key.appearance.rawValue) }
     }
 
+    /// Scales the palette and its floating siblings only. Read through `InterfaceSize.metrics`.
+    var interfaceSize: InterfaceSize {
+        didSet { defaults.set(interfaceSize.rawValue, forKey: Key.interfaceSize.rawValue) }
+    }
+
     var paletteTransparency: Int {
         didSet { defaults.set(paletteTransparency, forKey: Key.paletteTransparency.rawValue) }
     }
@@ -505,6 +510,9 @@ final class AppSettings {
             ?? .navigateBackOrClose
         appearance =
             defaults.string(forKey: Key.appearance.rawValue).flatMap(AppAppearance.init) ?? .system
+        interfaceSize =
+            defaults.string(forKey: Key.interfaceSize.rawValue).flatMap(InterfaceSize.init)
+            ?? .standard
         paletteTransparency = max(-100, min(100, defaults.integer(forKey: Key.paletteTransparency.rawValue)))
         compactMode = defaults.bool(forKey: Key.compactMode.rawValue)
         // Defaults to true, so absence must be distinguished from a stored `false`.

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -15,6 +15,7 @@ enum AppSettingsKey: String, CaseIterable {
     case popToRootTimeout = "popToRootTimeout"
     case escapeKeyBehavior = "escapeKeyBehavior"
     case appearance = "appearance"
+    case interfaceSize = "interfaceSize"
     case paletteTransparency = "paletteTransparency"
     case compactMode = "compactMode"
     case showFavoritesInCompactMode = "showFavoritesInCompactMode"

--- a/Tinycast/Features/Settings/InterfaceSize.swift
+++ b/Tinycast/Features/Settings/InterfaceSize.swift
@@ -1,0 +1,28 @@
+import CoreGraphics
+
+/// How large the palette and its floating siblings render; an unset key reads as `.standard`.
+enum InterfaceSize: String, CaseIterable, Identifiable, Sendable {
+    case standard
+    case large
+    case larger
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .standard: "Default"
+        case .large: "Large"
+        case .larger: "Larger"
+        }
+    }
+
+    var scale: CGFloat {
+        switch self {
+        case .standard: 1
+        case .large: 1.1
+        case .larger: 1.2
+        }
+    }
+
+    var metrics: InterfaceMetrics { InterfaceMetrics(scale: scale) }
+}

--- a/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/GeneralSettingsView.swift
@@ -119,6 +119,7 @@ struct GeneralSettingsView: View {
                     SettingsRowTitle(.generalAppearance, "Theme")
                     Text("Match macOS, or pin Tinycast to Light or Dark.")
                 }
+                InterfaceSizeRow()
                 PaletteTransparencyRow()
                 Toggle(isOn: $settings.compactMode) {
                     SettingsRowTitle(.generalAppearance, "Compact mode")
@@ -213,6 +214,50 @@ struct GeneralSettingsView: View {
 
     private func refreshInputSources() {
         inputSources = core.inputSourceSwitcher.options(selecting: settings.autoSwitchInputSourceID)
+    }
+}
+
+/// Three glyph steps read as a legend; a true-to-scale "Aa" would look identical at 1.1.
+private struct InterfaceSizeRow: View {
+    @Environment(AppSettings.self) private var settings
+
+    private static let glyph: [InterfaceSize: CGFloat] = [
+        .standard: 11, .large: 14, .larger: 17
+    ]
+
+    var body: some View {
+        SettingsRow(
+            title: "Interface size",
+            subtitle: "Scale the launcher and the windows that float with it. Settings stay put.",
+            subtitleLineLimit: 2,
+            anchor: .generalAppearance
+        ) {
+            HStack(spacing: Theme.Spacing.xxs) {
+                ForEach(InterfaceSize.allCases) { size in
+                    segment(size)
+                }
+            }
+        }
+    }
+
+    private func segment(_ size: InterfaceSize) -> some View {
+        let selected = settings.interfaceSize == size
+        let shape = RoundedRectangle(cornerRadius: Theme.Radius.barControl, style: .continuous)
+        return Button {
+            settings.interfaceSize = size
+        } label: {
+            Text("Aa")
+                .font(.system(size: Self.glyph[size] ?? 13, weight: .medium))
+                .foregroundStyle(selected ? Color.primary : Color.secondary)
+                .frame(width: Theme.Size.interfaceSizeSegment, height: Theme.Size.settingsSearchField)
+                // Without this only the glyphs take the click, not the segment around them.
+                .contentShape(shape)
+                .background(shape.fill(selected ? Theme.Colors.controlSurface : Color.clear))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(size.title)
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+        .help(size.title)
     }
 }
 

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -134,6 +134,9 @@ enum SettingsSearchCatalog {
             .generalAppearance, "Theme",
             keywords: ["dark", "light", "mode", "appearance"]),
         .init(
+            .generalAppearance, "Interface size",
+            keywords: ["text size", "font size", "scale", "zoom", "bigger", "larger", "legible"]),
+        .init(
             .generalAppearance, "Background transparency",
             keywords: ["glass", "opacity", "blur", "translucency", "reset"]),
         .init(

--- a/Tinycast/Features/Snippets/UI/SnippetArgumentsPrompt.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetArgumentsPrompt.swift
@@ -7,7 +7,8 @@ enum SnippetArgumentsPrompt {
     /// The collected values, or nil on cancel. Modal: expansion is mid-flight and blocking.
     static func run(
         snippetName: String,
-        arguments: [SnippetTemplateEngine.MissingArgument]
+        arguments: [SnippetTemplateEngine.MissingArgument],
+        metrics: InterfaceMetrics
     ) -> [String: String]? {
         guard !arguments.isEmpty else { return [:] }
 
@@ -22,10 +23,11 @@ enum SnippetArgumentsPrompt {
         alert.addButton(withTitle: "Expand")
         alert.addButton(withTitle: "Cancel")
 
-        let form = NSHostingView(rootView: SnippetArgumentsForm(values: values))
+        let form = NSHostingView(
+            rootView: SnippetArgumentsForm(values: values).environment(\.metrics, metrics))
         form.frame = NSRect(
             x: 0, y: 0,
-            width: Theme.Size.argumentPromptWidth,
+            width: metrics.size.argumentPromptWidth,
             height: form.fittingSize.height)
         alert.accessoryView = form
 
@@ -59,13 +61,15 @@ private final class ArgumentValues {
 }
 
 private struct SnippetArgumentsForm: View {
+
+    @Environment(\.metrics) private var metrics
     let values: ArgumentValues
     @FocusState private var focusedArgument: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+        VStack(alignment: .leading, spacing: metrics.spacing.lg) {
             ForEach(values.arguments, id: \.name) { argument in
-                VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                VStack(alignment: .leading, spacing: metrics.spacing.sm) {
                     Text(argument.name)
                         .font(.callout.weight(.medium))
                     if argument.options.isEmpty {
@@ -86,7 +90,7 @@ private struct SnippetArgumentsForm: View {
                 .accessibilityLabel("Snippet argument \(argument.name)")
             }
         }
-        .frame(width: Theme.Size.argumentPromptWidth, alignment: .leading)
+        .frame(width: metrics.size.argumentPromptWidth, alignment: .leading)
         // Focus the first text field so the prompt is typeable without a click.
         .onAppear { focusedArgument = values.arguments.first { $0.options.isEmpty }?.name }
     }

--- a/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetCoordinator.swift
@@ -222,7 +222,8 @@ final class SnippetCoordinator {
         guard
             let arguments = SnippetArgumentsPrompt.run(
                 snippetName: record.snippet.name,
-                arguments: missingArgs)
+                arguments: missingArgs,
+                metrics: settings.interfaceSize.metrics)
         else {
             injector.cancelArgumentPrompt(
                 automaticGeneration: automaticGeneration,

--- a/Tinycast/Features/Snippets/UI/SnippetsListView.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetsListView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct SnippetsList: View {
+
+    @Environment(\.metrics) private var metrics
     let results: [StoredSnippet]
     let selectedID: StoredSnippet.ID?
     let scroll: ScrollIntent
@@ -30,9 +32,9 @@ struct SnippetsList: View {
                             .onRightClick { onActions(record) }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -45,6 +47,8 @@ struct SnippetsList: View {
 }
 
 private struct SnippetRow: View {
+
+    @Environment(\.metrics) private var metrics
     let record: StoredSnippet
     let selected: Bool
     @State private var hovered = false
@@ -56,30 +60,30 @@ private struct SnippetRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
-            RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+        HStack(spacing: metrics.spacing.lg) {
+            RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
                 .fill(Theme.Colors.controlSurface)
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 .overlay(
                     Image(systemName: "curlybraces")
                         .font(.system(size: 12))
                         .symbolRenderingMode(.hierarchical)
                         .foregroundStyle(.secondary))
             Text(record.snippet.name)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
-            Spacer(minLength: Theme.Spacing.lg)
+            Spacer(minLength: metrics.spacing.lg)
             if let keyword = record.snippet.keyword, !keyword.isEmpty {
                 Text(keyword)
-                    .font(Theme.Typography.keyCap)
+                    .font(metrics.typography.keyCap)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .lineLimit(1)
             }
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous).fill(fill)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous).fill(fill)
         )
         .armedHover($hovered)
     }
@@ -110,6 +114,7 @@ struct SnippetPreview: View {
 
 /// The "Information" block; everything in it is already in memory, so nothing is gathered off-main.
 private struct SnippetInfoSection: View {
+    @Environment(\.metrics) private var metrics
     let record: StoredSnippet
 
     private struct InfoRow: Identifiable {
@@ -130,24 +135,24 @@ private struct SnippetInfoSection: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+        VStack(alignment: .leading, spacing: metrics.spacing.sm) {
             Text("Information")
-                .font(Theme.Typography.sectionHeader)
+                .font(metrics.typography.sectionHeader)
                 .foregroundStyle(.secondary)
             VStack(spacing: 0) {
                 let rows = self.rows
                 ForEach(rows) { row in
                     if row.id != rows.first?.id { Divider() }
-                    HStack(spacing: Theme.Spacing.sm) {
+                    HStack(spacing: metrics.spacing.sm) {
                         Text(row.label).foregroundStyle(.secondary)
-                        Spacer(minLength: Theme.Spacing.lg)
+                        Spacer(minLength: metrics.spacing.lg)
                         Text(row.value).lineLimit(1).truncationMode(.middle)
                     }
-                    .font(Theme.Typography.keyCap)
-                    .padding(.vertical, Theme.Spacing.xs)
+                    .font(metrics.typography.keyCap)
+                    .padding(.vertical, metrics.spacing.xs)
                 }
             }
         }
-        .padding(.vertical, Theme.Spacing.md)
+        .padding(.vertical, metrics.spacing.md)
     }
 }

--- a/Tinycast/Features/Snippets/UI/SnippetsScreen.swift
+++ b/Tinycast/Features/Snippets/UI/SnippetsScreen.swift
@@ -5,6 +5,8 @@ struct SnippetsScreen: PaletteScreen {
     let store: SnippetsStore
     let core: AppCore
     let vm: PaletteState
+
+    private var metrics: InterfaceMetrics { core.settings.interfaceSize.metrics }
     let openActions: () -> Void
 
     /// A disabled snippet is off everywhere, so the browser lists exactly what the launcher does.
@@ -60,7 +62,7 @@ struct SnippetsScreen: PaletteScreen {
                         openActions()
                     }
                 )
-                .frame(width: Theme.Size.clipboardListWidth)
+                .frame(width: metrics.size.clipboardListWidth)
                 Rectangle().fill(Theme.Colors.separator).frame(width: Theme.Size.hairline)
                 SnippetPreview(record: selected)
             }

--- a/Tinycast/Features/SystemActions/UI/SystemActionCoordinator.swift
+++ b/Tinycast/Features/SystemActions/UI/SystemActionCoordinator.swift
@@ -4,7 +4,7 @@ import AppKit
 @MainActor
 final class SystemActionCoordinator {
     private let paletteCoordinator: PaletteCoordinator
-    private let volumeHUD = VolumeHUDController()
+    @ObservationIgnored private lazy var volumeHUD = VolumeHUDController(settings: core.settings)
     /// Dialog and message-HUD presentation only — never for state this type owns.
     private unowned let core: AppCore
 

--- a/Tinycast/Features/Uninstall/UI/UninstallView.swift
+++ b/Tinycast/Features/Uninstall/UI/UninstallView.swift
@@ -2,6 +2,8 @@ import AppKit
 import SwiftUI
 
 struct UninstallList: View {
+
+    @Environment(\.metrics) private var metrics
     let results: [UninstallCandidate]
     let selectedID: UninstallCandidate.ID?
     let summary: String
@@ -42,9 +44,9 @@ struct UninstallList: View {
                         .onRightClick { onActions(candidate) }
                     }
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.top, Theme.Spacing.xs)
-                .padding(.bottom, Theme.Spacing.md)
+                .padding(.horizontal, metrics.spacing.md)
+                .padding(.top, metrics.spacing.xs)
+                .padding(.bottom, metrics.spacing.md)
                 .hideNativeScrollers()
                 .scrollOriginAnchor()
             }
@@ -59,6 +61,8 @@ struct UninstallList: View {
 }
 
 private struct UninstallRow: View {
+
+    @Environment(\.metrics) private var metrics
     let candidate: UninstallCandidate
     let selected: Bool
     let checked: Bool
@@ -78,42 +82,42 @@ private struct UninstallRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.lg) {
+        HStack(spacing: metrics.spacing.lg) {
             // Smaller glyph, same `rowIcon` slot, so titles line up at one x across modes.
-            SymbolImage(name: glyph, size: Theme.Size.checkbox)
+            SymbolImage(name: glyph, size: metrics.size.checkbox)
                 .foregroundStyle(candidate.isLocked ? Theme.Colors.textTertiary : .primary)
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 .contentShape(Rectangle())
                 // Only the checkbox toggles; the rest of the row selects.
                 .onTapGesture(perform: onToggle)
                 .tooltip(candidate.lockReason)
             Text(candidate.name)
-                .font(Theme.Typography.rowTitle)
+                .font(metrics.typography.rowTitle)
                 .lineLimit(1)
                 .layoutPriority(1)
             Text(candidate.locationLabel)
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(Theme.Colors.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
             if let label = candidate.evidence.label {
                 Text(label)
-                    .font(Theme.Typography.rowTrailing)
+                    .font(metrics.typography.rowTrailing)
                     .foregroundStyle(Theme.Colors.textTertiary)
                     .lineLimit(1)
             }
-            Spacer(minLength: Theme.Spacing.md)
+            Spacer(minLength: metrics.spacing.md)
             Text(candidate.size?.formatted ?? "")
-                .font(Theme.Typography.rowTrailing)
+                .font(metrics.typography.rowTrailing)
                 .foregroundStyle(.secondary)
             FileIconView(path: candidate.path)
-                .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
         }
         .opacity(candidate.isLocked ? 0.55 : 1)
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, metrics.spacing.md)
+        .padding(.vertical, metrics.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous)
                 .fill(fill)
         )
         .armedHover($hovered)
@@ -121,6 +125,8 @@ private struct UninstallRow: View {
 }
 
 private struct FileIconView: View {
+
+    @Environment(\.metrics) private var metrics
     let path: String
     @State private var image: NSImage?
 
@@ -134,7 +140,7 @@ private struct FileIconView: View {
             if let image {
                 Image(nsImage: image).resizable()
             } else {
-                RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.radius.thumbnail, style: .continuous)
                     .fill(Theme.Colors.iconPlaceholder)
             }
         }

--- a/Tinycast/Palette/MenuPanel.swift
+++ b/Tinycast/Palette/MenuPanel.swift
@@ -47,9 +47,6 @@ final class MenuPanelController {
     private weak var parent: NSWindow?
     private var clipsToMenuCorners = false
 
-    /// `bottomBar`'s own padding: a menu's edge must line up with the button it hangs off.
-    private static let inset: CGFloat = Theme.Spacing.md
-
     var isOpen: Bool { panel?.isVisible ?? false }
 
     func show(
@@ -61,7 +58,7 @@ final class MenuPanelController {
         self.parent = parent
         // Open disarmed: a menu opened by click lands under the pointer, which chose no row of it.
         core.palette.disarmHoverHighlight(pointerAt: NSEvent.mouseLocation)
-        layout(corner: corner, parent: parent)
+        layout(corner: corner, parent: parent, metrics: core.settings.interfaceSize.metrics)
         if panel.parent == nil { parent.addChildWindow(panel, ordered: .above) }
         refreshShadow(panel)
     }
@@ -71,7 +68,7 @@ final class MenuPanelController {
         guard let panel, let parent else { return }
         setContent(
             AnyView(content.paletteEnvironment(core)), clipsToMenuCorners: clipsToMenuCorners, in: panel)
-        layout(corner: corner, parent: parent)
+        layout(corner: corner, parent: parent, metrics: core.settings.interfaceSize.metrics)
     }
 
     private func setContent(_ root: AnyView, clipsToMenuCorners: Bool, in panel: MenuPanel) {
@@ -82,7 +79,6 @@ final class MenuPanelController {
         let view = NSHostingView(rootView: root)
         if clipsToMenuCorners {
             view.wantsLayer = true
-            view.layer?.cornerRadius = Theme.Radius.menuPanel
             view.layer?.cornerCurve = .continuous
             view.layer?.masksToBounds = true
             view.layer?.allowsEdgeAntialiasing = true
@@ -118,21 +114,26 @@ final class MenuPanelController {
     }
 
     /// Sizes to the hosted menu, then seats it against the palette's frame in screen space.
-    private func layout(corner: Corner, parent: NSWindow) {
+    private func layout(corner: Corner, parent: NSWindow, metrics: InterfaceMetrics) {
         guard let panel, let hosting else { return }
+        // Set here, not once at build: the AppKit corner must track the SwiftUI clip's radius.
+        if clipsToMenuCorners { hosting.layer?.cornerRadius = metrics.radius.menuPanel }
         let size = hosting.intrinsicContentSize
         guard size.width > 0, size.height > 0 else { return }
         let host = parent.frame
+        // `bottomBar`'s own padding: a menu's edge must line up with the button it hangs off.
+        let inset = metrics.spacing.md
         let origin: NSPoint =
             switch corner {
             case .bottomLeading:
-                NSPoint(x: host.minX + Self.inset, y: host.minY + Self.inset)
+                NSPoint(x: host.minX + inset, y: host.minY + inset)
             case .bottomTrailing:
-                NSPoint(x: host.maxX - Self.inset - size.width, y: host.minY + Self.inset)
+                NSPoint(x: host.maxX - inset - size.width, y: host.minY + inset)
             case .belowHeaderTrailing:
                 NSPoint(
-                    x: host.maxX - Theme.Spacing.md * 2 - size.width,
-                    y: host.maxY - Theme.Size.headerPadding - Theme.Size.headerHeight - size.height)
+                    x: host.maxX - inset * 2 - size.width,
+                    y: host.maxY - metrics.size.headerPadding - metrics.size.headerHeight
+                        - size.height)
             }
         let frame = NSRect(origin: origin, size: size)
         // Every arrow key re-pushes the tree, and only the highlight moved.

--- a/Tinycast/Palette/PaletteDropGuideController.swift
+++ b/Tinycast/Palette/PaletteDropGuideController.swift
@@ -8,11 +8,13 @@ final class PaletteDropGuideController {
     private var host: NSHostingView<PaletteDropGuideView>?
     private var screenFrame: CGRect = .zero
     private var home: CGPoint = .zero
+    private var width: CGFloat = 0
     private var armed = false
 
     /// Reveal the guides, with `home` the default placement's top-left in screen coordinates.
-    func show(home: CGPoint, screenFrame: CGRect, armed: Bool) {
+    func show(home: CGPoint, width: CGFloat, screenFrame: CGRect, armed: Bool) {
         self.home = home
+        self.width = width
         self.screenFrame = screenFrame
         self.armed = armed
         let panel = ensurePanel()
@@ -66,7 +68,7 @@ final class PaletteDropGuideController {
     private var guides: PaletteDropGuideView {
         PaletteDropGuideView(
             topLeft: CGPoint(x: home.x - screenFrame.minX, y: screenFrame.maxY - home.y),
-            width: Theme.Size.panelWidth,
+            width: width,
             armed: armed)
     }
 }

--- a/Tinycast/Palette/PaletteEnvironment.swift
+++ b/Tinycast/Palette/PaletteEnvironment.swift
@@ -1,9 +1,19 @@
 import SwiftUI
 
+/// A stored environment value would freeze at panel-build time; a body re-reads under Observation.
+private struct InterfaceMetricsScope: ViewModifier {
+    let settings: AppSettings
+
+    func body(content: Content) -> some View {
+        content.environment(\.metrics, settings.interfaceSize.metrics)
+    }
+}
+
 extension View {
     /// Shared, so the ⌘K menu's own hosted hierarchy cannot drift from the palette's.
     func paletteEnvironment(_ core: AppCore) -> some View {
         self
+            .modifier(InterfaceMetricsScope(settings: core.settings))
             .environment(core)
             .environment(core.settings)
             .environment(core.palette)

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -191,7 +191,8 @@ final class PalettePanel: NSPanel {
     }
     init<Content: View>(rootView: Content) {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 750, height: 475),
+            contentRect: NSRect(
+                x: 0, y: 0, width: Theme.Size.panelWidth, height: Theme.Size.panelHeight),
             styleMask: [.borderless, .fullSizeContentView, .nonactivatingPanel],
             backing: .buffered,
             defer: false

--- a/Tinycast/Palette/PaletteScreen.swift
+++ b/Tinycast/Palette/PaletteScreen.swift
@@ -28,7 +28,7 @@ enum PaletteAxis {
     }
 
     init(
-        popover: PopoverMenuContent, selection: Binding<Int>, width: CGFloat = Theme.Size.menuWidth,
+        popover: PopoverMenuContent, selection: Binding<Int>, width: CGFloat? = nil,
         onActivate: @escaping (Int) -> Void
     ) {
         self.init(

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -268,7 +268,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         } else {
             session.moved = true
             dropGuides.show(
-                home: session.home, screenFrame: session.screenFrame, armed: session.armed)
+                home: session.home, width: metrics.size.panelWidth,
+                screenFrame: session.screenFrame, armed: session.armed)
         }
         drag = session
     }
@@ -346,12 +347,20 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         positionPanel(panel, collapsed: collapsed)
     }
 
+    /// A new width invalidates the placement the cached anchor encoded, so re-resolve it.
+    func applyInterfaceSize() {
+        guard let panel else { return }
+        anchor = nil
+        positionPanel(panel, collapsed: core.paletteCoordinator.paletteIsCollapsed)
+    }
+
     /// Size to height and place against the session anchor, so the list grows downward.
     private func positionPanel(_ panel: NSPanel, collapsed: Bool) {
         guard let anchor = resolveAnchor() else { return }
-        let height = collapsed ? Theme.Size.compactHeight : Theme.Size.panelHeight
+        let size = metrics.size
+        let height = collapsed ? size.compactHeight : size.panelHeight
         let frame = NSRect(
-            x: anchor.x, y: anchor.y - height, width: Theme.Size.panelWidth, height: height)
+            x: anchor.x, y: anchor.y - height, width: size.panelWidth, height: height)
         panel.setFrame(frame, display: true)
     }
 
@@ -373,7 +382,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         guard let stored = core.settings.palettePosition else { return nil }
         return PalettePlacement.restored(
             stored,
-            graspable: CGSize(width: Theme.Size.panelWidth, height: Theme.Size.compactHeight),
+            graspable: CGSize(width: metrics.size.panelWidth, height: metrics.size.compactHeight),
             visibleFrames: NSScreen.screens.map(\.visibleFrame),
             minimumVisible: Theme.Size.paletteMinimumVisible)
     }
@@ -381,7 +390,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// The untouched placement on one display; the summon path and the drop guides share it.
     private func defaultAnchor(on screen: NSScreen) -> CGPoint {
         PalettePlacement.defaultAnchor(
-            in: screen.visibleFrame, width: Theme.Size.panelWidth,
+            in: screen.visibleFrame, width: metrics.size.panelWidth,
             topMarginFraction: Theme.Size.paletteTopMarginFraction)
     }
+
+    private var metrics: InterfaceMetrics { core.settings.interfaceSize.metrics }
 }

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -23,6 +23,7 @@ struct RootPaletteView: View {
     @Environment(SnippetsStore.self) private var snippets
     @Environment(ExtensionManager.self) private var extensions
     @Environment(AppSettings.self) private var settings
+    @Environment(\.metrics) private var metrics
     @FocusState private var searchFocused: Bool
     /// Kept apart from the search field's own focus. See docs/features/palette.md.
     @FocusState private var argumentFocused: String?
@@ -86,12 +87,12 @@ struct RootPaletteView: View {
                 scrollToFollow: { scroll = ScrollIntent(kind: .follow) })
         case .ai:
             return AIScreen(
-                vm: vm, chat: core.aiChat, settings: core.aiSettings,
+                vm: vm, metrics: metrics, chat: core.aiChat, settings: core.aiSettings,
                 coordinator: core.aiChatCoordinator)
         case .aiHistory:
             return ChatHistoryScreen(
                 history: core.chatHistory, chat: core.aiChat, coordinator: core.aiChatCoordinator,
-                vm: vm, openActions: openActions)
+                vm: vm, openActions: openActions, metrics: metrics)
         case .calculatorHistory:
             return CalculatorHistoryScreen(
                 history: calcHistory, currencyRates: currencyRates, core: core, vm: vm,
@@ -291,7 +292,7 @@ struct RootPaletteView: View {
                 // The window's frame is the size source, so the glass and clip stay matched.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .background(PaletteBackground(window: hostWindow))
-                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.panel, style: .continuous))),
+                .clipShape(RoundedRectangle(cornerRadius: metrics.radius.panel, style: .continuous))),
             selection: sel)
     }
 
@@ -589,7 +590,7 @@ struct RootPaletteView: View {
     /// A thin strip along the top edge for grabbing the window; the Appearance setting gates it.
     private var topDragStrip: some View {
         Color.clear
-            .frame(height: Theme.Size.headerPadding)
+            .frame(height: metrics.size.headerPadding)
             .windowDraggable(settings.paletteDraggable, onBegan: beginDrag, onEnded: endDrag)
     }
 
@@ -612,18 +613,18 @@ struct RootPaletteView: View {
     private var header: some View {
         HStack(alignment: .center, spacing: 0) {
             // Matches the list rows and section headers' own indent below.
-            headerGutter(width: Theme.Spacing.md * 2)
+            headerGutter(width: metrics.spacing.md * 2)
             // Every sub-screen leaves the same way, so the slot reads the same on all of them.
             if vm.mode != .launcher {
                 HeaderBackButton(help: backHelp, action: goBack)
             } else {
                 Image(systemName: vm.mode.systemImage)
-                    .font(Theme.Typography.headerIcon)
+                    .font(metrics.typography.headerIcon)
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(.secondary)
-                    .frame(width: Theme.Size.headerIconSlot)
+                    .frame(width: metrics.size.headerIconSlot)
             }
-            headerGutter(width: Theme.Spacing.md)
+            headerGutter(width: metrics.spacing.md)
             // One structural position: a field inside a branch loses first responder when it flips.
             headerField
             if let accessory = headerAccessory {
@@ -631,25 +632,25 @@ struct RootPaletteView: View {
                 Spacer(minLength: 0)
             }
             if tabOpensChat {
-                headerGutter(width: Theme.Spacing.md)
+                headerGutter(width: metrics.spacing.md)
                 aiChatTabHint
             }
             // Keyed off the mode, which says which screen is up; the field just flexes narrower.
             if !isCollapsed, vm.mode == .clipboard {
-                headerGutter(width: Theme.Spacing.md)
+                headerGutter(width: metrics.spacing.md)
                 ClipboardFilterButton(
                     filter: vm.clipboardFilter, isOpen: openMenu == .clipboardFilter,
                     action: toggleClipboardFilter)
             }
             if !isCollapsed, vm.mode == .ai {
-                headerGutter(width: Theme.Spacing.md)
+                headerGutter(width: metrics.spacing.md)
                 AIModelButton(
                     title: core.aiChatCoordinator.selectedModelTitle,
                     icon: core.aiChatCoordinator.selectedModelIcon,
                     isOpen: openMenu == .aiModel,
                     action: toggleAIModel)
                 if !core.aiChatCoordinator.reasoningEfforts.isEmpty {
-                    headerGutter(width: Theme.Spacing.md)
+                    headerGutter(width: metrics.spacing.md)
                     AIReasoningButton(
                         title: core.aiChatCoordinator.selectedReasoningTitle,
                         isOpen: openMenu == .aiReasoning,
@@ -662,7 +663,7 @@ struct RootPaletteView: View {
             {
                 let favorites = launcher.compactFavorites
                 if !favorites.isEmpty {
-                    headerGutter(width: Theme.Spacing.md)
+                    headerGutter(width: metrics.spacing.md)
                     CompactFavoritesRow(
                         favorites: favorites,
                         showsOverflow: launcher.hasUnshownFavorites,
@@ -674,16 +675,16 @@ struct RootPaletteView: View {
             if !isCollapsed, let command = extensionCommandScreen,
                 let accessory = command.searchAccessory
             {
-                headerGutter(width: Theme.Spacing.md)
+                headerGutter(width: metrics.spacing.md)
                 command.searchAccessoryButton(
                     accessory, isOpen: openMenu == .extensionAccessory,
                     action: toggleExtensionSearchAccessory)
             }
-            headerGutter(width: Theme.Spacing.md * 2)
+            headerGutter(width: metrics.spacing.md * 2)
         }
         // Identical metrics in both states, so typing can't move the search bar.
-        .frame(height: Theme.Size.headerHeight)
-        .padding(.top, Theme.Size.headerPadding)
+        .frame(height: metrics.size.headerHeight)
+        .padding(.top, metrics.size.headerPadding)
         .frame(maxWidth: .infinity)
         // Set after the show, so the field it names is focused rather than the search field.
         .onChange(of: vm.pendingArgumentEntryID) { focusPendingArgument() }
@@ -705,9 +706,9 @@ struct RootPaletteView: View {
     /// Nothing else advertises Tab, so the launcher says where it goes.
     private var aiChatTabHint: some View {
         BarButton(chrome: .rounded, action: cycleMode) {
-            HStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: metrics.spacing.sm) {
                 Text("AI Chat")
-                    .font(Theme.Typography.bar)
+                    .font(metrics.typography.bar)
                     .foregroundStyle(Theme.Colors.textSecondary)
                 KeyCapChip(text: "⇥", style: .outline)
             }
@@ -748,13 +749,14 @@ struct RootPaletteView: View {
     /// The field's own text, floored for the caret and capped so the strip stays on screen.
     /// Empty, that is the prompt where one is drawn — which is what seats the strip right after it.
     private func searchFieldWidth(for accessory: PaletteHeaderAccessory) -> CGFloat {
-        let font = Theme.Typography.searchFieldNSFont
+        let font = metrics.typography.searchFieldNSFont
         let text = vm.query.isEmpty ? searchPrompt : vm.query
         let typed = (text as NSString).size(withAttributes: [.font: font]).width
-        let chrome = Theme.Size.headerIconSlot + Theme.Spacing.md * 4
+        let chrome = metrics.size.headerIconSlot + metrics.spacing.md * 4
         // +3pt so the caret sits after the last glyph rather than on top of it.
         return min(
-            max(typed + 3, 18), max(Theme.Size.panelWidth - accessory.width - chrome, 60))
+            max(typed + metrics.scaled(3), metrics.scaled(18)),
+            max(metrics.size.panelWidth - accessory.width - chrome, metrics.scaled(60)))
     }
 
     /// In the argument form the field is that argument's input, so it names the argument.
@@ -776,7 +778,7 @@ struct RootPaletteView: View {
         @Bindable var vm = vm
         return TextField("", text: $vm.query)
             .textFieldStyle(.plain)
-            .font(Theme.Typography.searchField)
+            .font(metrics.typography.searchField)
             .tint(Theme.Colors.textPrimary)
             .focused($searchFocused)
             // Fills the row's height, so there's no gap above it for topDragStrip to meet.
@@ -785,7 +787,7 @@ struct RootPaletteView: View {
                 // An IME's marked text leaves `query` empty, so the placeholder would overlap it.
                 if vm.query.isEmpty, !vm.isComposing {
                     Text(searchPrompt)
-                        .font(Theme.Typography.searchField)
+                        .font(metrics.typography.searchField)
                         .foregroundStyle(Theme.Colors.textTertiary)
                         .lineLimit(1)
                         // Never a click target: tapping the placeholder must still land the caret.
@@ -798,7 +800,7 @@ struct RootPaletteView: View {
             .overlay {
                 if settings.paletteDraggable {
                     TextTrailingDragHandle(
-                        text: vm.query, font: Theme.Typography.searchFieldNSFont,
+                        text: vm.query, font: metrics.typography.searchFieldNSFont,
                         onBegan: beginDrag, onEnded: endDrag)
                 }
             }
@@ -829,8 +831,8 @@ struct RootPaletteView: View {
                     showActions: showActions)
             }
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .frame(height: Theme.Size.bottomBarHeight)
+        .padding(.horizontal, metrics.spacing.md)
+        .frame(height: metrics.size.bottomBarHeight)
         .frame(maxWidth: .infinity)
     }
 
@@ -846,12 +848,12 @@ struct RootPaletteView: View {
     ) -> some View {
         HStack(spacing: 2) {
             BarButton(action: activateSelection) {
-                HStack(spacing: Theme.Spacing.sm) {
+                HStack(spacing: metrics.spacing.sm) {
                     Text(pillLabel)
-                        .font(Theme.Typography.bar)
+                        .font(metrics.typography.bar)
                         .foregroundStyle(pillTint)
                     if formPrimaryShortcut {
-                        HStack(spacing: Theme.Spacing.xxs) {
+                        HStack(spacing: metrics.spacing.xxs) {
                             KeyCapChip(text: "⌘", style: .outline)
                             KeyCapChip(text: "↵", style: .outline)
                         }
@@ -862,11 +864,11 @@ struct RootPaletteView: View {
             }
             if showActions {
                 BarButton(action: toggleActions) {
-                    HStack(spacing: Theme.Spacing.sm) {
+                    HStack(spacing: metrics.spacing.sm) {
                         Text("Actions")
-                            .font(Theme.Typography.bar)
+                            .font(metrics.typography.bar)
                             .foregroundStyle(Theme.Colors.textSecondary)
-                        HStack(spacing: Theme.Spacing.xxs) {
+                        HStack(spacing: metrics.spacing.xxs) {
                             KeyCapChip(text: "⌘", style: .outline)
                             KeyCapChip(text: "K", style: .outline)
                         }
@@ -874,7 +876,7 @@ struct RootPaletteView: View {
                 }
             }
         }
-        .padding(Theme.Spacing.xs)
+        .padding(metrics.spacing.xs)
         .frosted(in: Capsule())
     }
 
@@ -963,8 +965,8 @@ struct RootPaletteView: View {
 
     private var headerMenuWidth: CGFloat {
         switch openMenu {
-        case .aiModel, .aiReasoning, .argumentOptions: Theme.Size.menuWidth
-        default: Theme.Size.clipboardFilterMenuWidth
+        case .aiModel, .aiReasoning, .argumentOptions: metrics.size.menuWidth
+        default: metrics.size.clipboardFilterMenuWidth
         }
     }
 
@@ -1226,6 +1228,7 @@ private struct SearchFieldHiding: ViewModifier {
 private struct MenuCircleButton: View {
     let action: () -> Void
     @State private var hovered = false
+    @Environment(\.metrics) private var metrics
 
     var body: some View {
         Button(action: action) {
@@ -1234,7 +1237,7 @@ private struct MenuCircleButton: View {
                 Capsule().frame(width: 8, height: 1.5)
             }
             .foregroundStyle(Theme.Colors.textSecondary)
-            .frame(width: Theme.Size.menuButton, height: Theme.Size.menuButton)
+            .frame(width: metrics.size.menuButton, height: metrics.size.menuButton)
             .background(Circle().fill(hovered ? Theme.Colors.rowHover : Color.clear))
             .contentShape(.circle)
         }
@@ -1249,14 +1252,15 @@ private struct HeaderBackButton: View {
     let help: String
     let action: () -> Void
     @State private var hovered = false
+    @Environment(\.metrics) private var metrics
 
     var body: some View {
         Button(action: action) {
             Image(systemName: "chevron.left")
-                .font(Theme.Typography.headerIcon)
+                .font(metrics.typography.headerIcon)
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(hovered ? Theme.Colors.textPrimary : Theme.Colors.textSecondary)
-                .frame(width: Theme.Size.headerIconSlot)
+                .frame(width: metrics.size.headerIconSlot)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -1308,16 +1312,17 @@ private struct CompactFavoritesRow: View {
     let showsOverflow: Bool
     let onLaunch: (AppEntry) -> Void
     let onOverflow: () -> Void
+    @Environment(\.metrics) private var metrics
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.xs) {
+        HStack(spacing: metrics.spacing.xs) {
             // Identified by the app, so a reorder moves an icon with its app, not by position.
             ForEach(Array(favorites.enumerated()), id: \.element.id) { index, app in
                 CompactFavoriteButton(help: help(for: app, at: index)) {
                     onLaunch(app)
                 } content: {
                     AppIconView(app: app)
-                        .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                        .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 }
             }
             if showsOverflow {
@@ -1325,11 +1330,11 @@ private struct CompactFavoritesRow: View {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 10))
                         .foregroundStyle(Theme.Colors.textSecondary)
-                        .frame(width: Theme.Size.rowIcon, height: Theme.Size.rowIcon)
+                        .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                         .background(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
                                 .fill(Theme.Colors.controlSurface)
-                                .padding(Theme.Spacing.xxs)
+                                .padding(metrics.spacing.xxs)
                         )
                 }
             }
@@ -1347,11 +1352,12 @@ private struct CompactFavoriteButton<Content: View>: View {
     let help: String
     let action: () -> Void
     @ViewBuilder let content: Content
+    @Environment(\.metrics) private var metrics
 
     var body: some View {
         Button(action: action) {
             content
-                .contentShape(RoundedRectangle(cornerRadius: Theme.Radius.row, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: metrics.radius.row, style: .continuous))
         }
         .buttonStyle(.plain)
         .help(help)
@@ -1362,6 +1368,7 @@ private struct PaletteBackground: View {
     @Environment(AppSettings.self) private var settings
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.displayScale) private var displayScale
+    @Environment(\.metrics) private var metrics
     let window: NSWindow?
 
     private var usesSystemShadow: Bool {
@@ -1373,7 +1380,7 @@ private struct PaletteBackground: View {
             .background(VisualEffectView())
             .overlay {
                 if settings.paletteTransparency != 0 {
-                    let edge = RoundedRectangle(cornerRadius: Theme.Radius.panel, style: .continuous)
+                    let edge = RoundedRectangle(cornerRadius: metrics.radius.panel, style: .continuous)
                     if usesSystemShadow {
                         edge.strokeBorder(
                             Theme.Colors.panelEdgeHighlight(transparency: settings.paletteTransparency),

--- a/Tinycast/Windows/Dialog/DialogController.swift
+++ b/Tinycast/Windows/Dialog/DialogController.swift
@@ -4,8 +4,13 @@ import SwiftUI
 /// Tinycast's own dialogs; `NSAlert`'s nested run loop would let hotkeys stack them.
 @MainActor
 final class DialogController: NSObject, NSWindowDelegate {
+    private let settings: AppSettings
     private var panel: DialogPanel?
     private var continuation: CheckedContinuation<Int, Never>?
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
 
     /// The palette reads this so its own dialog taking key isn't a click-away.
     var isPresenting: Bool { continuation != nil }
@@ -98,7 +103,7 @@ final class DialogController: NSObject, NSWindowDelegate {
                         guard Self.accepts(index, for: request) else { return }
                         self?.finish(index)
                     }),
-                width: Theme.Size.dialogWidth, minHeight: 0)
+                width: metrics.size.dialogWidth, minHeight: 0)
             let panel = DialogPanel(content: content)
             panel.handlesArrowKeys = request.accessory?.claimsArrowKeys ?? false
             panel.delegate = self
@@ -146,8 +151,10 @@ final class DialogController: NSObject, NSWindowDelegate {
         closing?.fadeOut(duration: Theme.Duration.exit)
     }
 
+    private var metrics: InterfaceMetrics { settings.interfaceSize.metrics }
+
     private func hostingView(_ view: some View, width: CGFloat, minHeight: CGFloat) -> NSView {
-        let hosting = NSHostingView(rootView: AnyView(view))
+        let hosting = NSHostingView(rootView: AnyView(view.environment(\.metrics, metrics)))
         // Measure at the fixed width first: the message wraps, so height follows width.
         hosting.setFrameSize(NSSize(width: width, height: minHeight))
         let fitted = hosting.fittingSize

--- a/Tinycast/Windows/HUD/MessageHUDController.swift
+++ b/Tinycast/Windows/HUD/MessageHUDController.swift
@@ -1,11 +1,14 @@
 import AppKit
+import SwiftUI
 
 /// The message pill, shared by every feature that reports a transient confirmation.
 @MainActor
 final class MessageHUDController {
     private let presenter: HUDPresenter
+    private let settings: AppSettings
 
     init(settings: AppSettings) {
+        self.settings = settings
         presenter = HUDPresenter(
             anchor: .edgeInset(Theme.Size.hudEdgeOffset),
             dwell: Theme.Duration.messageHUD,
@@ -13,15 +16,20 @@ final class MessageHUDController {
     }
 
     func show(message: String, tone: DialogTone = .success) {
-        presenter.show(MessageHUDView(message: message, accessory: .tone(tone)))
+        presenter.show(
+            MessageHUDView(message: message, accessory: .tone(tone)).environment(\.metrics, metrics))
     }
 
     /// Stays up until the work it reports ends and something replaces it, or `dismiss()` runs.
     func showProgress(message: String) {
-        presenter.show(MessageHUDView(message: message, accessory: .progress), dwells: false)
+        presenter.show(
+            MessageHUDView(message: message, accessory: .progress).environment(\.metrics, metrics),
+            dwells: false)
     }
 
     func dismiss() {
         presenter.dismiss()
     }
+
+    private var metrics: InterfaceMetrics { settings.interfaceSize.metrics }
 }

--- a/Tinycast/Windows/HUD/VolumeHUDController.swift
+++ b/Tinycast/Windows/HUD/VolumeHUDController.swift
@@ -1,12 +1,18 @@
 import AppKit
+import SwiftUI
 
 /// The volume readout; a box, not the pill, because a level needs a bar and a number.
 @MainActor
 final class VolumeHUDController {
+    private let settings: AppSettings
     private let presenter = HUDPresenter(
         anchor: .heightFraction(bottomFraction), dwell: Theme.Duration.volumeHUD,
         screen: { .underCursor })
     private let state = VolumeState(level: 0)
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
 
     func show(level: Float32, muted: Bool) {
         // The view observes `state`, so a repeat animates the bar rather than replaying.
@@ -16,9 +22,10 @@ final class VolumeHUDController {
         if showing {
             presenter.extend()
         } else {
+            let metrics = settings.interfaceSize.metrics
             presenter.show(
-                VolumeHUDView(state: state),
-                size: CGSize(width: Theme.Size.hudWidth, height: Theme.Size.hudHeight))
+                VolumeHUDView(state: state).environment(\.metrics, metrics),
+                size: CGSize(width: metrics.size.hudWidth, height: metrics.size.hudHeight))
         }
     }
 

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -236,6 +236,12 @@ anchor is dropped on hide, so the next summon re-resolves for wherever the user 
 All of the arithmetic lives in `PalettePlacement`, which is CoreGraphics-only and takes every screen
 fact as a parameter, so `palette-placement-test` drives the shipped rules rather than a copy of them.
 
+The panel's width and height are not constants: they come from `InterfaceMetrics`, so Interface Size
+changes them. A change re-enters through `AppCore.track` → `applyInterfaceSize()`, which **drops the
+cached anchor** and re-resolves it — one rule, the summon's. An untouched palette re-centres at the new
+width; a dragged one keeps its stored top-left unless the wider bar no longer leaves
+`paletteMinimumVisible` on any display, in which case it falls home.
+
 ### Drag to reposition
 
 **Drag to reposition** (`AppSettings.paletteDraggable`, off by default) is the only thing that moves a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,6 +97,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `emoji-test` | `Emoji/Model/EmojiCatalog.swift`, `EmojiGridGeometry.swift`, the generated data |
 | `palette-navigation-test` | `Palette/PaletteState.swift`'s screen motions — `prepare`, `replace`, `push`, `pop` |
 | `palette-selection-test` | `Features/PaletteRowIndex.swift` |
+| `interface-size-test` | `DesignSystem/InterfaceMetrics.swift`, `Features/Settings/InterfaceSize.swift`, `Extensions/Model/ExtensionFormMetrics.swift` |
 | `palette-placement-test` | `DesignSystem/Theme.swift`, `Palette/PalettePlacement.swift` |
 | `hotkey-test` | `HotKeys/Model/DoubleTapModifier.swift`, `DoubleTapDetector.swift`, `HyperKey.swift`, `HotKeyAction.swift`, `Service/KeyShortcut.swift`, and the command→action mapping in `Launcher/Model/CommandID.swift` |
 | `fallback-test` | `Launcher/Model/Fallback.swift`, plus the `CommandID` and `Quicklink` ids it is built from |

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -60,6 +60,27 @@ Source: `Tinycast/DesignSystem/Theme.swift`.
 `Theme` is the single source of truth. **Never hardcode a spacing/radius/size/color that has a token.**
 Add a token rather than a magic number when introducing a new value.
 
+### Interface Size (`InterfaceMetrics`)
+
+`AppSettings.interfaceSize` scales the palette and the surfaces that float with it — the ⌘K menu, the
+extension list panel, Quick Actions, the snippet prompt, dialogs and HUDs. Settings, Onboarding,
+Support, Update, About and Notes never scale.
+
+`DesignSystem/InterfaceMetrics.swift` stores **only a scale** and derives every value from the `Theme`
+literal, so `Theme` stays the one place a number is written down. **In any view a scaled surface can
+reach, read `@Environment(\.metrics)` rather than `Theme.Spacing/Radius/Size/Typography`** — the key
+defaults to `.standard`, so a shared `DesignSystem/` component renders unscaled in Settings without
+being forked. An AppKit site reads `settings.interfaceSize.metrics` where it computes its frame.
+
+A length measured against the **screen** does not scale; a length measured against **our own content**
+does. So `hairline`, `paletteTopMarginFraction`, `paletteSnapDistance`, `paletteMinimumVisible`, the
+drop-guide dashes, `hudEdgeOffset` and every row *count* stay on `Theme`, as does every chrome token.
+
+Scaling rounds to whole points, once, at the leaf accessor. A **derived** token composes already
+scaled parts (`compactHeight`, `menuRowHeight`) rather than scaling the derived result, so an AppKit
+frame can never disagree with the SwiftUI view inside it by a point. `interface-size-test` pins all of
+this, member by member, including that `.standard` is `Theme` verbatim.
+
 ### Spacing (`Theme.Spacing`)
 
 `xxs 2` · `xs 4` · `sm 6` · `md 8` · `lg 10` · `xl 12` · `xxl 20`
@@ -138,9 +159,14 @@ Notes adds `noteWindow 520×420` (opening size on a first run only), `noteWindow
 
 ### Typography (`Theme.Typography`)
 
-System fonts only — **no fixed point sizes in views** (honors Dynamic Type). `searchField` is the one
-explicit size (20pt regular). Use `rowTitle` (`.body`), `sectionHeader` (`.subheadline.medium`),
+System text styles only — **no fixed point sizes in views**. `searchField` is the one explicit size
+(20pt regular). Use `rowTitle` (`.body`), `sectionHeader` (`.subheadline.medium`),
 `rowTrailing`/`bar`/`menuRow`/`keyCap` etc. as named.
+
+`InterfaceMetrics.Typography` scales a style by rebuilding its `NSFont` **from that font's own
+descriptor** at the scaled point size. Never reconstruct one as `.system(size:weight:)` from a
+hand-written weight table: on macOS `.headline` is Bold and `.caption2` is Medium, so a table
+*lightens* them the moment the user leaves the default size.
 
 ### Colors (`Theme.Colors`) — the alpha ramp
 


### PR DESCRIPTION
## Related issue

Closes #543

## What changed

**General ▸ Appearance** carries an Interface Size control — Default, Large, Larger — that uniformly zooms the palette and the surfaces that float with it, at 1.0 / 1.1 / 1.2.

It reaches the palette, the ⌘K menu, the extension list panel, Quick Actions, the snippet prompt, dialogs and HUDs. Settings, Onboarding, Support, Update, About and Notes never scale — a zoom there only breaks their layout.

`DesignSystem/InterfaceMetrics.swift` stores a scale and nothing else, deriving every value from the `Theme` literal, so `Theme` stays the one place a number is written down. It reaches views through an `@Entry` environment key defaulting to `.standard`, which is why `BarButton`, `KeyCapChip`, `PopoverMenu` and the rest render unscaled in Settings without being forked — the scope is the injection, not the component. An AppKit site reads `settings.interfaceSize.metrics` where it computes its frame, so there is no second owner of the value.

Three things worth a reviewer's attention, none of them obvious from the diff:

- **A scaled font is rebuilt from that style's own `NSFontDescriptor`**, never reconstructed as `.system(size:weight:)` from a written-out weight table. Measured on macOS 26: `Font.headline` resolves to `.SFNS-Bold` and `Font.caption2` to `.SFNS-Medium`, so a table *lightens* both the moment the user leaves the default size. The same helper yields the `NSFont` twins the caret width and the AI chips are measured against, which must move in lock-step with what SwiftUI renders.
- **The palette's environment is pushed by a `ViewModifier`, not a stored `.environment(_:_:)` value.** `PaletteWindowController` builds the hosted tree once and reuses the panel, so a stored value freezes at build time and the setting never takes effect — not even on the next summon.
- **`.scaleEffect` / a layer transform was rejected**, despite being a one-liner: glyphs rasterise at the base size and get resampled, and a soft palette is a worse regression than the one this fixes.

A length measured against the *screen* does not scale; a length measured against *our own content* does. `hairline`, `paletteTopMarginFraction`, `paletteSnapDistance`, `paletteMinimumVisible`, the drop-guide dashes, `hudEdgeOffset` and every row *count* stay on `Theme`, as does every chrome token. Scaling rounds to whole points once, at the leaf accessor; a derived token (`compactHeight`, `menuRowHeight`) composes already-scaled parts rather than scaling the derived result, so an AppKit frame can never disagree with the SwiftUI view inside it by a point.

A size change re-enters through `AppCore.track` → `applyInterfaceSize()`, which drops the cached anchor and re-resolves it — one rule, the summon's. An untouched palette re-centres at the new width; a dragged one keeps its stored top-left unless the wider bar no longer leaves `paletteMinimumVisible` on any display, in which case it falls home.

`ExtensionFormMetrics` becomes a struct taking a scale, staying inside `Features/Extensions/` and Foundation-only. `EdgeDissolve` derives its bands from the metrics and resolves to the same 86 and 80 it draws today. `PalettePanel`'s stale `750, 475` literal is gone.

## Memory footprint

Not measured for this change.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no.

The change allocates no new long-lived state — `InterfaceMetrics` is a value wrapping one `CGFloat`, built on demand and discarded. The one place that could move the number is `IconCache`, which keys tiles by extent: a user who changes size makes the launcher's icons re-rasterise at a second extent. That is worth a look on a large app index if you want one measurement out of this.

## Demo

None recorded. This is a visual change and warrants a before/after clip before merge.

For reference while reviewing, the three sizes rendered from the shipped metrics — 750×475 → 825×523 → 900×570:

<img width="1000" alt="Default, Large and Larger rendered side by side" src="https://github.com/user-attachments/assets/PLACEHOLDER" />

(Still, not a clip — it does not substitute for the demo above.)

## Drawbacks

- **Blast radius.** ~93 files, because a true uniform zoom has to reach every token a palette surface reads. The migration is mechanical (`Theme.X` → `metrics.X` plus one `@Environment`), and the tokens deliberately left behind are listed in `docs/ui.md`, but it is a large diff to review.
- **Fonts lose their text-style identity above 1.0.** A scaled font is a concrete point size rather than `Font.body`, so text-style leading is not identical at Large/Larger. At Default the original `Theme` token is returned untouched, so nothing changes for anyone who does not opt in.
- **The 3 / 18 / 60 literals in `searchFieldWidth` now scale**, which is right, but that path is measured in AppKit and has no harness. It is the most likely place for a caret to drift.
- **A dragged palette that is still graspable but hangs further off the right edge stays there.** Deliberate — that state is already reachable by dragging, and clamping would add a second placement rule competing with the tested one.
- Small displays: 900×570 clears the bottom on 1440×900, which the harness pins. Below that it is untested.

## Tests & validation

- `./Scripts/run-tests.sh` — 69 harnesses pass.
- New `Tests/interface-size-test.swift`: asserts `.standard` is `Theme` verbatim member by member (this is the case that would have caught the Bold/Medium font bug), every scaled length lands on a whole point, lengths never shrink between sizes, and the derived-token identities hold at all three sizes.
- `Tests/palette-placement-test.swift` gains a pass over `InterfaceSize.allCases`: the panel stays centred and clears the bottom of a 1440×900 display at every size, and a stored position that lapses under the wider bar is dropped.
- `Tests/ext-form-test.swift` retargeted at `ExtensionFormMetrics.base`.
- Debug build: no new warnings. `./Scripts/lint.sh`: clean. `Features/*/Model/` import grep: clean.
- Rendered the three sizes to PNG from the shipped metrics and inspected them.
- By hand: all three sizes exercised in the running app. One bug found and fixed — the Settings segments had no `contentShape`, so only the "Aa" glyphs took the click.
- **Not verified here:** live resize while the palette is open, and the dragged-panel fallback. Both need the running app and a global hotkey.