### PR TITLE
Label a bundle in the language it is written in, not the next one down

### DIFF
--- a/Tests/app-name-test.swift
+++ b/Tests/app-name-test.swift
@@ -122,6 +122,13 @@ struct AppNameTest {
             return url
         }
 
+        /// The scan's own call: an app's untranslated name is the file name it sits under on disk.
+        func names(_ url: URL, _ preferred: [String], region: String? = "en") -> [String] {
+            BundleLocalization.names(
+                for: url, base: url.deletingPathExtension().lastPathComponent,
+                developmentRegion: region, languages: codes(preferred))
+        }
+
         let monitor = makeLocalizedApp(
             "Activity Monitor.app",
             table: [
@@ -131,12 +138,46 @@ struct AppNameTest {
             ])
         check(
             "a loctable app is found by its Chinese name, English still indexed",
-            BundleLocalization.names(for: monitor, languages: codes(["zh-Hans-CN"]))
-                == ["活动监视器", "Activity Monitor"])
+            names(monitor, ["zh-Hans-CN"]) == ["活动监视器", "Activity Monitor"])
         check(
             "an English Mac indexes only the English name",
-            BundleLocalization.names(for: monitor, languages: codes(["en-US"]))
-                == ["Activity Monitor"])
+            names(monitor, ["en-US"]) == ["Activity Monitor"])
+
+        // Tips.app ships every language but its own: `en` is the one key Apple's loctables omit.
+        let tips = makeLocalizedApp(
+            "Tips.app", table: ["ru": ["CFBundleName": "Советы"], "de": ["CFBundleName": "Tipps"]])
+        check(
+            "an untranslated name outranks a language the user reads less well",
+            names(tips, ["en-US", "ru-RU"]) == ["Tips", "Советы"])
+        check(
+            "the language a Mac actually prefers still wins over the untranslated name",
+            names(tips, ["ru-RU"]) == ["Советы", "Tips"])
+        check(
+            "a language nobody asked for is never indexed",
+            !names(tips, ["en-US", "ru-RU"]).contains("Tipps"))
+
+        // Safari's `CFBundleDevelopmentRegion` still reads "English", not "en".
+        check(
+            "a pre-BCP-47 development region names the same language",
+            names(tips, ["en-US", "ru-RU"], region: "English") == ["Tips", "Советы"])
+        check(
+            "a bundle claiming no region leaves its name last, still searchable",
+            names(tips, ["en-US", "ru-RU"], region: nil) == ["Советы", "Tips"])
+
+        // Print Center ships `en_GB` but no `en`; the file name is the English name it already has.
+        let printCenter = makeLocalizedApp(
+            "Print Center.app", table: ["en_GB": ["CFBundleName": "Print Centre"]])
+        check(
+            "a regional spelling never relabels the app the file name already names",
+            names(printCenter, ["en-US"]).first == "Print Center")
+
+        // VoiceMemos.app names itself nowhere on disk, so `en` carries the name the user sees.
+        let memos = makeLocalizedApp(
+            "VoiceMemos.app",
+            table: ["en": ["CFBundleName": "Voice Memos"], "ru": ["CFBundleName": "Диктофон"]])
+        check(
+            "a translated English name still beats the file name it was written for",
+            names(memos, ["en-US", "ru-RU"]) == ["Voice Memos", "VoiceMemos", "Диктофон"])
 
         try? fm.removeItem(at: root)
         print(failures == 0 ? "\nALL PASSED" : "\n\(failures) FAILED")

