### PR TITLE
Hide empty icon slots in extension rows

### DIFF
--- a/Tinycast/Features/Extensions/UI/ExtensionListView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionListView.swift
@@ -181,8 +181,10 @@ private struct ExtensionItemRow: View {
 
     var body: some View {
         HStack(spacing: metrics.spacing.lg) {
-            ExtensionIconView(
-                resolved: ExtensionImage.resolve(node.props["icon"], assetsPath: assetsPath, isDark: isDark))
+            if let icon = node.props["icon"], icon != .null {
+                ExtensionIconView(
+                    resolved: ExtensionImage.resolve(icon, assetsPath: assetsPath, isDark: isDark))
+            }
             Text(node.string("title") ?? "")
                 .font(metrics.typography.rowTitle)
                 .lineLimit(1)


### PR DESCRIPTION
## Related issue

Part of #573 — Open Ports rows show an empty icon box.

## What changed

Rows reserve the icon column only when an `icon` prop exists. Commands without icons now align directly with their titles.

Old:
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/2f8781a2-ce67-4bb0-9d7f-768eb39a5fbd" />

New:
<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/fc21bb2d-8340-4e58-8abf-771042212732" />

## Tests & validation

Debug build succeeds, lint clean, all 69 harnesses pass.
