### PR TITLE
Keep the palette up through a drag out, until a click outside

### DIFF
--- a/Tinycast/Features/Clipboard/UI/ClipDrag.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipDrag.swift
@@ -3,17 +3,21 @@ import SwiftUI
 
 /// AppKit, not `onDrag`: only an `NSDraggingSource` can force `.copy` over a same-volume move.
 struct ClipDragHandle: NSViewRepresentable {
+    /// The handle is what knows when the gesture starts and ends, so it holds the palette open
+    /// itself. Reporting that out to the screen and back down bought nothing but parameters.
+    @Environment(AppCore.self) private var core
     /// Read when the drag starts, not when the row draws: resolving it stats the file.
     var payload: () -> ClipDragPayload?
     var onSelect: () -> Void
     var onActivate: () -> Void
-    var onDropped: () -> Void
 
     func makeNSView(context: Context) -> NSView { ClipDragView() }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        (nsView as? ClipDragView)?
-            .bind(payload: payload, onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
+        let palette = core.paletteCoordinator
+        (nsView as? ClipDragView)?.bind(
+            payload: payload, onSelect: onSelect, onActivate: onActivate,
+            onDragBegan: { palette.beginDragOut() })
     }
 }
 
@@ -22,12 +26,10 @@ extension View {
     func clipDraggable(
         payload: @escaping () -> ClipDragPayload?,
         onSelect: @escaping () -> Void,
-        onActivate: @escaping () -> Void,
-        onDropped: @escaping () -> Void
+        onActivate: @escaping () -> Void
     ) -> some View {
         overlay {
-            ClipDragHandle(
-                payload: payload, onSelect: onSelect, onActivate: onActivate, onDropped: onDropped)
+            ClipDragHandle(payload: payload, onSelect: onSelect, onActivate: onActivate)
         }
     }
 }
@@ -40,16 +42,16 @@ private final class ClipDragView: NSView, NSDraggingSource {
     private var payload: (() -> ClipDragPayload?)?
     private var onSelect: (() -> Void)?
     private var onActivate: (() -> Void)?
-    private var onDropped: (() -> Void)?
+    private var onDragBegan: (() -> Void)?
 
     func bind(
         payload: @escaping () -> ClipDragPayload?, onSelect: @escaping () -> Void,
-        onActivate: @escaping () -> Void, onDropped: @escaping () -> Void
+        onActivate: @escaping () -> Void, onDragBegan: @escaping () -> Void
     ) {
         self.payload = payload
         self.onSelect = onSelect
         self.onActivate = onActivate
-        self.onDropped = onDropped
+        self.onDragBegan = onDragBegan
     }
 
     /// Left button only, so the row's right-click catcher underneath still opens the actions menu.
@@ -98,6 +100,8 @@ private final class ClipDragView: NSView, NSDraggingSource {
                 x: origin.x - image.size.width / 2, y: origin.y - image.size.height / 2,
                 width: image.size.width, height: image.size.height),
             contents: image)
+        // Before the session starts: the drop target takes the key the moment the drag is in flight.
+        onDragBegan?()
         let session = beginDraggingSession(with: [item], event: event, source: self)
         // A refused drop flies back, so a drag that achieved nothing says so.
         session.animatesToStartingPositionsOnCancelOrFail = true
@@ -163,12 +167,5 @@ private final class ClipDragView: NSView, NSDraggingSource {
         _ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext
     ) -> NSDragOperation {
         .copy
-    }
-
-    func draggingSession(
-        _ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation
-    ) {
-        guard operation != [] else { return }
-        onDropped?()
     }
 }

--- a/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardCoordinator.swift
@@ -148,11 +148,6 @@ final class ClipboardCoordinator {
         return clipURL(for: item).map(ClipDragPayload.file)
     }
 
-    /// A landed drop is a finished errand, so the palette leaves as it does after a paste.
-    func clipDropped() {
-        paletteCoordinator.hidePalette(restoreFocus: false)
-    }
-
     func openClip(_ item: ClipboardItem) {
         guard let url = clipURL(for: item) else { return }
         paletteCoordinator.hidePalette(restoreFocus: false)

--- a/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardScreen.swift
@@ -118,8 +118,7 @@ struct ClipboardScreen: PaletteScreen {
                         if let index = rows.firstIndex(of: item) { vm.selection = index }
                         openActions()
                     },
-                    onDragPayload: { core.clipboardCoordinator.dragPayload(for: $0) },
-                    onDropped: { core.clipboardCoordinator.clipDropped() }
+                    onDragPayload: { core.clipboardCoordinator.dragPayload(for: $0) }
                 )
                 .frame(width: metrics.size.clipboardListWidth)
                 Rectangle()