--- a/Tinycast/Features/Launcher/Service/AppIndex.swift
+++ b/Tinycast/Features/Launcher/Service/AppIndex.swift
@@ -477,7 +477,8 @@ final class AppIndex {
             let languages = BundleLocalization.indexedLanguages(Locale.preferredLanguages)
             let reusing = BundleNameCache(reusing: nameCache, languages: languages)
             let (found, cache, panes) = await Task.detached(priority: .utility) {
-                AppIndex.scan(scopes: scopes, cache: reusing, paneCache: reusingPanes)
+                AppIndex.scan(
+                    scopes: scopes, languages: languages, cache: reusing, paneCache: reusingPanes)
             }.value
             nameCache = cache
             paneCache = panes
@@ -488,7 +489,8 @@ final class AppIndex {
     }
 
     nonisolated private static func scan(
-        scopes: [String], cache: BundleNameCache, paneCache: SettingsPaneScanner.Cache?
+        scopes: [String], languages: [String], cache: BundleNameCache,
+        paneCache: SettingsPaneScanner.Cache?
     ) -> ([AppEntry], BundleNameCache, SettingsPaneScanner.Cache?) {
         Signposts.interval("AppIndex.scan") {
             var cache = cache
@@ -504,8 +506,9 @@ final class AppIndex {
                     continue
                 }
 
-                let names = cache.names(for: url)
                 // Finder's rule: LaunchServices ignores a display name the file name contradicts.
+                let names = cache.names(
+                    for: url, base: fileName, developmentRegion: bundle?.developmentLocalization)
                 let name = names.localized.first ?? fileName
                 let executable =
                     bundle?.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
@@ -525,7 +528,7 @@ final class AppIndex {
                 $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
             }
             // Settings panes are `.appex` bundles, which carry no Spotlight alternate names.
-            let (panes, panesCache) = SettingsPaneScanner.scan(cache: paneCache)
+            let (panes, panesCache) = SettingsPaneScanner.scan(languages: languages, cache: paneCache)
             // Named here, not at publish: romanizing a CJK index is ~50 ms of main-actor time.
             return (AppIndex.named(apps + panes), cache, panesCache)
         }

--- a/Tinycast/Features/Launcher/Service/BundleNameCache.swift
+++ b/Tinycast/Features/Launcher/Service/BundleNameCache.swift
@@ -31,7 +31,7 @@ struct BundleNameCache: Sendable {
         previous = cache.languages == languages ? cache.current : [:]
     }
 
-    mutating func names(for url: URL) -> Names {
+    mutating func names(for url: URL, base: String, developmentRegion: String?) -> Names {
         let modified = try? url.resourceValues(forKeys: [.contentModificationDateKey])
             .contentModificationDate
         if let cached = previous[url.path], cached.modified == modified {
@@ -39,7 +39,8 @@ struct BundleNameCache: Sendable {
             return cached.names
         }
         let names = Names(
-            localized: BundleLocalization.names(for: url, languages: languages),
+            localized: BundleLocalization.names(
+                for: url, base: base, developmentRegion: developmentRegion, languages: languages),
             alternates: SpotlightNames.alternateNames(for: url))
         current[url.path] = Entry(modified: modified, names: names)
         return names

--- a/Tinycast/Features/Launcher/Service/SettingsPaneScanner.swift
+++ b/Tinycast/Features/Launcher/Service/SettingsPaneScanner.swift
@@ -18,15 +18,18 @@ enum SettingsPaneScanner {
     /// Panes change only on an OS update, and an unreadable listing or date is never cached.
     struct Cache: Sendable {
         fileprivate let modified: Date
+        fileprivate let languages: [String]
         fileprivate let panes: [AppEntry]
     }
 
     /// All Settings panes, sorted by display name.
-    nonisolated static func scan(cache: Cache?) -> ([AppEntry], Cache?) {
+    nonisolated static func scan(languages: [String], cache: Cache?) -> ([AppEntry], Cache?) {
         let fm = FileManager.default
         let modified = try? extensionsDir.resourceValues(forKeys: [.contentModificationDateKey])
             .contentModificationDate
-        if let cache, cache.modified == modified { return (cache.panes, cache) }
+        if let cache, cache.modified == modified, cache.languages == languages {
+            return (cache.panes, cache)
+        }
         guard
             let items = try? fm.contentsOfDirectory(
                 at: extensionsDir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
@@ -39,17 +42,23 @@ enum SettingsPaneScanner {
                 isSettingsPane(info: info),
                 let bundleID = info["CFBundleIdentifier"] as? String,
                 !skippedBundleIDs.contains(bundleID),
-                let name = displayName(appexURL: url, info: info, bundleID: bundleID)
+                let base = AppDisplayName.inInfo(info)
             else { continue }
+            let names = BundleLocalization.names(
+                for: url, base: base,
+                developmentRegion: info["CFBundleDevelopmentRegion"] as? String,
+                languages: languages)
             result.append(
                 AppEntry(
-                    id: url.path, name: name, url: url, bundleID: bundleID,
-                    kind: .systemSettings))
+                    id: url.path, name: nameOverrides[bundleID] ?? names.first ?? base, url: url,
+                    bundleID: bundleID, kind: .systemSettings,
+                    // `EntryNaming` drops whatever repeats the name, so the whole list can go in.
+                    alternateNames: names))
         }
         let panes = result.sorted {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
-        return (panes, modified.map { Cache(modified: $0, panes: panes) })
+        return (panes, modified.map { Cache(modified: $0, languages: languages, panes: panes) })
     }
 
     private static func isSettingsPane(info: [String: Any]) -> Bool {
@@ -57,36 +66,6 @@ enum SettingsPaneScanner {
         if ex as? String == settingsExtensionPoint { return true }
         let ns = (info["NSExtension"] as? [String: Any])?["NSExtensionPointIdentifier"]
         return ns as? String == settingsExtensionPoint
-    }
-
-    /// Overrides, then loctable, then Info.plist; nil skips the pane entirely.
-    private static func displayName(
-        appexURL: URL, info: [String: Any], bundleID: String
-    ) -> String? {
-        if let override = nameOverrides[bundleID] { return override }
-        if let localized = loctableName(appexURL: appexURL) { return localized }
-        return AppDisplayName.inInfo(info)
-    }
-
-    /// Localized name from `InfoPlist.loctable`, preferred languages first, then English.
-    private static func loctableName(appexURL: URL) -> String? {
-        let url = appexURL.appendingPathComponent("Contents/Resources/InfoPlist.loctable")
-        guard let table = plist(at: url) else { return nil }
-        var codes = Locale.preferredLanguages.flatMap { tag -> [String] in
-            // loctable keys use underscores where language tags use hyphens.
-            let underscored = tag.replacingOccurrences(of: "-", with: "_")
-            let bare = tag.split(separator: "-").first.map(String.init)
-            return ([underscored, bare].compactMap { $0 }).filter { !$0.isEmpty }
-        }
-        codes.append("en")
-        for code in codes {
-            if let entry = table[code] as? [String: Any],
-                let name = AppDisplayName.named(entry["CFBundleDisplayName"])
-            {
-                return name
-            }
-        }
-        return nil
     }
 
     private static func plist(at url: URL) -> [String: Any]? {

--- a/Tinycast/Platform/BundleLocalization.swift
+++ b/Tinycast/Platform/BundleLocalization.swift
@@ -33,23 +33,41 @@ enum BundleLocalization {
         return "\(code)-\(region.identifier)"
     }
 
-    /// Every localized name the bundle carries, most preferred language first.
-    nonisolated static func names(for bundleURL: URL, languages: [String]) -> [String] {
+    /// Every name the bundle carries, most preferred language first. `base` — an app's file name, a
+    /// pane's `Info.plist` — ranks with the language it is written in, which ships no table.
+    nonisolated static func names(
+        for bundleURL: URL, base: String, developmentRegion: String?, languages: [String]
+    ) -> [String] {
         let resources = bundleURL.appendingPathComponent("Contents/Resources", isDirectory: true)
         let table = plist(at: resources.appendingPathComponent("InfoPlist.loctable"))
+        let development = developmentRegion.flatMap { languageCode(of: $0) }
         var result: [String] = []
         var seen = Set<String>()
+
+        func append(_ name: String?) {
+            guard let name, seen.insert(FuzzyMatch.normalized(name)).inserted else { return }
+            result.append(name)
+        }
+
         for code in languages {
             let strings = plist(
                 at: resources.appendingPathComponent("\(code).lproj/InfoPlist.strings"))
             for source in [table?[code] as? [String: Any], strings] {
-                guard let source, let name = AppDisplayName.inInfo(source),
-                    seen.insert(FuzzyMatch.normalized(name)).inserted
-                else { continue }
-                result.append(name)
+                append(source.flatMap(AppDisplayName.inInfo))
+            }
+            if let development, code.caseInsensitiveCompare(development) == .orderedSame {
+                append(base)
             }
         }
+        // A development region this Mac doesn't read still leaves the name searchable.
+        append(base)
         return result
+    }
+
+    /// `CFBundleDevelopmentRegion` still ships its pre-BCP-47 spelling: Safari's reads "English".
+    private static func languageCode(of region: String) -> String? {
+        Locale.Language(identifier: Locale.canonicalLanguageIdentifier(from: region))
+            .languageCode?.identifier
     }
 
     private static func plist(at url: URL) -> [String: Any]? {

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -168,7 +168,20 @@ ICU entirely on a fast scalar check.
 all 65 of them read English on every Mac, whatever language it is set to.
 
 The user's own language wins the **display name**, so a row reads the way Finder reads it. The rest,
-English included, ride along as `.translation`. `AppDisplayName.inInfo` reads the `-macos` variant of
+English included, ride along as `.translation`.
+
+**A bundle ships no table for the language it is already written in, so `CFBundleDevelopmentRegion`
+places its untranslated name — an app's file name, a pane's `Info.plist` — in the walk at that
+language's own position.** Apple omits a loctable's `en` key exactly when the base name already says
+it in English: `Tips.app`, `Calculator.app` and `AppleIDSettings.appex` all do, and without this the
+walk fell straight past English into whatever *second* language the Mac listed, so an English Mac
+with Russian under it labelled them `Советы` and `Аккаунт Apple`. The base name still loses to a real
+table for that same language — `VoiceMemos.app` does ship `en`, and `Voice Memos` beats the file name
+it was written for. Reading the `en_GB` those bundles *do* carry is the wrong repair: it relabels
+`Print Center` as `Print Centre`. Below the development region the walk carries on, so every language
+under it stays indexed as a `.translation`. The region is canonicalized before it is matched, because
+`CFBundleDevelopmentRegion` still ships its pre-BCP-47 spelling — Safari's and Terminal's read
+`English`. `AppDisplayName.inInfo` reads the `-macos` variant of
 each key before the bare one, the way `CFBundle` does: Image Playground's loctable spells the bare
 `CFBundleDisplayName` `Playground` and only the suffixed key `Image Playground`. A non-English user finds their app by the name they
 see *and* by the English name the vendor advertises.
@@ -374,8 +387,9 @@ reruns on every launcher open — so `BundleNameCache` memoizes **both** per bun
 only when the bundle's modification date moves. Caching one and not the other leaves most of a warm
 pass uncached. Each pass is seeded from the last and keeps only what it looked at, so uninstalled apps
 fall out instead of accumulating; a changed system language drops the whole table, because the names
-in it are in the old one. `.appex` Settings panes carry no alternate names, so `SettingsPaneScanner`
-doesn't ask.
+in it are in the old one. `.appex` Settings panes carry no Spotlight alternates, so `SettingsPaneScanner`
+doesn't ask — it runs the same `BundleLocalization` walk for its own names, and retires its cache
+when either the extensions folder or the language list moves.
 
 Selecting a launcher result records **one row for the submitted query** — `submittedQuery`, named
 so because a table written when the field held one row per *prefix* cannot decode here, which is the


### PR DESCRIPTION
## Related issue

None filed — reported in conversation with screenshots of `Советы` ranking above Tinycast and
Time Machine for `t`, and `Аккаунт Apple` topping `app`. Closes #595

## What changed

`BundleLocalization` walks the user's preferred languages — `en-US`, `en_US`, `en`, `ru-MD`,
`ru_MD`, `ru` — looking each up in the bundle's `InfoPlist.loctable`. **A bundle ships no table
entry for the language it is already written in**, so the walk fell straight past English into the
Mac's *second* language.

`Tips.app` carries `ru`, `de`, `ja` and no `en`, because its `Info.plist` already says `Tips`. The
row was therefore labelled `Советы` while matching `t` on `Tips` — the file name, indexed as a
strong alias. The label and the match came from different names, which is what made the ranking
look arbitrary.

`CFBundleDevelopmentRegion` now places that untranslated name — an app's file name, a pane's
`Info.plist` — into the walk at its own language's position. The region is canonicalised before it
is matched, because it still ships its pre-BCP-47 spelling: Safari's and Terminal's read `English`.

Two details are the whole fix, and both are load-bearing:

- The name goes **after** that language's own tables. `VoiceMemos.app` does ship `en`, so it still
  reads `Voice Memos` and not its file name.
- Reading the `en_GB` these bundles *do* carry is the tempting alternative and is wrong: it
  relabels `Print Center` as `Print Centre`.

Below the development region the walk carries on, so every language under it stays indexed as a
`.translation` — `обои` still finds Wallpaper.

`SettingsPaneScanner` held a second, weaker copy of the same walk with the same defect, which is
what made `Аккаунт Apple` the first hit for `app`. It now shares `BundleLocalization` and gains
script-tag handling, `.lproj` strings and the `-macos` key variants, and indexes panes'
other-language names the way applications already are. Its cache is keyed on the language list as
well — it previously served names from the language before last.

## Memory footprint

Not measured. This is a naming path inside a scan that already reads these plists; it adds no
allocation beyond the extra strings in `alternateNames`, and no new ownership, timer or observer.

| Step                    | Memory       |
| ----------------------- | ------------ |
| Idle after launch       | not measured |
| Palette open            | not measured |
| Feature in use (peak)   | not measured |
| Palette closed, settled | not measured |

Leak-tested: no.

## Drawbacks

Settings panes now index their other-language names as translations, which applications already
did. That is two or three extra aliases per pane and includes the junk base names Apple ships
(`WiFiSettings`, `GeneralSettings`) — harmless at `.translation` strength, but they are searchable
where they were not before.

The rule trusts `CFBundleDevelopmentRegion`. A bundle that declares the wrong one, and ships no
table for the user's language, will be labelled by its base name; that is the same name Finder
shows, so the failure mode is the old fallback rather than a new one.

## Tests & validation

`./Scripts/run-tests.sh` — all 70 harnesses pass. `app-name-test` gains eight cases: the untranslated
name outranking a lesser-read language, the preferred language still winning, the `English`
spelling of the region, a bundle declaring no region, the `en_GB` regional-spelling trap, and a
bundle whose `en` table beats its own file name.

Debug build compiles with no new warnings; `./Scripts/lint.sh` clean.

Probed every app and pane in the default scopes against the reported language state
(English (US) primary, Русский second):

- **10 labels change**, exactly the broken ones — `Советы → Tips`, `Аккаунт Apple → Apple Account`,
  `Калькулятор → Calculator`, `Захват изображений → Image Capture`,
  `Системные настройки → System Settings`, `Центр печати → Print Center`, `Обои → Wallpaper`,
  `Хранилище → Storage`, `Touch ID и пароль → Touch ID & Password`,
  `Улучшения безопасности… → Background Security Improvements`.
- **0/95 apps and 0/52 panes change** under `ru-RU` or `zh-Hans-CN`; the English name stays indexed
  as a translation there.
- Names that were already right stay right: `Voice Memos`, `Find My`, `General`, `Wi‑Fi`,
  `Desktop & Dock`, `AppleCare & Warranty`.
