### PR TITLE
Right-size launcher file icons for the selected layout

### DIFF
--- a/Tests/icon-cache-test.swift
+++ b/Tests/icon-cache-test.swift
@@ -62,7 +62,119 @@ struct IconCacheTests {
         expect(first == IconCache.styleFingerprint(), "an unchanged style renders identically")
     }
 
-    static func main() {
+    static let finder = "/System/Library/CoreServices/Finder.app"
+
+    static func pixelWidth(_ image: NSImage) -> Int {
+        autoreleasepool { (image.representations.first as? NSBitmapImageRep)?.pixelsWide ?? 0 }
+    }
+
+    static func rowSizes() {
+        IconCache.invalidateStyled()
+        let full = IconCache.icon(forFile: finder)
+        expect(pixelWidth(full) == 96, "unsized consumers retain 96px")
+        for scale: CGFloat in [1, 2] {
+            for points: CGFloat in [24, 26, 29, 24] {
+                let size = IconSize(points: points, scale: scale)
+                let row = IconCache.icon(forFile: finder, size: size)
+                expect(pixelWidth(row) == Int(points * scale), "row follows points and backing scale")
+                expect(IconCache.cached(forFile: finder, size: size) === row, "warm row reuses its image")
+                expect(
+                    IconCache.cached(forFile: finder) === full, "row resizing preserves full-size consumers")
+                let other = IconSize(points: points + 1, scale: scale)
+                expect(IconCache.cached(forFile: finder, size: other) == nil, "wrong sizes never hit")
+            }
+        }
+        let fractional = IconSize(points: 26.4, scale: 2)
+        expect(pixelWidth(IconCache.icon(forFile: finder, size: fractional)) == 53, "round pixels up")
+        let size = IconSize(points: 24, scale: 2)
+        let first = IconCache.icon(forFile: finder, stamp: 1, size: size)
+        let changed = IconCache.icon(forFile: finder, stamp: 2, size: size)
+        expect(first !== changed, "file stamps separate row entries")
+        IconCache.invalidateStyled()
+        expect(IconCache.cached(forFile: finder, stamp: 2, size: size) == nil, "restyle clears rows")
+        let newer = IconCache.icon(forFile: finder, stamp: 2, size: size)
+        expect(newer !== changed, "a style change regenerates a row")
+    }
+
+    static func rowLifetime() {
+        IconCache.invalidateStyled()
+        weak var old: NSImage?
+        weak var oldBitmap: NSBitmapImageRep?
+        autoreleasepool {
+            let image = IconCache.icon(forFile: finder, size: IconSize(points: 24, scale: 2))
+            old = image
+            oldBitmap = image.representations.first as? NSBitmapImageRep
+        }
+        expect(old != nil && oldBitmap != nil, "cache holds the current row")
+        autoreleasepool {
+            _ = IconCache.icon(forFile: finder, size: IconSize(points: 29, scale: 2))
+        }
+        expect(old == nil && oldBitmap == nil, "replacing a size releases the previous bitmap")
+        expect(
+            IconCache.cached(forFile: finder, size: IconSize(points: 24, scale: 2)) == nil,
+            "previous sizes do not accumulate")
+        IconCache.invalidateStyled()
+    }
+
+    static func rendered(_ source: NSImage, size: IconSize) -> Data {
+        autoreleasepool {
+            let rep = NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: size.pixels, pixelsHigh: size.pixels, bitsPerSample: 8,
+                samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB,
+                bytesPerRow: 0, bitsPerPixel: 0)!
+            rep.size = NSSize(width: size.points, height: size.points)
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+            NSGraphicsContext.current?.imageInterpolation = .high
+            source.draw(in: NSRect(origin: .zero, size: rep.size))
+            NSGraphicsContext.restoreGraphicsState()
+            return Data(bytes: rep.bitmapData!, count: rep.bytesPerRow * rep.pixelsHigh)
+        }
+    }
+
+    static func rowRendering() {
+        let paths = [
+            finder, "/System/Applications/Calculator.app", "/System/Applications/Calendar.app",
+            "/System/Applications/Notes.app", "/System/Applications/System Settings.app",
+            "/System/Applications/Preview.app"
+        ]
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            NSAppearance(named: name)!.performAsCurrentDrawingAppearance {
+                IconCache.invalidateStyled()
+                for path in paths {
+                    for scale: CGFloat in [1, 2] {
+                        for points: CGFloat in [24, 26, 29] {
+                            autoreleasepool {
+                                let size = IconSize(points: points, scale: scale)
+                                let baseline = IconCache.icon(forFile: path)
+                                let candidate = IconCache.icon(forFile: path, size: size)
+                                expect(
+                                    rendered(baseline, size: size) == rendered(candidate, size: size),
+                                    "final-size bytes match: \(path), \(name), \(points)pt @\(scale)x")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static func asynchronousRows() async {
+        let size = IconSize(points: 26, scale: 2)
+        IconCache.invalidateStyled()
+        let image = await IconCache.loadAsync(.file(stamp: 3), fileURL: URL(filePath: finder), size: size)
+        expect(image != nil && pixelWidth(image!) == 52, "entry load carries the requested size off-main")
+        expect(
+            IconCache.cached(.file(stamp: 3), fileURL: URL(filePath: finder), size: size) === image,
+            "entry cache lookup uses the same size")
+        let missing = await IconCache.loadAsync(forFile: "/no-such-application.app", size: size)
+        expect(missing == nil, "a missing path stays a placeholder")
+        let symbol = await IconCache.loadAsync(.symbol("star"), fileURL: URL(filePath: finder), size: size)
+        expect(symbol === IconCache.symbolIcon(named: "star"), "symbols use the existing rendering path")
+    }
+
+    static func main() async {
         var generation = IconCacheGeneration()
         let captured = generation.value
         var stored: [Int] = []
@@ -75,6 +187,10 @@ struct IconCacheTests {
         expect(stale == 2, "a stale decode still reaches its active caller")
         expect(stored == [1], "a stale decode cannot repopulate the cache")
 
+        rowSizes()
+        rowLifetime()
+        rowRendering()
+        await asynchronousRows()
         tintedTiles()
         restyling()
         styleFingerprint()

--- a/Tinycast/Features/Launcher/UI/AppIconView.swift
+++ b/Tinycast/Features/Launcher/UI/AppIconView.swift
@@ -3,24 +3,28 @@ import SwiftUI
 /// Row icon decoding off the main thread; warm icons seed synchronously, so no flash.
 struct AppIconView: View {
     @Environment(\.metrics) private var metrics
+    @Environment(\.displayScale) private var displayScale
     let app: AppEntry
-    @State private var image: NSImage?
+    /// Nil keeps the shared 96px bitmap; a size gets this row its own, far smaller one.
+    var pointSize: CGFloat?
+    @State private var loaded: Loaded?
 
-    init(app: AppEntry) {
-        self.app = app
-        _image = State(initialValue: Self.cached(app))
+    private struct Key: Hashable {
+        let icon: String
+        let size: IconSize?
     }
 
-    /// Cache-only, so a warm icon paints on the same frame; the kind is `iconSource`'s answer.
-    private static func cached(_ app: AppEntry) -> NSImage? {
-        IconCache.cached(app.iconSource, fileURL: app.url)
-    }
-
-    private static func load(_ app: AppEntry) async -> NSImage? {
-        await IconCache.loadAsync(app.iconSource, fileURL: app.url)
+    private struct Loaded {
+        let request: IconRequest<Key>
+        let image: NSImage?
     }
 
     var body: some View {
+        let size = pointSize.map { IconSize(points: $0, scale: displayScale) }
+        // Keyed on the icon, not the entry: re-skinning an extension leaves `id` untouched.
+        let request = IconRequest(Key(icon: app.iconKey, size: size))
+        let warm = IconCache.cached(app.iconSource, fileURL: app.url, size: size)
+        let image = warm ?? (loaded?.request == request ? loaded?.image : nil)
         Group {
             if let image {
                 Image(nsImage: image).resizable()
@@ -29,13 +33,11 @@ struct AppIconView: View {
                     .fill(Theme.Colors.iconPlaceholder)
             }
         }
-        // Keyed on the icon, not the entry: re-skinning an extension leaves `id` untouched.
-        .task(id: IconRequest(app.iconKey)) {
-            if let warm = Self.cached(app) {
-                image = warm
-                return
-            }
-            image = await Self.load(app)
+        .task(id: request) {
+            guard warm == nil else { return }
+            let image = await IconCache.loadAsync(app.iconSource, fileURL: app.url, size: size)
+            guard !Task.isCancelled else { return }
+            loaded = Loaded(request: request, image: image)
         }
     }
 }

--- a/Tinycast/Features/Launcher/UI/LauncherList.swift
+++ b/Tinycast/Features/Launcher/UI/LauncherList.swift
@@ -236,7 +236,7 @@ private struct AppRow: View {
 
     var body: some View {
         HStack(spacing: metrics.spacing.lg) {
-            AppIconView(app: app)
+            AppIconView(app: app, pointSize: metrics.size.rowIcon)
                 .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 .overlay(alignment: .bottom) {
                     if running {

--- a/Tinycast/Palette/RootPaletteView.swift
+++ b/Tinycast/Palette/RootPaletteView.swift
@@ -1414,7 +1414,7 @@ private struct CompactFavoritesRow: View {
                 CompactFavoriteButton(help: help(for: app, at: index)) {
                     onLaunch(app)
                 } content: {
-                    AppIconView(app: app)
+                    AppIconView(app: app, pointSize: metrics.size.rowIcon)
                         .frame(width: metrics.size.rowIcon, height: metrics.size.rowIcon)
                 }
             }

--- a/Tinycast/Platform/Images/IconCache.swift
+++ b/Tinycast/Platform/Images/IconCache.swift
@@ -50,12 +50,38 @@ enum EntryIcon: Hashable, Sendable {
     case artwork(path: String, extent: CGFloat)
 }
 
+struct IconSize: Hashable, Sendable {
+    let points: CGFloat
+    let scale: CGFloat
+
+    var pixels: Int { Int((points * scale).rounded(.up)) }
+}
+
 /// App icons by path, downsampled and byte-bounded, so rows don't re-hit `NSWorkspace`.
 enum IconCache {
     /// `NSCache` is thread-safe but not `Sendable`, so assert the guarantee once here.
     private final class Cache: NSCache<NSString, NSImage>, @unchecked Sendable {}
 
-    // Plenty for the ≤24pt draw, and a scrolled `LazyVStack` pins every row's icon.
+    /// Carries the size so a lookup can reject a bitmap the interface has since resized past.
+    private final class RowImage {
+        let size: IconSize
+        let image: NSImage
+
+        init(size: IconSize, image: NSImage) {
+            self.size = size
+            self.image = image
+        }
+    }
+
+    private final class RowCache: NSCache<NSString, RowImage>, @unchecked Sendable {}
+
+    // One entry per file, not per file and size: resizing must replace rows, never accumulate them.
+    private static let rowCache: RowCache = {
+        let cache = RowCache()
+        cache.totalCostLimit = 8 * 1024 * 1024
+        return cache
+    }()
+
     private static let displayPixel: CGFloat = 48
 
     private static let cache: Cache = {
@@ -73,8 +99,11 @@ enum IconCache {
     private static let fittedGeneration = Mutex(IconCacheGeneration())
 
     /// Cache-only lookups (never decode) so a row can paint an already-warm icon on the same frame.
-    static func cached(forFile path: String, stamp: Int = 0) -> NSImage? {
-        cache.object(forKey: fileKey(path, stamp))
+    static func cached(forFile path: String, stamp: Int = 0, size: IconSize? = nil) -> NSImage? {
+        let key = fileKey(path, stamp)
+        guard let size else { return cache.object(forKey: key) }
+        guard let entry = rowCache.object(forKey: key), entry.size == size else { return nil }
+        return entry.image
     }
     static func cachedSymbol(named name: String, tint: SymbolTint? = nil) -> NSImage? {
         cache.object(forKey: symbolKey(name, tint))
@@ -105,6 +134,7 @@ enum IconCache {
     @MainActor static func invalidateStyled() {
         styleGeneration.withLock { $0 &+= 1 }
         cache.removeAllObjects()
+        rowCache.removeAllObjects()
         purgeFitted()
         style.bump()
     }
@@ -152,11 +182,11 @@ enum IconCache {
     }
 
     /// Returns the decode directly, so a purge mid-decode can't strand a placeholder.
-    static func loadAsync(forFile path: String, stamp: Int = 0) async -> NSImage? {
-        if let cached = cached(forFile: path, stamp: stamp) { return cached }
+    static func loadAsync(forFile path: String, stamp: Int = 0, size: IconSize? = nil) async -> NSImage? {
+        if let cached = cached(forFile: path, stamp: stamp, size: size) { return cached }
         return await Task.detached(priority: .userInitiated) { () -> Decoded in
             guard FileManager.default.fileExists(atPath: path) else { return Decoded(image: nil) }
-            return Decoded(image: icon(forFile: path, stamp: stamp))
+            return Decoded(image: icon(forFile: path, stamp: stamp, size: size))
         }.value.image
     }
     static func loadSymbolAsync(named name: String, tint: SymbolTint? = nil) async -> NSImage? {
@@ -166,12 +196,44 @@ enum IconCache {
         }.value.image
     }
 
-    static func icon(forFile path: String, stamp: Int = 0) -> NSImage {
+    static func icon(forFile path: String, stamp: Int = 0, size: IconSize? = nil) -> NSImage {
+        if let size { return rowIcon(forFile: path, stamp: stamp, size: size) }
         let key = fileKey(path, stamp)
         if let cached = cache.object(forKey: key) { return cached }
         let (icon, cost) = downsampled(NSWorkspace.shared.icon(forFile: path))
         cache.setObject(icon, forKey: key, cost: cost)
         return icon
+    }
+
+    private static func rowIcon(forFile path: String, stamp: Int, size: IconSize) -> NSImage {
+        if let warm = cached(forFile: path, stamp: stamp, size: size) { return warm }
+        let (image, cost) = autoreleasepool { () -> (NSImage, Int) in
+            let (source, sourceCost) = downsampled(NSWorkspace.shared.icon(forFile: path))
+            return resized(source, to: size) ?? (source, sourceCost)
+        }
+        rowCache.setObject(RowImage(size: size, image: image), forKey: fileKey(path, stamp), cost: cost)
+        return image
+    }
+
+    /// Redraws the 96px result rather than the file's icon: AppKit picks its rep and shadow there.
+    private static func resized(_ source: NSImage, to size: IconSize) -> (NSImage, Int)? {
+        guard size.pixels < Int(displayPixel * 2) else { return nil }
+        guard
+            let rep = NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: size.pixels, pixelsHigh: size.pixels,
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0)
+        else { return nil }
+        rep.size = NSSize(width: size.points, height: size.points)
+        guard let context = NSGraphicsContext(bitmapImageRep: rep) else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        context.imageInterpolation = .high
+        source.draw(in: NSRect(origin: .zero, size: rep.size))
+        NSGraphicsContext.restoreGraphicsState()
+        let image = NSImage(size: rep.size)
+        image.addRepresentation(rep)
+        return (image, rep.bytesPerRow * rep.pixelsHigh)
     }
 
     /// A symbol on an app-icon-shaped tile; a tint fills it and brightens the glyph to white.
@@ -274,18 +336,18 @@ enum IconCache {
         }
     }
 
-    static func cached(_ source: EntryIcon, fileURL: URL) -> NSImage? {
+    static func cached(_ source: EntryIcon, fileURL: URL, size: IconSize? = nil) -> NSImage? {
         switch source {
-        case .file(let stamp): return cached(forFile: fileURL.path, stamp: stamp)
+        case .file(let stamp): return cached(forFile: fileURL.path, stamp: stamp, size: size)
         case .symbol(let name): return cachedSymbol(named: name)
         case .tintedSymbol(let name, let tint): return cachedSymbol(named: name, tint: tint)
         case .artwork(let path, let extent): return cachedArtwork(atPath: path, extent: extent)
         }
     }
 
-    static func loadAsync(_ source: EntryIcon, fileURL: URL) async -> NSImage? {
+    static func loadAsync(_ source: EntryIcon, fileURL: URL, size: IconSize? = nil) async -> NSImage? {
         switch source {
-        case .file(let stamp): return await loadAsync(forFile: fileURL.path, stamp: stamp)
+        case .file(let stamp): return await loadAsync(forFile: fileURL.path, stamp: stamp, size: size)
         case .symbol(let name): return await loadSymbolAsync(named: name)
         case .tintedSymbol(let name, let tint): return await loadSymbolAsync(named: name, tint: tint)
         case .artwork(let path, let extent):

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -586,8 +586,16 @@ internals live in [navigation.md](navigation.md) and [menu-search.md](menu-searc
 The ranking harness covers prefix learning, frequency/recency scoring, persistence, and both reset
 paths; see the command in `development.md`.
 
-Launcher icons use a persistent 32 MB cost-capped `NSCache`. Fitted file-row icons use a separate
-transient 8 MB cache that is purged when its palette list disappears (`IconCache`).
+Launcher rows and compact favorites ask for the point size they actually draw at, scaled by the
+view's `displayScale`: 24/26/29pt becomes 48/52/58px at 2×. `IconCache` still rasterizes through its
+96px canvas first — AppKit picks the representation and the drop shadow from that size — and then
+keeps only the row-sized bitmap, in an 8 MB cost-capped row cache separate from the 32 MB one.
+
+That cache holds **one size per path and stamp**: switching interface size replaces each entry
+rather than accumulating all three. A lookup carrying a different size is a miss, so a row can never
+paint a bitmap meant for another layout. Everything else — settings, symbols, artwork — keeps the
+96px path and the persistent 32 MB cache. Fitted file-row icons keep their own transient 8 MB cache,
+purged when its palette list disappears.
 
 A file-icon key carries a `FileIconStamp` as well as the path — the bundle's own modification and
 attribute dates plus its `Icon\r` — because pasting a custom icon in Finder leaves the bundle's

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,6 +119,7 @@ If a change touches anything in the right column, the harness on the left is man
 | `ext-metadata-test` | `Extensions/Service/ExtensionCommandMetadataStore.swift` — round-trip, failure runs, uninstall |
 | `ext-test` | the extension runtime end to end — boots a real bundle in JavaScriptCore and renders it |
 | `ext-icon-test` | `Extensions/Service/ExtensionIconCache.swift` — artwork sizing and its fallback |
+| `icon-cache-test` | `Platform/Images/IconCache.swift` — row sizing at 1×/2×, warm reuse, stamp and style invalidation, bitmap release, and that a row icon draws identically to the 96px one |
 | `entry-icon-test` | `EntryIcon` — that each case draws, caches and prints apart from the others, and that a moved `FileIconStamp` retires the bitmap decoded before it |
 | `text-diff-test` | `QuickActions/Model/TextDiffEngine.swift` — exact chunks, Unicode, ties, token-cap boundaries and fast paths |
 | `settings-backup-test` | `Settings/AppSettingsKey.swift`, `Backup/Model/SettingsBackupCoverage.swift` |


### PR DESCRIPTION
## Related issue

Closes #568

Prepared following @abue-ammar's [invitation to submit a PR for manual visual verification](https://github.com/abue-ammar/tinycast/issues/568#issuecomment-5645379414). The issue currently still has `wontfix`; it needs the maintainer's `approved` label for the automated contribution gate.

## What changed

Launcher rows and compact favorites request their actual point size and SwiftUI display scale: **48/52/58px at 2×** for Default/Large/Larger. The cache renders through the existing 96px source context first, preserving AppKit's source-selection path, then retains only the smaller bitmap.

An 8 MiB row cache keeps one size per path/stamp/style key and validates the size on lookup. Layout changes replace entries instead of accumulating every size; cancelled view loads cannot display an obsolete result. Settings, larger consumers, symbols, extension artwork and file previews keep their existing rendering paths. The change targets runtime memory; it does not reduce the app package size or unload JavaScript runtimes.

## Memory footprint

Three fresh-process runs per configuration, Swift 6 `-O`, M4 Pro/macOS 26.6.2. The shipped cache is exercised with 500 independent stamped keys cycling six built-in app icons. **These are isolated cache measurements, not whole-app savings.**

| Case | Bitmap allocation | Held-process footprint, median (range) |
| --- | ---: | ---: |
| Existing 96px | 17.58 MiB | 30.95 (30.86–31.00) MiB |
| Default 48px | 4.39 MiB (−75.0%) | 15.81 (15.70–16.09) MiB |
| Large 52px | 5.55 MiB (−68.4%) | 15.91 (15.63–15.94) MiB |
| Larger 58px | 7.08 MiB (−59.7%) | 15.66 (15.64–16.06) MiB |

About **15.0–15.3 MiB less held-process footprint with 500 entries**, or **2.9–3.0 MiB with 100**. Incremental layout switching stayed at 16.11–16.74 MiB in the candidate fixture. Bitmap figures include row padding.

| Full-app step | Memory |
| --- | --- |
| Idle after launch | Not measured for this branch |
| Palette open | Not measured for this branch |
| Feature in use (peak) | Not measured for this branch |
| Palette closed, settled | Not measured for this branch |

The separate probe settled to 7.86–8.11 MiB after purge and reference release, compared with 7.53 MiB for the baseline. It does not establish the whole-app 100 MB budget or return-to-baseline requirement.

Leak-tested: `leaks --atExit` on baseline and candidate transition workloads. Both report 287 allocations in the same three AppIntents/LinkServices NSXPCConnection root-cycle families (18,720 vs 18,768 bytes), with a restricted-process diagnostic. **This is not a zero-leak result.** Weak image and bitmap release assertions pass. Full-app leak validation remains outstanding.

Reproduction commands, lifecycle samples, raw runs and source hashes are in [the validation record](docs/validation/icon-cache-sizing.md).

## Demo

The Dev build was opened for local visual review; the user approved submitting this PR. All **72 offscreen final-size comparisons** match (six icons × three layouts × 1×/2× × light/dark). A fixture linking the built SwiftUI view also passes eight layout/scale transitions and visible style invalidation.

No matched native before/after video is attached. This draft is for the maintainer's requested visual testing, particularly shadows and icon corners. Offscreen equality does not establish appearance on every physical display.

## Drawbacks

- Cold generation for all 500 icons rises from 180ms median to 192–201ms. Warm lookup remains about 0.11–0.12ms total. Resizing can require fresh generation.
- A shared path used by two differently sized rows can replace the same slot and cause a later cache miss. Size checks prevent returning the wrong bitmap.
- Existing 96px consumers have a separate cache; retaining both representations reduces the net saving. NSCache limits are advisory, and view-held images survive eviction.
- Whole-app memory/leak measurements and matched native video remain to be completed before treating this as ready to merge.

## Tests & validation

- `./Scripts/run-tests.sh`: all 70 harnesses pass; focused icon tests pass again after formatting.
- Expanded `icon-cache-test`: 1×/2× and fractional sizing, warm object reuse, mixed row/96px consumers, file stamps, style invalidation, old bitmap release, asynchronous loads and 72 rendering comparisons.
- Debug build passes with no new compiler warnings; the existing AppIntents metadata warning remains.
- `./Scripts/lint.sh` exits 0 with pre-existing warnings; changed files have no lint warnings.
- Model import purity and `git diff --check` pass.
- 30 fresh-process optimized benchmark cases; built-view layout/scale fixture passes.
- Based on current upstream `8b3f802`. No unrelated local performance or native-extension work is included.
