### PR TITLE
Select the search field's text when the palette is re-summoned

### DIFF
--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -15,17 +15,11 @@ enum PopToRootTimeout: Int, CaseIterable, Identifiable, Sendable {
     case afterThirty = 30
     case afterSixty = 60
     case afterNinety = 90
-    /// Never pops: the next summon shows the last query selected, ready to be typed over.
-    case selectPreviousQuery = -1
 
     var id: Int { rawValue }
 
     var title: String {
-        switch self {
-        case .immediately: return "Immediately"
-        case .selectPreviousQuery: return "Select previous query"
-        default: return "After \(rawValue) seconds"
-        }
+        self == .immediately ? "Immediately" : "After \(rawValue) seconds"
     }
 
     var interval: TimeInterval { TimeInterval(rawValue) }

--- a/Tinycast/Features/Settings/AppSettings.swift
+++ b/Tinycast/Features/Settings/AppSettings.swift
@@ -15,11 +15,17 @@ enum PopToRootTimeout: Int, CaseIterable, Identifiable, Sendable {
     case afterThirty = 30
     case afterSixty = 60
     case afterNinety = 90
+    /// Never pops: the next summon shows the last query selected, ready to be typed over.
+    case selectPreviousQuery = -1
 
     var id: Int { rawValue }
 
     var title: String {
-        self == .immediately ? "Immediately" : "After \(rawValue) seconds"
+        switch self {
+        case .immediately: return "Immediately"
+        case .selectPreviousQuery: return "Select previous query"
+        default: return "After \(rawValue) seconds"
+        }
     }
 
     var interval: TimeInterval { TimeInterval(rawValue) }

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -32,8 +32,6 @@ final class PalettePanel: NSPanel {
     /// SwiftUI's text fields all edit through the window's one shared field editor.
     private var fieldEditor: NSTextView? { firstResponder as? NSTextView }
 
-    /// A re-summon leaves the field editor's selection as it was; select its text outright
-    /// so a fresh search replaces last time's instead of requiring a manual clear first.
     func selectAllFieldEditorText() {
         fieldEditor?.selectAll(nil)
     }

--- a/Tinycast/Palette/PalettePanel.swift
+++ b/Tinycast/Palette/PalettePanel.swift
@@ -32,6 +32,12 @@ final class PalettePanel: NSPanel {
     /// SwiftUI's text fields all edit through the window's one shared field editor.
     private var fieldEditor: NSTextView? { firstResponder as? NSTextView }
 
+    /// A re-summon leaves the field editor's selection as it was; select its text outright
+    /// so a fresh search replaces last time's instead of requiring a manual clear first.
+    func selectAllFieldEditorText() {
+        fieldEditor?.selectAll(nil)
+    }
+
     /// Nil while a selection can still collapse normally, or when the caret is not at an edge.
     private func headerFieldBoundary(for event: NSEvent) -> HeaderFieldBoundary? {
         guard event.modifierFlags.isDisjoint(with: [.command, .option, .control, .shift]),

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -10,9 +10,6 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// Our key window at summon time, so hiding hands focus back to Settings, not a stale app.
     private weak var previousOwnWindow: NSWindow?
     private var popToRootTimer: Timer?
-    /// What the query held at the moment of hiding; Pop to Root may have since cleared the live
-    /// one, but the next summon puts this back, selected, so closing by accident costs nothing.
-    private var queryAtHide: String?
     /// Resolved once per show; the top edge is the one that must not drift.
     private var anchor: CGPoint?
     /// Live only between mouse-down and mouse-up on a drag handle; nil means a move was ours.
@@ -61,11 +58,6 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             }
             // Once per summon, and from `previousApp`, so the label names the paste target.
             core.palette.pasteTarget = PasteTarget(app: previousApp)
-            // Nothing else has put fresh text in the field, so Pop to Root's clear wasn't final.
-            if core.palette.query.isEmpty, let queryAtHide, !queryAtHide.isEmpty {
-                core.palette.query = queryAtHide
-            }
-            queryAtHide = nil
             let panel = ensurePanel()
             // Open disarmed: a pointer already over a row must not highlight it.
             core.palette.disarmHoverHighlight(pointerAt: NSEvent.mouseLocation)
@@ -130,7 +122,6 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     }
 
     func hide(restoreFocus: Bool) {
-        queryAtHide = core.palette.query
         panel?.orderOut(nil)
         commandEscapeTap.disable()
         core.inputSourceSwitcher.endSession()
@@ -161,7 +152,10 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         // Don't pop to root if an extension is waiting for OAuth authorization in the browser.
         guard !core.extensions.isAuthorizing else { return }
         popToRootTimer?.invalidate()
+        popToRootTimer = nil
         let timeout = core.settings.popToRootTimeout
+        // Never pops: `consumePreservedState` treats this option as permanently preserved.
+        guard timeout != .selectPreviousQuery else { return }
         guard timeout != .immediately else {
             popToRoot()
             return
@@ -191,6 +185,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     /// True while a hidden palette still holds pre-close state; consuming cancels the reset.
     func consumePreservedState() -> Bool {
+        // This option never schedules a reset in the first place, so it's always preserved.
+        guard core.settings.popToRootTimeout != .selectPreviousQuery else { return true }
         guard let timer = popToRootTimer else { return false }
         timer.invalidate()
         popToRootTimer = nil
@@ -226,8 +222,10 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             if let context = panel?.fieldEditorContext {
                 core.inputSourceSwitcher.applySession(to: context)
             }
-            // Same reason: select what's left so typing right away replaces last time's search.
-            panel?.selectAllFieldEditorText()
+            // Only this option ever leaves old text behind to begin with.
+            if core.settings.popToRootTimeout == .selectPreviousQuery {
+                panel?.selectAllFieldEditorText()
+            }
         }
     }
 

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -10,6 +10,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// Our key window at summon time, so hiding hands focus back to Settings, not a stale app.
     private weak var previousOwnWindow: NSWindow?
     private var popToRootTimer: Timer?
+    /// What the query held at the moment of hiding; Pop to Root may have since cleared the live
+    /// one, but the next summon puts this back, selected, so closing by accident costs nothing.
+    private var queryAtHide: String?
     /// Resolved once per show; the top edge is the one that must not drift.
     private var anchor: CGPoint?
     /// Live only between mouse-down and mouse-up on a drag handle; nil means a move was ours.
@@ -58,6 +61,11 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             }
             // Once per summon, and from `previousApp`, so the label names the paste target.
             core.palette.pasteTarget = PasteTarget(app: previousApp)
+            // Nothing else has put fresh text in the field, so Pop to Root's clear wasn't final.
+            if core.palette.query.isEmpty, let queryAtHide, !queryAtHide.isEmpty {
+                core.palette.query = queryAtHide
+            }
+            queryAtHide = nil
             let panel = ensurePanel()
             // Open disarmed: a pointer already over a row must not highlight it.
             core.palette.disarmHoverHighlight(pointerAt: NSEvent.mouseLocation)
@@ -122,6 +130,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     }
 
     func hide(restoreFocus: Bool) {
+        queryAtHide = core.palette.query
         panel?.orderOut(nil)
         commandEscapeTap.disable()
         core.inputSourceSwitcher.endSession()
@@ -217,6 +226,8 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             if let context = panel?.fieldEditorContext {
                 core.inputSourceSwitcher.applySession(to: context)
             }
+            // Same reason: select what's left so typing right away replaces last time's search.
+            panel?.selectAllFieldEditorText()
         }
     }
 

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -10,8 +10,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// Our key window at summon time, so hiding hands focus back to Settings, not a stale app.
     private weak var previousOwnWindow: NSWindow?
     private var popToRootTimer: Timer?
-    /// True when the last `consumePreservedState` found the delay still running: the reopen
-    /// beat Pop to Root, so the query it kept deserves to be selected rather than just left as-is.
+    // Reopen beat the timeout, so select the preserved query.
     private var queryWasPreserved = false
     /// Resolved once per show; the top edge is the one that must not drift.
     private var anchor: CGPoint?
@@ -188,7 +187,6 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         guard let timer = popToRootTimer else { return false }
         timer.invalidate()
         popToRootTimer = nil
-        // The delay hadn't run out, so the query beat it back — worth selecting on the show.
         queryWasPreserved = true
         return true
     }
