### PR TITLE
Close an open menu on a right click, not only a left one

### DIFF
--- a/Tinycast/Features/Extensions/UI/ExtensionFormView.swift
+++ b/Tinycast/Features/Extensions/UI/ExtensionFormView.swift
@@ -31,6 +31,7 @@ struct ExtensionFormView: View {
                 .background {
                     Color.clear.contentShape(Rectangle())
                         .onTapGesture { palette.dismissControlList() }
+                        .onRightClick { palette.dismissControlList() }
                 }
                 .hideNativeScrollers()
                 .scrollOriginAnchor()

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -280,6 +280,7 @@ struct RootPaletteView: View {
                         .contentShape(Rectangle())
                         // Not a tap: a drifting press must still dismiss, the way a native menu's does.
                         .gesture(DragGesture(minimumDistance: 0).onEnded { _ in closeMenus() })
+                        .onRightClick { closeMenus() }
                         .allowsHitTesting(menuOpen)
                 }
                 // The menu lives in its own window; this only reports the one to hang it from.

--- a/docs/features/palette.md
+++ b/docs/features/palette.md
@@ -393,6 +393,11 @@ and states where the highlight starts: the first row, except the pop-up-shaped m
 filter, the AI model and effort menus, an extension's search-bar dropdown — which open on the choice
 they already hold.
 
+**The click-away catcher answers either mouse button.** A left press arrives as a `DragGesture`, so a
+drifting press still dismisses the way a native menu's does; a right press arrives through
+`onRightClick`, whose `NSView` sits above the row catchers beneath it, so a right click on a row
+closes the open menu rather than reopening it on that row.
+
 Every row closes the menu behind it — `activateMenuItem` is the one path, and a row that reorders the
 list under itself (Move Favorite Up/Down) is no exception, so no row ever runs against a rebuilt menu.
 


### PR DESCRIPTION
## Related issue

Closes #

## What changed

An open palette menu now closes on a right click outside it, not only a left one.

The click-away catcher in `RootPaletteView` dismissed through a zero-distance `DragGesture`, and a
SwiftUI gesture on macOS answers the primary button alone. Because that one catcher serves every
menu — the app menu, ⌘K Actions, the clipboard type filter, an extension's search-bar dropdown and
`ExtensionActionsPanel`, the AI model and effort menus, an `options=` argument's choices — a right
click anywhere outside an open menu did nothing at all. The extension form's control lists
(`ExtensionPickerField`, `ExtensionDateField`) had the same gap through their own `onTapGesture`
scrim.

Both scrims now also take `onRightClick`, the existing `RightClickCatcher`, which is an `NSView`
declining the left button in `hitTest`.

The non-obvious part is hit-test ordering. The scrim's catcher is mounted at the root while the row
catchers (`LauncherList`, `ClipboardView`, `ExtensionListView`, …) sit deeper, so it was not obvious
from reading which one would claim a right click on a row with a menu already open. The scrim wins,
which is the behaviour we want: the menu closes rather than reopening on that row. This is the same
ordering `ClipDragView` already depends on (see docs/features/clipboard.md), and it is now written
down in docs/features/palette.md.

## Memory footprint

Not measured — no allocation, no new long-lived state, no new window or observer. The change is two
modifier lines that mount an `NSView` already used by every launcher row.

| Step                    | Memory        |
| ----------------------- | ------------- |
| Idle after launch       | not measured  |
| Palette open            | not measured  |
| Feature in use (peak)   | not measured  |
| Palette closed, settled | not measured  |

Leak-tested: no — nothing retains, and the catcher's lifetime is the scrim's.

## Demo

No visual change: same menu, same dismissal, one more button that triggers it.

## Drawbacks

A right click that previously fell through to a row's own actions catcher while a menu was open now
closes the menu instead. That is the intended native behaviour, but it does mean two right clicks
where one used to move the menu from one row to another.

## Tests & validation

`./Scripts/run-tests.sh` — all 69 harnesses pass. Debug build compiles with no new warnings.
`./Scripts/lint.sh` reports `✓ lint-clean`. The `Features/*/Model/` import grep returns nothing.

By hand, this is behavioural and not covered by a harness. I drove an isolated copy of the Debug
build with synthetic `CGEvent`s and used the menu panel's own window (it is a separate `NSWindow`)
as the oracle: ⌘K makes it appear, a right click outside makes it disappear. @abue-ammar then
confirmed it in the real app.