--- a/Tinycast/Features/Clipboard/UI/ClipboardView.swift
+++ b/Tinycast/Features/Clipboard/UI/ClipboardView.swift
@@ -13,7 +13,6 @@ struct ClipboardList: View {
     let onActions: (ClipboardItem) -> Void
     /// Nil when the entry has nothing left to hand over, which is reported rather than dragged.
     let onDragPayload: (ClipboardItem) -> ClipDragPayload?
-    let onDropped: () -> Void
     @Environment(ClipboardStore.self) private var store
 
     private enum Row: Identifiable {
@@ -74,8 +73,7 @@ struct ClipboardList: View {
                                 onActivate: {
                                     onSelect(item)
                                     onActivate()
-                                },
-                                onDropped: onDropped
+                                }
                             )
                         }
                     }

--- a/Tinycast/Palette/PaletteCoordinator.swift
+++ b/Tinycast/Palette/PaletteCoordinator.swift
@@ -128,4 +128,11 @@ final class PaletteCoordinator {
     func endPaletteDrag() {
         windowController.endDrag()
     }
+
+    // MARK: - Dragging content out
+
+    /// A drag that carries an entry to another app. Moving the panel itself is `beginPaletteDrag`.
+    func beginDragOut() {
+        windowController.beginDragOut()
+    }
 }

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -17,6 +17,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     private let dropGuides = PaletteDropGuideController()
     /// ⌘V: `Edit ▸ Paste` claims it before `sendEvent` whenever the board also carries text.
     private var pasteMonitor: Any?
+    /// Non-nil while a drag has carried an entry out of the app: the palette ignores losing the
+    /// key, and this is what closes it on the first click outside.
+    private var dragOutMonitor: Any?
     /// ⌘⎋: the window server claims it, so no keystroke is left for the responder chain to see.
     private lazy var commandEscapeTap = CommandEscapeTap { [weak self] in
         guard let self, self.panel?.isKeyWindow == true else { return false }
@@ -123,6 +126,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     func hide(restoreFocus: Bool) {
         panel?.orderOut(nil)
+        clearDragOut()
         commandEscapeTap.disable()
         core.inputSourceSwitcher.endSession()
         core.calendarCoordinator.paletteDidHide()
@@ -199,16 +203,48 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         Paster.pasteStringInPlace(text, into: previousApp)
     }
 
+    // MARK: - Dragging content out
+
+    /// Hold the palette up for a drag that leaves the app, until the first click outside it.
+    /// See docs/features/clipboard.md#dragging-out.
+    ///
+    /// Armed when the drag starts, not when it ends: the button stays down for the whole gesture,
+    /// so no mouse-down can reach the monitor before the drop. That lets one piece of state answer
+    /// both questions, whether to ignore losing the key and what closes the palette afterwards.
+    func beginDragOut() {
+        guard isVisible, dragOutMonitor == nil else { return }
+        // Global only, which is the test itself: a click inside the palette never reaches one.
+        dragOutMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.clearDragOut()
+                guard self.isVisible, !self.core.isShowingDialog else { return }
+                self.core.paletteCoordinator.hidePalette(restoreFocus: false)
+            }
+        }
+    }
+
+    private func clearDragOut() {
+        guard let dragOutMonitor else { return }
+        NSEvent.removeMonitor(dragOutMonitor)
+        self.dragOutMonitor = nil
+    }
+
     // MARK: - NSWindowDelegate
 
     /// Not for one of our own dialogs: hiding would tear down a command mid-`confirmAlert`.
