### PR TITLE
Group menu search by menu, and seat its settings with its command

### DIFF
--- a/Tests/menu-search-test.swift
+++ b/Tests/menu-search-test.swift
@@ -11,7 +11,7 @@ struct MenuSearchTests {
 
         init(firstSlow: Bool = false) { self.firstSlow = firstSlow }
 
-        func walk(_ pid: pid_t) async -> [MenuSearchItem] {
+        func walk(_ pid: pid_t, _ showsAppleMenu: Bool) async -> [MenuSearchItem] {
             calls += 1
             let call = calls
             if firstSlow, call == 1 { try? await Task.sleep(for: .milliseconds(200)) }
@@ -73,6 +73,7 @@ struct MenuSearchTests {
         snapshotCancel()
         snapshotFrozen()
         snapshotDuplicates()
+        snapshotAppleMenu()
         targetClassify()
         sessionPresent()
         shortcutDecoding()
@@ -95,9 +96,20 @@ struct MenuSearchTests {
 
     static func pathModel() {
         let nested = item("PDF", parents: ["File", "Export as"])
-        expect(nested.displayPath == "File > Export as > PDF", "the path spans bar to leaf")
+        expect(
+            nested.displayPath == "File → Export as → PDF", "the path spans bar to leaf")
         expect(item("About", parents: []).displayPath == "About", "a top-level leaf is bare")
         expect(nested.id != item("PDF", parents: ["Edit"]).id, "identity includes the path")
+        expect(nested.menu == "File", "the top-level menu is what the list groups on")
+        expect(
+            nested.menuPath == "File → Export as",
+            "the searching row trails its parents only")
+        expect(
+            nested.submenuPath == "Export as",
+            "a grouped row trails the path below its own header")
+        expect(
+            item("About", parents: ["Apple"]).submenuPath.isEmpty,
+            "a direct child of a menu repeats nothing under its header")
     }
 
     static func searchMapping() {
@@ -133,9 +145,9 @@ struct MenuSearchTests {
             ).displayString == nil, "a missing character shows no glyph")
         expect(
             MenuSearchShortcut(
-                character: "s", hasCommand: false, hasShift: false, hasOption: false,
+                character: "\u{F707}", hasCommand: false, hasShift: false, hasOption: false,
                 hasControl: false
-            ).displayString == nil, "a modifier-less character shows no glyph")
+            ).displayString == "F4", "a bare function key still shows its own cap")
         expect(item("Save").shortcut == nil, "a shortcut-less item carries path alone")
     }
 
@@ -164,7 +176,7 @@ struct MenuSearchTests {
         let ties = MenuSearchQuery.rank(
             [item("Copy", parents: ["Edit"]), item("Copy", parents: ["Format"])], for: "copy")
         expect(
-            ties.map(\.displayPath) == ["Edit > Copy", "Format > Copy"],
+            ties.map(\.displayPath) == ["Edit → Copy", "Format → Copy"],
             "identical titles break ties on the path")
 
         let capped = (0..<205).map { item("Report \($0)", parents: ["File"]) }
@@ -201,7 +213,8 @@ struct MenuSearchTests {
         ]
         let items = MenuSnapshotPolicy.collect(bar)
         expect(
-            items.map(\.displayPath) == ["File > New", "File > Export as > PDF", "Edit > Copy"],
+            items.map(\.displayPath)
+                == ["File → New", "File → Export as → PDF", "Edit → Copy"],
             "one snapshot holds every eligible leaf with its full path")
         expect(
             items.first { $0.title == "PDF" }?.shortcut == nil,
@@ -233,8 +246,8 @@ struct MenuSearchTests {
             items.count == MenuSnapshotPolicy.itemLimit,
             "the snapshot truncates silently at the item cap")
         expect(
-            items.first?.displayPath == "Menu 0 > Item 0"
-                && items.last?.displayPath == "Menu 19 > Item 199",
+            items.first?.displayPath == "Menu 0 → Item 0"
+                && items.last?.displayPath == "Menu 19 → Item 199",
             "truncation keeps pre-order, so ranking still sees the front of the menu")
     }
 
@@ -364,18 +377,25 @@ struct MenuSearchTests {
         expect(
             session.filtered == items,
             "presenting shows the whole snapshot before anything is typed")
+        expect(!session.isSearching, "an untouched query browses rather than searches")
         session.filter("copy")
         expect(
             session.filtered.map(\.title) == ["Copy"],
             "a typed query filters the frozen snapshot")
+        expect(session.isSearching, "a typed query flips the list to one Results section")
+        session.filter("   ")
+        expect(
+            !session.isSearching && session.filtered == items,
+            "whitespace alone is no query, so browsing resumes")
         session.filter("zzz")
         expect(session.filtered.isEmpty, "a matchless query empties the rows, not the snapshot")
         expect(session.snapshot == items, "filtering never shrinks what was captured")
         session.filter("")
         expect(session.filtered == items, "clearing the query browses the whole snapshot again")
+        session.filter("copy")
         session.reset()
         expect(
-            session.snapshot.isEmpty && session.filtered.isEmpty
+            session.snapshot.isEmpty && session.filtered.isEmpty && !session.isSearching
                 && session.target == .noApplication,
             "reset clears the show back to no application")
     }
@@ -395,8 +415,16 @@ struct MenuSearchTests {
             MenuSearchShortcut.commandEquivalent(character: "", modifiers: 0) == nil,
             "a missing character carries no shortcut, whatever the modifiers claim")
         expect(
-            MenuSearchShortcut.commandEquivalent(character: "E", modifiers: 24) == nil,
-            "higher bits mark keys outside ⌘ chords, which have no glyph to show")
+            MenuSearchShortcut.commandEquivalent(character: "E", modifiers: 0b10000) == nil,
+            "bits above the four AX flags mark a chord we cannot render")
+        expect(
+            MenuSearchShortcut.commandEquivalent(character: "\u{8}", modifiers: 0b001)?
+                .displayString == "⇧⌘⌫",
+            "a control scalar renders as its keycap glyph, never as a blank chip")
+        expect(
+            MenuSearchShortcut.commandEquivalent(character: "\u{1B}", modifiers: 0b011)?
+                .displayString == "⌥⇧⌘⎋",
+            "Escape renders as ⎋ rather than an unrenderable control scalar")
         expect(
             MenuSearchShortcut(
                 character: "x", hasCommand: true, hasShift: true, hasOption: true,
@@ -405,10 +433,18 @@ struct MenuSearchTests {
             "keycaps split the chord in menu order for the row's chips")
         expect(
             MenuSearchShortcut(
-                character: "s", hasCommand: false, hasShift: false, hasOption: false,
+                character: "", hasCommand: true, hasShift: true, hasOption: false,
                 hasControl: false
             ).keycaps.isEmpty,
-            "a chord with no glyph carries no chips")
+            "a chord with no character carries no chips")
+        let noCommand = MenuSearchShortcut.commandEquivalent(character: "f", modifiers: 0b1100)
+        expect(
+            noCommand?.displayString == "⌃F",
+            "bit 3 clears the implied ⌘ instead of dropping the whole chord")
+        expect(
+            MenuSearchShortcut.commandEquivalent(character: "\u{F70A}", modifiers: 0b1000)?
+                .displayString == "F7",
+            "a modifier-less function key survives the no-command bit")
         let upArrow = MenuSearchShortcut.commandEquivalent(character: "\u{F700}", modifiers: 0b100)
         expect(
             upArrow?.displayString == "⌃⌘↑",
@@ -430,8 +466,25 @@ struct MenuSearchTests {
         ]
         let items = MenuSnapshotPolicy.collect(bar).map(\.displayPath)
         expect(
-            items == ["File > Eject", "Special > Eject"],
+            items == ["File → Eject", "Special → Eject"],
             "an exact repeated path keeps its first row only: \(items)")
+    }
+
+    static func snapshotAppleMenu() {
+        let bar: [MenuTreeNode] = [
+            tree("Apple", children: [tree("", children: [tree("About This Mac")])]),
+            tree("File", children: [tree("", children: [tree("New")])])
+        ]
+        expect(
+            MenuSnapshotPolicy.collect(bar).map(\.title) == ["About This Mac", "New"],
+            "the whole bar is collected when the Apple menu is shown")
+        expect(
+            MenuSnapshotPolicy.collect(MenuSnapshotPolicy.excludingAppleMenu(bar)).map(\.title)
+                == ["New"],
+            "dropping the bar's first item drops the Apple menu and nothing else")
+        expect(
+            MenuSnapshotPolicy.excludingAppleMenu([]).isEmpty,
+            "a bar that read as empty stays empty rather than trapping")
     }
 
     static func waitForReady(_ session: MenuSearchSession) async {
@@ -444,7 +497,7 @@ struct MenuSearchTests {
     static func sessionWalk() async {
         let probe = WalkProbe()
         let session = MenuSearchSession(walkOperation: probe.walk)
-        session.startWalk(target: .searchable(name: "TextEdit"), pid: 42)
+        session.startWalk(target: .searchable(name: "TextEdit"), pid: 42, showsAppleMenu: true)
         expect(session.state == .reading, "the walk starts reading with empty rows")
         expect(session.filtered.isEmpty, "nothing publishes before the walk lands")
         await waitForReady(session)
@@ -461,8 +514,8 @@ struct MenuSearchTests {
     static func sessionWalkSuperseded() async {
         let probe = WalkProbe(firstSlow: true)
         let session = MenuSearchSession(walkOperation: probe.walk)
-        session.startWalk(target: .searchable(name: "A"), pid: 1)
-        session.startWalk(target: .searchable(name: "B"), pid: 2)
+        session.startWalk(target: .searchable(name: "A"), pid: 1, showsAppleMenu: true)
+        session.startWalk(target: .searchable(name: "B"), pid: 2, showsAppleMenu: true)
         await waitForReady(session)
         expect(
             session.target == .searchable(name: "B")

--- a/Tinycast/Features/Backup/Model/SettingsBackup.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackup.swift
@@ -49,6 +49,7 @@ struct SettingsBackup: Codable {
         // Safe to carry: it grants no permission class paste doesn't already prompt for.
         var navigationEnabled: Bool?
         var menuSearchDisabledApps: [String]?
+        var menuSearchShowsAppleMenu: Bool?
         var windowManagementEnabled: Bool?
         var windowManagementShowInLauncher: Bool?
         var windowGap: Int?
@@ -142,6 +143,7 @@ extension SettingsBackup {
             snippetsShowInLauncher: s.snippetsShowInLauncher,
             navigationEnabled: s.navigationEnabled,
             menuSearchDisabledApps: s.menuSearchDisabledApps,
+            menuSearchShowsAppleMenu: s.menuSearchShowsAppleMenu,
             windowManagementEnabled: s.windowManagementEnabled,
             windowManagementShowInLauncher: s.windowManagementShowInLauncher,
             windowGap: s.windowGap,
@@ -365,6 +367,10 @@ extension SettingsBackup {
         }
         if let apps = s.menuSearchDisabledApps {
             settings.menuSearchDisabledApps = apps
+            count += 1
+        }
+        if let flag = s.menuSearchShowsAppleMenu {
+            settings.menuSearchShowsAppleMenu = flag
             count += 1
         }
         if let flag = s.windowManagementEnabled {

--- a/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
+++ b/Tinycast/Features/Backup/Model/SettingsBackupCoverage.swift
@@ -31,6 +31,7 @@ enum SettingsBackupCoverage {
         "snippetsShowInLauncher": .snippetsShowInLauncher,
         "navigationEnabled": .navigationEnabled,
         "menuSearchDisabledApps": .menuSearchDisabledApps,
+        "menuSearchShowsAppleMenu": .menuSearchShowsAppleMenu,
         "windowManagementEnabled": .windowManagementEnabled,
         "windowManagementShowInLauncher": .windowManagementShowInLauncher,
         "windowGap": .windowGap,

--- a/Tinycast/Features/Launcher/Settings/DisabledApplicationsSection.swift
+++ b/Tinycast/Features/Launcher/Settings/DisabledApplicationsSection.swift
@@ -1,28 +1,38 @@
 import SwiftUI
 
-/// The excluded-apps list a feature offers: rows with a remove button, and a picker below.
+/// The excluded-apps control: one row per exclusion, then the picker that adds another. The caller
+/// owns the label above it, so a pane can seat the list beside the command the exclusions belong to.
+struct DisabledApplicationsList: View {
+    @Binding var bundleIDs: [String]
+
+    @State private var picking = false
+
+    var body: some View {
+        ForEach(bundleIDs, id: \.self) { bundleID in
+            DisabledAppRow(bundleID: bundleID) {
+                bundleIDs.removeAll { $0 == bundleID }
+            }
+        }
+
+        Button("Add Application…") { picking = true }
+            .popover(isPresented: $picking, arrowEdge: .bottom) {
+                AppPickerPopover(excluded: Set(bundleIDs)) { bundleID in
+                    if let bundleID { bundleIDs.append(bundleID) }
+                    picking = false
+                }
+            }
+    }
+}
+
+/// A whole section of them, for a pane whose exclusions are a subject of their own.
 struct DisabledApplicationsSection: View {
     @Binding var bundleIDs: [String]
     let anchor: SettingsAnchor
     let footer: String
 
-    @State private var picking = false
-
     var body: some View {
         Section {
-            ForEach(bundleIDs, id: \.self) { bundleID in
-                DisabledAppRow(bundleID: bundleID) {
-                    bundleIDs.removeAll { $0 == bundleID }
-                }
-            }
-
-            Button("Add Application…") { picking = true }
-                .popover(isPresented: $picking, arrowEdge: .bottom) {
-                    AppPickerPopover(excluded: Set(bundleIDs)) { bundleID in
-                        if let bundleID { bundleIDs.append(bundleID) }
-                        picking = false
-                    }
-                }
+            DisabledApplicationsList(bundleIDs: $bundleIDs)
         } header: {
             SettingsSectionHeader(anchor)
         } footer: {

--- a/Tinycast/Features/Launcher/Settings/FeatureCommandsSection.swift
+++ b/Tinycast/Features/Launcher/Settings/FeatureCommandsSection.swift
@@ -3,23 +3,15 @@ import SwiftUI
 struct FeatureCommandsSection: View {
     let owner: SettingsTab
     let anchor: SettingsAnchor
-    @Environment(VisibilityStore.self) private var visibility
+    /// Commands the pane draws elsewhere; excluded here rather than listed there, so a command
+    /// added to `ownedCommands` later still shows up without a second edit.
+    var excluding: Set<CommandID> = []
 
     var body: some View {
         Section {
             ForEach(CommandCatalog.entries(ownedBy: owner)) { entry in
-                SettingsRow(title: entry.name) {
-                    AppIconView(app: entry)
-                        .frame(width: Theme.Size.settingsRowIcon, height: Theme.Size.settingsRowIcon)
-                } trailing: {
-                    AliasField(entry: entry)
-                    if let action = entry.hotKeyAction {
-                        ShortcutRecorder(action: action)
-                    }
-                    Toggle("", isOn: visibilityBinding(entry))
-                        .labelsHidden()
-                        .toggleStyle(.checkbox)
-                        .accessibilityLabel("Show \(entry.name) in launcher")
+                if !excluding.contains(where: { $0.rawValue == entry.id }) {
+                    FeatureCommandRow(entry: entry)
                 }
             }
         } header: {
@@ -30,8 +22,30 @@ struct FeatureCommandsSection: View {
                 .foregroundStyle(.secondary)
         }
     }
+}
 
-    private func visibilityBinding(_ entry: AppEntry) -> Binding<Bool> {
+/// One command's controls — alias, shortcut, launcher visibility — wherever its pane seats them.
+struct FeatureCommandRow: View {
+    let entry: AppEntry
+    @Environment(VisibilityStore.self) private var visibility
+
+    var body: some View {
+        SettingsRow(title: entry.name) {
+            AppIconView(app: entry)
+                .frame(width: Theme.Size.settingsRowIcon, height: Theme.Size.settingsRowIcon)
+        } trailing: {
+            AliasField(entry: entry)
+            if let action = entry.hotKeyAction {
+                ShortcutRecorder(action: action)
+            }
+            Toggle("", isOn: visibilityBinding)
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .accessibilityLabel("Show \(entry.name) in launcher")
+        }
+    }
+
+    private var visibilityBinding: Binding<Bool> {
         Binding(
             get: { visibility.isItemVisible(entry) },
             set: { visibility.setItemVisible($0, for: entry) })

--- a/Tinycast/Features/MenuSearch/Model/MenuSearchItem.swift
+++ b/Tinycast/Features/MenuSearch/Model/MenuSearchItem.swift
@@ -14,8 +14,16 @@ struct MenuSearchItem: Identifiable, Hashable, Sendable {
     }
 
     var displayPath: String {
-        Self.joined(title: title, parents: parentComponents, separator: " > ")
+        Self.joined(title: title, parents: parentComponents, separator: Self.separator)
     }
+
+    var menu: String { parentComponents.first ?? "" }
+
+    var menuPath: String { parentComponents.joined(separator: Self.separator) }
+
+    var submenuPath: String { parentComponents.dropFirst().joined(separator: Self.separator) }
+
+    private static let separator = " → "
 
     private static func joined(title: String, parents: [String], separator: String) -> String {
         (parents + [title]).joined(separator: separator)

--- a/Tinycast/Features/MenuSearch/Model/MenuSearchShortcut.swift
+++ b/Tinycast/Features/MenuSearch/Model/MenuSearchShortcut.swift
@@ -7,45 +7,35 @@ struct MenuSearchShortcut: Hashable, Sendable {
     let hasOption: Bool
     let hasControl: Bool
 
-    // AX bits, verified live: 0 Shift, 1 Option, 2 Control, ⌘ implied; higher bits unrenderable.
+    // AX bits, verified live: 0 Shift, 1 Option, 2 Control, 3 clears the otherwise implied ⌘.
     static func commandEquivalent(character: String, modifiers: Int) -> Self? {
-        guard !character.isEmpty, modifiers & ~0b111 == 0 else { return nil }
+        guard !character.isEmpty, modifiers & ~0b1111 == 0 else { return nil }
         return Self(
-            character: character, hasCommand: true,
+            character: character,
+            hasCommand: modifiers & 0b1000 == 0,
             hasShift: modifiers & 0b001 != 0,
             hasOption: modifiers & 0b010 != 0,
             hasControl: modifiers & 0b100 != 0)
     }
 
-    // AX reports special keys as PUA scalars no text font renders; map them to visible glyphs.
+    // AX reports a non-typing key as a control or PUA scalar no text font draws; name it instead.
     var displayCharacter: String {
-        guard character.unicodeScalars.count == 1,
-            let scalar = character.unicodeScalars.first
-        else { return character }
-        switch scalar.value {
-        case 0xF700: return "↑"
-        case 0xF701: return "↓"
-        case 0xF702: return "←"
-        case 0xF703: return "→"
-        case 0xF729: return "↖"
-        case 0xF72B: return "↘"
-        case 0xF72C: return "⇞"
-        case 0xF72D: return "⇟"
-        default: return character
-        }
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first
+        else { return character.uppercased() }
+        if let glyph = Self.glyphs[scalar.value] { return glyph }
+        guard Self.functionKeys.contains(scalar.value) else { return character.uppercased() }
+        return "F\(scalar.value - Self.functionKeys.lowerBound + 1)"
     }
 
     // Glyphs in the order macOS menus use, so a row reads like the menu it came from.
     var keycaps: [String] {
-        guard !character.isEmpty, hasCommand || hasShift || hasOption || hasControl else {
-            return []
-        }
+        guard !character.isEmpty else { return [] }
         var caps: [String] = []
         if hasControl { caps.append("⌃") }
         if hasOption { caps.append("⌥") }
         if hasShift { caps.append("⇧") }
         if hasCommand { caps.append("⌘") }
-        caps.append(displayCharacter.uppercased())
+        caps.append(displayCharacter)
         return caps
     }
 
@@ -53,4 +43,12 @@ struct MenuSearchShortcut: Hashable, Sendable {
         let caps = keycaps
         return caps.isEmpty ? nil : caps.joined()
     }
+
+    private static let functionKeys: ClosedRange<UInt32> = 0xF704...0xF726
+
+    private static let glyphs: [UInt32: String] = [
+        0x03: "⌤", 0x08: "⌫", 0x09: "⇥", 0x0D: "↩", 0x19: "⇤", 0x1B: "⎋", 0x20: "␣",
+        0x7F: "⌫", 0xF700: "↑", 0xF701: "↓", 0xF702: "←", 0xF703: "→", 0xF728: "⌦",
+        0xF729: "↖", 0xF72B: "↘", 0xF72C: "⇞", 0xF72D: "⇟", 0xF739: "⌧", 0xF746: "?"
+    ]
 }

--- a/Tinycast/Features/MenuSearch/Model/MenuSnapshotPolicy.swift
+++ b/Tinycast/Features/MenuSearch/Model/MenuSnapshotPolicy.swift
@@ -7,6 +7,11 @@ enum MenuSnapshotPolicy {
     // One History-like submenu must not eat the snapshot: each submenu contributes this many at most.
     static let perSubmenuLimit = 200
 
+    // The Apple menu is always the bar's first item, which beats matching a title that localises.
+    static func excludingAppleMenu(_ roots: [MenuTreeNode]) -> [MenuTreeNode] {
+        Array(roots.dropFirst())
+    }
+
     static func collect(
         _ roots: [MenuTreeNode], isCancelled: () -> Bool = { false }
     ) -> [MenuSearchItem] {

--- a/Tinycast/Features/MenuSearch/Service/MenuSearchSession.swift
+++ b/Tinycast/Features/MenuSearch/Service/MenuSearchSession.swift
@@ -3,7 +3,7 @@ import Foundation
 @MainActor
 @Observable
 final class MenuSearchSession {
-    typealias WalkOperation = @Sendable (pid_t) async -> [MenuSearchItem]
+    typealias WalkOperation = @Sendable (pid_t, _ showsAppleMenu: Bool) async -> [MenuSearchItem]
 
     enum State {
         case idle
@@ -16,6 +16,8 @@ final class MenuSearchSession {
     private(set) var snapshot: [MenuSearchItem] = []
     /// The rows the list reads: filtered once per query change, so one keystroke ranks once.
     private(set) var filtered: [MenuSearchItem] = []
+    /// Whether a query narrows the rows, so the list groups by menu only while browsing.
+    private(set) var isSearching = false
 
     private var query = ""
     private var revision = 0
@@ -23,11 +25,12 @@ final class MenuSearchSession {
     @ObservationIgnored private let walkOperation: WalkOperation
 
     init() {
-        walkOperation = { pid in
+        walkOperation = { pid, showsAppleMenu in
             await Task.detached(priority: .userInitiated) {
                 let deadline = ContinuousClock.now + AXMenuAccess.walkBudget
                 let application = AXMenuAccess.application(for: pid)
-                let roots = AXMenuAccess.readTopLevel(in: application, deadline: deadline)
+                let bar = AXMenuAccess.readTopLevel(in: application, deadline: deadline)
+                let roots = showsAppleMenu ? bar : MenuSnapshotPolicy.excludingAppleMenu(bar)
                 return MenuSnapshotPolicy.collect(roots) { ContinuousClock.now >= deadline }
             }.value
         }
@@ -54,7 +57,7 @@ final class MenuSearchSession {
         applyQuery()
     }
 
-    func startWalk(target: MenuSearchTarget, pid: pid_t) {
+    func startWalk(target: MenuSearchTarget, pid: pid_t, showsAppleMenu: Bool) {
         revision &+= 1
         walkTask?.cancel()
         self.target = target
@@ -63,7 +66,7 @@ final class MenuSearchSession {
         state = .reading
         let revision = self.revision
         walkTask = Task { [weak self] in
-            let items = await self?.walkOperation(pid) ?? []
+            let items = await self?.walkOperation(pid, showsAppleMenu) ?? []
             guard let self, self.revision == revision else { return }
             self.snapshot = items
             self.state = .ready
@@ -80,6 +83,7 @@ final class MenuSearchSession {
         snapshot = []
         filtered = []
         query = ""
+        isSearching = false
         state = .idle
     }
 
@@ -90,7 +94,8 @@ final class MenuSearchSession {
 
     private func applyQuery() {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
+        isSearching = !trimmed.isEmpty
+        guard isSearching else {
             filtered = snapshot
             return
         }

--- a/Tinycast/Features/MenuSearch/UI/MenuSearchCoordinator.swift
+++ b/Tinycast/Features/MenuSearch/UI/MenuSearchCoordinator.swift
@@ -57,7 +57,9 @@ final class MenuSearchCoordinator {
         switch target {
         case .searchable:
             if let app {
-                session.startWalk(target: target, pid: app.processIdentifier)
+                session.startWalk(
+                    target: target, pid: app.processIdentifier,
+                    showsAppleMenu: settings.menuSearchShowsAppleMenu)
             } else {
                 session.present(target: .noApplication, snapshot: [])
             }

--- a/Tinycast/Features/MenuSearch/UI/MenuSearchList.swift
+++ b/Tinycast/Features/MenuSearch/UI/MenuSearchList.swift
@@ -5,6 +5,8 @@ struct MenuSearchList: View {
     @Environment(\.metrics) private var metrics
     let items: [MenuSearchItem]
     let targetName: String
+    /// Ranked rows arrive in score order, so they read as one Results run instead of menus.
+    let isSearching: Bool
     let iconURL: URL?
     let iconStamp: Int
     let selectedID: MenuSearchItem.ID?
@@ -13,6 +15,34 @@ struct MenuSearchList: View {
 
     /// One bitmap for the whole list; every row paints the same frozen app icon.
     @State private var icon: NSImage?
+
+    private struct Section: Identifiable {
+        let id: Int
+        let title: String
+        let items: ArraySlice<MenuSearchItem>
+
+        var label: String { "\(title) (\(items.count) item\(items.count == 1 ? "" : "s"))" }
+    }
+
+    /// The walk emits a menu's leaves contiguously, so runs group without reordering the rows.
+    private var sections: [Section] {
+        guard !isSearching else {
+            return [Section(id: 0, title: "Results", items: items[...])]
+        }
+        var sections: [Section] = []
+        var start = items.startIndex
+        while start < items.endIndex {
+            let menu = items[start].menu
+            var end = items.index(after: start)
+            while end < items.endIndex, items[end].menu == menu { end = items.index(after: end) }
+            sections.append(
+                Section(
+                    id: sections.count, title: menu.isEmpty ? targetName : menu,
+                    items: items[start..<end]))
+            start = end
+        }
+        return sections
+    }
 
     private var firstRowSelected: Bool {
         selectedID != nil && selectedID == items.first?.id
@@ -24,12 +54,17 @@ struct MenuSearchList: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    SectionHeader(title: targetName, isFirst: true)
-                    ForEach(items) { item in
-                        MenuSearchRow(item: item, icon: icon, selected: item.id == selectedID)
+                    ForEach(sections) { section in
+                        SectionHeader(title: section.label, isFirst: section.id == 0)
+                        ForEach(section.items) { item in
+                            MenuSearchRow(
+                                item: item, path: isSearching ? item.menuPath : item.submenuPath,
+                                icon: icon, selected: item.id == selectedID
+                            )
                             .selectionFrame(item.id == selectedID)
                             .contentShape(Rectangle())
                             .onTapGesture { onActivate(item) }
+                        }
                     }
                 }
                 .padding(.horizontal, metrics.spacing.md)
@@ -59,6 +94,7 @@ private struct MenuSearchRow: View {
 
     @Environment(\.metrics) private var metrics
     let item: MenuSearchItem
+    let path: String
     let icon: NSImage?
     let selected: Bool
     @State private var hovered = false
@@ -83,12 +119,15 @@ private struct MenuSearchRow: View {
             Text(item.title)
                 .font(metrics.typography.rowTitle)
                 .lineLimit(1)
+                .layoutPriority(1)
+            if !path.isEmpty {
+                Text(path)
+                    .font(metrics.typography.rowTrailing)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
             Spacer(minLength: metrics.spacing.md)
-            Text(item.displayPath)
-                .font(metrics.typography.rowTrailing)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
             let caps = item.shortcut?.keycaps ?? []
             if !caps.isEmpty {
                 HStack(spacing: metrics.spacing.xxs) {

--- a/Tinycast/Features/MenuSearch/UI/MenuSearchScreen.swift
+++ b/Tinycast/Features/MenuSearch/UI/MenuSearchScreen.swift
@@ -37,7 +37,7 @@ struct MenuSearchScreen: PaletteScreen {
                 EmptyResults(text: "No menu items found in \(name)")
             } else {
                 MenuSearchList(
-                    items: rows, targetName: name,
+                    items: rows, targetName: name, isSearching: session.isSearching,
                     iconURL: core.menuSearchCoordinator.frozenIconURL,
                     iconStamp: core.menuSearchCoordinator.frozenIconStamp,
                     selectedID: rows.indices.contains(selection) ? rows[selection].id : nil,

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -309,6 +309,13 @@ final class AppSettings {
         didSet { defaults.set(menuSearchDisabledApps, forKey: Key.menuSearchDisabledApps.rawValue) }
     }
 
+    /// Off: the Apple menu is the same on every app, so it would only pad every snapshot.
+    var menuSearchShowsAppleMenu: Bool {
+        didSet {
+            defaults.set(menuSearchShowsAppleMenu, forKey: Key.menuSearchShowsAppleMenu.rawValue)
+        }
+    }
+
     /// Consent to run third-party JavaScript: it confirms, defaults off, rides no backup.
     var extensionsEnabled: Bool {
         didSet { defaults.set(extensionsEnabled, forKey: Key.extensionsEnabled.rawValue) }
@@ -609,6 +616,7 @@ final class AppSettings {
         navigationEnabled = defaults.bool(forKey: Key.navigationEnabled.rawValue)
         menuSearchDisabledApps =
             defaults.stringArray(forKey: Key.menuSearchDisabledApps.rawValue) ?? []
+        menuSearchShowsAppleMenu = defaults.bool(forKey: Key.menuSearchShowsAppleMenu.rawValue)
         windowManagementEnabled = defaults.bool(forKey: Key.windowManagementEnabled.rawValue)
         windowManagementShowInLauncher =
             defaults.object(forKey: Key.windowManagementShowInLauncher.rawValue) == nil

--- a/Tinycast/Features/Settings/AppSettingsKey.swift
+++ b/Tinycast/Features/Settings/AppSettingsKey.swift
@@ -34,6 +34,7 @@ enum AppSettingsKey: String, CaseIterable {
     case snippetsShowInLauncher = "snippetsShowInLauncher"
     case navigationEnabled = "navigationEnabled"
     case menuSearchDisabledApps = "menuSearchDisabledApps"
+    case menuSearchShowsAppleMenu = "menuSearchShowsAppleMenu"
     case windowManagementEnabled = "windowManagementEnabled"
     case windowManagementShowInLauncher = "windowManagementShowInLauncher"
     case windowGap = "windowManagementGap"

--- a/Tinycast/Features/Settings/Panes/NavigationSettingsView.swift
+++ b/Tinycast/Features/Settings/Panes/NavigationSettingsView.swift
@@ -18,14 +18,36 @@ struct NavigationSettingsView: View {
             }
 
             // No "show in launcher" switch: the per-command checkboxes below already are one.
-            FeatureCommandsSection(owner: .navigation, anchor: .navigationCommands)
-                .settingsEnabled(settings.navigationEnabled)
-
-            DisabledApplicationsSection(
-                bundleIDs: $settings.menuSearchDisabledApps,
-                anchor: .navigationDisabledApplications,
-                footer: "Search Menu Bar Items won't read the menu bar of these apps."
+            FeatureCommandsSection(
+                owner: .navigation, anchor: .navigationCommands,
+                excluding: [.searchMenuItems]
             )
+            .settingsEnabled(settings.navigationEnabled)
+
+            // The menu-search command sits with the two settings that only it reads.
+            Section {
+                if let entry = CommandCatalog.entry(for: .searchMenuItems) {
+                    FeatureCommandRow(entry: entry)
+                }
+
+                Toggle(isOn: $settings.menuSearchShowsAppleMenu) {
+                    SettingsRowTitle(.navigationMenuSearch, "Show Apple menu items")
+                    Text("Include the Apple menu, which is the same under every application.")
+                }
+
+                SettingsRow(
+                    title: "Disabled Applications",
+                    subtitle:
+                        "Search Menu Bar Items will not show menu items from these applications.",
+                    anchor: .navigationMenuSearch
+                ) {
+                    EmptyView()
+                }
+
+                DisabledApplicationsList(bundleIDs: $settings.menuSearchDisabledApps)
+            } header: {
+                SettingsSectionHeader(.navigationMenuSearch)
+            }
             .settingsEnabled(settings.navigationEnabled)
         }
         .formStyle(.grouped)

--- a/Tinycast/Features/Settings/SettingsAnchor.swift
+++ b/Tinycast/Features/Settings/SettingsAnchor.swift
@@ -61,8 +61,7 @@ extension SettingsAnchor {
 
     static let navigationNavigation = Self(tab: .navigation, title: "Navigation")
     static let navigationCommands = Self(tab: .navigation, title: "Commands")
-    static let navigationDisabledApplications = Self(
-        tab: .navigation, title: "Disabled Applications")
+    static let navigationMenuSearch = Self(tab: .navigation, title: "Search Menu Bar Items")
 
     static let windowManagementWindowManagement = Self(
         tab: .windowManagement, title: "Window Management")

--- a/Tinycast/Features/Settings/SettingsSearchCatalog.swift
+++ b/Tinycast/Features/Settings/SettingsSearchCatalog.swift
@@ -364,7 +364,10 @@ enum SettingsSearchCatalog {
             group: .navigationCommands, "Navigation commands",
             keywords: ["shortcut", "hotkey", "alias", "launcher"]),
         .init(
-            group: .navigationDisabledApplications, "Disabled Applications",
+            .navigationMenuSearch, "Show Apple menu items",
+            keywords: ["apple menu", "about this mac", "recent items", "sleep", "logo"]),
+        .init(
+            .navigationMenuSearch, "Disabled Applications",
             keywords: ["exclude", "password manager", "ignore", "privacy", "menu bar"])
     ]
 

--- a/docs/features/menu-search.md
+++ b/docs/features/menu-search.md
@@ -9,7 +9,18 @@ ranking runs in memory over it, and activating a row re-resolves the live elemen
 - **The target is frozen at open, and activation never retargets.** `MenuSearchCoordinator.show()`
   captures `paletteCoordinator.targetApp` once, into `frozenApp`; `activate` re-resolves against that
   app, not against whatever is frontmost by the time the user hits ↵. There is no app picker, so the
-  app named in the section header is the only app a row can ever reach.
+  app whose icon every row paints is the only app a row can ever reach.
+- **The Apple menu is dropped by position, not by name.** `menuSearchShowsAppleMenu` ships **off**,
+  and `MenuSnapshotPolicy.excludingAppleMenu` drops the menu bar's *first* item — the one slot macOS
+  reserves for it — rather than matching a title that may localise. The flag is read once, in
+  `show()`, and rides into `startWalk` beside the pid: a snapshot always answers the question the
+  summon asked, whatever Settings says by the time the walk lands.
+- **Sections are runs of the snapshot, never a regrouping.** While browsing, `MenuSearchList` cuts
+  the rows into consecutive runs of one top-level menu; the walk emits a menu's leaves contiguously,
+  so a run *is* a section. A query ranks across menus, so the list collapses to a single `Results`
+  section instead. Either way the drawn order stays exactly `session.filtered`, which is what the
+  palette's selection index counts — a `Dictionary`-based grouping would silently reorder it and
+  make every row activate its neighbour.
 - **The walk never opens a menu.** `AXMenuAccess` reads the bar cold. Opening submenus to index them
   would flash the target app's UI on every summon, so a submenu macOS has not built yet exposes no
   children and contributes no rows — accepted coverage loss, not a bug to fix by opening menus.
@@ -48,25 +59,34 @@ ranking runs in memory over it, and activating a row re-resolves the live elemen
 | `Service/MenuSearchSession.swift` | the observable state — walk lifecycle, snapshot, filtered rows |
 | `UI/MenuSearchCoordinator.swift` | freezing the target and icon, activation, the failure reports |
 | `UI/MenuSearchScreen.swift` | the `PaletteScreen` conformance and the empty-state switch |
-| `UI/MenuSearchList.swift` | the list and its row: app icon, title, path, keycap chips |
+| `UI/MenuSearchList.swift` | the menu sections and the row: app icon, title, path, keycap chips |
 
 `MenuSearchTarget.classify` splits a summon five ways — `searchable`, `excluded`, `selfTarget`,
 `menuLess` and `noApplication` — so each gets its own sentence instead of an empty list. `selfTarget`
 is checked before the menu-bar test, because Tinycast runs as an accessory and would otherwise read
 as menu-less; `excluded` is checked next, for the same reason.
 
-`MenuSearchSession` takes its walk as an injected `WalkOperation`, which is what lets
-`Tests/menu-search-test.swift` drive publication, supersession and cancellation without an AX server.
+`MenuSearchSession` takes its walk as an injected `WalkOperation` — `(pid, showsAppleMenu)` — which
+is what lets `Tests/menu-search-test.swift` drive publication, supersession and cancellation without
+an AX server.
 
 Ranking scores the title and the `File > Export As` display path together, but the path rides as a
 `.owner` field rather than a name one: a hierarchy string is shared by every row beneath it, so
 letting it match as a name would pull unrelated rows in.
 
+A row reads left to right — icon, title, then the path in secondary text — so the right edge carries
+keycaps and nothing else. The path says only what the header has not: while browsing, the trail
+*below* the section menu, which is empty for a direct child of it; while searching, the whole parent
+path. The leaf title never rides along, because the row already draws it, and `MenuSearchItem`
+joins every path on one ` → ` so the id, the row and the search field cannot drift apart.
+
 Two AX details are worth knowing before touching `MenuSearchShortcut`. The modifier field is **not**
-`NSEvent.ModifierFlags` — bit 0 is Shift, bit 1 is Option, bit 2 is Control, ⌘ is implied, and
-anything above bit 2 is unrenderable, so the shortcut is dropped. And AX reports special keys as
-private-use scalars (`0xF700`…) that no text font draws, so `displayCharacter` maps them to
-`↑ ↓ ← → ↖ ↘ ⇞ ⇟`; without it an arrow-key row renders as tofu.
+`NSEvent.ModifierFlags` — bit 0 is Shift, bit 1 is Option, bit 2 is Control, and ⌘ is implied *unless*
+bit 3 clears it; only a bit above those four is unrenderable, so the shortcut is dropped. And AX
+reports a non-typing key either as a control scalar (`0x1B` Escape, `0x08` Delete) or as a private-use
+one (`0xF700`…), neither of which a text font draws, so `displayCharacter` names them instead:
+`⎋ ⌫ ⇥ ↩ ⌤ ⇤ ␣ ⌦ ⌧ ↑ ↓ ← → ↖ ↘ ⇞ ⇟` and `F1`…`F35`. Without both, a chord renders as tofu, as a blank
+chip, or not at all.
 
 The list decodes exactly one `NSImage` — the frozen app's icon — and every row paints it, so a
 4,000-row snapshot never costs more than one bitmap.

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -100,9 +100,18 @@ window's app quit between the sweep and the ↵.
   reprojects into both coordinators; each owns only its own command and its own palette mode, so
   neither knows about the other. `AppIndex.isCommandEnabled` feeds `hotKeys.allowsAction`, so both
   shortcuts go dead with the switch, and each `show()` re-guards the flag anyway.
-- **`menuSearchDisabledApps`** (empty) is the exclusion list, rendered by the shared
-  `DisabledApplicationsSection` that Settings › Clipboard also uses. It ships with no seeded entries,
-  unlike the clipboard's: a menu read only ever happens because the user asked for one.
+- **`menuSearchDisabledApps`** (empty) is the exclusion list. It ships with no seeded entries, unlike
+  the clipboard's: a menu read only ever happens because the user asked for one.
+- **`menuSearchShowsAppleMenu`** (off) lists the Apple menu's own items. Off by default because that
+  menu is identical under every app, so it would pad every snapshot with the same ~50 rows;
+  [menu-search.md](menu-search.md) owns how it is applied.
+- **Both ride in the pane's own `Search Menu Bar Items` section, beside the command row itself.**
+  `FeatureCommandsSection` takes `excluding: [.searchMenuItems]` and the section draws that one
+  command through `FeatureCommandRow`, so a command added to `ownedCommands` later still appears
+  under `Commands` without a second edit. A list of excluded apps in a box of its own read as
+  belonging to the pane rather than to one command, which is what this section exists to fix;
+  `DisabledApplicationsList` is the shared half — the rows and the picker — that Settings ›
+  Clipboard still wraps in a `DisabledApplicationsSection` of its own.
 - Both settings ride in backups. Neither grants a permission class of its own — Accessibility is
   already required for paste — which is the call `windowManagementEnabled` made, and the opposite of
   `snippetsEnabled`.


### PR DESCRIPTION
## Related issue

Closes #

## What changed

Four things, all inside `Features/MenuSearch/` and the Navigation settings pane.

**Sections.** Browsing a menu bar now draws one section per top-level menu — `Apple (57 items)`,
`File (38 items)` — and a typed query collapses to a single `Results (n items)` run, the way the
launcher already switches between its kind sections and `Results`. The non-obvious part is that the
sections are **consecutive runs** of `session.filtered`, not a `Dictionary` grouping: the palette's
selection is a flat index into that array, so a regrouping would silently make every row activate its
neighbour. The walk already emits a menu's leaves contiguously, so a run *is* a section.

**Row layout.** Icon, title, then the path in secondary text beside it; the right edge carries
keycaps and nothing else. The path says only what the section header has not — the trail below the
section menu while browsing, the whole parent path while searching — and the leaf title no longer
rides along, since the row already draws it. Paths join on one ` → ` defined in `MenuSearchItem`, so
the id, the row and the search field cannot drift apart.

**Two AX keycap defects.** Both were visible on any Brave or VS Code menu bar:

- The modifier field's bit 3 means *the chord has no ⌘*. `commandEquivalent` read anything above bit
  2 as unrenderable and returned nil, so every ⌃-only chord and every bare function key was dropped
  entirely — no chips at all, on a row that has a shortcut.
- A non-typing key arrives either as a control scalar (`0x1B` Escape, `0x08` Delete) or a private-use
  one (`0xF700`…). Only the four arrows and a few navigation keys were mapped, so Force Quit's ⎋ drew
  as a font substitution and Delete Browsing Data's ⌫ as an empty chip. `displayCharacter` now names
  the full set — `⎋ ⌫ ⇥ ↩ ⌤ ⇤ ␣ ⌦ ⌧`, the arrows, and `F1`…`F35`.

**`menuSearchShowsAppleMenu`**, new and off by default. The Apple menu is identical under every app,
so it padded every snapshot with the same ~50 rows. It is dropped by **position** —
`MenuSnapshotPolicy.excludingAppleMenu` takes the bar's first item, the one slot macOS reserves for
it — rather than by matching a title that may localise. The flag is read once in `show()` and rides
into `startWalk` beside the pid, so a snapshot always answers the question the summon asked.

**Settings.** `Disabled Applications` sat in a box of its own, reading as if it belonged to the pane
rather than to one command. Navigation now has a `Search Menu Bar Items` section holding that
command's row, the new toggle, and the exclusion list together; `Commands` keeps Switch Windows.
Getting there split two shared pieces: `FeatureCommandRow` out of `FeatureCommandsSection`, and
`DisabledApplicationsList` — the rows and the picker — out of `DisabledApplicationsSection`, which
Settings › Clipboard still uses unchanged. `FeatureCommandsSection` takes `excluding:` rather than an
explicit command list, so a command added to `ownedCommands` later still appears under `Commands`
without a second edit.

## Memory footprint

Not measured — no new allocation, no new long-lived state, no new window, observer or task. The list
still decodes exactly one `NSImage` for the whole snapshot, the sections are computed slices of an
array that already existed, and the new setting is one `Bool`.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no — nothing new retains; `MenuSearchSession.reset()` still drops both arrays.

## Demo

Visual, and I have stills rather than side-by-side video: the grouped list, the ranked list and the
rebuilt pane were each rendered from the shipped sources into a real `NSWindow` and captured. Happy
to record before/after clips against a live build if that is wanted before merge.

## Drawbacks

- **Section headers carry an item count** (`File (38 items)`), which no other palette list does. It
  earns its place here — a menu bar run can be hundreds of rows deep — but it is a local convention,
  not one I propagated.
- **`menuSearchShowsAppleMenu` defaults off**, so anyone who was using Search Menu Bar Items to reach
  About This Mac or Sleep loses those rows until they turn it on. That is the intended trade: the
  same 50 rows under every app is what the default is protecting against.
- **The Apple menu is dropped by position.** If a future macOS ever puts something else first in the
  bar, this drops the wrong menu. The alternative — matching the title `"Apple"` — breaks on any
  localisation, which seemed the likelier failure.
- **`excluding:` on `FeatureCommandsSection`** is a second place a pane says something about a
  command. I chose it over passing an explicit list because the failure mode is milder: a new
  navigation command shows up in the wrong section rather than vanishing from Settings entirely.

## Tests & validation

`./Scripts/run-tests.sh` — all 70 harnesses pass. Debug build compiles with no new warnings.
`./Scripts/lint.sh` reports `✓ lint-clean`. The `Features/*/Model/` import grep returns nothing.

Added to `Tests/menu-search-test.swift`: the `menu` / `menuPath` / `submenuPath` split and the ` → `
separator; bit 3 clearing the implied ⌘; a modifier-less function key surviving; Escape and Delete
rendering as `⎋` and `⌫` rather than a blank chip; `excludingAppleMenu` dropping the first root and
nothing else, including on an empty bar; and `isSearching` flipping on a real query but not on
whitespace.

By hand, the AX half has no harness. I rendered `MenuSearchList` from the shipped sources into a real
`NSWindow` — `ImageRenderer` will not draw a `ScrollView` — with the exact chords under discussion
(`⌥⇧⌘⎋`, `⇧⌘⌫`, `⌃⌘⇟`, `F7`, `⌘A`) and confirmed every chip draws, in both the grouped and the ranked
view. The settings pane was captured the same way. What that does **not** cover, and is worth a
minute against a live build: that a real Apple menu is the bar's first item on your Mac, and that
toggling the setting changes the next summon.