@@ -222,7 +220,6 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             if let context = panel?.fieldEditorContext {
                 core.inputSourceSwitcher.applySession(to: context)
             }
-            // Only a reopen that beat Pop to Root left a query worth selecting.
             if queryWasPreserved {
                 queryWasPreserved = false
                 panel?.selectAllFieldEditorText()

--- a/Tinycast/Palette/PaletteWindowController.swift
+++ b/Tinycast/Palette/PaletteWindowController.swift
@@ -10,6 +10,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
     /// Our key window at summon time, so hiding hands focus back to Settings, not a stale app.
     private weak var previousOwnWindow: NSWindow?
     private var popToRootTimer: Timer?
+    /// True when the last `consumePreservedState` found the delay still running: the reopen
+    /// beat Pop to Root, so the query it kept deserves to be selected rather than just left as-is.
+    private var queryWasPreserved = false
     /// Resolved once per show; the top edge is the one that must not drift.
     private var anchor: CGPoint?
     /// Live only between mouse-down and mouse-up on a drag handle; nil means a move was ours.
@@ -152,10 +155,7 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
         // Don't pop to root if an extension is waiting for OAuth authorization in the browser.
         guard !core.extensions.isAuthorizing else { return }
         popToRootTimer?.invalidate()
-        popToRootTimer = nil
         let timeout = core.settings.popToRootTimeout
-        // Never pops: `consumePreservedState` treats this option as permanently preserved.
-        guard timeout != .selectPreviousQuery else { return }
         guard timeout != .immediately else {
             popToRoot()
             return
@@ -185,11 +185,11 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
 
     /// True while a hidden palette still holds pre-close state; consuming cancels the reset.
     func consumePreservedState() -> Bool {
-        // This option never schedules a reset in the first place, so it's always preserved.
-        guard core.settings.popToRootTimeout != .selectPreviousQuery else { return true }
         guard let timer = popToRootTimer else { return false }
         timer.invalidate()
         popToRootTimer = nil
+        // The delay hadn't run out, so the query beat it back — worth selecting on the show.
+        queryWasPreserved = true
         return true
     }
 
@@ -222,8 +222,9 @@ final class PaletteWindowController: NSObject, NSWindowDelegate {
             if let context = panel?.fieldEditorContext {
                 core.inputSourceSwitcher.applySession(to: context)
             }
-            // Only this option ever leaves old text behind to begin with.
-            if core.settings.popToRootTimeout == .selectPreviousQuery {
+            // Only a reopen that beat Pop to Root left a query worth selecting.
+            if queryWasPreserved {
+                queryWasPreserved = false
                 panel?.selectAllFieldEditorText()
             }
         }


### PR DESCRIPTION
## Summary
- Closing the palette (click-outside/Escape) and reopening it left the previous query sitting in the field with the caret wherever it was last, so starting a new search meant manually backspacing the old one out first.
- Reopening now selects the leftover query when it's still relevant to your Pop to Root Search setting: typing immediately replaces it, and pressing → moves the caret to the end and keeps it — both via standard `NSTextView` selection behavior, no extra key handling needed.
- This respects each existing Pop to Root Search option's own timing, with no new setting added:
  - **Immediately**: unaffected — the query is cleared the instant the window hides, same as before.
  - **After N seconds**: reopening *before* the delay elapses selects the preserved query; reopening *after* it has already fired shows an empty root search, same as before.

## Changes
- `Tinycast/Palette/PalettePanel.swift`: adds `selectAllFieldEditorText()`, selecting the shared AppKit field editor's full text.
- `Tinycast/Palette/PaletteWindowController.swift`: `consumePreservedState()` already reports whether a reopen beat the pending Pop to Root timer — it now also flags that the surviving query is worth selecting, and `windowDidBecomeKey` calls the new select-all only when that flag is set. `Immediately` never has a timer to survive, so it's never affected.

## Test plan
- [x] `xcodebuild -project Tinycast.xcodeproj -scheme Tinycast -configuration Debug -destination 'platform=macOS' build` succeeds
- [x] "Immediately": type a query, click outside, reopen — root search is empty, no leftover text
- [x] "After 5 seconds": reopening within 5s selects the preserved query; reopening after 5s shows an empty root search
- [x] Manually verified normal in-palette navigation (mode switches, tabbing) is unaffected

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)