+    /// Not during a drag-out either: the drop target takes the key, and the palette must survive it.
     func windowDidResignKey(_ notification: Notification) {
-        guard isVisible, !core.isShowingDialog else { return }
+        guard isVisible, !core.isShowingDialog, dragOutMonitor == nil else { return }
         core.paletteCoordinator.hidePalette(restoreFocus: false)
     }
 
     /// Re-bump a turn later: on the first show a synchronous bump lands before `onChange`.
     func windowDidBecomeKey(_ notification: Notification) {
+        // Clicking back into the palette ends the drag-out hold, so the normal rules apply again.
+        clearDragOut()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             core.palette.focusToken = UUID()

--- a/docs/features/clipboard.md
+++ b/docs/features/clipboard.md
@@ -390,8 +390,21 @@ tile, `cached` only and never `load`, because a decode on mouse-down stalls the 
 begins on. A link or a copy gets a drawn text tile. The dragging frame is sized to that image and
 centred on the cursor, since the row's own shape would stretch a thumbnail.
 
-**A landed drop hides the palette**, the ending a paste has, through `clipDropped()`. A cancelled
-drag leaves it up and animates back to the row it came from, so a drag that achieved nothing says
-so. The session outliving the panel is safe for the reason the player teardown above is delicate:
+**The palette stays up through the drag and past the drop**, so a run of entries goes over in one
+summon. The drop target takes the keyboard the moment the drag is in flight, and `windowDidResignKey`
+closed the palette on that alone.
+
+One piece of state answers the whole behaviour. `beginDragOut` arms a global mouse monitor when the
+session starts, and `dragOutMonitor` being non-nil is both the reason `windowDidResignKey` leaves the
+panel alone and the thing that closes it later. Arming at the start rather than the end is what
+collapses the two: the button stays down for the whole gesture, so no mouse-down can reach the
+monitor before the drop, and the first one that does is the click that dismisses. The monitor is
+global on purpose, since a click inside the palette never reaches one, which is the test itself.
+Clicking back into the panel returns it to the normal rules through `windowDidBecomeKey`.
+
+The handle asks for this itself rather than reporting out to the screen: `ClipDragHandle` reads
+`AppCore` from the palette environment, so no row, list or screen carries a drag callback. A
+cancelled drag animates back to the row it came from, so a drag that achieved nothing still says so.
+The session outliving the panel is safe for the reason the player teardown above is delicate:
 `orderOut` leaves the SwiftUI tree mounted, and the pasteboard holds the payload from the moment the
 session begins.


### PR DESCRIPTION
## Related issue

Follow-up to #596, which added the drag-out. No separate issue, so the triage bot will close this on
sight. Reopen it if the behaviour is what you want.

## What changed

Dragging an entry to another app closed the palette, so every entry cost a fresh summon. Raycast
leaves its window up, and #544 asked for that.

Two paths closed it, which is why removing one changed nothing visible:

- `clipDropped()` hid the palette on a landed drop.
- `windowDidResignKey` hid it the moment the drop target took the keyboard.

`beginDragOut` now arms a global mouse monitor when the session starts. While `dragOutMonitor` is
non-nil the palette ignores losing the key, and the first click outside closes it.

Arming at the start rather than the end is what lets one piece of state answer both questions. The
button stays down for the whole gesture, so no mouse-down can reach the monitor before the drop, and
the first one that does is the dismissing click. A cancelled drag lands in the same state, which is
correct. The palette is still up and one click still closes it.

The monitor is global on purpose. A click inside the palette never reaches one, so "outside" needs no
frame test. Clicking back into the panel restores the normal rules through `windowDidBecomeKey`, and
`hide()` drops the monitor on every other exit.

`ClipDragHandle` reads `AppCore` from the palette environment and asks for the hold itself, so no
row, list or screen carries a drag callback. `ClipboardList` and `ClipboardScreen` lose parameters
here, and `ClipboardCoordinator` has nothing to add.

## Memory footprint

Not measured. There is no Xcode on the machine this was written on, so no Instruments run and no leak
test.

It allocates one `NSEvent` global monitor, live only between a drag leaving the app and the click
that closes the palette. `clearDragOut` removes it, and `hide()` calls that on every path out, so
nothing survives the panel. Against #596 as merged this is a net reduction, since it deletes a stored
flag and two closures per visible row.

| Step                    | Memory |
| ----------------------- | ------ |
| Idle after launch       |        |
| Palette open            |        |
| Feature in use (peak)   |        |
| Palette closed, settled |        |

Leak-tested: no

## Demo

Not recorded.

## Drawbacks

- A right-click in another app while the drag is still in flight closes the palette. The monitor
  cannot tell that click from the one that ends the errand. Rare enough that I left it.
- The palette outliving the drop means it sits over the app you just dropped into until you click.
  That is the request, but it is a real change in where focus appears to be.
- `beginDragOut` lives on `PaletteWindowController`, so any future drag source gets the behaviour by
  calling it. Nothing enforces that a caller pairs it with a matching call, because there is no
  matching call to make.

## Tests & validation

`Scripts/run-tests.sh`, all 70 harnesses pass. No cases added.

`swiftc -typecheck` over the whole app module: clean. SwiftLint: no warnings in the touched files.
`Scripts/format.sh --check`: clean for every file in this diff.

The `test` check on this PR passed. That run is the `xcodebuild` build I cannot do locally, so it
covers the toolchain gap above.

`docs/features/clipboard.md` § Dragging out rewritten against the code here.

By hand, on a local build of this branch: the palette stays up through a drag out and closes on the
first click outside. That is the behaviour this PR is for, and it works.
